### PR TITLE
fix: make quantum import optional under TESSERA_QUANTUM=0

### DIFF
--- a/tessera/__init__.py
+++ b/tessera/__init__.py
@@ -25,8 +25,16 @@ from tessera._tessera import (                              # noqa: F401
     spacetime,
     observables,
     simulations,
-    quantum,
 )
+
+# The ``quantum`` submodule is only built when ``TESSERA_QUANTUM=1`` is
+# set at build time. Tolerate its absence so the CDT-only configuration
+# (``TESSERA_QUANTUM=0``) imports cleanly. Scripts that need quantum
+# features should ``import tessera.quantum`` and let that fail loudly.
+try:
+    from tessera._tessera import quantum                    # noqa: F401
+except ImportError:
+    pass
 
 # Backward-compat re-exports at top level. Star-import each submodule so
 # existing scripts that do `from tessera import Spacetime`, `tessera.CDT`,


### PR DESCRIPTION
## Summary

``tessera/__init__.py`` unconditionally imported the C++ ``quantum`` submodule, breaking the CDT-only build path (``TESSERA_QUANTUM=0``). Move that one import into its own ``try/except ImportError`` block.

## Why this exists

The smoke test in ``.github/workflows/build.yml`` runs ``import tessera`` after building with ``TESSERA_QUANTUM=0``. That failed with:

```
ImportError: cannot import name 'quantum' from 'tessera._tessera'
```

— the matrix entries ``pip install (py3.11/3.12/3.13, quantum=0)`` have been red on ``main`` since the namespace alignment work (PR #47) added the subsystem imports.

## Change

```diff
 from tessera._tessera import (                              # noqa: F401
     mesh,
     spacetime,
     observables,
     simulations,
-    quantum,
 )

+try:
+    from tessera._tessera import quantum                    # noqa: F401
+except ImportError:
+    pass
```

Scripts that actually rely on quantum should ``import tessera.quantum`` directly; that path still raises loudly when quantum isn't built.

## Test plan

- [x] ``TESSERA_QUANTUM=0 pip install -e .`` → ``import tessera`` succeeds, ``hasattr(tessera, 'quantum')`` is ``False``, ``tessera.CDT`` / ``tessera.Spacetime`` present
- [x] ``TESSERA_QUANTUM=1 pip install -e .`` (default) → ``import tessera`` succeeds, ``tessera.quantum`` present and ``import tessera.quantum`` works
- [ ] CI: quantum=0 matrix entries pass (was the only failure source on main)