### PR TITLE
cobordism: scaffold subsystem; CombinatorialDimension Observable (#62)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ set(TESSERA_PYBIND_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/spacetime/Bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/observables/Bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/simulations/Bindings.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/cobordism/Bindings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/quantum/Bindings.cpp")
 # ---- </Define source partitions> -----------------------------------------
 

--- a/include/cobordism/CombinatorialDimension.h
+++ b/include/cobordism/CombinatorialDimension.h
@@ -1,0 +1,69 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_COMBINATORIALDIMENSION_H
+#define TESSERA_COBORDISM_COMBINATORIALDIMENSION_H
+
+#include <memory>
+
+#include "observables/Observable.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::observables;
+using namespace ::tessera::spacetime;
+
+/// # CombinatorialDimension
+///
+/// Observable: the combinatorial dimension of a triangulation — the largest
+/// \f$ k \f$ for which a \f$ k \f$-simplex is present (the maximum simplex
+/// vertex count minus one), or \f$ -1 \f$ for the empty complex.
+///
+/// This is a purely combinatorial/topological quantity: an exact integer equal
+/// to \f$ n \f$ for a clean PL \f$ n \f$-manifold triangulation, fixed by the
+/// simplex set alone. It is **not** the spectral dimension
+/// (``Spacetime::getSpectralDimensionOnSkeleton``), which is a real-valued,
+/// scale-dependent diffusion quantity that can differ from \f$ n \f$
+/// (dimensional reduction); nor the Hausdorff (volume-scaling) dimension. It is
+/// also distinct from the metric's *declared* dimension: a hand-assembled
+/// lower-dimensional triangulation (e.g. a surface \f$ S^2 \f$) can live inside
+/// a 4D-signature ``Spacetime``.
+///
+/// The cobordism capabilities key their dimension-dependent logic off this
+/// integer (the existence table is indexed by \f$ n \in \{0,1,2,3,4\} \f$, the
+/// signature is defined only for \f$ n=4 \f$, vertex links must be
+/// \f$ (n-1) \f$-spheres, …) — a role a real-valued spectral dimension cannot
+/// fill.
+///
+/// Implemented as an :class:`Observable` (returning the dimension as a double)
+/// following tessera's convention for scalar measurements of a triangulation.
+/// The characteristic-number capabilities (Euler characteristic, signature, …)
+/// are likewise Observables; multi-complex / structural operations (cobordism
+/// verification, reconstruction, Pachner search) are static-only classes.
+class CombinatorialDimension : public Observable {
+  public:
+    double compute(const std::shared_ptr<Spacetime> &spacetime) override;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_INTRINSICDIMENSION_H

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -69,6 +69,7 @@ void register_mesh(py::module_ m);
 void register_spacetime(py::module_ m);
 void register_observables(py::module_ m);
 void register_simulations(py::module_ m);
+void register_cobordism(py::module_ m);
 
 PYBIND11_MODULE(_tessera, m) {
   m.doc() = R"doc(
@@ -114,12 +115,16 @@ References:
       "WilsonLoop, VolumeProfile.");
   auto m_simulations = m.def_submodule("simulations",
       "Monte Carlo simulations: CDT, ReggeSolver, Simulation base class.");
+  auto m_cobordism   = m.def_submodule("cobordism",
+      "Cobordisms between PL manifolds: characteristic numbers, verification, "
+      "reconstruction.");
 
   // --- Per-subsystem bindings (one file per subsystem) ---
   register_mesh(m_mesh);
   register_spacetime(m_spacetime);
   register_observables(m_observables);
   register_simulations(m_simulations);
+  register_cobordism(m_cobordism);
 
   // ========================================
   // MatterConfiguration

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -1,0 +1,62 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Pybind11 bindings for the cobordism subsystem. Lives outside tessera_core
+// (which is pybind-free) so the static library can be reused without pulling
+// in the Python dependency. This translation unit is always added to
+// _tessera's sources (see CMakeLists.txt, TESSERA_PYBIND_SOURCES).
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "cobordism/CombinatorialDimension.h"
+#include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
+
+namespace py = pybind11;
+
+using namespace tessera;
+using namespace tessera::cobordism;
+
+void register_cobordism(py::module_ m) {
+  // Smoke hook: lets tests assert the subsystem loaded before any
+  // mathematical capability (issues #63–#70) is implemented. Single leading
+  // underscore (not double) to avoid Python name-mangling inside test classes.
+  m.def("_cobordism_smoke", [] { return true; },
+        "Returns True; confirms the cobordism subsystem is built and importable.");
+
+  // Per-complex scalar measurements are Observables (tessera's convention),
+  // not methods on Spacetime or a bespoke wrapper. The characteristic-number
+  // capabilities (Euler characteristic, signature, …) follow the same pattern;
+  // multi-complex / structural operations (cobordism verification,
+  // reconstruction, Pachner search) will be static-only classes taking a
+  // Spacetime.
+  py::class_<CombinatorialDimension, std::shared_ptr<CombinatorialDimension>>(
+      m, "CombinatorialDimension",
+      R"doc(Observable: combinatorial dimension of a triangulation.
+
+The largest k with a k-simplex present (max simplex size - 1), or -1 if empty.
+A purely combinatorial/topological integer (= n for a PL n-manifold), distinct
+from the spectral dimension (a real-valued diffusion quantity) and from the
+Spacetime's declared metric dimension.)doc")
+      .def(py::init<>())
+      .def("compute", &CombinatorialDimension::compute, py::arg("spacetime"),
+           "Return the combinatorial dimension of the given Spacetime as a double.");
+}

--- a/src/cobordism/CombinatorialDimension.cpp
+++ b/src/cobordism/CombinatorialDimension.cpp
@@ -1,0 +1,41 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/CombinatorialDimension.h"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "mesh/Simplex.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+double CombinatorialDimension::compute(const std::shared_ptr<Spacetime> &spacetime) {
+  if (spacetime == nullptr) return -1.0;
+  std::size_t maxVerts = 0;
+  for (const auto &simplex : spacetime->getSimplices()) {
+    maxVerts = std::max(maxVerts, static_cast<std::size_t>(simplex->size()));
+  }
+  return maxVerts == 0 ? -1.0 : static_cast<double>(maxVerts) - 1.0;
+}
+
+}  // namespace tessera::cobordism

--- a/tessera/__init__.py
+++ b/tessera/__init__.py
@@ -25,6 +25,7 @@ from tessera._tessera import (                              # noqa: F401
     spacetime,
     observables,
     simulations,
+    cobordism,
 )
 
 # The ``quantum`` submodule (Schwinger model / DMRG, ITensor-backed) is
@@ -38,5 +39,6 @@ from tessera._tessera.mesh        import *                  # noqa: F401,F403
 from tessera._tessera.spacetime   import *                  # noqa: F401,F403
 from tessera._tessera.observables import *                  # noqa: F401,F403
 from tessera._tessera.simulations import *                  # noqa: F401,F403
+from tessera._tessera.cobordism   import *                  # noqa: F401,F403
 # Quantum is also subsystem-namespaced; expose at top level for symmetry
 # with the others (existing scripts already use `tessera.quantum.*`).

--- a/tests/cobordism/test_smoke_python.py
+++ b/tests/cobordism/test_smoke_python.py
@@ -1,0 +1,60 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Smoke tests for the cobordism subsystem scaffold (issue #62)."""
+
+import itertools
+import unittest
+
+import tessera
+
+# Subsystem submodules are exposed as attributes of the `tessera` package
+# (via tessera/__init__.py), matching mesh/spacetime/observables/simulations.
+# Dotted `import tessera.cobordism` is not supported for the C++ subsystems
+# (only the pure-Python `tessera.quantum` package allows it).
+cobordism = tessera.cobordism
+
+
+class TestCobordismScaffold(unittest.TestCase):
+
+    def test_submodule_imports(self):
+        self.assertTrue(hasattr(tessera, "cobordism"))
+        self.assertTrue(cobordism._cobordism_smoke())
+
+    def test_combinatorial_dimension_observable_empty(self):
+        # Per-complex measurements are Observables (#62). Empty complex -> -1.
+        st = tessera.Spacetime()
+        self.assertEqual(cobordism.CombinatorialDimension().compute(st), -1.0)
+
+    def test_combinatorial_dimension_is_intrinsic_not_declared(self):
+        # Build S^2 = ∂Δ³ (triangles) inside a 4D-declared Spacetime. The
+        # combinatorial dimension is 2, independent of the Spacetime's signature.
+        st = tessera.Spacetime()
+        V = [st.createVertex(i, [0.0]) for i in range(4)]
+        for a, b in itertools.combinations(range(4), 2):
+            st.createEdge(V[a], V[b], 1.0)
+        for combo in itertools.combinations(range(4), 3):
+            st.createSimplex([V[i] for i in combo])
+        self.assertEqual(cobordism.CombinatorialDimension().compute(st), 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #62. **Stacked on #72** (`cobordism/drop-quantum-flag`) — review/merge that first; this PR's base retargets to `main` once #72 lands. (The `getExternalSimplices` fix #73 is already in `main`.)

## What

Stands up the `cobordism` C++ subsystem (namespace `tessera::cobordism`), parallel to `mesh`/`spacetime`/`observables`/`simulations`, wired into `tessera_core` and exposed as `tessera.cobordism`.

- `cobordism::CombinatorialDimension : public observables::Observable` — `compute()` returns the largest `k` with a `k`-simplex present (max simplex size − 1), or −1 if empty. This is the complex's dimension **as built**, distinct from the Spacetime's declared metric dimension (a 2-complex can live in a 4D-signature Spacetime).
- `src/cobordism/Bindings.cpp` — `register_cobordism`: binds `CombinatorialDimension` and a `_cobordism_smoke()` hook; wired into `src/bindings.cpp` and `TESSERA_PYBIND_SOURCES`.
- `tessera/__init__.py` — exposes the submodule via attribute access (the convention for C++ subsystems).
- `tests/cobordism/` — smoke tests.

## Design (recorded on #62)

Reuse `Spacetime` as the geometric container — **no parallel `Complex` wrapper**. Per-complex scalar invariants (combinatorial dimension; and Capability A's characteristic numbers) are **`Observable` subclasses**, tessera's established pattern. Multi-complex / structural operations (verification, reconstruction, Pachner search) will be **static-only classes** taking a `Spacetime`. Boundary is computed by the dimension-agnostic coface-count rule. The spike's one casualty — `getExternalSimplices()` segfaulting on non-CDT complexes — was fixed in #73.

Design specs live as comments on epic #71 (not in the repo).

## Verification

`tessera.cobordism` imports; 3 cobordism smoke tests pass; full non-slow suite (427) green; all six subsystems import.

Part of epic #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)