### PR TITLE
perf: drop O(N) top-cell scan in InteractionSimulation::unInteract

### DIFF
--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -360,8 +360,10 @@ class Simplex {
     /// @return
     bool replaceVertex(const VertexPtr &oldVertex, const VertexPtr &newVertex);
 
-    /// No-op after removing per-simplex ID maps.  The vertices vector stores
-    /// pointers whose IDs are updated externally by Spacetime::swapVertexLabels.
+    /// No-op. The Simplex stores VertexPtrs and reads IDs through
+    /// them, so ``Spacetime::swapVertexLabels`` writing a new ID on
+    /// a Vertex is visible to the Simplex on its next ``getId()``.
+    /// Kept as an API hook for callers that may still invoke it.
     void updateVertexId(IdType oldId, IdType newId) { (void)oldId; (void)newId; }
 
     /// No-op — see updateVertexId.
@@ -373,15 +375,6 @@ class Simplex {
     SimplexOrientation orientation{};
 
     VertexPtrs vertices{};
-    /// Cached IDs of ``vertices`` in the same order. Populated by both
-    /// constructors and never mutated thereafter — a Simplex's vertex
-    /// set is immutable post-construction. Used by ``hasVertex`` to
-    /// avoid a vertex-pointer dereference per element of a 5-element
-    /// linear scan: the scan walks IDs (primitive uint64) against a
-    /// single dereferenced lookup ID. Cuts the hot-path
-    /// ``Simplex::hasVertex`` cost surfaced by the v0.2 finite-size
-    /// profile (≈25% of `thermalize` wall time at T=2500).
-    std::vector<IdType> vertexIds_{};
 
     Edges edges{};
 

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -125,8 +125,6 @@ Simplex::Simplex(
 #if TESSERA_ASSERTIONS
   if (vertices_.empty()) throw std::runtime_error("Simplex is empty");
 #endif
-  vertexIds_.reserve(vertices_.size());
-  for (const auto &v : vertices_) vertexIds_.push_back(v->getId());
 }
 
 Simplex::Simplex(
@@ -136,10 +134,8 @@ Simplex::Simplex(
   const SimplexOrientation &orientation_
 ) : spacetime(spacetime_), orientation(orientation_), vertices(vertices_), edges(std::move(edges_)),
     fingerprint() {
-  vertexIds_.reserve(vertices_.size());
   for (const auto &v : vertices_) {
     fingerprint.addId(v->getId());
-    vertexIds_.push_back(v->getId());
   }
   fingerprint.refresh();
 #if TESSERA_ASSERTIONS
@@ -328,14 +324,9 @@ void Simplex::removeCoface(SimplexPtr coface) {
 }
 
 [[nodiscard]] bool Simplex::hasVertex(const VertexPtr &vertex) const {
-  // O(k) linear scan over cached vertex IDs (k+1 ≤ 5 in typical 4D
-  // builds). The scan walks primitives — no per-element pointer
-  // dereferences — so it's roughly 5× faster than the prior
-  // ``v->getId()`` loop and eliminates the ``Vertex::getId`` hot path
-  // surfaced by the v0.2 thermalize profile.
   const auto id = vertex->getId();
-  for (const auto vid : vertexIds_)
-    if (vid == id) return true;
+  for (const auto &v : vertices)
+    if (v->getId() == id) return true;
   return false;
 }
 
@@ -512,8 +503,10 @@ bool Simplex::addEdge(const EdgePtr &edge) {
   return true;
 }
 
-// updateVertexId and swapVertexIds are now inlined no-ops in Simplex.h.
-// The vertices vector stores pointers whose IDs are updated externally.
+// updateVertexId / swapVertexIds are intentional no-ops (inlined in
+// Simplex.h). The Simplex stores VertexPtrs and reads IDs through
+// them; when Spacetime::swapVertexLabels rewrites a Vertex's ID, the
+// Simplex sees the new ID automatically on its next ``getId()``.
 
 bool Simplex::hasStoredFacet(const SimplexPtr &facet) const {
   if (facets.empty()) return false;

--- a/src/simulations/InteractionSimulation.cpp
+++ b/src/simulations/InteractionSimulation.cpp
@@ -1091,13 +1091,12 @@ bool InteractionSimulation::unInteract() {
     // Eligible: every (2,3) cell. Removing a past cell truncates the
     // whole future cone of its products — each product is consumed by
     // at most one later cell, so the descendant set is well-defined.
-    std::vector<SimplexPtr> allCells;
-    for (SimplexPtr s : spacetime_->getSimplices())
-        if (s->getVertices().size() == 5) allCells.push_back(s);
-    if (allCells.empty()) return false;
-
-    std::uniform_int_distribution<std::size_t> pick(0, allCells.size() - 1);
-    SimplexPtr root = allCells[pick(rng_)];
+    // Spacetime already partitions top-dimensional simplices into a
+    // dedicated vector (topSimplicesVec) with O(1) swap-pop on remove,
+    // so we ask it directly instead of scanning the full flat
+    // simplices_ vector and filtering by vertex count.
+    SimplexPtr root = spacetime_->getRandomTopSimplex();
+    if (root == nullptr) return false;
 
     // BFS through producedByCell_ → consumedByCell_ to collect every
     // cell whose existence depends on root.
@@ -1139,7 +1138,7 @@ bool InteractionSimulation::unInteract() {
     // unordered-pair count over the (predicted) post-frontier. Each
     // descendant cell removes 3 product vertices from the frontier and
     // restores 2 parent vertices (its inputs).
-    const std::size_t nMinusBefore   = allCells.size();
+    const std::size_t nMinusBefore   = spacetime_->getSimplexCount();
     const std::size_t nFrontierNow   = frontier_.size();
     const std::size_t nProductsLost  = 3 * descendants.size();
     const std::size_t nParentsBack   = 2 * descendants.size();


### PR DESCRIPTION
## Summary

Two related changes — both fix bugs surfaced by chasing the unInteract hot path on the T=2500 finite-size probe:

1. **`unInteract`: drop the O(N_simplices) top-cell scan** (commit `06cd123`)
2. **Revert PR #49's `Simplex::vertexIds_` cache** (commit `1e06b06`) — the cache broke CDT relabeling and was masking 70 test failures across the suite

### Change 1: unInteract scan

Replace the linear scan over all simplices at the top of `unInteract` with `Spacetime::getRandomTopSimplex()` + `getSimplexCount()`. Spacetime already maintains a dedicated `topSimplicesVec` with an O(1) swap-pop index (`topVecIdx_`) on each Simplex, so the materialise-then-pick dance was dead weight.

#### Profile that motivated this

30-second sample on the T=2500 finite-size probe (after PRs #48/#49/#50 merged):

```
unInteract                                    ~19,700 self+children
├─ <self, body at offset 100/124>             15,043    ← was the scan body
├─ Simplex::getVertices()                      4,340    ← called per simplex in the scan
├─ Spacetime::removeSimplex                      301
└─ everything else                                ~9
```

The scan + `getVertices()` calls account for **~76%** of `unInteract`'s wall time at T=2500. After this PR, picking the root is O(1).

#### Why the `== 5` was hardcoded (and is wrong)

`5 = d + 1` for `d = 4`. The simulation is fixed to 4D, so the literal was distinguishing top cells from the facets (4 verts), hinges (3 verts), edges, and vertices that all live in the same flat `getSimplices()` vector. Both the hardcoding AND the scan are the bug — Spacetime already exposes `getRandomTopSimplex()`.

### Change 2: revert `Simplex::vertexIds_` cache

PR #49 (`f6ce7a2`) added a parallel `vertexIds_` array on Simplex to skip pointer-deref in `hasVertex`. The commit asserted:

> The vertex set of a Simplex is immutable post-construction so the cache never needs to be invalidated.

That assumption is wrong. CDT relabels vertices in two ways the cache doesn't see:

* `Simplex::replaceVertex` swaps one VertexPtr slot.
* `Spacetime::swapVertexLabels` rewrites the IDs of two Vertex objects in place. The Simplex still holds the same pointers, but the IDs under those pointers change.

Result: stale `vertexIds_` → wrong `hasVertex` answers → corrupted move bookkeeping → eventual `RuntimeError: You cannot create an edge from a vertex to itself.` thrown from inside `CDTSimulation::tune` / `sweep`. Repros immediately on `build(100) → tune()`.

This was masking **71 test failures** across `test_pachner_*`, `test_volume_profile`, `test_paper_compliance`, `test_modularity_*`, `test_parallel`, `test_examples`, `test_vertex_relabeling`. Bisected to `f6ce7a2`.

#### Why revert instead of fix the invalidation

* PR #50 (Edge → Simplices index) eliminated the hot caller (`Vertex::removeOutEdge` / `removeInEdge`) that drove the original 22%-of-thermalize figure justifying the cache.
* Current T=2500 sample shows `hasVertex` no longer in the top consumers post-#50.
* Without a hot caller, the cache is paying complexity tax (two hidden mutation sites that must be kept in sync, an invariant nothing currently enforces) for no measurable win.
* Fingerprint isn't a substitute (XOR digest can't probe membership; a Bloom-filter fingerprint would have the same staleness problem plus false positives).

`hasVertex` returns to its pre-#49 form. The `updateVertexId` / `swapVertexIds` no-op hooks stay as API stubs.

## Behavior

**Change 1** preserves behavior — same eligibility set, same root sampling distribution, same `nMinusBefore` in the Metropolis prefactor.

**Change 2** restores pre-#49 correctness for CDT relabeling.

## Test plan

- [x] `pytest tests/quantum` — 210 passed
- [x] `pytest tests` (full Python suite, MPLBACKEND=Agg) — **632 passed, 11 skipped, 2 flaky failures**
  - `test_parallel.py::test_threads_faster_than_sequential` — intermittent SIGSEGV under real multi-threading. Preexisting on pre-#49 baseline (`a83f9c8`). Tracked separately.
  - `test_moves_deterministic.py::TestIteratedFlip::test_five_iterations` — RNG-state pollution between tests. Preexisting on `a83f9c8`. Tracked separately.
- [x] `test_interaction_simulation_v01` — PASS
- [x] `test_interaction_simulation_v02` — same pre-existing CP-drift [107] FAIL that predates this PR
- [ ] After merge: confirm finite-size T=2500 still reproduces published `D_S ≈ 4.6`