### PR TITLE
Fix invalid Simplex after gluing/attachment

### DIFF
--- a/.idea/caset.iml
+++ b/.idea/caset.iml
@@ -2,7 +2,7 @@
 <module classpath="CMake" type="CPP_MODULE" version="4">
   <component name="FacetManager">
     <facet type="Python" name="Python facet">
-      <configuration sdkName="Python 3.12 virtualenv at ~/.virtualenvs/caset" />
+      <configuration sdkName="Python 3.10 (caset)" />
     </facet>
   </component>
 </module>

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -8,6 +8,13 @@ from caset import Spacetime
 spacetime = Spacetime()
 ```
 
+You can see an example of how the spacetime is constructed and embedded into a 3D euclidean space with the example 
+script, examples/plot4D.py.
+
+```bash
+python3 plot4D.py --n-simplices 10
+```
+
 You can adjust the behavior of that `Spacetime` by defining a `Metric` with a `Signature` as well as setting an 
 `alpha` value to use as the default edge length.
 

--- a/examples/plot4D.py
+++ b/examples/plot4D.py
@@ -21,11 +21,10 @@
 
 import argparse
 
+import time
 import torch
 from caset import Spacetime, Simplex
 
-import collections
-import timeit
 from matplotlib import pyplot as plt
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # just to register 3D projection
@@ -42,243 +41,154 @@ def project4_to_3(t, x, y, z, alpha=0.7, beta=0.7):
     x_p = x
     y_p = y
     z_p = alpha * z + beta * t
-    return x_p, y_p, z_p
+    return x_p, y_p, t
 
 
 def embed_euclidean(st, dimensions=4, epsilon=1e-10):
     """
-   pybind11::gil_scoped_release no_gil;
-   if (vertexList->size() == 0) return;
-   if (edgeList->size() == 0) return;
-
-   const int N = vertexList->size();
-   const int E = edgeList->size();
-   double lr = 10e-3;
-
-   std::vector<std::shared_ptr<Edge>> edgeVector = edgeList->toVector();
-   std::vector<std::shared_ptr<Vertex>> vertexVector = vertexList->toVector();
-
-   if (vertexVector.empty()) {
-     CASET_LOG(WARN_LEVEL, "No vertices to embed!");
-     return;
-   }
-   if (edgeVector.empty()) {
-     CASET_LOG(WARN_LEVEL, "No edges to embed!");
-     return;
-   }
-
-   CASET_LOG(INFO_LEVEL, "Embedding a ", dimensions, "-d Euclidean space with ", N, " vertices and ", E, " edges.");
-   std::unordered_map<std::uint64_t, int> vertexIdToIndex;
-   vertexIdToIndex.reserve(vertexVector.size());
-   std::unordered_map<std::uint64_t, double> vertexIdToTime;
-   vertexIdToTime.reserve(vertexVector.size());
-   for (int i = 0; i < static_cast<int>(vertexVector.size()); ++i) {
-     vertexIdToIndex[vertexVector[i]->getId()] = i;
-     vertexIdToTime[vertexVector[i]->getId()] = vertexVector[i]->getTime();
-   }
-
-   std::vector<int64_t> edgeIdxToSourceIndex(E);
-   std::vector<int64_t> edgeIdxToTargetIndex(E);
-   std::vector<double> edgeIdxToSourceTime(E);
-   std::vector<double> edgeIdxToTargetTime(E);
-   std::vector<double>  edgeIdxToAbsoluteSquaredLength(E);
-
-   for (int e = 0; e < E; ++e) {
-     const auto& edge = edgeVector[e];
-     auto sourceIndexIterator = vertexIdToIndex.find(edge->getSourceId());
-     auto targetIndexIterator = vertexIdToIndex.find(edge->getTargetId());
-     if (sourceIndexIterator == vertexIdToIndex.end() || targetIndexIterator == vertexIdToIndex.end()) {
-       throw std::runtime_error("Edge refers to unknown vertex id");
-     }
-     auto sourceTimeIterator = vertexIdToTime.find(edge->getSourceId());
-     auto targetTimeIterator = vertexIdToTime.find(edge->getTargetId());
-
-     edgeIdxToSourceIndex[e] = sourceIndexIterator->second;
-     edgeIdxToTargetIndex[e] = targetIndexIterator->second;
-     edgeIdxToSourceTime[e] = sourceTimeIterator->second;
-     edgeIdxToTargetTime[e] = targetTimeIterator->second;
-
-     double L = edge->getSquaredLength();
-     // If you have Minkowski lengths and want magnitude-only, use std::abs(L).
-     edgeIdxToAbsoluteSquaredLength[e] = std::abs(L)
-       ? std::abs(L)
-       : epsilon; // Avoid zero target distances which can cause issues in optimization;
-   }
-
-   auto edgeIdxToSourceIdxTensor = torch::from_blob(edgeIdxToSourceIndex.data(), {E}, torch::TensorOptions().dtype(torch::kLong)).clone();
-   auto edgeIdxToTargetIdxTensor = torch::from_blob(edgeIdxToTargetIndex.data(), {E}, torch::TensorOptions().dtype(torch::kLong)).clone();
-   auto edgeIdxToSourceTimeTensor = torch::from_blob(edgeIdxToSourceTime.data(), {E}, torch::TensorOptions().dtype(torch::kDouble)).clone();
-   auto edgeIdxToTargetTimeTensor = torch::from_blob(edgeIdxToTargetTime.data(), {E}, torch::TensorOptions().dtype(torch::kDouble)).clone();
-
-   auto edgeIdxToAbsoluteSquaredLengthTensor = torch::from_blob(edgeIdxToAbsoluteSquaredLength.data(), {E}, torch::TensorOptions().dtype(torch::kDouble)).clone();
-
-   // 4. Set up optimizer (Adam is simple and robust)
-   torch::Tensor positions = torch::randn({N, dimensions}, torch::TensorOptions()
-     .dtype(torch::kDouble))
-     .set_requires_grad(true);
-
-   torch::Tensor vertexTimesTensor = torch::zeros(
-     {N},
-     torch::TensorOptions().dtype(torch::kDouble)
-     );
-   for (int i = 0; i < N; ++i) {
-     vertexTimesTensor[i] = vertexVector[i]->getTime();
-   }
-
-   torch::optim::Adam optimizer({positions}, torch::optim::AdamOptions(lr));
-
-   auto previousLoss = torch::tensor({0});
-   auto loss = torch::tensor({0});
-   auto iter = 0;
-   auto epsilonTensor = torch::tensor({epsilon}, torch::TensorOptions().dtype(torch::kDouble));
-   while (iter == 0 || ((loss - previousLoss).abs() > epsilonTensor).item<bool>()) {
-     iter++;
-     optimizer.zero_grad();
-
-     // 5. Compute predicted squared distances for all edges
-     auto srcPositions = positions.index_select(0, edgeIdxToSourceIdxTensor);  // (E, dim)
-     auto tgtPositions = positions.index_select(0, edgeIdxToTargetIdxTensor);  // (E, dim)
-
-     auto expectedSrcTimes = vertexTimesTensor.index_select(0, edgeIdxToSourceIdxTensor);
-     auto expectedTgtTimes = vertexTimesTensor.index_select(0, edgeIdxToTargetIdxTensor);
-     auto expectedTimes = (expectedSrcTimes + expectedTgtTimes) / 2.;                             // (E,)
-     auto observedLengths = srcPositions - tgtPositions;                        // (E, dim - 1)
-
-     auto sqdist = observedLengths.pow(2).sum(-1);            // (E,)
-
-     // The observed time is the 0th element of the coordinate vector
-     auto observedSrcTimes = srcPositions.index({torch::arange(0, E), 0});
-     auto observedTgtTimes = tgtPositions.index({torch::arange(0, E), 0});
-     auto observedTimes = (observedSrcTimes + observedTgtTimes) / 2.;                             // (E,)
-
-     auto sqtime = (observedTimes - expectedTimes).pow(2);                     // (E,)
-
-     // 6. Loss: match squared distances
-     auto residual = sqdist - edgeIdxToAbsoluteSquaredLengthTensor + (sqtime * dimensions);
-     previousLoss = loss;
-     loss = residual.pow(2).mean();
-
-     loss.backward();
-     optimizer.step();
-
-     // Optional: early stopping / logging
-     if (iter % 100 == 0) {
-       std::cout << "[embedEuclidean] iter " << iter
-                 << " loss = " << loss.item<double>() << std::endl;
-     }
-
-  // 7. Write back into Vertex coordinates
-  auto posCpu = positions.detach().cpu();
-  auto posAccessor = posCpu.accessor<double, 2>();
-
-  for (int i = 0; i < N; ++i) {
-    std::vector<double> coords(dimensions);
-    coords[0] = vertexVector[i]->getTime();
-    for (int d = 1; d < dimensions; ++d) {
-      coords[d] = posAccessor[i][d];
-    }
-    vertexVector[i]->setCoordinates(coords);
-  }
-  CASET_LOG(INFO_LEVEL, "Iteration: ", iter, " Loss: ", loss.item<double>(), " Previous Loss: ", previousLoss.item<double>());
-
+    Embed vertices in (t, x_1, ..., x_{d-1}) with:
+      - t fixed to vertex.getTime() in {0,1}
+      - spatial coordinates learned to roughly match edge lengths
+      - repulsive term to reduce overlap within the same time slice
     """
+    assert dimensions >= 2, "Need at least 1 time + 1 spatial dimension"
+    spatial_dims = dimensions - 1
+
     N = st.getVertexList().size()
     E = st.getEdgeList().size()
-    lr = 10e-3
+    lr = 1e-2
+    max_iters = 10000  # safety cap
 
     edgeVector = st.getEdgeList().toVector()
     vertexVector = st.getVertexList().toVector()
 
+    # --- Map vertex IDs to indices and times ---
     vertexIdToIndex = {}
-    vertexIdToTime = {}
-    for (i, vertex) in enumerate(vertexVector):
-        vertexIdToIndex[vertex.getId()] = i
-        vertexIdToTime[vertex.getId()] = vertex.getTime()
+    vertexTimes = []
+    for i, vertex in enumerate(vertexVector):
+        vid = vertex.getId()
+        vertexIdToIndex[vid] = i
+        vertexTimes.append(vertex.getTime())
 
+    vertexTimesTensor = torch.tensor(vertexTimes, dtype=torch.double)  # (N,)
+
+    # --- Edge index and length data ---
     edgeIdxToSourceIndex = [0] * E
     edgeIdxToTargetIndex = [0] * E
-    edgeIdxToSourceTime = [0.0] * E
-    edgeIdxToTargetTime = [0.0] * E
     edgeIdxToAbsoluteSquaredLength = [0.0] * E
-    for e, edge in enumerate(edgeVector):
-        sourceIndex = vertexIdToIndex[edge.getSourceId()]
-        targetIndex = vertexIdToIndex[edge.getTargetId()]
-        sourceTime = vertexIdToTime[edge.getSourceId()]
-        targetTime = vertexIdToTime[edge.getTargetId()]
 
-        edgeIdxToSourceIndex[e] = sourceIndex
-        edgeIdxToTargetIndex[e] = targetIndex
-        edgeIdxToSourceTime[e] = sourceTime
-        edgeIdxToTargetTime[e] = targetTime
+    for e, edge in enumerate(edgeVector):
+        s_id = edge.getSourceId()
+        t_id = edge.getTargetId()
+
+        s_idx = vertexIdToIndex[s_id]
+        t_idx = vertexIdToIndex[t_id]
+
+        edgeIdxToSourceIndex[e] = s_idx
+        edgeIdxToTargetIndex[e] = t_idx
 
         L = edge.getSquaredLength()
+        # Treat |L| as the "target" squared Euclidean edge length
         edgeIdxToAbsoluteSquaredLength[e] = abs(L) if abs(L) > 0 else epsilon
 
     edgeIdxToSourceIdxTensor = torch.tensor(edgeIdxToSourceIndex, dtype=torch.long)
     edgeIdxToTargetIdxTensor = torch.tensor(edgeIdxToTargetIndex, dtype=torch.long)
-    edgeIdxToSourceTimeTensor = torch.tensor(edgeIdxToSourceTime, dtype=torch.double)
-    edgeIdxToTargetTimeTensor = torch.tensor(edgeIdxToTargetTime, dtype=torch.double)
-    edgeIdxToAbsoluteSquaredLengthTensor = torch.tensor(edgeIdxToAbsoluteSquaredLength, dtype=torch.double)
-    # 4. Set up optimizer (Adam is simple and robust)
-    positions = torch.randn((N, dimensions), dtype=torch.double, requires_grad=True)
-    vertexTimesTensor = torch.zeros((N,), dtype=torch.double)
-    for i, vertex in enumerate(vertexVector):
-        vertexTimesTensor[i] = vertex.getTime()
+    targetSqLenTensor = torch.tensor(edgeIdxToAbsoluteSquaredLength, dtype=torch.double)
+
+    # --- Learn ONLY spatial coordinates (time is fixed separately) ---
+    # positions[i] is (x_1, ..., x_{d-1}) for vertex i
+    positions = torch.randn((N, spatial_dims), dtype=torch.double, requires_grad=True)
+
     optimizer = torch.optim.Adam([positions], lr=lr)
-    previousLoss = torch.tensor(0.0)
-    loss = torch.tensor(0.0)
-    iter = 0
+    previousLoss = torch.tensor(float("inf"), dtype=torch.double)
+
     epsilonTensor = torch.tensor(epsilon, dtype=torch.double)
-    while iter == 0 or (loss - previousLoss).abs().item() > epsilon:
+    repulsion_weight = 1.15  # tune this to taste
+
+    iter = 0
+    while True:
         iter += 1
         optimizer.zero_grad()
-        # 5. Compute predicted squared distances for all edges
-        srcPositions = positions.index_select(0, edgeIdxToSourceIdxTensor)  # (E, dim)
-        tgtPositions = positions.index_select(0, edgeIdxToTargetIdxTensor)  # (E, dim)
 
-        expectedSrcTimes = vertexTimesTensor.index_select(0, edgeIdxToSourceIdxTensor)
-        expectedTgtTimes = vertexTimesTensor.index_select(0, edgeIdxToTargetIdxTensor)
-        expectedTimes = (expectedSrcTimes + expectedTgtTimes) / 2.0
-        observedLengths = srcPositions - tgtPositions  # (E, dim - 1)
-        sqdist = observedLengths.pow(2).sum(-1)  # (E,)
+        # --- Edge length term ---
+        srcPositions = positions.index_select(0, edgeIdxToSourceIdxTensor)  # (E, spatial_dims)
+        tgtPositions = positions.index_select(0, edgeIdxToTargetIdxTensor)  # (E, spatial_dims)
 
-        # The observed time is the 0th element of the coordinate vector
-        observedSrcTimes = srcPositions[:, 0]
-        observedTgtTimes = tgtPositions[:, 0]
-        observedTimes = (observedSrcTimes + observedTgtTimes) / 2.
-        sqtime = (observedTimes - expectedTimes).pow(2)  # (E,)
+        diff = srcPositions - tgtPositions
+        sqdist = diff.pow(2).sum(-1)  # (E,)
 
-        # 6. Loss: match squared distances
-        residual = sqdist - edgeIdxToAbsoluteSquaredLengthTensor + (sqtime * dimensions)
-        previousLoss = loss
-        loss = residual.pow(2).mean()
+        length_residual = sqdist - targetSqLenTensor
+        length_loss = (length_residual.pow(2)).mean()
+
+        # --- Repulsion term (mostly within same time slice) ---
+        # pairwise distances (N x N)
+        # Note: O(N^2), fine for a few thousand vertices, but you can replace with
+        # sampling if this gets too big.
+        pos_i = positions.unsqueeze(0)         # (1, N, spatial_dims)
+        pos_j = positions.unsqueeze(1)         # (N, 1, spatial_dims)
+        pair_diff = pos_i - pos_j              # (N, N, spatial_dims)
+        pair_sqdist = pair_diff.pow(2).sum(-1) # (N, N)
+
+        # Avoid self-interaction
+        eye = torch.eye(N, dtype=torch.double)
+        pair_sqdist = pair_sqdist + eye * 1e9
+
+        # More repulsion for vertices with the same time
+        same_time = (vertexTimesTensor.unsqueeze(0) == vertexTimesTensor.unsqueeze(1)).to(torch.double)
+
+        # 1 / r^2 repulsion, small epsilon to avoid blow-ups
+        repulsion_matrix = same_time * (1.0 / (pair_sqdist + 1e-6))
+
+        # Normalise by number of same-time pairs so weight is scale-ish-independent
+        same_time_count = same_time.sum().clamp(min=1.0)
+        repulsion_loss = repulsion_matrix.sum() / same_time_count
+
+        loss = length_loss + repulsion_weight * repulsion_loss
+
         loss.backward()
         optimizer.step()
 
-        # Optional: early stopping / logging
-        if iter % 100 == 0:
-            print(f"[embedEuclidean] iter {iter} loss = {loss.item():.6f}")
+        if iter % 200 == 0:
+            print(
+                f"[embedEuclidean-fixedTime] iter {iter} "
+                f"loss={loss.item():.6f} length={length_loss.item():.6f} "
+                f"rep={repulsion_loss.item():.6f}"
+            )
 
-    # 7. Write back into Vertex coordinates
+        # convergence check
+        if (previousLoss - loss).abs().item() <= epsilon:
+            break
+        if iter >= max_iters:
+            print(f"[embedEuclidean-fixedTime] Hit max_iters={max_iters}, stopping.")
+            break
+
+        previousLoss = loss.detach()
+
+    # --- Write back into Vertex coordinates ---
     posCpu = positions.detach().cpu()
     for i, vertex in enumerate(vertexVector):
         coords = [0.0] * dimensions
-        coords[0] = vertex.getTime()
+        # HARD-CONSTRAINED time coordinate:
+        coords[0] = float(vertex.getTime())      # should already be 0 or 1
         for d in range(1, dimensions):
-            coords[d] = posCpu[i, d].item()
+            coords[d] = posCpu[i, d - 1].item()
         vertex.setCoordinates(coords)
 
-    print(f"[embedEuclidean] Iteration: {iter} Loss: {loss.item():.6f} Previous Loss: {previousLoss.item():.6f}")
+    print(
+        f"[embedEuclidean-fixedTime] Iteration: {iter} "
+        f"Final loss: {loss.item():.6f} Previous loss: {previousLoss.item():.6f}"
+    )
+
 
 
 # Label Vertices:
 def label_vertices(st, ax):
-    vertex_positions = {}  # id -> (x, y, z)
     for vertex in st.getVertexList().toVector():
         x, y, z = project4_to_3(*vertex.getCoordinates())
+        _t, _x, _y, _z = vertex.getCoordinates()
         ax.text(
             x, y, z,
-            f"{vertex.getId()};t={vertex.getTime():.2f}",  # label
+            f"({_x:.1f},{_y:.1f},{_z:.1f},{_t:.1f})",
             color="black",
             fontsize=7,
             ha="center",
@@ -290,21 +200,13 @@ def label_edges(st, ax):
     for edge in st.getEdgeList().toVector():
         src = st.getVertexList().get(edge.getSourceId())
         tgt = st.getVertexList().get(edge.getTargetId())
-
         srcX = project4_to_3(*src.getCoordinates())
         tgtX = project4_to_3(*tgt.getCoordinates())
 
         # Midpoint
         m = [0.5 * (s + t) + .02 for s, t in zip(srcX, tgtX)]
-
         label = f"l={edge.getSquaredLength():.1f}"
-
-        ax.text(
-            *m,
-            label,
-            color="gray",
-            fontsize=7
-        )
+        ax.text(*m, label, color="gray", fontsize=7)
 
 
 def get_orientations(dimensions):
@@ -319,55 +221,20 @@ def get_orientations(dimensions):
 def build(args):
     st = Spacetime()
 
-    # Glue:
-    orientations = [(1, 2), (2, 1)]
-    unglued = collections.deque()
-    for i in range(args.n_simplices):
-        newSimplex = st.createSimplex(orientations[i % 2])
-        print("----------------------------------------------")
-        print("New simplex: ", newSimplex, newSimplex.getOrientation());
-        if i == 0:
-            continue
-
-        leftFace, rightFace = st.chooseSimplexFacesToGlue(newSimplex)
-        print("left Face: ", leftFace, "right face: ", rightFace)
-
-        complex, succeeded = st.causallyAttachFaces(leftFace, rightFace)
-        if complex:
-            print(complex.getCofaces(), 'Glued: ', succeeded)
-        else:
-            unglued.append((newSimplex, 0))
-            print("Gluing failed.")
-            continue
-
-        if unglued:
-            print("Attempting to glue unglued simplices...")
-            for i in range(len(unglued)):
-                newSimplex, retries = unglued.popleft()
-                if retries > 3:
-                    print("Giving up on simplex after 3 retries: ", newSimplex)
-                    continue
-                try:
-                    leftFace, rightFace = st.chooseSimplexFacesToGlue(newSimplex)
-                    complex, succeeded = st.causallyAttachFaces(leftFace, rightFace)
-                except RuntimeError:
-                    continue
-                if not succeeded:
-                    unglued.append((newSimplex, retries + 1))
-                    print("Gluing from unglued queue failed.")
-
-
-
-    print("-------------------</Gluing>---------------------------")
+    print("---------------Building Spacetime-------------")
+    start = time.time() * 1000.
+    st.build(args.n_simplices)
+    end = time.time() * 1000.
+    print("Elapsed time: ", end - start)
 
     # Embed:
-    embed_euclidean(st, dimensions=4, epsilon=10e-10)
-    print("----------------------------------------------")
 
-    ccs = st.getConnectedComponents()
-    print(f"Number of connected components: {len(ccs)}", ccs)
-    for edge in st.getEdgeList().toVector():
-        print(edge)
+    print("---------------Embedding Euclidean------------")
+    start = time.time() * 1000.
+    embed_euclidean(st, dimensions=4, epsilon=10e-10)
+    end = time.time() * 1000.
+    print("Elapsed time: ", end - start)
+    print("----------------------------------------------")
 
     # Plot:
     fig = plt.figure(figsize=(8, 8))
@@ -404,7 +271,6 @@ def label_bounds_and_get_edges(st, ax):
         zmin = min(zmin, z1, z2)
         zmax = max(zmax, z1, z2)
 
-        print("Squared length: ", edge.getSquaredLength())
         if edge.getSquaredLength() < 0:
             timeEdges.append([(x1, y1, z1), (x2, y2, z2)])
         else:

--- a/include/Edge.h
+++ b/include/Edge.h
@@ -38,7 +38,6 @@ inline double random_uniform(double min = -1.0, double max = 1.0) {
 }
 
 namespace caset {
-
 /// # Edge Disposition
 ///
 /// There are two things that determine the disposition (spacelike, timelike, light/null-like). The first is the squared
@@ -57,7 +56,7 @@ enum class EdgeDisposition : uint8_t {
 };
 
 struct EdgeKeyHash {
-  std::size_t operator()(const std::pair<std::uint64_t, std::uint64_t>& p) const noexcept {
+  std::size_t operator()(const std::pair<std::uint64_t, std::uint64_t> &p) const noexcept {
     // Standard-ish hash combine
     std::size_t h1 = std::hash<std::uint64_t>{}(p.first);
     std::size_t h2 = std::hash<std::uint64_t>{}(p.second);
@@ -68,12 +67,13 @@ struct EdgeKeyHash {
 
 // Optional: custom equality if you ever need something non-trivial
 struct EdgeKeyEqual {
-  bool operator()(const std::pair<std::uint64_t, std::uint64_t>& a,
-                  const std::pair<std::uint64_t, std::uint64_t>& b) const noexcept {
+  bool operator()(const std::pair<std::uint64_t, std::uint64_t> &a,
+                  const std::pair<std::uint64_t, std::uint64_t> &b) const noexcept {
     return a.first == b.first && a.second == b.second;
   }
 };
 
+class Simplex;
 
 /// # Edge Class
 ///
@@ -130,6 +130,11 @@ class Edge : public std::enable_shared_from_this<Edge> {
       refreshFingerprint();
     }
 
+    bool hasVertex(std::uint64_t vertexId) {
+      if (getSourceId() == vertexId || getTargetId() == vertexId) return true;
+      return false;
+    }
+
     void redirect(std::uint64_t from, std::uint64_t to) {
       if (getSourceId() == from) {
         replaceSourceVertex(to);
@@ -149,13 +154,19 @@ class Edge : public std::enable_shared_from_this<Edge> {
 
     Fingerprint fingerprint;
 
-    std::pair<IdType, IdType> getKey() const noexcept{
+    std::pair<IdType, IdType> getKey() const noexcept {
       return {sourceId, targetId};
     }
+
+    std::vector<std::shared_ptr<Simplex> > getSimplices() const noexcept { return simplices; }
+
+    void addSimplex(const std::shared_ptr<Simplex> &simplex) noexcept { simplices.push_back(simplex); }
 
   private:
     std::uint64_t sourceId;
     std::uint64_t targetId;
+    std::vector<std::shared_ptr<Simplex> > simplices;
+
     double squaredLength;
 };
 
@@ -163,12 +174,10 @@ using EdgeHash = FingerprintHash<Edge>;
 using EdgeEq = FingerprintEq<Edge>;
 using EdgePtr = std::shared_ptr<Edge>;
 using Edges = std::vector<EdgePtr>;
+
 using EdgeKey = std::pair<IdType, IdType>;
-using EdgeMap = std::unordered_map<EdgeKey, EdgePtr, EdgeKeyHash, EdgeKeyEqual>;
 using EdgeIdSet = std::unordered_set<EdgeKey, EdgeKeyHash, EdgeKeyEqual>;
 using EdgeIds = std::vector<EdgeKey>;
-using EdgeIndexMap = std::unordered_map<EdgeKey, std::size_t, EdgeKeyHash, EdgeKeyEqual>;
-
 }
 
 #endif //CASET_CASET_SRC_EDGE_H_

--- a/include/VertexList.h
+++ b/include/VertexList.h
@@ -62,15 +62,18 @@ class VertexList {
     }
 
     std::shared_ptr<Vertex> add(const std::uint64_t id) noexcept {
-      if (vertexList.contains(id)) {
-        return vertexList.at(id);
-      }
+      if (vertexList.contains(id)) return vertexList.at(id);
       std::shared_ptr<Vertex> vertex = std::make_shared<Vertex>(id);
       vertexList.insert_or_assign(id, vertex);
       return vertex;
     }
 
-    void replace(const std::shared_ptr<Vertex> &toRemove, const std::shared_ptr<Vertex> &toAdd) noexcept {
+    void replace(const std::shared_ptr<Vertex> &toRemove, const std::shared_ptr<Vertex> &toAdd) {
+#if CASET_DEBUG
+      if (toAdd == nullptr) throw std::invalid_argument("Cannot remove a nullptr vertex");
+      if (toRemove == nullptr) throw std::invalid_argument("Cannot remove a nullptr vertex");
+#endif
+
       remove(toRemove);
       add(toAdd);
     }
@@ -84,7 +87,7 @@ class VertexList {
     }
 
     std::vector<std::shared_ptr<Vertex>> toVector() const noexcept {
-      std::vector<std::shared_ptr<Vertex>> result;
+      std::vector<std::shared_ptr<Vertex>> result{};
       result.reserve(vertexList.size());
       for (const auto &[key, vertex] : vertexList) {
         result.push_back(vertex);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ optional-dependencies.dev = [
 
 [tool.scikit-build]
 build-dir = "cmake-build-debug/{wheel_tag}"
-cmake.build-type = "Debug" # "Release"
+cmake.build-type = "Release"
 
 [tool.scikit-build.cmake.define]
 Python_EXECUTABLE = "${python.executable}"

--- a/src/Vertex.cpp
+++ b/src/Vertex.cpp
@@ -20,3 +20,182 @@
 // SOFTWARE.
 
 #include "Vertex.h"
+#include "EdgeList.h"
+#include "VertexList.h"
+
+namespace caset {
+[[nodiscard]] double Vertex::getTime() const {
+  if (coordinates.empty()) {
+    return 0;
+  }
+  if (coordinates.size() == 1) {
+    return std::abs(coordinates[0]);
+  }
+  if (coordinates.size() >= 4) {
+    double sumOfSquares = 0;
+    for (const auto c : coordinates) {
+      sumOfSquares += c * c;
+    }
+    return std::sqrt(sumOfSquares);
+  }
+  const std::string msg = "Invalid coordinate vector of length " + std::to_string(coordinates.size());
+  throw std::out_of_range(msg);
+}
+
+bool Vertex::operator==(const Vertex &vertex) const noexcept {
+  return vertex.getId() == id;
+}
+
+std::vector<double>
+Vertex::getCoordinates() const
+{
+  if (coordinates.empty()) {
+    throw std::runtime_error("You requested coordinates for a vertex that is coordinate independent.");
+  }
+  return coordinates;
+}
+
+void
+Vertex::setCoordinates(const std::vector<double> &coords) noexcept
+{
+  coordinates = coords;
+}
+
+[[nodiscard]] std::pair<std::shared_ptr<Edge>, std::shared_ptr<Vertex> >
+Vertex::moveTo(const std::shared_ptr<Vertex> &vertex)
+{
+  if (outEdges.empty()) {
+    throw std::runtime_error("Cannot execute move; outEdges is empty!");
+  }
+  std::shared_ptr<Edge> edge = std::make_shared<Edge>(getId(), vertex->getId());
+  if (!outEdges.contains(edge)) {
+    throw std::runtime_error("No edge to this vertex exists.");
+  }
+  return std::pair<std::shared_ptr<Edge>, std::shared_ptr<Vertex> >({
+      *outEdges.find(edge), vertex
+  });
+}
+
+std::unordered_set<std::shared_ptr<Edge>, EdgeHash, EdgeEq>
+Vertex::getEdges() const noexcept {
+  std::unordered_set<std::shared_ptr<Edge>, EdgeHash, EdgeEq> edges;
+  edges.reserve(inEdges.size() + outEdges.size());
+  edges.insert(inEdges.begin(), inEdges.end());
+  edges.insert(outEdges.begin(), outEdges.end());
+  return edges;
+}
+
+std::shared_ptr<Edge>
+Vertex::getEdge(const EdgeKey &key)
+{
+  const auto testEdge = std::make_shared<Edge>(key.first, key.second);
+  if (inEdges.contains(testEdge)) return *inEdges.find(testEdge);
+  if (outEdges.contains(testEdge)) return *outEdges.find(testEdge);
+  return nullptr;
+}
+
+std::shared_ptr<Edge> Vertex::getEdge(const EdgePtr &edge)
+{
+  if (inEdges.contains(edge)) return *inEdges.find(edge);
+  if (outEdges.contains(edge)) return *outEdges.find(edge);
+  return nullptr;
+}
+
+std::pair<std::shared_ptr<EdgeIdSet>, std::shared_ptr<EdgeIdSet>>
+Vertex::moveInEdgesTo(
+  const std::shared_ptr<Vertex> &vertex,
+  const std::shared_ptr<EdgeList> &edgeList,
+  const std::shared_ptr<VertexList> &vertexList
+  ) {
+  std::shared_ptr<EdgeIdSet> oldEdges = std::make_shared<EdgeIdSet>();
+  std::shared_ptr<EdgeIdSet> newEdges = std::make_shared<EdgeIdSet>();
+  for (const auto &edge : inEdges) {
+    CLOG(DEBUG_LEVEL, "Moving in-edge ", edge->toString(), " to ", vertex->toString());
+    oldEdges->insert(edge->getKey());
+    edgeList->remove(edge);
+    const auto sourceVertex = vertexList->get(edge->getSourceId());
+    sourceVertex->removeOutEdge(edge);
+    CLOG(DEBUG_LEVEL, "Changing target vertex from ", std::to_string(edge->getTargetId()), " to ", std::to_string(vertex->getId()));
+    edge->replaceTargetVertex(vertex->getId());
+    newEdges->insert(edge->getKey());
+    vertex->addInEdge(edgeList->add(edge));
+    sourceVertex->addOutEdge(edgeList->get(edge->getKey()));
+  }
+  inEdges.clear();
+  return {oldEdges, newEdges};
+}
+
+std::pair<EdgeIdSet, EdgeIdSet>
+Vertex::moveEdgesTo(const std::shared_ptr<Vertex> &vertex, const std::shared_ptr<EdgeList> &edgeList, const std::shared_ptr<VertexList> &vertexList) {
+  EdgeIdSet oldEdges = EdgeIdSet{};
+  EdgeIdSet newEdges = EdgeIdSet{};
+  const auto &[oldInEdges, newInEdges] = moveInEdgesTo(vertex, edgeList, vertexList);
+  const auto &[oldOutEdges, newOutEdges] = moveOutEdgesTo(vertex, edgeList, vertexList);
+  oldEdges.insert(oldInEdges->begin(), oldInEdges->end());
+  oldEdges.insert(oldOutEdges->begin(), oldOutEdges->end());
+  newEdges.insert(newInEdges->begin(), newInEdges->end());
+  newEdges.insert(newOutEdges->begin(), newOutEdges->end());
+  return {oldEdges, newEdges};
+}
+
+std::pair<std::shared_ptr<EdgeIdSet>, std::shared_ptr<EdgeIdSet>>
+Vertex::moveOutEdgesTo(const std::shared_ptr<Vertex> &vertex, const std::shared_ptr<EdgeList> &edgeList, const std::shared_ptr<VertexList> &vertexList) {
+  std::shared_ptr<EdgeIdSet> oldEdges = std::make_shared<EdgeIdSet>();
+  std::shared_ptr<EdgeIdSet> newEdges = std::make_shared<EdgeIdSet>();
+  std::unordered_set<std::shared_ptr<Edge>, EdgeHash, EdgeEq> newOutEdges{};
+  for (const auto &edge : outEdges) {
+    CLOG(DEBUG_LEVEL, "Moving out-edge ", edge->toString(), " to ", vertex->toString());
+    oldEdges->insert(edge->getKey());
+    edgeList->remove(edge);
+    const auto targetVertex = vertexList->get(edge->getTargetId());
+    targetVertex->removeInEdge(edge);
+    CLOG(DEBUG_LEVEL, "Changing source vertex from ", std::to_string(edge->getSourceId()), " to ", std::to_string(vertex->getId()));
+    edge->replaceSourceVertex(vertex->getId());
+    newEdges->insert(edge->getKey());
+    vertex->addOutEdge(edgeList->add(edge));
+    targetVertex->addInEdge(edgeList->get(edge->getKey()));
+  }
+  outEdges.clear();
+  return {oldEdges, newEdges};
+}
+
+void Vertex::addSimplex(const std::shared_ptr<Simplex> &simplex) {
+  CLOG(INFO_LEVEL, "Adding simplex to vertex", toString());
+#if CASET_DEBUG
+  for (const auto &simp : simplices) {
+    if (simp == simplex) {
+      CLOG(ERROR_LEVEL, "You tried to add a simplex more than once!");
+      throw std::runtime_error("you tried to add a simplex more than once.");
+    }
+  }
+#endif
+  simplices.push_back(simplex);
+}
+
+void Vertex::removeSimplex(const std::shared_ptr<Simplex> &simplex) {
+  for (auto i=0; i<simplices.size(); i++) {
+    if (simplex == simplices[i]) {
+      simplices.erase(simplices.begin() + i);
+      return;
+    }
+  }
+#if CASET_DEBUG
+  throw std::runtime_error("You tried to remove a simplex that the Vertex does not contain!");
+#endif
+}
+
+std::vector<std::shared_ptr<Simplex>>
+Vertex::getSimplices() const noexcept
+{
+  return simplices;
+}
+
+std::string Vertex::toString() const noexcept {
+  std::stringstream ss;
+  ss << "<V" << std::to_string(id) << " ";
+  ss << "(in=" << std::to_string(inEdges.size());
+  ss << ", out=" << std::to_string(outEdges.size());
+  ss << ", t=" << std::to_string(getTime()) << ")>";
+  return ss.str();
+}
+};

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -88,6 +88,7 @@ PYBIND11_MODULE(caset, m) {
       .def("getOutEdges", &Vertex::getOutEdges)
       .def("removeInEdge", &Vertex::removeInEdge)
       .def("removeOutEdge", &Vertex::removeOutEdge)
+      .def("moveEdgesTo", &Vertex::moveEdgesTo)
       .def("getTime", &Vertex::getTime)
       .def("moveTo", &Vertex::moveTo);
 
@@ -128,6 +129,8 @@ PYBIND11_MODULE(caset, m) {
       .def("getOrientation", &SimplexOrientation::getOrientation)
       .def("__hash__", &SimplexOrientation::fingerprint)
       .def("__eq__", &SimplexOrientation::operator==)
+      .def("__str__", &SimplexOrientation::toString)
+      .def("__repr__", &SimplexOrientation::toString)
       .def("numeric", &SimplexOrientation::numeric);
 
   py::class_<SimplexOrientationHash, std::shared_ptr<SimplexOrientationHash>>(m, "SimplexOrientationHash")
@@ -136,29 +139,25 @@ PYBIND11_MODULE(caset, m) {
     .def(py::init<>());
 
   py::class_<Simplex, std::shared_ptr<Simplex> >(m, "Simplex")
-      .def(py::init<const std::vector<std::shared_ptr<Vertex> >>(),
-           py::arg("vertices"))
+      .def(py::init<const std::vector<std::shared_ptr<Vertex>>, std::vector<std::shared_ptr<Edge>>>(),
+           py::arg("vertices"), py::arg("edges"))
       .def("__repr__", &Simplex::toString)
       .def("__str__", &Simplex::toString)
       .def("checkPairty", &Simplex::checkParity)
       .def("getCofaces", &Simplex::getCofaces)
-      .def("getDeficitAngle", &Simplex::getDeficitAngle)
       .def("getEdges", &Simplex::getEdges)
       .def("getFacets", &Simplex::getFacets)
-      .def("getHinges", &Simplex::getHinges)
       .def("getNumberOfFaces", &Simplex::getNumberOfFaces)
       .def("getOrientation", &Simplex::getOrientation)
       .def("getVertexIdLookup", &Simplex::getVertexIdLookup)
       .def("getVertices", &Simplex::getVertices)
       .def("getVerticesWithPairtyTo", &Simplex::getVerticesWithParityTo, py::arg("other"))
-      .def("getVolume", &Simplex::getVolume)
-      .def("hasEdge", py::overload_cast<const EdgePtr &>(&Simplex::hasEdge), py::arg("edge"))
-      .def("hasEdge", py::overload_cast<const IdType, const IdType>(&Simplex::hasEdge), py::arg("source"), py::arg("target"))
+      // .def("hasEdge", py::overload_cast<const EdgePtr &>(&Simplex::hasEdge), py::arg("edge"))
+      // .def("hasEdge", py::overload_cast<const IdType, const IdType>(&Simplex::hasEdge), py::arg("source"), py::arg("target"))
+      .def("hasVertex", &Simplex::hasVertex)
       .def("isTimelike", &Simplex::isTimelike)
-      .def("removeEdge", py::overload_cast<const EdgeKey &>(&Simplex::removeEdge), py::arg("edgeKey"))
-      .def("removeEdge", py::overload_cast<const EdgePtr &>(&Simplex::removeEdge), py::arg("edge"))
-      .def("removeVertex", &Simplex::removeVertex)
-      .def("replaceVertex", &Simplex::replaceVertex);
+      .def("attach", &Simplex::attach, py::arg("unattachedVertex"), py::arg("unattachedVertex"), py::arg("edgeList"), py::arg("vertexList"))
+      .def("validate", &Simplex::validate);
 
   py::class_<SimplexHash, std::shared_ptr<SimplexHash>>(m, "SimplexHash")
     .def(py::init<>());
@@ -226,8 +225,8 @@ PYBIND11_MODULE(caset, m) {
            py::arg("target"),
            py::arg("squaredLength"))
       .def("createSimplex",
-           py::overload_cast<std::vector<std::shared_ptr<Vertex> > &>(&Spacetime::createSimplex),
-           py::arg("vertices"))
+           py::overload_cast<const std::vector<std::shared_ptr<Vertex> > &, const std::vector<std::shared_ptr<Edge>> &>(&Spacetime::createSimplex),
+           py::arg("vertices"), py::arg("edges"))
       .def("createSimplex",
            py::overload_cast<const std::tuple<uint8_t, uint8_t> &>(&Spacetime::createSimplex),
            py::arg("orientation"))

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -37,6 +37,37 @@ class TestEdge(unittest.TestCase):
         self.assertIs(src, v1.getId())
         self.assertIs(tgt, v2.getId())
 
+    def test_sets_of_edges(self):
+        edges = [Edge(i, i+1) for i in range(51)]
+        self.assertEqual(len(set(edges)), len(edges))
+
+        e1 = Edge(0, 1)
+        e2 = Edge(0, 1)
+        e3 = Edge(1, 0)
+        edges = set()
+        edges.add(e1)
+        edges.add(e2)
+        edges.add(e3)
+        self.assertEqual(len(edges), 1)
+
+    def test_maps_of_edges(self):
+        edges = [Edge(i, i+1) for i in range(51)]
+        edge_dict = {Edge(i, i+1): i for i in range(51)}
+        for i, e in enumerate(edges):
+            self.assertEqual(e, edges[i])
+            self.assertEqual(edge_dict.get(e), i)
+
+        self.assertEqual(len(set(edges)), len(edges))
+
+    def test_equality(self):
+        e1 = Edge(0, 1)
+        e2 = Edge(1, 0)
+        self.assertEqual(e1, e2)
+        e3 = Edge(0, 1)
+        self.assertEqual(e1, e3)
+        e4 = Edge(1, 2)
+        self.assertNotEqual(e1, e4)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug in the Simplex where mutations are cascaded to children and parent simplices but not to siblings.

Also fixes getK, since a k-simplex has k+1 vertices.

Requires edges to be passed to create a simplex rather than being computed.

Create a new hasCausallyAvailableFaces method and changes isCausallyAvailable to operate in the context of `this` being a face.