### PR TITLE
cobordism: fixture triangulations as Topology subclasses (#63)

### DIFF
--- a/include/spacetime/topologies/RealProjectivePlane.h
+++ b/include/spacetime/topologies/RealProjectivePlane.h
@@ -1,0 +1,50 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_REALPROJECTIVEPLANE_H
+#define TESSERA_REALPROJECTIVEPLANE_H
+
+#include "Topology.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+class Spacetime;
+
+/// # Real projective plane \f$ \mathbb{RP}^2 \f$ (minimal 6-vertex)
+///
+/// The unique minimal triangulation of \f$ \mathbb{RP}^2 \f$ — the
+/// hemi-icosahedron, i.e. the 10 triangles of the icosahedron modulo the
+/// antipodal map, on the complete graph \f$ K_6 \f$. f-vector (6, 15, 10),
+/// \f$ \chi = 1 \f$, **non-orientable** (\f$ w_1^2[\mathbb{RP}^2] = 1 \f$).
+///
+/// Exact, fixed, pre-geometric (coordinate-free); ``build()`` ignores
+/// ``numSimplices``.
+class RealProjectivePlane : public Topology {
+  public:
+    RealProjectivePlane() = default;
+
+    /// Build the 6-vertex \f$ \mathbb{RP}^2 \f$. ``numSimplices`` is ignored.
+    void build(Spacetime *spacetime, int numSimplices) override;
+};
+
+} // namespace tessera::spacetime
+
+#endif // TESSERA_REALPROJECTIVEPLANE_H

--- a/include/spacetime/topologies/SimplexBoundarySphere.h
+++ b/include/spacetime/topologies/SimplexBoundarySphere.h
@@ -1,0 +1,60 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_SIMPLEXBOUNDARYSPHERE_H
+#define TESSERA_SIMPLEXBOUNDARYSPHERE_H
+
+#include "Topology.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+class Spacetime;
+
+/// # Simplex-boundary sphere \f$ S^n = \partial\Delta^{n+1} \f$
+///
+/// The minimal triangulation of the n-sphere: the boundary of the
+/// (n+1)-simplex, i.e. \f$ n+2 \f$ vertices with every \f$ (n+1) \f$-subset a
+/// top n-simplex. f-vector \f$ \binom{n+2}{k+1} \f$ for \f$ k = 0..n \f$
+/// (e.g. \f$ S^4 \f$: (6, 15, 20, 15, 6)); \f$ \chi = 1 + (-1)^n \f$.
+///
+/// This is the exact, fixed minimal triangulation used by the cobordism
+/// fixtures — distinct from :class:`Sphere`, which grows a CDT-style
+/// \f$ S^{d-1}\times S^1 \f$ initial condition of a requested size. Its
+/// ``build()`` ignores ``numSimplices`` and is *pre-geometric* (coordinate-free
+/// vertices; see ``Topology::buildExplicit``).
+class SimplexBoundarySphere : public Topology {
+  public:
+    /// @param n Dimension of the sphere (n >= 1).
+    explicit SimplexBoundarySphere(int n) : n_(n) {}
+
+    [[nodiscard]] int n() const noexcept { return n_; }
+
+    /// Build \f$ S^n = \partial\Delta^{n+1} \f$. ``numSimplices`` is ignored
+    /// (the triangulation is fixed).
+    void build(Spacetime *spacetime, int numSimplices) override;
+
+  private:
+    int n_;
+};
+
+} // namespace tessera::spacetime
+
+#endif // TESSERA_SIMPLEXBOUNDARYSPHERE_H

