### PR TITLE
Fix #77: createSimplex rejects >kMax-vertex simplices instead of silently dropping

### DIFF
--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -29,6 +29,8 @@
 #include <memory>
 #include <queue>
 #include <set>
+#include <stdexcept>
+#include <string>
 #include "spacetime/Spacetime.h"
 #include "graph/CSRBuilder.hpp"
 #include "graph/DualGraph.hpp"
@@ -93,6 +95,20 @@ std::pair<SimplexPtr, bool> Spacetime::createSimplex(
   const VertexPtrs &vertices,
   const Edges &edges
 ) {
+  // A Simplex's identity is its Fingerprint, which stores at most kMax vertex
+  // IDs (mesh/Fingerprint.h). Past that, addId() silently drops IDs, so two
+  // distinct >kMax-vertex simplices can share a (truncated) fingerprint and the
+  // second is silently treated as a duplicate — never registered, but returned
+  // with created=true. Fail loudly instead of corrupting the complex (issue
+  // #77). kMax = 8 supports simplices up to dimension 7, well beyond CDT (≤5
+  // vertices) and the cobordism extension (≤6).
+  if (vertices.size() > kMax) {
+    throw std::invalid_argument(
+        "Spacetime::createSimplex: " + std::to_string(vertices.size()) +
+        "-vertex simplex exceeds the Fingerprint capacity kMax=" +
+        std::to_string(kMax) + " (max simplex dimension " +
+        std::to_string(kMax - 1) + "). See issue #77.");
+  }
   // Compute hash directly without allocating a temporary Fingerprint.
   std::uint64_t hash = 0;
   for (const auto &v : vertices) {

--- a/tests/test_spacetime.py
+++ b/tests/test_spacetime.py
@@ -309,5 +309,51 @@ class TestExternalSimplicesNonCDT(unittest.TestCase):
                          "each remaining triangle should touch the new boundary")
 
 
+class TestCreateSimplexVertexCap(unittest.TestCase):
+    """createSimplex must reject simplices beyond the Fingerprint capacity.
+
+    The Fingerprint stores at most kMax = 8 vertex IDs; past that it truncates,
+    so a >8-vertex simplex would collide with another and be silently dropped
+    (returned created=true but never registered). createSimplex now raises
+    instead of corrupting the complex (issue #77).
+    """
+
+    KMAX = 8  # mesh/Fingerprint.h
+
+    def _verts(self, st, n):
+        return [st.createVertex(i) for i in range(n)]
+
+    def test_max_capacity_simplex_registers(self):
+        # A kMax-vertex simplex (dimension 7) is the largest that round-trips.
+        st = Spacetime()
+        s, created = st.createSimplex(self._verts(st, self.KMAX))
+        self.assertTrue(created)
+        self.assertEqual(len(s.getVertices()), self.KMAX)
+        self.assertIn(s, st.getSimplices())
+
+    def test_over_capacity_simplex_raises(self):
+        st = Spacetime()
+        verts = self._verts(st, self.KMAX + 1)  # 9 vertices
+        with self.assertRaises(Exception):
+            st.createSimplex(verts)
+
+    def test_no_silent_drop_for_S8(self):
+        # S^8 = ∂Δ^9 has ten 8-simplices (9 vertices each). Previously only 9 of
+        # the 10 registered silently; now each over-capacity create raises, so
+        # the complex is never partially built behind the caller's back.
+        st = Spacetime()
+        V = self._verts(st, 10)
+        raised = 0
+        for omit in range(10):
+            verts = [V[i] for i in range(10) if i != omit]  # 9 vertices
+            try:
+                st.createSimplex(verts)
+            except Exception:
+                raised += 1
+        self.assertEqual(raised, 10)
+        self.assertEqual(len([s for s in st.getSimplices()
+                              if len(s.getVertices()) == 9]), 0)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #77.

## Bug

A `Simplex`'s identity is its `Fingerprint`, which stores at most `kMax = 8` vertex IDs (`mesh/Fingerprint.h`); `Fingerprint::addId` silently ignores IDs past `kMax`. Two distinct >8-vertex simplices sharing their first 8 recorded vertices therefore collide on a truncated fingerprint, and `registerSimplex` treats the second as a duplicate — returning `created=true` while **never adding it to `simplicesVec`**. Building `S⁸ = ∂Δ⁹` (ten 8-simplices, 9 vertices each) registered only 9 of 10.

There was also a latent inconsistency: `createSimplex` computed its dedup lookup hash by mixing **all** vertex IDs, while the `Fingerprint` it's compared against truncates at 8.

## Fix

`createSimplex(vertices, edges)` — the funnel for every simplex-creation path (`createSimplex(vertices)`, `(tuple)`, `(k)`, and `Simplex::getFacets`) — now throws `std::invalid_argument` when `vertices.size() > kMax`, naming the cap and the issue. For in-range inputs the lookup hash and the fingerprint always agree, so the inconsistency is moot.

`kMax = 8` supports simplices up to **dimension 7** — well beyond CDT (≤5 vertices) and the cobordism extension (≤6) — so no existing usage is affected; the change only makes the limit **loud rather than silent**.

> Supporting larger simplices (raising `kMax`, or an inline-then-spill ID store) is a separate enhancement to weigh against per-simplex memory on CDT hot paths (`kMax` was deliberately reduced 64→8 to save ~214 MB at 500k simplices). Happy to do it if you want triangulations past dimension 7 — say the word.

## Tests

`tests/test_spacetime.py::TestCreateSimplexVertexCap`:
- a `kMax`-vertex simplex registers (largest that round-trips);
- a `(kMax+1)`-vertex simplex raises;
- the `S⁸` reproduction raises on every over-capacity create and leaves no 9-vertex simplices registered.

Green: `test_spacetime` (incl. new cap tests), `test_simplex`/`cdt`/`pachner`/`build` (68), cobordism suite (11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)