### PR TITLE
Edge → Simplices index: drop hasVertex from removeOutEdge / removeInEdge

### DIFF
--- a/include/mesh/Edge.h
+++ b/include/mesh/Edge.h
@@ -157,11 +157,37 @@ class Edge {
     /// Index into EdgeList::liveVec_ (maintained by EdgeList).
     std::uint32_t liveIdx_{UINT32_MAX};
 
+    /// Simplices currently containing this edge (the edge's "cofaces" in
+    /// the codim-1 sense). Mirror of ``Vertex::simplices`` but at edge
+    /// granularity, used by ``Vertex::removeOutEdge`` /
+    /// ``Vertex::removeInEdge`` to drop the edge from just the simplices
+    /// that actually contain it — instead of iterating every simplex
+    /// touching the endpoint and filtering by ``hasVertex``. Surfaced by
+    /// the v0.2 finite-size profile: hasVertex was ≈22% of `thermalize`
+    /// wall time even after the per-call cache.
+    ///
+    /// Maintained in lockstep with ``Simplex::edges``:
+    ///   * Spacetime::registerSimplex registers the simplex on each of
+    ///     its edges
+    ///   * Spacetime::unregisterSimplex removes it
+    ///   * Simplex::addEdge / Simplex::removeEdge mirror the same
+    ///     callbacks at runtime
+    ///
+    /// Callers that intend to mutate the index from inside an iteration
+    /// loop (e.g. ``simplex->removeEdge(this)`` invalidates ``simplices_``)
+    /// MUST use ``simplicesCopy()`` to snapshot first.
+    void registerSimplex(SimplexPtr s);
+    void unregisterSimplex(SimplexPtr s) noexcept;
+    [[nodiscard]] Simplices const& simplices() const noexcept { return simplices_; }
+    [[nodiscard]] Simplices simplicesCopy() const { return simplices_; }
+
   private:
     VertexPtr source = nullptr;
     VertexPtr target = nullptr;
 
     double squaredLength;
+
+    Simplices simplices_{};
 };
 
 }

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -22,6 +22,7 @@
 #include "mesh/Fingerprint.h"
 #include "mesh/Edge.h"
 #include "mesh/EdgeKey.h"
+#include "mesh/Simplex.h"
 #include "mesh/Vertex.h"
 #include "utils.h"
 
@@ -106,6 +107,29 @@ class Simplex;
 
     EdgeKey Edge::getKey() const noexcept {
       return {source->getId(), target->getId()};
+    }
+
+    void Edge::registerSimplex(SimplexPtr s) {
+      // Append; the registry is duplicate-free by construction because
+      // Simplex::addEdge / Spacetime::registerSimplex deduplicate before
+      // calling. Idempotency under multiple registers would require a
+      // scan we don't want in the hot path.
+      simplices_.push_back(s);
+    }
+
+    void Edge::unregisterSimplex(SimplexPtr s) noexcept {
+      // Swap-pop by fingerprint to keep the storage tight. The list is
+      // small (≤ few simplices per edge in typical 4D builds) so the
+      // linear scan is cheap; the canonical Simplex pointer is unique
+      // per fingerprint so the first match suffices.
+      const auto fp = s->fingerprint.fingerprint();
+      for (std::size_t i = 0; i < simplices_.size(); ++i) {
+        if (simplices_[i]->fingerprint.fingerprint() == fp) {
+          simplices_[i] = simplices_.back();
+          simplices_.pop_back();
+          return;
+        }
+      }
     }
 
 }

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -491,6 +491,11 @@ bool Simplex::removeEdge(const EdgePtr &edge) {
     if ((*it)->fingerprint.fingerprint() == fp) {
       *it = edges.back();
       edges.pop_back();
+      // Keep the Edge → Simplex index in sync. Without this the
+      // edge's `simplices_` still claims this simplex as a member and
+      // the next `Vertex::removeOutEdge` would dispatch into a
+      // simplex that no longer contains the edge.
+      edge->unregisterSimplex(this);
       return true;
     }
   }
@@ -503,6 +508,7 @@ bool Simplex::addEdge(const EdgePtr &edge) {
     if (e->fingerprint.fingerprint() == fp) return false;
   }
   edges.push_back(edge);
+  edge->registerSimplex(this);
   return true;
 }
 

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -277,10 +277,16 @@ void Vertex::removeInEdge(const EdgePtr &edge) noexcept {
     std::abort();
   }
 #endif