--- a/include/spacetime/topologies/SolidSimplex.h
+++ b/include/spacetime/topologies/SolidSimplex.h
@@ -1,0 +1,57 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_SOLIDSIMPLEX_H
+#define TESSERA_SOLIDSIMPLEX_H
+
+#include "Topology.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+class Spacetime;
+
+/// # Solid simplex \f$ \Delta^n \f$ (closed n-ball)
+///
+/// A single top n-simplex on \f$ n+1 \f$ vertices with all its faces — a
+/// triangulated closed n-ball whose boundary is \f$ S^{n-1} = \partial\Delta^n \f$.
+/// f-vector \f$ \binom{n+1}{k+1} \f$ for \f$ k = 0..n \f$; \f$ \chi = 1 \f$
+/// (contractible). \f$ \Delta^4 \f$ is the smallest cobordism filling
+/// \f$ S^3 \to \emptyset \f$.
+///
+/// Exact, fixed, pre-geometric (coordinate-free); ``build()`` ignores
+/// ``numSimplices``.
+class SolidSimplex : public Topology {
+  public:
+    /// @param n Dimension of the simplex (n >= 1).
+    explicit SolidSimplex(int n) : n_(n) {}
+
+    [[nodiscard]] int n() const noexcept { return n_; }
+
+    /// Build the solid n-simplex. ``numSimplices`` is ignored.
+    void build(Spacetime *spacetime, int numSimplices) override;
+
+  private:
+    int n_;
+};
+
+} // namespace tessera::spacetime
+
+#endif // TESSERA_SOLIDSIMPLEX_H

--- a/include/spacetime/topologies/Topology.h
+++ b/include/spacetime/topologies/Topology.h
@@ -22,6 +22,10 @@
 #ifndef TESSERA_TOPOLOGY_H
 #define TESSERA_TOPOLOGY_H
 
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
 // === tessera subsystem ns fwd-decls ===
 namespace tessera::graph {}
 namespace tessera::mesh {}
@@ -69,6 +73,27 @@ class Topology {
     /// @param spacetime The spacetime in which to build the triangulation
     /// @param numSimplices Target number of top-dimensional simplices to create
     virtual void build(Spacetime *spacetime, int numSimplices) = 0;
+
+  protected:
+    /// Build an explicit, *pre-geometric* triangulation from a combinatorial
+    /// description: create `numVertices` **coordinate-free** vertices
+    /// (ids 0..numVertices-1) and one top simplex per vertex-id tuple in
+    /// `topSimplices`.
+    ///
+    /// No coordinates are assigned — the cobordism capabilities (homology,
+    /// characteristic numbers, cobordism existence) are purely combinatorial;
+    /// geometry (vertex coordinates / edge lengths) is layered on only when a
+    /// geometric capability (reconstruction, Regge) actually needs it. Edges
+    /// are still materialized by ``createSimplex`` so the incidence structure
+    /// is complete; any squared length they carry is an unused placeholder, not
+    /// meaningful geometry.
+    ///
+    /// Shared by the exact, fixed-triangulation topologies
+    /// (``SimplexBoundarySphere``, ``SolidSimplex``, ``RealProjectivePlane``,
+    /// …) whose ``build()`` ignores ``numSimplices``.
+    static void buildExplicit(
+        Spacetime *spacetime, std::size_t numVertices,
+        const std::vector<std::vector<std::uint64_t>> &topSimplices);
 };
 
 } // namespace tessera::spacetime

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -30,6 +30,9 @@
 #include "spacetime/topologies/Cylinder.h"
 #include "spacetime/topologies/Sphere.h"
 #include "spacetime/topologies/Toroid.h"
+#include "spacetime/topologies/SimplexBoundarySphere.h"
+#include "spacetime/topologies/SolidSimplex.h"
+#include "spacetime/topologies/RealProjectivePlane.h"
 #include "simulations/CDT.h"
 #include "spacetime/PachnerMove.h"
 #include "spacetime/pachner/AddMove.h"
@@ -96,6 +99,38 @@ Pachner moves (add, remove, flip, iflip, shift).)doc")
       .def(py::init<>())
       .def("build", &Toroid::build, py::arg("spacetime"), py::arg("numSimplices"),
            "Build a toroidal staircase triangulation with the given number of simplices.");
