### PR TITLE
docs: emergent spacetime is the boundary's dual, not the complex of vertices

### DIFF
--- a/docs/source/quantum-experiments/charged-cartan/design/h_pair_first_cell.md
+++ b/docs/source/quantum-experiments/charged-cartan/design/h_pair_first_cell.md
@@ -887,6 +887,20 @@ The H_DS4 hypothesis (§3 of the [v0.2 design](v0.2.md)) is the
 claim that *some* $\beta$ exists where the equilibrium ensemble's
 geometry has emergent spectral dimension $D_S = 4$.
 
+> **Primal vs. dual lattice.** The Metropolis weight uses the Regge
+> action $S_{\mathrm{Regge}}$, which lives on the **primal** complex
+> $\mathcal K_T$ — areas and deficit angles of its hinges — and each
+> $\Delta S_n$ is local to the cell just added. The dual lattice never
+> enters a move's accept/reject. The spectral dimension is a separate
+> *observable*: exactly as in CDT (Ambjørn, Jurkiewicz, Loll,
+> *Reconstructing the Universe*, eq. 24 — a random walk hopping between
+> four-simplices, $1/5$ to each of its five neighbours), $D_S$ is
+> measured by heat-kernel diffusion on the **dual** lattice, on
+> equilibrated configurations — not per move. So $\mathcal K_T$ here is
+> CDT-style: the triangulation *is* the geometry, and the dual is the
+> discretization the diffusion runs on. Tracked in [issue
+> #31](https://github.com/akellehe/tessera/issues/31).
+
 ### 9.4 Putting cells 1 and 2 into the path integral
 
 For our 2-cell intermediate-engagement example:

--- a/docs/source/quantum-experiments/overview/intellectual_lineage.md
+++ b/docs/source/quantum-experiments/overview/intellectual_lineage.md
@@ -400,10 +400,12 @@ exists a regime where this `D_S` reaches 4, signalling an emergent
 
 > **Boundary vs. dual (see §1).** `D_S` should be the spectral
 > dimension of the emergent spacetime — the geometry *dual* to the MI
-> complex. The current pipeline (`EmergentGraph` /
-> `EmergentSpectralDimension`) computes the heat kernel directly on the
-> **boundary** MI complex, so the `D_S` it reports is the boundary
-> network's, not the dual's. Reconciling this is tracked in [issue
+> complex. Measuring it on the dual is also the faithful CDT procedure:
+> Ambjørn–Jurkiewicz–Loll run the diffusion on the dual lattice (a
+> walker hopping between four-simplices), not on the triangulation
+> itself. The current pipeline (`EmergentGraph` /
+> `EmergentSpectralDimension`) instead computes the heat kernel on the
+> **boundary** MI complex. Reconciling this is tracked in [issue
 > #31](https://github.com/akellehe/tessera/issues/31).
 
 The v0.2 β-scan ([writeup](../charged-cartan/experiments/02-v0.2-beta-scan.md))

--- a/docs/source/quantum-experiments/overview/intellectual_lineage.md
+++ b/docs/source/quantum-experiments/overview/intellectual_lineage.md
@@ -28,8 +28,13 @@ The construction in this project takes this literally:
 - **Edge lengths** between vertices are computed from their mutual
   information `ℓ = −log(I / I_max)`. Strong correlation ↔ short edge;
   no correlation ↔ infinite edge.
-- The simplicial complex of vertices, with these MI-derived lengths,
-  *is* the emergent spacetime — there is no separate background metric.
+- The simplicial complex of vertices, with these MI-derived lengths, is
+  the **boundary** data — the network of quantum systems and their
+  correlations. The emergent spacetime is *not* this complex but the
+  geometry **holographically dual** to it: in van Raamsdonk's essay the
+  `ℓ ∝ −log I` relation ties *boundary* mutual information to *bulk*
+  distance. Spacetime is built up from the correlation pattern, on the
+  dual side of it — there is no separate background metric.
 
 This is the founding principle and remains intact through every
 subsequent generalisation.
@@ -387,11 +392,19 @@ seen by a random walker diffusing on the lattice for time `σ` — as
 the diagnostic for whether their path-integral over geometries
 produces 4D macroscopic spacetime.
 
-We borrow exactly this observable. On our MI-weighted simplicial
-complex, the heat kernel `P(σ) = (1/N) Σ_v ⟨v| exp(−σ L) |v⟩` gives
-us `D_S(σ) = −2 d log P / d log σ`. The H_DS4 hypothesis is: there
+We borrow exactly this observable. The heat kernel
+`P(σ) = (1/N) Σ_v ⟨v| exp(−σ L) |v⟩` gives us
+`D_S(σ) = −2 d log P / d log σ`. The H_DS4 hypothesis is: there
 exists a regime where this `D_S` reaches 4, signalling an emergent
 3+1-dimensional macroscopic phase.
+
+> **Boundary vs. dual (see §1).** `D_S` should be the spectral
+> dimension of the emergent spacetime — the geometry *dual* to the MI
+> complex. The current pipeline (`EmergentGraph` /
+> `EmergentSpectralDimension`) computes the heat kernel directly on the
+> **boundary** MI complex, so the `D_S` it reports is the boundary
+> network's, not the dual's. Reconciling this is tracked in [issue
+> #31](https://github.com/akellehe/tessera/issues/31).
 
 The v0.2 β-scan ([writeup](../charged-cartan/experiments/02-v0.2-beta-scan.md))
 finds a stable plateau at peak `D_S ≈ 4.6 ± 0.1` across a decade of


### PR DESCRIPTION
## Summary

Corrects a conceptual error in how the docs describe the emergent-spacetime construction, verified against the primary sources.

`intellectual_lineage.md` §1 claimed the MI-weighted simplicial complex of quantum-system vertices *is* the emergent spacetime. Per van Raamsdonk ([1005.3035](https://arxiv.org/abs/1005.3035)), the quantum systems are the **boundary** degrees of freedom and the emergent spacetime is the geometry **holographically dual** to them — the `ℓ ∝ −log I` relation ties boundary mutual information to bulk distance. The project's own holography charter already states this correctly; §1 was the inconsistent outlier.

## Changes (docs only)

- **`intellectual_lineage.md` §1** — the complex of vertices is the boundary data; the emergent spacetime is its holographic dual.
- **`intellectual_lineage.md` §8** — annotate that the heat-kernel `D_S` pipeline (`EmergentGraph` / `EmergentSpectralDimension`) computes on the boundary MI complex, not the dual; measuring on the dual is the faithful CDT procedure (AJL diffuse on the dual lattice of four-simplices).
- **`h_pair_first_cell.md` §9** — CDT-style primal/dual note: the interaction-history Monte Carlo runs the Regge action / Metropolis accept-reject on the primal complex `K_T` (local `ΔS`); `D_S` is a separate observable measured by heat-kernel diffusion on the dual lattice, not per move.

## Verification

- **van Raamsdonk 1005.3035** — confirmed the boundary/bulk holographic framing (the emergent spacetime is the *dual geometry*, not the network of quantum subsystems).
- **CDT methodology** — confirmed against Ambjørn–Jurkiewicz–Loll, *Reconstructing the Universe* (hep-th/0505154): `D_S` is measured by diffusion on the dual lattice (eq. 24 — a walk hopping between four-simplices); the dual never enters a Metropolis accept/reject.

## Scope

Docs only — **no application code changed**. The code discrepancy (the holography `EmergentGraph` pipeline computes `D_S` on the boundary MI complex rather than its dual) is tracked separately in #31.

Refs #31.
