### PR TITLE
Build: make quantum subsystem unconditional; remove TESSERA_QUANTUM flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,12 @@ concurrency:
 
 jobs:
   pip-install:
-    name: pip install (py${{ matrix.python-version }}, quantum=${{ matrix.quantum }})
+    name: pip install (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        quantum: ["0", "1"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +34,8 @@ jobs:
       # config lands in /usr/lib/cmake/pybind11 — a default find_package()
       # search path — so a green run asserts the build still selects
       # pybind11 >= 3.0 and never falls back to the system v2.
-      # liblapack/libblas satisfy the quantum subsystem's BLAS/LAPACK need.
+      # liblapack/libblas satisfy the (unconditional) quantum subsystem's
+      # BLAS/LAPACK need.
       - name: Install system packages (incl. pybind11 v2 regression trap)
         run: |
           sudo apt-get update
@@ -44,22 +44,15 @@ jobs:
       - name: Build and install
         env:
           TESSERA_CUDA: "0"
-          TESSERA_QUANTUM: ${{ matrix.quantum }}
         run: python -m pip install -e . -v
 
       - name: Import smoke test
         working-directory: ${{ runner.temp }}
-        env:
-          EXPECT_QUANTUM: ${{ matrix.quantum }}
         run: |
           python - <<'PY'
-          import os, tessera, tessera._tessera
+          import tessera, tessera._tessera, tessera.quantum
           print("tessera  ->", tessera.__file__)
           print("_tessera ->", tessera._tessera.__file__)
-          if os.environ["EXPECT_QUANTUM"] == "1":
-              assert hasattr(tessera, "quantum"), \
-                  "TESSERA_QUANTUM=1 but tessera.quantum is missing"
-              print("quantum subsystem present")
-          else:
-              print("quantum subsystem off (TESSERA_QUANTUM=0)")
+          assert hasattr(tessera, "quantum"), "tessera.quantum is missing"
+          print("quantum subsystem present")
           PY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ set(TESSERA_PYBIND_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/spacetime/Bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/observables/Bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/simulations/Bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/cobordism/Bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/quantum/Bindings.cpp")
 # ---- </Define source partitions> -----------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,94 +54,48 @@ option(TESSERA_PROFILE "Build with -g -O1 to keep symbol names for stack traces"
 if (NOT TESSERA_PROFILE)
     set(TESSERA_PROFILE OFF)
 endif()
-# ---- Quantum subsystem (Schwinger / MPS / DMRG): auto-detected ----
-# Mirrors TESSERA_CUDA above: built automatically when its prerequisites
-# are present, with an env var to override. Prerequisites are (1) the
-# ITensor submodule checked out under third_party/itensor and (2) a
-# BLAS/LAPACK backend. TESSERA_QUANTUM=1 forces it on — fetching the
-# ITensor submodule automatically when it is missing; a missing BLAS/LAPACK
-# is still a hard error. TESSERA_QUANTUM=0 forces it off.
-#
-# Kept as a plain variable rather than option(): it is recomputed on every
-# configure, so checking out the submodule and re-running the build picks
-# the subsystem up without needing a fresh build directory.
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/itensor/itensor/itensor.h")
-    set(_quantum_itensor_present TRUE)
-else()
-    set(_quantum_itensor_present FALSE)
-endif()
-if (APPLE)
-    set(_quantum_lapack_present TRUE)   # Accelerate framework ships with macOS
-else()
-    find_package(LAPACK QUIET)
-    set(_quantum_lapack_present ${LAPACK_FOUND})
-endif()
-
-if (DEFINED ENV{TESSERA_QUANTUM} AND NOT "$ENV{TESSERA_QUANTUM}" STREQUAL "")
-    set(TESSERA_QUANTUM $ENV{TESSERA_QUANTUM})        # explicit override
-elseif (_quantum_itensor_present AND _quantum_lapack_present)
-    set(TESSERA_QUANTUM ON)                           # auto-detect
-else()
-    set(TESSERA_QUANTUM OFF)
-endif()
-
-if (TESSERA_QUANTUM)
-    set(TESSERA_QUANTUM ON)
-    # The ITensor submodule is the one prerequisite we can satisfy for the
-    # user: when quantum is explicitly requested (TESSERA_QUANTUM=1) but the
-    # submodule is missing, fetch it with git instead of erroring out. The
-    # auto-detect path never reaches here without the submodule — only an
-    # explicit request does — so a bare `pip install -e .` stays opt-in.
-    if (NOT _quantum_itensor_present)
-        find_package(Git QUIET)
-        if (NOT Git_FOUND OR NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-            message(FATAL_ERROR
-                "TESSERA_QUANTUM=1 but third_party/itensor is not checked out, "
-                "and it cannot be fetched automatically (git not found, or "
-                "this is not a git checkout).\n"
-                "  Install tessera from a git clone, or fetch it manually:\n"
-                "    git submodule update --init --recursive")
-        endif()
-        message(STATUS "TESSERA_QUANTUM=1: fetching the ITensor submodule "
-                       "(one-time network download)...")
-        execute_process(
-            COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive
-                    -- third_party/itensor third_party/itensor_tdvp
-            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-            RESULT_VARIABLE _quantum_submodule_result)
-        if (NOT _quantum_submodule_result EQUAL 0)
-            message(FATAL_ERROR
-                "Failed to fetch the ITensor submodule (git exited "
-                "${_quantum_submodule_result}).\n"
-                "  Check your network, then re-run the build — or fetch it "
-                "manually:\n"
-                "    git submodule update --init --recursive")
-        endif()
-        if (NOT EXISTS
-                "${CMAKE_CURRENT_SOURCE_DIR}/third_party/itensor/itensor/itensor.h")
-            message(FATAL_ERROR
-                "ITensor submodule fetch reported success but "
-                "third_party/itensor is still empty.")
-        endif()
-        set(_quantum_itensor_present TRUE)
-        message(STATUS "ITensor submodule ready.")
-    endif()
-    if (NOT _quantum_lapack_present)
+# ---- Quantum subsystem (Schwinger / MPS / DMRG): always built ----
+# ITensor and a BLAS/LAPACK backend are unconditional dependencies of
+# tessera. The ITensor submodule under third_party/itensor is fetched
+# automatically when missing (one-time network download); a missing
+# BLAS/LAPACK backend is a hard error. Eigen3 (resolved below near ZLIB)
+# is likewise unconditional and is linked into tessera_core so every
+# subsystem — including cobordism — can use it.
+if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/itensor/itensor/itensor.h")
+    find_package(Git QUIET)
+    if (NOT Git_FOUND OR NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
         message(FATAL_ERROR
-            "TESSERA_QUANTUM is on but no BLAS/LAPACK backend was found.\n"
-            "  Install one (e.g. apt-get install liblapack-dev libblas-dev),\n"
-            "  or set TESSERA_QUANTUM=0 to skip the quantum subsystem.")
+            "third_party/itensor is not checked out and cannot be fetched "
+            "automatically (git not found, or this is not a git checkout).\n"
+            "  Install tessera from a git clone, or fetch it manually:\n"
+            "    git submodule update --init --recursive")
     endif()
-else()
-    set(TESSERA_QUANTUM OFF)
-    if (NOT _quantum_itensor_present)
-        message(STATUS "Quantum subsystem OFF — third_party/itensor not checked "
-                       "out (run `git submodule update --init --recursive`).")
-    elseif (NOT _quantum_lapack_present)
-        message(STATUS "Quantum subsystem OFF — no BLAS/LAPACK backend found.")
-    else()
-        message(STATUS "Quantum subsystem OFF — disabled via TESSERA_QUANTUM=0.")
+    message(STATUS "Fetching the ITensor submodule (one-time network download)...")
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive
+                -- third_party/itensor third_party/itensor_tdvp
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE _itensor_submodule_result)
+    if (NOT _itensor_submodule_result EQUAL 0)
+        message(FATAL_ERROR
+            "Failed to fetch the ITensor submodule (git exited "
+            "${_itensor_submodule_result}).\n"
+            "  Check your network, then re-run the build — or fetch it "
+            "manually:\n"
+            "    git submodule update --init --recursive")
     endif()
+    if (NOT EXISTS
+            "${CMAKE_CURRENT_SOURCE_DIR}/third_party/itensor/itensor/itensor.h")
+        message(FATAL_ERROR
+            "ITensor submodule fetch reported success but "
+            "third_party/itensor is still empty.")
+    endif()
+    message(STATUS "ITensor submodule ready.")
+endif()
+
+# BLAS/LAPACK backend: Accelerate ships with macOS; elsewhere it is required.
+if (NOT APPLE)
+    find_package(LAPACK REQUIRED)
 endif()
 # ---- Read version from pyproject.toml ----
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml" PYPROJECT_CONTENTS)
@@ -175,6 +129,9 @@ execute_process(
 find_package(pybind11 3.0 CONFIG REQUIRED HINTS "${_pybind11_hint}")
 message(STATUS "pybind11 ${pybind11_VERSION} (${pybind11_DIR})")
 find_package(ZLIB REQUIRED)
+# Eigen3 is an unconditional dependency (used by the quantum and cobordism
+# subsystems). Resolved here so it can be linked into tessera_core below.
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
 include(CheckCXXSourceCompiles)
 
@@ -200,7 +157,7 @@ endif()
 #   tessera_core  — pybind-free C++ implementation: mesh primitives,
 #                 spacetime, observables, Poset infrastructure, etc.
 #                 Linked into _tessera and (when enabled) tessera_quantum.
-#   tessera_quantum (when TESSERA_QUANTUM=ON) — Schwinger / DMRG / TDVP code,
+#   tessera_quantum — Schwinger / DMRG / TDVP code (always built),
 #                 also pybind-free, links tessera_core PUBLIC for shared
 #                 mesh / Poset types.
 # Plus a thin pybind11 module:
@@ -224,17 +181,14 @@ list(FILTER TESSERA_CORE_SOURCES EXCLUDE REGEX "/src/bindings\\.cpp$")
 # (they include pybind11 / Python.h).
 list(FILTER TESSERA_CORE_SOURCES EXCLUDE REGEX "/src/[^/]+/Bindings\\.cpp$")
 
-# Sources for the pybind11 module. quantum bindings only when enabled.
+# Sources for the pybind11 module. The quantum bindings are always built.
 set(TESSERA_PYBIND_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/mesh/Bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/spacetime/Bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/observables/Bindings.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/simulations/Bindings.cpp")
-if(TESSERA_QUANTUM)
-    list(APPEND TESSERA_PYBIND_SOURCES
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/quantum/Bindings.cpp")
-endif()
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/simulations/Bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/quantum/Bindings.cpp")
 # ---- </Define source partitions> -----------------------------------------
 
 # ---- <Build CUDA kernels as static library> ----
@@ -265,7 +219,7 @@ add_library(tessera_core STATIC ${TESSERA_CORE_SOURCES})
 target_include_directories(tessera_core PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/src"
     "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(tessera_core PUBLIC ZLIB::ZLIB)
+target_link_libraries(tessera_core PUBLIC ZLIB::ZLIB Eigen3::Eigen)
 
 # Optional OpenMP for the spectral-graph heat-kernel parallel loop and
 # similar embarrassingly-parallel hot paths. Bit-identical to the
@@ -367,59 +321,55 @@ install(TARGETS _tessera
 )
 
 # ---- <Quantum subsystem (ITensor + Schwinger MPO)> ----
-if(TESSERA_QUANTUM)
-    message(STATUS "Quantum subsystem turned ON (ITensor + DMRG).")
-    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/BuildITensor.cmake)
-    tessera_build_itensor()
+message(STATUS "Building quantum subsystem (ITensor + DMRG).")
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/BuildITensor.cmake)
+tessera_build_itensor()
 
-    file(GLOB_RECURSE TESSERA_QUANTUM_SOURCES
-            CONFIGURE_DEPENDS
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/quantum/*.cpp"
-            "${CMAKE_CURRENT_SOURCE_DIR}/include/quantum/*.hpp")
-    # InteractionSimulation lives in src/simulations/ for architectural
-    # alignment with CDT (#44) but its Eigen/ITensor dependency makes it
-    # part of tessera_quantum, not tessera_core.
-    list(APPEND TESSERA_QUANTUM_SOURCES
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/simulations/InteractionSimulation.cpp")
-    # bindings.cpp uses pybind11 + Python.h and goes into _tessera, not the
-    # pybind-free static lib.
-    list(FILTER TESSERA_QUANTUM_SOURCES EXCLUDE REGEX "/src/quantum/Bindings\\.cpp$")
-    add_library(tessera_quantum STATIC ${TESSERA_QUANTUM_SOURCES})
-    target_include_directories(tessera_quantum PUBLIC
-            ${CMAKE_CURRENT_SOURCE_DIR}/include)
-    find_package(Eigen3 3.3 REQUIRED NO_MODULE)
-    # PUBLIC link to tessera_core: tessera::Poset / Vertex / EdgeList live in
-    # tessera_core, and quantum's Poset-using headers expose them in their
-    # public API. PUBLIC propagates symbols to test executables too.
-    target_link_libraries(tessera_quantum PUBLIC itensor Eigen3::Eigen tessera_core)
-    set_target_properties(tessera_quantum PROPERTIES
-            POSITION_INDEPENDENT_CODE ON
+file(GLOB_RECURSE TESSERA_QUANTUM_SOURCES
+        CONFIGURE_DEPENDS
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/quantum/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/quantum/*.hpp")
+# InteractionSimulation lives in src/simulations/ for architectural
+# alignment with CDT (#44) but its Eigen/ITensor dependency makes it
+# part of tessera_quantum, not tessera_core.
+list(APPEND TESSERA_QUANTUM_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/simulations/InteractionSimulation.cpp")
+# bindings.cpp uses pybind11 + Python.h and goes into _tessera, not the
+# pybind-free static lib.
+list(FILTER TESSERA_QUANTUM_SOURCES EXCLUDE REGEX "/src/quantum/Bindings\\.cpp$")
+add_library(tessera_quantum STATIC ${TESSERA_QUANTUM_SOURCES})
+target_include_directories(tessera_quantum PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
+# PUBLIC link to tessera_core: tessera::Poset / Vertex / EdgeList live in
+# tessera_core, and quantum's Poset-using headers expose them in their
+# public API. PUBLIC propagates symbols to test executables too.
+# (Eigen3 is already linked transitively via tessera_core, but kept explicit
+# here for clarity since quantum headers use it directly.)
+target_link_libraries(tessera_quantum PUBLIC itensor Eigen3::Eigen tessera_core)
+set_target_properties(tessera_quantum PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+file(GLOB TESSERA_QUANTUM_TESTS
+        CONFIGURE_DEPENDS
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/quantum/*.cpp")
+foreach(_test_src ${TESSERA_QUANTUM_TESTS})
+    get_filename_component(_test_name "${_test_src}" NAME_WE)
+    add_executable(${_test_name} "${_test_src}")
+    # tessera_quantum PUBLIC-links tessera_core, so tests get its symbols
+    # transitively without an explicit tessera_core link here.
+    target_link_libraries(${_test_name} PRIVATE tessera_quantum)
+    set_target_properties(${_test_name} PROPERTIES
             CXX_STANDARD 20
             CXX_STANDARD_REQUIRED ON)
+    add_test(NAME ${_test_name} COMMAND ${_test_name})
+endforeach()
 
-    enable_testing()
-    file(GLOB TESSERA_QUANTUM_TESTS
-            CONFIGURE_DEPENDS
-            "${CMAKE_CURRENT_SOURCE_DIR}/tests/quantum/*.cpp")
-    foreach(_test_src ${TESSERA_QUANTUM_TESTS})
-        get_filename_component(_test_name "${_test_src}" NAME_WE)
-        add_executable(${_test_name} "${_test_src}")
-        # tessera_quantum PUBLIC-links tessera_core, so tests get its symbols
-        # transitively without an explicit tessera_core link here.
-        target_link_libraries(${_test_name} PRIVATE tessera_quantum)
-        set_target_properties(${_test_name} PROPERTIES
-                CXX_STANDARD 20
-                CXX_STANDARD_REQUIRED ON)
-        add_test(NAME ${_test_name} COMMAND ${_test_name})
-    endforeach()
-
-    # Wire the quantum bindings TU (added to TESSERA_PYBIND_SOURCES above)
-    # into _tessera by linking against the implementation library and
-    # flipping the TESSERA_QUANTUM compile flag so src/bindings.cpp
-    # registers the `quantum` submodule.
-    target_link_libraries(_tessera PRIVATE tessera_quantum)
-    target_compile_definitions(_tessera PRIVATE TESSERA_QUANTUM=1)
-endif()  # the auto-detect block above already reports when quantum is OFF
+# Wire the quantum bindings TU (added to TESSERA_PYBIND_SOURCES above)
+# into _tessera by linking against the implementation library.
+target_link_libraries(_tessera PRIVATE tessera_quantum)
 # ---- </Quantum subsystem> ----
 
 if(NOT TESSERA_ASAN)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ tessera bundles several discrete-geometry formulations on a shared simplicial me
 
 ## Installation
 
-Requires Python 3.9+, a C++20 compiler, and CMake 3.18+.
+Requires Python 3.9+, a C++20 compiler, CMake 3.18+, and a BLAS/LAPACK backend
+(Accelerate ships with macOS; on Linux install `liblapack-dev libblas-dev`).
 
 ```bash
 pip install -e ".[dev]"
@@ -31,13 +32,12 @@ python -c "import tessera; print('tessera OK')"
 
 CUDA GPU acceleration is auto-detected. To force it off: `TESSERA_CUDA=0 pip install -e .`
 
-The **quantum subsystem** (Schwinger model / DMRG, ITensor-backed) is auto-detected. The easiest way to enable it is a single command:
-
-```bash
-TESSERA_QUANTUM=1 pip install -e .   # fetches the ITensor submodule, then builds it
-```
-
-`TESSERA_QUANTUM=1` checks out the ITensor submodule for you on the first build (a one-time network download). If the submodule is already present — e.g. you cloned with `git clone --recurse-submodules` — a plain `pip install -e .` detects and builds it automatically. `TESSERA_QUANTUM=0` forces it off.
+The **quantum subsystem** (Schwinger model / DMRG, ITensor-backed) is **always
+built** — ITensor, Eigen3, and a BLAS/LAPACK backend are unconditional
+dependencies. The ITensor submodule is fetched automatically on the first build
+(a one-time network download) if it is not already present; cloning with
+`git clone --recurse-submodules` avoids the fetch. A cold build is noticeably
+slower because ITensor is compiled from source — `ccache` (below) helps a lot.
 
 Builds also use [`ccache`](https://ccache.dev/) automatically when it is installed (`brew install ccache` / `apt-get install ccache`) — recommended: it makes rebuilds and CI dramatically faster.
 
@@ -182,20 +182,17 @@ pytest tests/ -v -m "not slow"     # skip the slow tests
 pytest tests/ -v -m slow           # run only the slow tests
 ```
 
-Some tests cover the quantum subsystem (Schwinger model / DMRG). They
-skip cleanly when it isn't built. Enable it once — `TESSERA_QUANTUM=1`
-fetches the ITensor submodule and builds the subsystem:
+Some tests cover the quantum subsystem (Schwinger model / DMRG). It is always
+built, so these run as part of the normal suite:
 
 ```bash
-TESSERA_QUANTUM=1 pip install -e .   # one-time: fetch + build quantum
-pytest tests/ -v                     # the quantum tests now run too
+pytest tests/ -v                     # includes the quantum tests
 ```
 
 Build options via environment variables:
 
 ```bash
 TESSERA_CUDA=0       pip install -e .     # CPU-only build
-TESSERA_QUANTUM=0    pip install -e .     # skip the quantum subsystem
 TESSERA_CCACHE=0     pip install -e .     # disable the ccache compiler cache
 TESSERA_ASAN=1       pytest tests/        # AddressSanitizer + UBSan
 TESSERA_VERBOSE=1    pytest tests/        # C++ logging

--- a/include/cobordism/CombinatorialDimension.h
+++ b/include/cobordism/CombinatorialDimension.h
@@ -1,0 +1,69 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_COMBINATORIALDIMENSION_H
+#define TESSERA_COBORDISM_COMBINATORIALDIMENSION_H
+
+#include <memory>
+
+#include "observables/Observable.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::observables;
+using namespace ::tessera::spacetime;
+
+/// # CombinatorialDimension
+///
+/// Observable: the combinatorial dimension of a triangulation — the largest
+/// \f$ k \f$ for which a \f$ k \f$-simplex is present (the maximum simplex
+/// vertex count minus one), or \f$ -1 \f$ for the empty complex.
+///
+/// This is a purely combinatorial/topological quantity: an exact integer equal
+/// to \f$ n \f$ for a clean PL \f$ n \f$-manifold triangulation, fixed by the
+/// simplex set alone. It is **not** the spectral dimension
+/// (``Spacetime::getSpectralDimensionOnSkeleton``), which is a real-valued,
+/// scale-dependent diffusion quantity that can differ from \f$ n \f$
+/// (dimensional reduction); nor the Hausdorff (volume-scaling) dimension. It is
+/// also distinct from the metric's *declared* dimension: a hand-assembled
+/// lower-dimensional triangulation (e.g. a surface \f$ S^2 \f$) can live inside
+/// a 4D-signature ``Spacetime``.
+///
+/// The cobordism capabilities key their dimension-dependent logic off this
+/// integer (the existence table is indexed by \f$ n \in \{0,1,2,3,4\} \f$, the
+/// signature is defined only for \f$ n=4 \f$, vertex links must be
+/// \f$ (n-1) \f$-spheres, …) — a role a real-valued spectral dimension cannot
+/// fill.
+///
+/// Implemented as an :class:`Observable` (returning the dimension as a double)
+/// following tessera's convention for scalar measurements of a triangulation.
+/// The characteristic-number capabilities (Euler characteristic, signature, …)
+/// are likewise Observables; multi-complex / structural operations (cobordism
+/// verification, reconstruction, Pachner search) are static-only classes.
+class CombinatorialDimension : public Observable {
+  public:
+    double compute(const std::shared_ptr<Spacetime> &spacetime) override;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_INTRINSICDIMENSION_H

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -69,6 +69,7 @@ void register_mesh(py::module_ m);
 void register_spacetime(py::module_ m);
 void register_observables(py::module_ m);
 void register_simulations(py::module_ m);
+void register_cobordism(py::module_ m);
 
 PYBIND11_MODULE(_tessera, m) {
   m.doc() = R"doc(
@@ -114,12 +115,16 @@ References:
       "WilsonLoop, VolumeProfile.");
   auto m_simulations = m.def_submodule("simulations",
       "Monte Carlo simulations: CDT, ReggeSolver, Simulation base class.");
+  auto m_cobordism   = m.def_submodule("cobordism",
+      "Cobordisms between PL manifolds: characteristic numbers, verification, "
+      "reconstruction.");
 
   // --- Per-subsystem bindings (one file per subsystem) ---
   register_mesh(m_mesh);
   register_spacetime(m_spacetime);
   register_observables(m_observables);
   register_simulations(m_simulations);
+  register_cobordism(m_cobordism);
 
   // ========================================
   // MatterConfiguration

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -62,11 +62,8 @@ namespace py = pybind11;
 
 using namespace tessera;
 
-#ifdef TESSERA_QUANTUM
-// Defined in src/quantum/bindings.cpp. Conditionally compiled when the
-// TESSERA_QUANTUM CMake option is on — see CMakeLists.txt for the wiring.
+// Defined in src/quantum/Bindings.cpp — always built.
 void register_quantum(py::module_ m);
-#endif
 
 void register_mesh(py::module_ m);
 void register_spacetime(py::module_ m);
@@ -214,12 +211,10 @@ Args:
   m.attr("__version__") = "unknown";
 #endif
 
-#ifdef TESSERA_QUANTUM
   // Register the Schwinger / DMRG bindings as a `quantum` submodule so users
   // call them as `tessera._tessera.quantum.computeGroundState(...)` (typically
   // routed through `tessera.quantum` — see tessera/quantum/__init__.py).
   register_quantum(m.def_submodule("quantum",
       "Schwinger model + DMRG (docs/source/quantum-plan.md)."));
-#endif
 }
 

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -1,0 +1,62 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Pybind11 bindings for the cobordism subsystem. Lives outside tessera_core
+// (which is pybind-free) so the static library can be reused without pulling
+// in the Python dependency. This translation unit is always added to
+// _tessera's sources (see CMakeLists.txt, TESSERA_PYBIND_SOURCES).
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "cobordism/CombinatorialDimension.h"
+#include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
+
+namespace py = pybind11;
+
+using namespace tessera;
+using namespace tessera::cobordism;
+
+void register_cobordism(py::module_ m) {
+  // Smoke hook: lets tests assert the subsystem loaded before any
+  // mathematical capability (issues #63–#70) is implemented. Single leading
+  // underscore (not double) to avoid Python name-mangling inside test classes.
+  m.def("_cobordism_smoke", [] { return true; },
+        "Returns True; confirms the cobordism subsystem is built and importable.");
+
+  // Per-complex scalar measurements are Observables (tessera's convention),
+  // not methods on Spacetime or a bespoke wrapper. The characteristic-number
+  // capabilities (Euler characteristic, signature, …) follow the same pattern;
+  // multi-complex / structural operations (cobordism verification,
+  // reconstruction, Pachner search) will be static-only classes taking a
+  // Spacetime.
+  py::class_<CombinatorialDimension, std::shared_ptr<CombinatorialDimension>>(
+      m, "CombinatorialDimension",
+      R"doc(Observable: combinatorial dimension of a triangulation.
+
+The largest k with a k-simplex present (max simplex size - 1), or -1 if empty.
+A purely combinatorial/topological integer (= n for a PL n-manifold), distinct
+from the spectral dimension (a real-valued diffusion quantity) and from the
+Spacetime's declared metric dimension.)doc")
+      .def(py::init<>())
+      .def("compute", &CombinatorialDimension::compute, py::arg("spacetime"),
+           "Return the combinatorial dimension of the given Spacetime as a double.");
+}

--- a/src/cobordism/CombinatorialDimension.cpp
+++ b/src/cobordism/CombinatorialDimension.cpp
@@ -1,0 +1,41 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/CombinatorialDimension.h"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "mesh/Simplex.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+double CombinatorialDimension::compute(const std::shared_ptr<Spacetime> &spacetime) {
+  if (spacetime == nullptr) return -1.0;
+  std::size_t maxVerts = 0;
+  for (const auto &simplex : spacetime->getSimplices()) {
+    maxVerts = std::max(maxVerts, static_cast<std::size_t>(simplex->size()));
+  }
+  return maxVerts == 0 ? -1.0 : static_cast<double>(maxVerts) - 1.0;
+}
+
+}  // namespace tessera::cobordism

--- a/src/quantum/Bindings.cpp
+++ b/src/quantum/Bindings.cpp
@@ -1,7 +1,7 @@
 // Pybind11 bindings for the quantum subsystem. Lives outside libtessera_quantum
 // (which is pybind-free) so the static library can be reused without pulling
-// in the Python dependency. This translation unit is added to _tessera's
-// sources only when TESSERA_QUANTUM=ON in CMakeLists.txt.
+// in the Python dependency. This translation unit is always added to
+// _tessera's sources (the quantum subsystem is unconditional).
 //
 // Surface area is deliberately minimal per PLAN.md §1: scalars in, scalars
 // out. No MPS / MPO / ITensor types cross the Python boundary.

--- a/tessera/__init__.py
+++ b/tessera/__init__.py
@@ -27,14 +27,9 @@ from tessera._tessera import (                              # noqa: F401
     simulations,
 )
 
-# The ``quantum`` submodule is only built when ``TESSERA_QUANTUM=1`` is
-# set at build time. Tolerate its absence so the CDT-only configuration
-# (``TESSERA_QUANTUM=0``) imports cleanly. Scripts that need quantum
-# features should ``import tessera.quantum`` and let that fail loudly.
-try:
-    from tessera._tessera import quantum                    # noqa: F401
-except ImportError:
-    pass
+# The ``quantum`` submodule (Schwinger model / DMRG, ITensor-backed) is
+# always built — ITensor/Eigen/BLAS are unconditional dependencies.
+from tessera._tessera import quantum                        # noqa: F401
 
 # Backward-compat re-exports at top level. Star-import each submodule so
 # existing scripts that do `from tessera import Spacetime`, `tessera.CDT`,

--- a/tessera/__init__.py
+++ b/tessera/__init__.py
@@ -25,6 +25,7 @@ from tessera._tessera import (                              # noqa: F401
     spacetime,
     observables,
     simulations,
+    cobordism,
 )
 
 # The ``quantum`` submodule (Schwinger model / DMRG, ITensor-backed) is
@@ -38,5 +39,6 @@ from tessera._tessera.mesh        import *                  # noqa: F401,F403
 from tessera._tessera.spacetime   import *                  # noqa: F401,F403
 from tessera._tessera.observables import *                  # noqa: F401,F403
 from tessera._tessera.simulations import *                  # noqa: F401,F403
+from tessera._tessera.cobordism   import *                  # noqa: F401,F403
 # Quantum is also subsystem-namespaced; expose at top level for symmetry
 # with the others (existing scripts already use `tessera.quantum.*`).

--- a/tests/cobordism/test_smoke_python.py
+++ b/tests/cobordism/test_smoke_python.py
@@ -1,0 +1,60 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Smoke tests for the cobordism subsystem scaffold (issue #62)."""
+
+import itertools
+import unittest
+
+import tessera
+
+# Subsystem submodules are exposed as attributes of the `tessera` package
+# (via tessera/__init__.py), matching mesh/spacetime/observables/simulations.
+# Dotted `import tessera.cobordism` is not supported for the C++ subsystems
+# (only the pure-Python `tessera.quantum` package allows it).
+cobordism = tessera.cobordism
+
+
+class TestCobordismScaffold(unittest.TestCase):
+
+    def test_submodule_imports(self):
+        self.assertTrue(hasattr(tessera, "cobordism"))
+        self.assertTrue(cobordism._cobordism_smoke())
+
+    def test_combinatorial_dimension_observable_empty(self):
+        # Per-complex measurements are Observables (#62). Empty complex -> -1.
+        st = tessera.Spacetime()
+        self.assertEqual(cobordism.CombinatorialDimension().compute(st), -1.0)
+
+    def test_combinatorial_dimension_is_intrinsic_not_declared(self):
+        # Build S^2 = ∂Δ³ (triangles) inside a 4D-declared Spacetime. The
+        # combinatorial dimension is 2, independent of the Spacetime's signature.
+        st = tessera.Spacetime()
+        V = [st.createVertex(i, [0.0]) for i in range(4)]
+        for a, b in itertools.combinations(range(4), 2):
+            st.createEdge(V[a], V[b], 1.0)
+        for combo in itertools.combinations(range(4), 3):
+            st.createSimplex([V[i] for i in combo])
+        self.assertEqual(cobordism.CombinatorialDimension().compute(st), 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of the cobordism extension (epic #71). Lands first because it unblocks Eigen use in `tessera_core` for the downstream cobordism work.

## What

Removes the `TESSERA_QUANTUM` build flag and makes the quantum subsystem — and its dependencies **ITensor**, **Eigen3**, and a **BLAS/LAPACK** backend — unconditional parts of every build. Eigen3 is now linked into `tessera_core` so all subsystems (including the forthcoming `cobordism` subsystem) can use it.

## Changes

- **CMakeLists.txt**: drop the `TESSERA_QUANTUM` detection block; fetch the ITensor submodule and require BLAS/LAPACK unconditionally; resolve Eigen3 up front and link `Eigen3::Eigen` into `tessera_core`; always build `tessera_quantum` + its bindings; remove the redundant Eigen find and the `TESSERA_QUANTUM=1` compile definition.
- **src/bindings.cpp**: remove both `#ifdef TESSERA_QUANTUM` guards; always register the `quantum` submodule.
- **tessera/__init__.py**: import the `quantum` submodule unconditionally.
- **.github/workflows/build.yml**: drop the obsolete `quantum: [0,1]` matrix dimension; smoke test always expects `tessera.quantum`.
- **README.md**: document ITensor/Eigen/BLAS as required; note slower cold builds.

## Consequences (accepted)

Every build now requires the ITensor submodule (one-time fetch) and a BLAS/LAPACK backend; cold builds are slower (ITensor compiled from source). CI already installs `liblapack-dev`/`libblas-dev` and recurses submodules.

## Verification

- Clean `pip install -e .` (no env flags) builds and `import tessera.quantum` works.
- `tests/quantum/` — 234 passed.
- Non-slow core suite — 424 passed, 9 skipped.

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)