+
+  // Exact, fixed minimal triangulations (cobordism fixtures). Unlike the CDT
+  // topologies above, these build a specific pre-geometric (coordinate-free)
+  // complex and ignore `numSimplices`.
+  py::class_<SimplexBoundarySphere, Topology,
+             std::shared_ptr<SimplexBoundarySphere> >(m, "SimplexBoundarySphere",
+      "S^n = boundary of the (n+1)-simplex: the minimal n-sphere triangulation "
+      "(n+2 vertices). Exact and pre-geometric; build() ignores numSimplices.")
+      .def(py::init<int>(), py::arg("n"))
+      .def("n", &SimplexBoundarySphere::n, "Dimension n of the sphere.")
+      .def("build", &SimplexBoundarySphere::build, py::arg("spacetime"),
+           py::arg("numSimplices") = 0,
+           "Build S^n = ∂Δ^{n+1} (numSimplices ignored).");
+
+  py::class_<SolidSimplex, Topology, std::shared_ptr<SolidSimplex> >(
+      m, "SolidSimplex",
+      "Solid n-simplex Δ^n (closed n-ball; ∂ = S^{n-1}), a single top simplex on "
+      "n+1 vertices. Exact and pre-geometric; build() ignores numSimplices.")
+      .def(py::init<int>(), py::arg("n"))
+      .def("n", &SolidSimplex::n, "Dimension n of the simplex.")
+      .def("build", &SolidSimplex::build, py::arg("spacetime"),
+           py::arg("numSimplices") = 0,
+           "Build the solid n-simplex (numSimplices ignored).");
+
+  py::class_<RealProjectivePlane, Topology,
+             std::shared_ptr<RealProjectivePlane> >(m, "RealProjectivePlane",
+      "Minimal 6-vertex ℝP² (hemi-icosahedron): f=(6,15,10), χ=1, "
+      "non-orientable. Exact and pre-geometric; build() ignores numSimplices.")
+      .def(py::init<>())
+      .def("build", &RealProjectivePlane::build, py::arg("spacetime"),
+           py::arg("numSimplices") = 0,
+           "Build the 6-vertex ℝP² (numSimplices ignored).");
   // ========================================
   // Metric
   // ========================================

--- a/src/spacetime/topologies/RealProjectivePlane.cpp
+++ b/src/spacetime/topologies/RealProjectivePlane.cpp
@@ -1,0 +1,38 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "spacetime/topologies/RealProjectivePlane.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace tessera::spacetime {
+
+void RealProjectivePlane::build(Spacetime *spacetime, int /*numSimplices*/) {
+  // Minimal 6-vertex RP² (hemi-icosahedron): 10 triangles on K_6. Every edge
+  // lies in exactly two triangles (closed surface); χ = 6 - 15 + 10 = 1.
+  const std::vector<std::vector<std::uint64_t>> tops{
+      {0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 5}, {0, 1, 5},
+      {1, 2, 4}, {2, 3, 5}, {1, 3, 4}, {1, 3, 5}, {2, 4, 5}};
+  buildExplicit(spacetime, 6, tops);
+}
+
+} // namespace tessera::spacetime

--- a/src/spacetime/topologies/SimplexBoundarySphere.cpp
+++ b/src/spacetime/topologies/SimplexBoundarySphere.cpp
@@ -1,0 +1,46 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "spacetime/topologies/SimplexBoundarySphere.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace tessera::spacetime {
+
+void SimplexBoundarySphere::build(Spacetime *spacetime, int /*numSimplices*/) {
+  if (n_ < 1) throw std::invalid_argument("SimplexBoundarySphere requires n >= 1");
+  // S^n = ∂Δ^{n+1}: n+2 vertices; each top n-simplex omits exactly one vertex.
+  const std::size_t numV = static_cast<std::size_t>(n_) + 2;
+  std::vector<std::vector<std::uint64_t>> tops;
+  tops.reserve(numV);
+  for (std::size_t omit = 0; omit < numV; ++omit) {
+    std::vector<std::uint64_t> s;
+    s.reserve(numV - 1);
+    for (std::size_t v = 0; v < numV; ++v)
+      if (v != omit) s.push_back(static_cast<std::uint64_t>(v));
+    tops.push_back(std::move(s));
+  }
+  buildExplicit(spacetime, numV, tops);
+}
+
+} // namespace tessera::spacetime

