### PR TITLE
Fix getExternalSimplices() segfault on hand-built (non-CDT) complexes

### DIFF
--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -388,6 +388,34 @@ const std::shared_ptr<VertexList> &Spacetime::getVertexList() const noexcept {
 }
 
 SimplexSet Spacetime::getExternalSimplices() noexcept {
+  // Boundary detection needs every facet's coface count to be complete:
+  // a facet is on the boundary iff it has fewer than two cofaces. Facets
+  // are materialized lazily — ``Simplex::getFacets()`` creates them on first
+  // access and registers each one back into ``simplicesVec`` (via
+  // ``registerSimplex``). For CDT-built complexes this already happened during
+  // gluing, so the loop below would converge immediately. For complexes
+  // assembled from scratch (e.g. a hand-built triangulation), the facets do
+  // not exist yet, and materializing them *during* a range-for over
+  // ``simplicesVec`` would both invalidate the iterator (the vector grows) and
+  // read incomplete coface counts (a shared facet looks like a boundary facet
+  // until its second coface registers).
+  //
+  // Force lazy facet materialization first. ``getFacets()`` appends any
+  // newly-created facet simplices to ``simplicesVec``; index iteration walks
+  // into them too, so a single pass reaches a fixpoint (dimension strictly
+  // decreases, terminating at vertices whose ``getFacets()`` is a no-op).
+  //
+  // Index iteration — re-reading ``simplicesVec[i]`` and ``size()`` each step —
+  // is safe under the growth a range-for would not survive: reallocation moves
+  // the buffer, but the next ``simplicesVec[i]`` reads the current buffer.
+  // No copy of the vector is made. For CDT-built complexes the facets already
+  // exist, so every ``getFacets()`` is a cached no-op and nothing is appended.
+  for (std::size_t i = 0; i < simplicesVec.size(); ++i) {
+    simplicesVec[i]->getFacets();
+  }
+
+  // Cofaces are now fully linked; no further simplices will be created, so a
+  // direct scan is safe.
   SimplexSet result{};
   for (const auto &simplex : simplicesVec) {
     if (simplex->hasBoundaryFacet()) result.insert(simplex);

--- a/tests/test_spacetime.py
+++ b/tests/test_spacetime.py
@@ -267,5 +267,47 @@ class TestSpacetime(unittest.TestCase):
                             self.assertIn(coface, vertex.getSimplices())
 
 
+class TestExternalSimplicesNonCDT(unittest.TestCase):
+    """getExternalSimplices() on hand-built (non-CDT) complexes.
+
+    Regression: facets are materialized lazily by Simplex.getFacets(), which
+    registers them back into the spacetime's simplex vector. A from-scratch
+    complex has no facets until something asks for them, so getExternalSimplices
+    used to (a) grow the vector it was iterating — a segfault — and (b) read
+    incomplete coface counts mid-pass. CDT-built complexes never hit this
+    because gluing materializes facets up front.
+    """
+
+    def _tetra_boundary(self):
+        """S^2 = boundary of a tetrahedron: 4 vertices, 4 triangles, closed."""
+        import itertools
+        st = Spacetime()
+        V = [st.createVertex(i, [0.0]) for i in range(4)]
+        for a, b in itertools.combinations(range(4), 2):
+            st.createEdge(V[a], V[b], 1.0)
+        tris = [st.createSimplex([V[i] for i in c])[0]
+                for c in itertools.combinations(range(4), 3)]
+        return st, V, tris
+
+    def test_closed_surface_has_no_external_top_simplices(self):
+        # Every edge of S^2 is shared by exactly two triangles, so no triangle
+        # has a boundary facet. (Must not segfault.)
+        st, _V, tris = self._tetra_boundary()
+        ext = st.getExternalSimplices()
+        triangles = [s for s in ext if len(s.getVertices()) == 3]
+        self.assertEqual(triangles, [],
+                         "closed S^2 should have no boundary triangles")
+
+    def test_open_complex_reports_boundary(self):
+        # Drop one triangle: the three edges it covered now have a single
+        # coface, so the three remaining triangles each gain a boundary edge.
+        st, _V, tris = self._tetra_boundary()
+        st.removeSimplex(tris[0])
+        ext = st.getExternalSimplices()
+        triangles = [s for s in ext if len(s.getVertices()) == 3]
+        self.assertEqual(len(triangles), 3,
+                         "each remaining triangle should touch the new boundary")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Surfaced by the cobordism extension's container spike (#62): building a PL complex from scratch and calling `getExternalSimplices()` segfaulted.

## Root cause

`Simplex::getFacets()` materializes facets lazily and registers each one back into `Spacetime::simplicesVec` (via `registerSimplex`). `getExternalSimplices()` iterated `simplicesVec` with a range-for while calling `hasBoundaryFacet()` → `getFacets()`. On a complex assembled from scratch (facets not yet materialized) that:

1. **grew the vector being iterated** → iterator invalidation → segfault, and
2. **read incomplete coface counts mid-pass** — a shared facet looks like a boundary facet until its second coface registers.

CDT-built complexes never hit this because gluing materializes facets up front, so `simplicesVec` doesn't grow during the call.

## Fix

A single **index-based** materialization pass over `simplicesVec`: `getFacets()` appends new facet simplices, and the index loop walks into them too, so it reaches a fixpoint in one pass (dimension strictly decreases, terminating at vertices). Index iteration — re-reading `simplicesVec[i]`/`size()` each step — is safe under the growth a range-for can't survive, and **copies nothing**. For already-materialized CDT complexes every `getFacets()` is a cached no-op, so this is just one extra cheap scan. A single boundary scan then runs once coface counts are complete.

## Tests

New regression class in `tests/test_spacetime.py` builds `S² = ∂Δ³` from scratch:
- closed surface → no boundary triangles (previously segfaulted);
- dropping one triangle → the three neighbours each report a boundary edge.

Verified green: the new tests, plus `test_cdt` / `test_pachner_*` / `test_simplex` / `test_build` and `test_spacetime`.

Part of the cobordism extension epic #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)