### PR TITLE
Spacetime: stable-address simplex storage to fix concurrent-sweep UAF

### DIFF
--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -298,7 +298,7 @@ class Simplex {
     /// Indices maintained by Spacetime for O(1) swap-and-pop removal.
     /// UINT32_MAX means "not registered in that vector".
     std::uint32_t vecIdx_{UINT32_MAX};    // index in Spacetime::simplicesVec
-    std::uint32_t poolSlot_{UINT32_MAX};  // index in Spacetime::simplexPool_
+    std::uint32_t poolSlot_{UINT32_MAX};  // index in Spacetime::simplexStorage_; never reset (storage slots are never recycled)
     std::uint32_t topVecIdx_{UINT32_MAX}; // index in Spacetime::topSimplicesVec
 
 #ifdef TESSERA_ASSERTIONS
@@ -370,6 +370,16 @@ class Simplex {
     void swapVertexIds(IdType id1, IdType id2) { (void)id1; (void)id2; }
 
     bool isInitialized() const noexcept;
+
+    /// Release this Simplex's heap-allocated children (vertex/edge/facet/
+    /// coface vectors), shrinking them to zero capacity.  Called by
+    /// ``Spacetime::unregisterSimplex`` once the simplex has been removed
+    /// from all live indices: the Simplex shell stays in
+    /// ``Spacetime::simplexStorage_`` at its stable address (so cached
+    /// ``Simplex*`` remain dereferenceable and read empty children), but the
+    /// memory backing those children is returned to the allocator.  Callers
+    /// MUST NOT invoke this while the simplex is still registered.
+    void releaseChildren() noexcept;
   private:
     Spacetime *spacetime{nullptr};
     SimplexOrientation orientation{};

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -85,9 +85,7 @@ class Spacetime {
 
     /// Default constructor. Creates a 4D Lorentzian spacetime with CDT type and Toroid topology.
     Spacetime();
-    ~Spacetime() {
-      for (auto *p : simplexPool_) delete p;
-    }
+    ~Spacetime() = default;
 
     /// Parameterized constructor.
     /// @param metric_ The metric tensor defining the signature and dimension
@@ -503,8 +501,20 @@ class Spacetime {
     std::shared_ptr<Topology> topology;
     std::uint64_t currentTime = 0;
 
-    std::vector<SimplexPtr> simplexPool_{}; // owns all Simplex allocations (raw new ptrs)
-    std::vector<std::uint32_t> simplexFreeSlots_{}; // recycled pool slots
+    /// Storage for every Simplex this Spacetime has ever owned, live or
+    /// logically removed.  std::deque is required: it gives stable element
+    /// addresses across push_back, so raw Simplex* cached anywhere (vertex
+    /// simplex lists, simplex facets/cofaces, edge simplex indices, Pachner-
+    /// move snapshots, etc.) remain valid for the Spacetime's lifetime.
+    ///
+    /// Slots are NEVER recycled.  unregisterSimplex marks a slot stale via
+    /// vecIdx_ == UINT32_MAX and clears the Simplex's heap-allocated children
+    /// (vertices/edges/facets/cofaces) to release most of its memory, but
+    /// leaves the shell in place at its original address.  This trades a
+    /// modest memory growth (the ~40-byte Simplex shell per ever-allocated
+    /// simplex) for elimination of the use-after-free hazard that slot
+    /// recycling otherwise creates.
+    std::deque<Simplex> simplexStorage_{};
     std::vector<SimplexPtr> simplicesVec{}; // flat array of live simplex pointers (swap-and-pop)
     FlatHashMap<SimplexPtr> simplexIndex_{}; // fingerprint → simplex ptr (dedup only)
     std::vector<SimplexPtr> topSimplicesVec{}; // top-dimensional simplices only

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -157,6 +157,16 @@ Simplex* Simplex::create(Spacetime *spacetime_, const VertexPtrs &vertices_, con
 
 bool Simplex::isInitialized() const noexcept { return initialized; }
 
+void Simplex::releaseChildren() noexcept {
+  // swap-with-empty deallocates the underlying buffer (clear() alone would
+  // keep capacity).  Order doesn't matter — none of these refer to each
+  // other.
+  VertexPtrs().swap(vertices);
+  Edges().swap(edges);
+  Simplices().swap(facets);
+  Simplices().swap(cofaces);
+}
+
 Simplex* Simplex::create(Spacetime *spacetime_,
                            const VertexPtrs &vertices_,
                            const Edges &edges_,

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -105,7 +105,16 @@ std::pair<SimplexPtr, bool> Spacetime::createSimplex(
 #endif
     return {*found, false};
   }
-  SimplexPtr simplex = Simplex::create(this, vertices, edges);
+  // Construct the Simplex in place in simplexStorage_ so its address is
+  // stable for the lifetime of this Spacetime.  initialize() registers the
+  // simplex pointer back on its vertices, so we must do that AFTER emplace
+  // (which is when &simplexStorage_.back() becomes the canonical address).
+  simplexStorage_.emplace_back(this, vertices, edges);
+  SimplexPtr simplex = &simplexStorage_.back();
+  simplex->poolSlot_ = static_cast<std::uint32_t>(simplexStorage_.size() - 1);
+  if (!simplex->initialized) {
+    simplex->initialize(simplex);
+  }
   registerSimplex(simplex, false);
   return {simplex, true};
 }
@@ -594,16 +603,10 @@ SimplexPtr Spacetime::registerSimplex(const SimplexPtr &simplex, bool internal) 
     return *existing;
   }
 
-  std::uint32_t slot;
-  if (!simplexFreeSlots_.empty()) {
-    slot = simplexFreeSlots_.back();
-    simplexFreeSlots_.pop_back();
-  } else {
-    slot = static_cast<std::uint32_t>(simplexPool_.size());
-    simplexPool_.push_back(nullptr);
-  }
-  simplexPool_[slot] = simplex;
-  simplex->poolSlot_ = slot;
+  // Storage ownership (poolSlot_) is established by the caller — either
+  // createSimplex's emplace_back into simplexStorage_, or an external caller
+  // who has already placed the Simplex in stable storage.  registerSimplex
+  // is only responsible for the live-set bookkeeping below.
 
   simplex->vecIdx_ = static_cast<std::uint32_t>(simplicesVec.size());
   simplicesVec.push_back(simplex);
@@ -644,7 +647,6 @@ void Spacetime::unregisterSimplex(const SimplexPtr &simplex) {
   }
 
   auto fp = simplex->fingerprint.fingerprint();
-  auto poolSlot = simplex->poolSlot_;
 
   // Swap-and-pop from simplicesVec (O(1) via stored index)
   if (vecIdx + 1 < static_cast<std::uint32_t>(simplicesVec.size())) {
@@ -666,11 +668,13 @@ void Spacetime::unregisterSimplex(const SimplexPtr &simplex) {
     simplex->topVecIdx_ = UINT32_MAX;
   }
 
-  // Release pool slot and free the allocation
-  delete simplexPool_[poolSlot];
-  simplexPool_[poolSlot] = nullptr;
-  simplex->poolSlot_ = UINT32_MAX;
-  simplexFreeSlots_.push_back(poolSlot);
+  // The Simplex shell stays in simplexStorage_ at its stable address so any
+  // raw Simplex* still cached elsewhere remains dereferenceable.  Release
+  // the heap-allocated children to reclaim most of the simplex's memory;
+  // vecIdx_ == UINT32_MAX is the stale marker callers should already be
+  // checking against.  poolSlot_ stays pointing at this simplex's slot in
+  // simplexStorage_ (informational only — no longer used for lookups).
+  simplex->releaseChildren();
 }
 
 void Spacetime::reserve(int nSimplices) {


### PR DESCRIPTION
## Summary

- Replace `std::vector<Simplex*> simplexPool_` + `simplexFreeSlots_` slot recycling with `std::deque<Simplex> simplexStorage_` (stable element addresses, append-only).
- `unregisterSimplex` no longer `delete`s the simplex; it marks it stale (`vecIdx_ == UINT32_MAX`) and calls a new `Simplex::releaseChildren()` that swap-empties the vertex/edge/facet/coface vectors to release their heap buffers, leaving the ~40-byte shell behind at its stable address.
- Fixes the intermittent SIGSEGV in `tests/test_parallel.py::TestThreadParallelism::test_threads_faster_than_sequential` (flagged in PR #51's test plan).

## Root cause

The old design `delete`d Simplex objects on removal and recycled their `simplexPool_` slots, but raw `Simplex*` pointers were cached extensively across the codebase — `Vertex::simplices`, `Simplex::facets`/`cofaces`, `Edge::simplices_`, Pachner-move state snapshots like `RemoveMove::incident_`. Any of those could be dangling after the underlying Simplex was freed.

The `ShiftMove::rollback` comment already documented the hazard explicitly:

> "the SimplexPtr captured at apply time can be stale (another move may have removed-and-recreated the same-verts simplex with a fresh allocation; the old pointer would be dangling and trigger a use-after-free in removeSimplex's swap-and-pop on stale vecIdx_)"

`ShiftMove::rollback` worked around it locally by re-resolving via vertex tuple. The architectural hazard was the same everywhere else.

Why this was invisible to the rest of the test suite: macOS's malloc has per-thread "magazine" caches, so single-threaded code mostly re-allocates from its own cache and freed regions tend to keep their old bytes until consciously reused — dangling reads return plausible-looking stale data. Under 4-thread `test_threads_faster_than_sequential`, the global heap pool aggressively recycled freed regions across thread arenas, so dangling pointers landed on unrelated bytes → garbage `poolSlot_` → `simplexPool_[0xFFFFFFFF * 8]` → SIGSEGV.

LLDB conditional-breakpoint at `Spacetime::unregisterSimplex` entry confirmed the diagnosis — at crash time the Simplex's fields read `vecIdx_=0x463` (valid) / `poolSlot_=0xFFFFFFFF` (sentinel) / `topVecIdx_=0x48` (valid) / real fingerprint — a combination unreachable from any clean register→unregister sequence.

## The fix

`std::deque<Simplex>` is what `EdgeList::pool_` and `VertexList::pool_` already use ("Edges live in a `std::deque` (stable element addresses) with a free-list for slot reuse"). `simplexPool_` ended up different because the pre-915f0cc design owned simplices via `unordered_map<fp, unique_ptr<Simplex>>` and the 915f0cc refactor preserved the heap-pointer ownership model while changing the *index* from hash-map to vector slot. This PR completes the EdgeList/VertexList pattern for Simplex.

## Memory tradeoff

`simplexStorage_` now grows monotonically with simplices ever created (~40-byte shell per dead slot after `releaseChildren()` swaps out the children), where the old design capped at peak-live via recycling. For typical T-scale CDT runs this is tens of MB; for very long runs we can layer `pop_front`-based reclamation of contiguous stale prefixes on top later (deque's `pop_front` is pointer-stable for the rest, just requires a `poolBase_` offset on Spacetime so `poolSlot_` indices stay valid).

A subtle longer-term hazard remains: even with stable addresses, a cached `Simplex*` to a removed simplex still reads valid memory (the shell), but with `vecIdx_ == UINT32_MAX` and empty children. Callers that want to detect this should check `vecIdx_` — which the existing `unregisterSimplex` early-return already does. Future code should be aware.

## Test plan

- [x] `tests/test_parallel.py::TestThreadParallelism::test_threads_faster_than_sequential` — **100/100 clean** (was intermittent SIGSEGV ~1 in 15 before)
- [x] `pytest tests/` — **635 passed, 0 failed, 10 skipped** (baseline per PR #51's test plan was 632/0/11 with 2 known flakies; both flakies — the parallel SIGSEGV and the RNG-state pollution in `test_iterated_flip` — are now stable)
- [ ] Smoke test on a real T=2500 finite-size run after merge to confirm published `D_S` is unchanged

## Files

- `include/spacetime/Spacetime.h`: `simplexPool_` + `simplexFreeSlots_` → `simplexStorage_`; destructor → `= default`
- `src/spacetime/Spacetime.cpp`: `createSimplex` emplaces into `simplexStorage_`; `registerSimplex` drops slot-allocation block; `unregisterSimplex` no longer `delete`s, calls `releaseChildren()`
- `include/mesh/Simplex.h` + `src/mesh/Simplex.cpp`: new `Simplex::releaseChildren()` swap-empties `vertices`/`edges`/`facets`/`cofaces`

`Simplex::create` is now unused in the live path (only `Spacetime::createSimplex` ever called it, and now goes direct). Left in place for this PR — happy to delete in a follow-up cleanup if desired.