--- a/src/spacetime/topologies/SolidSimplex.cpp
+++ b/src/spacetime/topologies/SolidSimplex.cpp
@@ -1,0 +1,40 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "spacetime/topologies/SolidSimplex.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace tessera::spacetime {
+
+void SolidSimplex::build(Spacetime *spacetime, int /*numSimplices*/) {
+  if (n_ < 1) throw std::invalid_argument("SolidSimplex requires n >= 1");
+  // Δ^n: a single top simplex on n+1 vertices.
+  const std::size_t numV = static_cast<std::size_t>(n_) + 1;
+  std::vector<std::uint64_t> s;
+  s.reserve(numV);
+  for (std::size_t v = 0; v < numV; ++v) s.push_back(static_cast<std::uint64_t>(v));
+  buildExplicit(spacetime, numV, {std::move(s)});
+}
+
+} // namespace tessera::spacetime

--- a/src/spacetime/topologies/Topology.cpp
+++ b/src/spacetime/topologies/Topology.cpp
@@ -24,6 +24,9 @@
 #include <memory>
 #include <iostream>
 
+#include "spacetime/Spacetime.h"
+#include "mesh/Vertex.h"
+
 // === tessera subsystem ns fwd-decls ===
 namespace tessera::graph {}
 namespace tessera::mesh {}
@@ -40,5 +43,22 @@ Topology::~Topology() = default;
 // std::vector<std::shared_ptr<Constraint> > Topology::getConstraints() {return {};}
 void Topology::build(Spacetime *spacetime, int numSimplices) {
   std::cout << "Building Topology (base)" << std::endl;
+}
+
+void Topology::buildExplicit(
+    Spacetime *spacetime, std::size_t numVertices,
+    const std::vector<std::vector<std::uint64_t>> &topSimplices) {
+  std::vector<VertexPtr> verts;
+  verts.reserve(numVertices);
+  // Coordinate-free vertices: the triangulation is purely combinatorial here.
+  for (std::size_t i = 0; i < numVertices; ++i) {
+    verts.push_back(spacetime->createVertex(static_cast<std::uint64_t>(i)));
+  }
+  for (const auto &simplex : topSimplices) {
+    VertexPtrs sv;
+    sv.reserve(simplex.size());
+    for (auto id : simplex) sv.push_back(verts.at(static_cast<std::size_t>(id)));
+    spacetime->createSimplex(sv);
+  }
 }
 } // namespace tessera::spacetime