-  for (const auto &simplex : simplices) {
-    if (simplex->hasVertex(edge->getSource()) && simplex->hasVertex(edge->getTarget())) {
-      simplex->removeEdge(edge);
-    }
+  // Edge-coface index: iterate only the simplices that actually contain
+  // this edge — replaces the previous "iterate all simplices touching
+  // this vertex, filter by hasVertex × 2" pattern that dominated
+  // `thermalize` wall time at T=2500 (≈22% of samples in
+  // `Simplex::hasVertex`). Snapshot is required because
+  // `simplex->removeEdge(edge)` calls back into `edge->unregisterSimplex`
+  // which mutates `edge->simplices_`.
+  Simplices cofaces = edge->simplicesCopy();
+  for (auto const& simplex : cofaces) {
+    if (simplex != nullptr) simplex->removeEdge(edge);
   }
   auto fp = edge->fingerprint.fingerprint();
   for (auto it = inEdges.begin(); it != inEdges.end(); ++it) {
@@ -299,10 +305,10 @@ void Vertex::removeOutEdge(const EdgePtr &edge) noexcept {
     std::abort();
   }
 #endif
-  for (const auto &simplex : simplices) {
-    if (simplex->hasVertex(edge->getSource()) && simplex->hasVertex(edge->getTarget())) {
-      simplex->removeEdge(edge);
-    }
+  // See removeInEdge for the design note — same pattern.
+  Simplices cofaces = edge->simplicesCopy();
+  for (auto const& simplex : cofaces) {
+    if (simplex != nullptr) simplex->removeEdge(edge);
   }
   auto fp = edge->fingerprint.fingerprint();
   for (auto it = outEdges.begin(); it != outEdges.end(); ++it) {

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -615,6 +615,13 @@ SimplexPtr Spacetime::registerSimplex(const SimplexPtr &simplex, bool internal) 
     topSimplicesVec.push_back(simplex);
   }
   updateOrientationCounters(simplex, +1);
+  // Mirror the simplex into each of its edges' simplex index so the
+  // hot path in Vertex::removeOutEdge / removeInEdge can look up edge
+  // cofaces directly instead of iterating every simplex incident to
+  // the endpoint and filtering by hasVertex.
+  for (auto const& e : simplex->getEdges()) {
+    if (e != nullptr) e->registerSimplex(simplex);
+  }
   return simplex;
 }
 
@@ -628,6 +635,13 @@ void Spacetime::unregisterSimplex(const SimplexPtr &simplex) {
   }
 
   updateOrientationCounters(simplex, -1);
+
+  // Drop this simplex from each of its edges' simplex index. Mirror of
+  // the registerSimplex hook; must happen BEFORE the pool slot is freed
+  // because we need to access ``simplex->getEdges()``.
+  for (auto const& e : simplex->getEdges()) {
+    if (e != nullptr) e->unregisterSimplex(simplex);
+  }
 
   auto fp = simplex->fingerprint.fingerprint();
   auto poolSlot = simplex->poolSlot_;


### PR DESCRIPTION
## Summary

After the per-call `Simplex::hasVertex` ID cache (#49), profiling the v0.2 T=2500 probe **still** showed `hasVertex` at ~20% of `thermalize` wall time. The remaining cost was the *call count* — `Vertex::removeOutEdge` iterated every simplex incident to the endpoint and filtered each by `hasVertex × 2` to find the few that contained the edge.

This PR adds **Edge → Simplices as a first-class index**. Each `Edge` now tracks the simplices currently containing it; `Vertex::removeOutEdge` / `removeInEdge` walk only those (typically ≤ a handful per edge) instead of the dozens-to-hundreds of simplices on the endpoint's side. `hasVertex` disappears from the hot path entirely.

## Synchronization

| event | hook | direction |
|---|---|---|
| `Spacetime::registerSimplex` | walk simplex.edges, call `edge->registerSimplex(simplex)` | + |
| `Spacetime::unregisterSimplex` | walk simplex.edges, call `edge->unregisterSimplex(simplex)` before pool free | − |
| `Simplex::addEdge` | `edge->registerSimplex(this)` after push | + |
| `Simplex::removeEdge` | `edge->unregisterSimplex(this)` after pop | − |

## Iteration safety

`simplex->removeEdge(edge)` calls back into `edge->unregisterSimplex(simplex)`, mutating the index. `Vertex::removeOutEdge` / `removeInEdge` snapshot `edge->simplicesCopy()` (a small vector copy, typically ≤ 5 elements) before iterating so the canonical list can shrink freely underneath.

## Test plan

- [ ] `pytest tests/quantum/` — 210 tests pass (verified locally)
- [ ] Build clean with `TESSERA_QUANTUM=ON`
- [ ] Public API: `Edge` gains `registerSimplex` / `unregisterSimplex` / `simplices()` / `simplicesCopy()`. No existing call site needs to change.

## Cost

~8 bytes × simplices-per-edge per edge. For a T=2500 4D complex with ~14k edges and ~5 simplices per edge, ~1 MB — negligible against the ~2 GB qudit-basis working set.

Pairs with #48 (heat-kernel Tier-1) and #49 (`hasVertex` ID cache).