### PR TITLE
Simplex: isStale() helper + ASSERTIONS-mode stale-deref tripwires

### DIFF
--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -371,6 +371,17 @@ class Simplex {
 
     bool isInitialized() const noexcept;
 
+    /// True iff this Simplex has been logically removed from its Spacetime
+    /// (i.e. ``Spacetime::unregisterSimplex`` has run on it).  Use this to
+    /// validate cached ``Simplex*`` pointers before dereferencing — with
+    /// stable-address storage the pointer itself is always safe to read,
+    /// but a stale simplex has its child vectors cleared, so iterating
+    /// them is a silent no-op rather than the live data the caller likely
+    /// expected.  Equivalent to ``vecIdx_ == UINT32_MAX``.
+    [[nodiscard]] bool isStale() const noexcept {
+      return vecIdx_ == UINT32_MAX;
+    }
+
     /// Release this Simplex's heap-allocated children (vertex/edge/facet/
     /// coface vectors), shrinking them to zero capacity.  Called by
     /// ``Spacetime::unregisterSimplex`` once the simplex has been removed

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -44,7 +44,29 @@ using namespace ::tessera::spacetime;
 using namespace ::tessera::observables;
 using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
+
+// Tripwire: catch dereferences of stale Simplex pointers.  Storage is
+// stable, so reads from a logically-removed simplex won't fault — they'd
+// just see empty child vectors and proceed silently.  This macro turns
+// that silent failure mode into a loud abort under TESSERA_ASSERTIONS,
+// while costing nothing in release builds.  Used at the top of the
+// hot getters that callers might invoke through a cached SimplexPtr.
+#ifdef TESSERA_ASSERTIONS
+  #define TESSERA_TRIPWIRE_LIVE(method_name)                              \
+    do {                                                                  \
+      if (isStale()) {                                                    \
+        CLOG(CRITICAL_LEVEL, "Stale Simplex* dereferenced via " method_name \
+                             " — caller is holding a pointer to a "      \
+                             "simplex that was already removed.");        \
+        std::abort();                                                     \
+      }                                                                   \
+    } while (0)
+#else
+  #define TESSERA_TRIPWIRE_LIVE(method_name) ((void)0)
+#endif
+
 bool Simplex::hasFacets() const {
+  TESSERA_TRIPWIRE_LIVE("hasFacets");
   return !facets.empty();
 }
 
@@ -54,6 +76,7 @@ class SimplexCorruptionDetector : public CorruptionDetector<SimplexPtr, SimplexP
 #endif
 
 const std::vector<SimplexPtr> &Simplex::getFacets() {
+  TESSERA_TRIPWIRE_LIVE("getFacets");
 #if TESSERA_ASSERTIONS
   if (getVertices().empty()) throw std::runtime_error("Simplex is empty");
 #endif
@@ -158,6 +181,13 @@ Simplex* Simplex::create(Spacetime *spacetime_, const VertexPtrs &vertices_, con
 bool Simplex::isInitialized() const noexcept { return initialized; }
 
 void Simplex::releaseChildren() noexcept {
+#ifdef TESSERA_ASSERTIONS
+  if (!isStale()) {
+    CLOG(CRITICAL_LEVEL, "releaseChildren() called on a still-registered "
+                         "simplex; caller must mark it stale first.");
+    std::abort();
+  }
+#endif
   // swap-with-empty deallocates the underlying buffer (clear() alone would
   // keep capacity).  Order doesn't matter — none of these refer to each
   // other.
@@ -251,7 +281,10 @@ std::string Simplex::toString() const noexcept {
 
 // getOrientation() inlined in Simplex.h
 
-[[nodiscard]] const VertexPtrs &Simplex::getVertices() const noexcept { return vertices; }
+[[nodiscard]] const VertexPtrs &Simplex::getVertices() const noexcept {
+  TESSERA_TRIPWIRE_LIVE("getVertices");
+  return vertices;
+}
 
 // isSpatial() / isTimelike() inlined in Simplex.h (uses cached _isSpatial)
 
@@ -326,6 +359,7 @@ void Simplex::removeCoface(SimplexPtr coface) {
 }
 
 [[nodiscard]] bool Simplex::hasCoface(SimplexPtr coface) const {
+  TESSERA_TRIPWIRE_LIVE("hasCoface");
   auto fp = coface->fingerprint.fingerprint();
   for (const auto &c : cofaces) {
     if (c->fingerprint.fingerprint() == fp) return true;
@@ -334,6 +368,7 @@ void Simplex::removeCoface(SimplexPtr coface) {
 }
 
 [[nodiscard]] bool Simplex::hasVertex(const VertexPtr &vertex) const {
+  TESSERA_TRIPWIRE_LIVE("hasVertex");
   const auto id = vertex->getId();
   for (const auto &v : vertices)
     if (v->getId() == id) return true;
@@ -374,6 +409,7 @@ void Simplex::validate() const {
 }
 
 [[nodiscard]] const Edges &Simplex::getEdges() const {
+  TESSERA_TRIPWIRE_LIVE("getEdges");
   return edges;
 }
 
@@ -407,6 +443,7 @@ void Simplex::validate() const {
 
 [[nodiscard]] const Simplices &
 Simplex::getCofaces() const noexcept {
+  TESSERA_TRIPWIRE_LIVE("getCofaces");
   return cofaces;
 }
 

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -629,13 +629,13 @@ SimplexPtr Spacetime::registerSimplex(const SimplexPtr &simplex, bool internal) 
 }
 
 void Spacetime::unregisterSimplex(const SimplexPtr &simplex) {
-  auto vecIdx = simplex->vecIdx_;
-  if (vecIdx == UINT32_MAX) {
+  if (simplex->isStale()) {
 #ifdef TESSERA_ASSERTIONS
     CLOG(CRITICAL_LEVEL, "You attempted to unregister a simplex that does not exist!");
 #endif
     return;
   }
+  auto vecIdx = simplex->vecIdx_;
 
   updateOrientationCounters(simplex, -1);
 
@@ -974,6 +974,12 @@ double Spacetime::modularityOnSkeleton(int M) const {
 }
 
 void Spacetime::removeSimplex(const SimplexPtr &simplex) {
+  // Defensive: double-remove (or remove of an already-stale simplex via a
+  // dangling cache entry) is a silent no-op.  Without this, the getters
+  // below would trip the stale-deref tripwire under TESSERA_ASSERTIONS,
+  // whereas every caller's intent here is "if this simplex is already gone,
+  // there's nothing to do."
+  if (simplex->isStale()) return;
   // Remove from vertex simplex lists
   for (const auto &v : simplex->getVertices()) {
     v->removeSimplex(simplex);


### PR DESCRIPTION
## Summary

Follow-up to #53 that turns the remaining "silent stale-deref" failure mode into a loud abort under `TESSERA_ASSERTIONS`, while leaving release builds completely unchanged.

After #53, Simplex storage uses `std::deque<Simplex>` so a cached `Simplex*` is always safe to dereference, but `unregisterSimplex` calls `releaseChildren()` which empties the vertex/edge/facet/coface vectors. A caller that holds a stale pointer and iterates `simplex->getVertices()` doesn't crash anymore — it just sees zero elements and silently no-ops. That's a worse signal than the old SIGSEGV for catching latent bugs.

This PR:

- Adds `Simplex::isStale()` returning `vecIdx_ == UINT32_MAX` (the existing stale marker, just named).
- Adds a `TESSERA_TRIPWIRE_LIVE(method_name)` macro that, under `TESSERA_ASSERTIONS`, `CLOG`s + `std::abort`s when called on a stale simplex; expands to `((void)0)` in release.
- Wires the tripwire into the hot getters: `getVertices`, `getEdges`, `getFacets`, `getCofaces`, `hasVertex`, `hasFacets`, `hasCoface`.
- `Spacetime::removeSimplex` short-circuits on `isStale()` so the defensive double-remove idiom doesn't trip the new tripwire.
- `Spacetime::unregisterSimplex` swaps its literal `vecIdx_ == UINT32_MAX` check for the named `isStale()` helper.
- `Simplex::releaseChildren` asserts under `TESSERA_ASSERTIONS` that the caller has marked the simplex stale first — releasing children of a still-registered simplex is a contract violation we want to catch loudly.

## Verification that internal code paths don't trip

Audited every internal caller of the trip-wired getters and confirmed each one reads the simplex BEFORE the `simplex->vecIdx_ = UINT32_MAX` write that marks it stale:

- `Spacetime::removeSimplex` — `getVertices`/`hasFacets`/`getFacets` all called before `unregisterSimplex`, which is where the stale transition happens. The new `isStale()` short-circuit at the top also short-circuits any pre-stale invocation cleanly.
- `Spacetime::unregisterSimplex` — `getEdges()` called early, well before `simplex->vecIdx_ = UINT32_MAX` later in the function.
- `Simplex::registerToVertices` — runs during `initialize()` on a fresh simplex; never stale.
- `Simplex::getFacets` — operates on the simplex being faceted (alive by assumption).
- `Simplex::hasEdgeContaining`, `Simplex::validate` — caller-responsibility; not invoked from any cleanup code path.

Also rebuilt the `cmake-build-asan` config (`TESSERA_ASAN=ON`, `TESSERA_ASSERTIONS=ON`) to confirm the tripwire macro compiles cleanly.

## Test plan

- [x] `tests/test_parallel.py::TestThreadParallelism::test_threads_faster_than_sequential` — 30/30 clean (no behavior change vs post-#53 baseline)
- [x] `pytest tests/` — 636 passed, 0 failed, 9 skipped (baseline post-#53 was 635/0/10)
- [x] Built with `TESSERA_ASSERTIONS=ON`; no internal path trips the tripwire on import
- [ ] If anyone has CI running the test suite under `TESSERA_ASSERTIONS=ON`, this PR would benefit from a green run there before merge

## Files

- `include/mesh/Simplex.h`: new `isStale()` accessor with docstring
- `src/mesh/Simplex.cpp`: `TESSERA_TRIPWIRE_LIVE` macro; tripwire calls in 7 getters; contract-check in `releaseChildren`
- `src/spacetime/Spacetime.cpp`: `removeSimplex` early-return on stale; `unregisterSimplex` uses `isStale()` helper