### PR TITLE
perf: parallelize SpectralGraph::diagonalHeatKernel (OpenMP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,23 @@ target_include_directories(tessera_core PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/src"
     "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(tessera_core PUBLIC ZLIB::ZLIB)
+
+# Optional OpenMP for the spectral-graph heat-kernel parallel loop and
+# similar embarrassingly-parallel hot paths. Bit-identical to the
+# serial code at OMP_NUM_THREADS=1 (the default in our 10-CPU-budget
+# scan policy); only kicks in for solo / exploratory runs that set
+# OMP_NUM_THREADS > 1 explicitly. Required so `#pragma omp parallel`
+# compiles and links cleanly; if OpenMP is absent the pragmas are
+# silently no-ops (we don't gate compilation on it).
+find_package(OpenMP COMPONENTS CXX)
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(tessera_core PUBLIC OpenMP::OpenMP_CXX)
+    message(STATUS "OpenMP found (${OpenMP_CXX_VERSION}); spectral-graph "
+                   "heat-kernel will respect OMP_NUM_THREADS.")
+else()
+    message(STATUS "OpenMP not found; #pragma omp directives in "
+                   "tessera_core will compile as no-ops.")
+endif()
 # tessera_core is pybind-free: the binding code (which uses pybind11) lives
 # only in src/bindings.cpp and src/quantum/bindings.cpp, both compiled
 # directly into the _tessera Python module. Earlier versions of tessera had

--- a/src/graph/spectral_graph.cpp
+++ b/src/graph/spectral_graph.cpp
@@ -216,21 +216,31 @@ SpectralGraph::diagonalHeatKernel(std::vector<int> const& starts,
     std::vector<double> out(static_cast<std::size_t>(nSt) * nSig, 0.0);
     if (n == 0 || nSt == 0 || nSig == 0) return out;
 
-    std::vector<double> v(static_cast<std::size_t>(n));
-    std::vector<double> w(static_cast<std::size_t>(n));
-    std::vector<double> prev(static_cast<std::size_t>(n));
-    std::vector<std::vector<double>> V;
-    std::vector<double> alpha, beta;
-
+    // The outer loop over `starts` is embarrassingly parallel: each
+    // iteration builds its own Krylov subspace from a distinct unit
+    // vector, calls applyLaplacian (const, thread-safe), and writes
+    // only to its own contiguous slice of `out` (positions
+    // s*nSig .. (s+1)*nSig). Scratch buffers (v, w, prev, V, alpha,
+    // beta) are per-iteration and therefore per-thread under OpenMP.
+    //
+    // `schedule(dynamic)` because per-start cost varies (sparser
+    // neighborhoods break out of the kMax loop earlier when normW <
+    // 1e-12). Bit-identical to the serial version — same arithmetic
+    // in the same order within each iteration, and inter-iteration
+    // independence means thread ordering doesn't affect output.
+    #pragma omp parallel for schedule(dynamic)
     for (int s = 0; s < nSt; ++s) {
         const int start = starts[static_cast<std::size_t>(s)];
         if (start < 0 || start >= n) continue;
 
-        std::fill(v.begin(), v.end(), 0.0);
+        std::vector<double> v(static_cast<std::size_t>(n));
+        std::vector<double> w(static_cast<std::size_t>(n));
+        std::vector<double> prev(static_cast<std::size_t>(n));
+        std::vector<std::vector<double>> V;
+        std::vector<double> alpha, beta;
+
         v[static_cast<std::size_t>(start)] = 1.0;
         V.assign(1, v);
-        alpha.clear();
-        beta.clear();
 
         const int kMax = std::min(krylovDim, n);
         for (int j = 0; j < kMax; ++j) {


### PR DESCRIPTION
Parallelize `SpectralGraph::diagonalHeatKernel` across start vertices.
The outer loop is embarrassingly parallel — each iteration builds its
own Krylov subspace from a distinct unit vector, calls the
const-and-thread-safe `applyLaplacian`, and writes only to its own
contiguous slice of the output buffer.

## Why

Profiling a T=2000 worker (the same code path the issue #10 finite-size
scan runs at every T) showed 70% of wall time in the spectral-dim
computation:

```
51.18%  SpectralGraph::diagonalHeatKernel
19.23%  EmergentGraph::applyLaplacian
 3.05%  __memmove_avx_unaligned_erms
 ...
```

The matrix-vector products in `applyLaplacian` already vectorize well
through gcc/eigen; the macro win is parallelizing the outer
start-vertex loop.

## Mechanic

Move per-iteration scratch buffers (`v`, `w`, `prev`, `V`, `alpha`,
`beta`) inside the loop so each thread has its own, then annotate
with `#pragma omp parallel for schedule(dynamic)`. Dynamic scheduling
because per-start cost varies (sparser neighbourhoods break out of
the `kMax` Krylov loop early when `normW < 1e-12`), so static
chunking can leave threads idle.

CMake adds `find_package(OpenMP COMPONENTS CXX)` and links
`OpenMP::OpenMP_CXX` into `tessera_core`. When OpenMP isn't found,
the `#pragma` is a no-op and the loop runs serially — no behaviour
change. At `OMP_NUM_THREADS=1` (the default for our 10-CPU-budget
scan policy) the pragma also produces serial execution that's
bit-identical to the pre-change code.

## Bit-identicality

Same arithmetic in the same order within each iteration; inter-iteration
independence means thread ordering doesn't change `out[s*nSig + j]` for
any (s, j). Verified on a T=5000 worker (8-vertex Delaunay, seed=777,
β=3e-4, qudit+Choi on, krylovDim=15, 20 σ values log-spaced over [1e-2,
1e10]):

| OMP | peak_dS | q_global | t_sd | speedup |
|---:|---|---|---:|---:|
| 1 | 4.515646785420355 | 2.43e-12 | 60.57 s | 1.00× |
| 2 | 4.515646785420355 | 2.43e-12 | 29.71 s | 2.04× |
| 4 | 4.515646785420355 | 2.43e-12 | 15.48 s | 3.91× |
| 8 | 4.515646785420355 | 2.43e-12 |  9.11 s | 6.65× |

`peak_dS` matches to 15 decimal digits across all thread counts;
`q_global` bit-identical; the pre-existing T=2500 smoke test
reproduces `peak_dS=4.541561` to machine precision.

## Test suite

`pytest tests/ -m "not slow"` — **628 passed**, 4 skipped, 4 deselected,
same as baseline. The single failure (`test_solver_reduces_gradient_norm`)
is a pre-existing CUDA-OOM caused by vLLM consuming 36 GB of GPU on
this dev box; CI runs CPU-only.

## What this does not do

Explicitly **not** in this PR (each of these would be a non-trivial
change with separate risk):

- `-march=native -mtune=native`: tried first, but applied `PRIVATE`
  to the cores it caused an Eigen-alignment ABI mismatch with the
  pybind module that wasn't compiled with the same flag, leading to
  segfaults at `Matrix4cd` boundaries. Doing it right requires
  applying it globally (every TU, including ITensor's headers),
  which is its own validation effort.
- `-flto`: paired with the above, removed alongside it.
- Algorithmic changes to the Krylov / Gram-Schmidt: the current code
  does full reorthogonalisation for numerical stability; any
  "partial" or "selective" variant would be an accuracy shortcut.

## Future scans

The running T=100k scan (started ~07:00 UTC on 2026-05-18, still
mid-run) does not benefit — its workers are pinned to the orphaned
pre-change `.so` inode via mv-atomic promotion. The **next** scan,
the H-parameter scan #11, and any solo / exploratory runs that set
`OMP_NUM_THREADS > 1` will see immediate speedup on the 70% hot path.

For an 8-thread solo run on this box, the T=100k spectral-dim phase
should drop from ~hours to ~tens of minutes — making interactive
parameter sweeps practical.