--- a/tests/cobordism/test_fixtures_python.py
+++ b/tests/cobordism/test_fixtures_python.py
@@ -1,0 +1,110 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Cobordism fixture triangulations (#63), built via Topology subclasses.
+
+These topologies build exact, minimal, pre-geometric (coordinate-free)
+triangulations. We verify each built complex against its known f-vector and
+Euler characteristic by counting distinct k-faces combinatorially from the top
+simplices — independent of any geometry.
+"""
+
+import itertools
+import unittest
+
+import tessera
+
+cobordism = tessera.cobordism
+
+
+def _build(topology):
+    """Build a topology into a fresh Spacetime via the idiomatic flow."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, topology)
+    st.build()  # delegates to topology.build(); numSimplices ignored
+    return st
+
+
+def _f_vector(st):
+    """Count distinct k-faces (k=0..dim) from the top simplices."""
+    tops = [tuple(sorted(v.getId() for v in s.getVertices()))
+            for s in st.getSimplices()]
+    if not tops:
+        return []
+    maxsz = max(len(t) for t in tops)
+    f = []
+    for card in range(1, maxsz + 1):
+        faces = set()
+        for t in tops:
+            if len(t) >= card:
+                faces.update(itertools.combinations(t, card))
+        f.append(len(faces))
+    return f
+
+
+def _euler(fvec):
+    return sum((-1) ** k * n for k, n in enumerate(fvec))
+
+
+class TestFixtures(unittest.TestCase):
+
+    def _check(self, topology, fvector, euler, dim):
+        st = _build(topology)
+        self.assertEqual(_f_vector(st), fvector)
+        self.assertEqual(_euler(fvector), euler)
+        self.assertEqual(cobordism.CombinatorialDimension().compute(st), float(dim))
+
+    # S^n = ∂Δ^{n+1}
+    def test_sphere_S1(self):
+        self._check(tessera.SimplexBoundarySphere(1), [3, 3], 0, 1)
+
+    def test_sphere_S2(self):
+        self._check(tessera.SimplexBoundarySphere(2), [4, 6, 4], 2, 2)
+
+    def test_sphere_S3(self):
+        self._check(tessera.SimplexBoundarySphere(3), [5, 10, 10, 5], 0, 3)
+
+    def test_sphere_S4(self):
+        self._check(tessera.SimplexBoundarySphere(4), [6, 15, 20, 15, 6], 2, 4)
+
+    # Solid simplices Δ^n (closed n-balls)
+    def test_ball_D2(self):
+        self._check(tessera.SolidSimplex(2), [3, 3, 1], 1, 2)
+
+    def test_ball_D4(self):
+        self._check(tessera.SolidSimplex(4), [5, 10, 10, 5, 1], 1, 4)
+
+    # ℝP² minimal 6-vertex
+    def test_rp2(self):
+        self._check(tessera.RealProjectivePlane(), [6, 15, 10], 1, 2)
+
+    def test_fixtures_are_pre_geometric(self):
+        # Vertices carry no coordinates until geometry is needed.
+        st = _build(tessera.SimplexBoundarySphere(2))
+        v = st.getVertexList().toVector()[0]
+        with self.assertRaises(Exception):
+            v.getCoordinates()  # coordinate-free vertex
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #63 (epic #71). Off `main`.

## What

Adds the first cobordism fixtures as exact, minimal triangulations — implemented as **`Topology` subclasses** alongside `Sphere`/`Toroid`/`Cylinder`, so they're part of the existing topology hierarchy rather than a parallel factory:

- **`SimplexBoundarySphere(n)`** — `S^n = ∂Δ^{n+1}` (minimal n-sphere, n+2 vertices)
- **`SolidSimplex(n)`** — solid `Δ^n` (closed n-ball; `∂ = S^{n-1}`)
- **`RealProjectivePlane`** — minimal 6-vertex `ℝP²` (hemi-icosahedron; non-orientable)

Construction is shared by a new protected `Topology::buildExplicit()` that builds a complex from a combinatorial description. Unlike the CDT topologies, these build a fixed triangulation and **ignore `numSimplices`**.

## Pre-geometric / coordinate-free

`buildExplicit` creates **coordinate-free vertices** (`createVertex(id)`, no coords) — the cobordism capabilities (homology, characteristic numbers, cobordism existence) are purely combinatorial, so geometry (coordinates / edge lengths) is layered on only when a geometric capability (reconstruction, Regge) actually needs it. A test asserts fixture vertices have no coordinates.

## Tests

`tests/cobordism/test_fixtures_python.py` verifies each fixture's f-vector and Euler characteristic by counting distinct k-faces combinatorially from the top simplices, and that `CombinatorialDimension` matches the top dimension:

| fixture | f-vector | χ |
|---|---|---|
| S¹..S⁴ | (3,3) … (6,15,20,15,6) | 0/2 |
| Δ²,Δ⁴ | (3,3,1), (5,10,10,5,1) | 1 |
| ℝP² | (6,15,10) | 1 |

11 cobordism tests pass; full non-slow suite (436) green.

## Deferred (follow-up within #63)

Fixtures that need sourced triangulations and/or the homology capabilities to validate are added alongside #64/#65 rather than fabricated now: Kühnel `ℂP²` (+ reverse), `S²×S²`, `T²`, Klein bottle, `T³`, `ℝP³`, the Poincaré homology sphere, and the hand-built cobordism fixtures (cylinders, pair-of-pants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)