### PR TITLE
cobordism: Capability C — cobordism verification, boundary structure (#66)

### DIFF
--- a/include/cobordism/Cobordism.h
+++ b/include/cobordism/Cobordism.h
@@ -1,0 +1,102 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_COBORDISM_H
+#define TESSERA_COBORDISM_COBORDISM_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// A list of simplices given by their sorted vertex-id tuples.
+using SimplexList = std::vector<std::vector<std::uint64_t>>;
+
+/// Outcome code for a cobordism-verification check.
+enum class CobordismCheck {
+  Ok,                              ///< W is a valid cobordism from M1 to M2.
+  BoundaryChainNotClosed,          ///< the boundary-of-a-boundary is not zero (a malformed complex)
+  WrongNumberOfBoundaryComponents, ///< the boundary doesn't split into the right number of pieces
+  BoundaryNotIsomorphic,           ///< a boundary piece does not match M1 or M2 as a triangulation
+};
+
+/// Result of verifying a cobordism: whether it passed, a machine-readable code,
+/// and a human-readable explanation when it failed.
+struct CobordismResult {
+  bool ok{false};
+  CobordismCheck code{CobordismCheck::Ok};
+  std::string detail{};
+};
+
+/// # Cobordism verification
+///
+/// A *cobordism* from one manifold \f$ M_1 \f$ to another \f$ M_2 \f$ is a
+/// higher-dimensional manifold \f$ W \f$ whose boundary is exactly the two of
+/// them placed side by side (\f$ \partial W = M_1 \sqcup M_2 \f$). For example
+/// a solid cylinder is a cobordism from a circle to a circle, and a solid disk
+/// is a cobordism from a circle to "nothing" (the empty manifold).
+///
+/// This class checks whether a given \f$ W \f$ really is such a cobordism. It
+/// is a static-only utility (no state) operating on triangulations
+/// (`Spacetime`s). This first version checks the **boundary structure**: that
+/// the boundary of \f$ W \f$ breaks into connected pieces that match
+/// \f$ M_1 \f$ and \f$ M_2 \f$ as triangulations, plus the basic
+/// chain-complex sanity check that the boundary of the boundary is empty.
+/// The two further checks the full specification calls for — that \f$ W \f$ is
+/// a genuine manifold (every vertex's neighborhood looks like a ball or sphere)
+/// and that the boundary's orientation is consistent — are separate follow-ups.
+class Cobordism {
+  public:
+    Cobordism() = delete;
+
+    /// The boundary of \f$ W \f$: the codimension-one faces (one dimension below
+    /// the top simplices) that belong to exactly one top simplex. Returned as
+    /// sorted vertex-id tuples. An interior face belongs to two top simplices
+    /// and is excluded; a boundary face belongs to just one.
+    [[nodiscard]] static SimplexList boundaryFaces(const Spacetime &W);
+
+    /// Split a list of same-dimensional simplices into connected pieces. Two
+    /// simplices are in the same piece when they share a codimension-one face
+    /// (i.e. they are glued along a common facet), extended transitively.
+    [[nodiscard]] static std::vector<SimplexList> connectedComponents(
+        const SimplexList &simplices);
+
+    /// True when two triangulations, each given as a list of top-simplex vertex
+    /// tuples, are isomorphic — i.e. some relabeling of the vertices of one
+    /// turns its simplex set into the other's.
+    [[nodiscard]] static bool areIsomorphic(const SimplexList &a, const SimplexList &b);
+
+    /// Verify that \f$ W \f$ is a cobordism from \f$ M_1 \f$ to \f$ M_2 \f$:
+    /// its boundary splits into connected pieces that are, up to relabeling, the
+    /// triangulations \f$ M_1 \f$ and \f$ M_2 \f$ (either of which may be the
+    /// empty manifold). Also checks the boundary-of-a-boundary is empty.
+    [[nodiscard]] static CobordismResult verify(const Spacetime &W,
+                                                const Spacetime &M1,
+                                                const Spacetime &M2);
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_COBORDISM_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -29,6 +29,7 @@
 
 #include "cobordism/ChainComplex.h"
 #include "cobordism/Characteristic.h"
+#include "cobordism/Cobordism.h"
 #include "cobordism/CombinatorialDimension.h"
 #include "cobordism/IntegerLinalg.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
@@ -147,4 +148,37 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
       .def_static("of", &CharacteristicNumbers::of, py::arg("spacetime"),
                   py::arg("oriented") = true,
                   "Compute the characteristic numbers of the given manifold.");
+
+  // ----- Capability C (#66): cobordism verification (boundary structure) -----
+  py::enum_<CobordismCheck>(m, "CobordismCheck")
+      .value("Ok", CobordismCheck::Ok)
+      .value("BoundaryChainNotClosed", CobordismCheck::BoundaryChainNotClosed)
+      .value("WrongNumberOfBoundaryComponents",
+             CobordismCheck::WrongNumberOfBoundaryComponents)
+      .value("BoundaryNotIsomorphic", CobordismCheck::BoundaryNotIsomorphic);
+
+  py::class_<CobordismResult>(m, "CobordismResult",
+      "Result of verifying a cobordism: ok flag, machine-readable code, and a "
+      "human-readable detail string.")
+      .def_readonly("ok", &CobordismResult::ok)
+      .def_readonly("code", &CobordismResult::code)
+      .def_readonly("detail", &CobordismResult::detail);
+
+  py::class_<Cobordism>(m, "Cobordism",
+      "Cobordism verification (static-only): does a triangulation W have "
+      "boundary equal to M1 disjoint-union M2? Checks the boundary structure "
+      "and that the boundary is itself closed.")
+      .def_static("boundaryFaces", &Cobordism::boundaryFaces, py::arg("W"),
+                  "Codimension-one faces of W belonging to exactly one top "
+                  "simplex (the boundary), as sorted vertex-id tuples.")
+      .def_static("connectedComponents", &Cobordism::connectedComponents,
+                  py::arg("simplices"),
+                  "Split same-dimensional simplices into facet-connected pieces.")
+      .def_static("areIsomorphic", &Cobordism::areIsomorphic, py::arg("a"),
+                  py::arg("b"),
+                  "Whether two triangulations (lists of top-simplex vertex "
+                  "tuples) are isomorphic under a vertex relabeling.")
+      .def_static("verify", &Cobordism::verify, py::arg("W"), py::arg("M1"),
+                  py::arg("M2"),
+                  "Verify W is a cobordism from M1 to M2 (boundary structure).");
 }

--- a/src/cobordism/Cobordism.cpp
+++ b/src/cobordism/Cobordism.cpp
@@ -1,0 +1,280 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/Cobordism.h"
+
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <numeric>
+#include <set>
+#include <string>
+#include <unordered_map>
+
+#include "mesh/Simplex.h"
+#include "mesh/Vertex.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+namespace {
+
+using Face = std::vector<std::uint64_t>;
+
+// Top simplices of a triangulation, as sorted vertex-id tuples. "Top" means
+// maximal dimension (largest vertex count present).
+SimplexList topSimplices(const Spacetime &complex) {
+  SimplexList all;
+  std::size_t topVertexCount = 0;
+  for (const auto &simplex : complex.getSimplices()) {
+    Face vertices;
+    for (const auto &v : simplex->getVertices()) vertices.push_back(v->getId());
+    std::sort(vertices.begin(), vertices.end());
+    topVertexCount = std::max(topVertexCount, vertices.size());
+    all.push_back(std::move(vertices));
+  }
+  SimplexList tops;
+  for (auto &s : all)
+    if (s.size() == topVertexCount) tops.push_back(std::move(s));
+  return tops;
+}
+
+// All cardinality-(k) sub-faces of a sorted vertex tuple.
+std::vector<Face> subfaces(const Face &simplex, std::size_t faceVertexCount) {
+  std::vector<Face> faces;
+  const std::size_t n = simplex.size();
+  if (faceVertexCount > n) return faces;
+  std::vector<std::size_t> idx(faceVertexCount);
+  std::iota(idx.begin(), idx.end(), 0);
+  for (;;) {
+    Face face;
+    face.reserve(faceVertexCount);
+    for (auto i : idx) face.push_back(simplex[i]);
+    faces.push_back(std::move(face));
+    std::size_t pos = faceVertexCount;
+    while (pos > 0) {
+      --pos;
+      if (idx[pos] != pos + n - faceVertexCount) {
+        ++idx[pos];
+        for (std::size_t j = pos + 1; j < faceVertexCount; ++j) idx[j] = idx[j - 1] + 1;
+        break;
+      }
+      if (pos == 0) { pos = faceVertexCount + 1; break; }
+    }
+    if (pos == faceVertexCount + 1) break;
+  }
+  return faces;
+}
+
+// Relabel a simplex list's vertices to a dense range 0..(numVertices-1) and
+// return the relabeled top-simplex set (sorted tuples) plus the vertex count.
+struct Normalized {
+  int numVertices{0};
+  std::set<std::vector<int>> simplices{};
+  int faceVertexCount{0};
+};
+Normalized normalize(const SimplexList &simplices) {
+  std::set<std::uint64_t> verts;
+  for (const auto &s : simplices)
+    for (auto v : s) verts.insert(v);
+  std::unordered_map<std::uint64_t, int> dense;
+  int next = 0;
+  for (auto v : verts) dense[v] = next++;
+  Normalized out;
+  out.numVertices = next;
+  for (const auto &s : simplices) {
+    std::vector<int> relabeled;
+    relabeled.reserve(s.size());
+    for (auto v : s) relabeled.push_back(dense.at(v));
+    std::sort(relabeled.begin(), relabeled.end());
+    out.faceVertexCount = static_cast<int>(relabeled.size());
+    out.simplices.insert(std::move(relabeled));
+  }
+  return out;
+}
+
+}  // namespace
+
+SimplexList Cobordism::boundaryFaces(const Spacetime &W) {
+  const SimplexList tops = topSimplices(W);
+  if (tops.empty()) return {};
+  const std::size_t topVertexCount = tops.front().size();
+  // Count how many top simplices each codimension-one face belongs to.
+  std::map<Face, int> incidence;
+  for (const auto &top : tops)
+    for (auto &face : subfaces(top, topVertexCount - 1)) ++incidence[face];
+  SimplexList boundary;
+  for (auto &[face, count] : incidence)
+    if (count == 1) boundary.push_back(face);
+  return boundary;
+}
+
+std::vector<SimplexList> Cobordism::connectedComponents(const SimplexList &simplices) {
+  const int n = static_cast<int>(simplices.size());
+  std::vector<int> parent(n);
+  std::iota(parent.begin(), parent.end(), 0);
+  std::function<int(int)> find = [&](int x) {
+    while (parent[x] != x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+    return x;
+  };
+  auto unite = [&](int a, int b) { parent[find(a)] = find(b); };
+
+  // Two simplices are adjacent when they share a codimension-one facet.
+  if (n > 0) {
+    const std::size_t faceVertexCount = simplices.front().size();
+    std::map<Face, int> firstOwner;  // facet -> a simplex index that has it
+    for (int i = 0; i < n; ++i)
+      for (auto &facet : subfaces(simplices[i], faceVertexCount - 1)) {
+        auto it = firstOwner.find(facet);
+        if (it == firstOwner.end()) firstOwner[facet] = i;
+        else unite(i, it->second);
+      }
+  }
+  std::map<int, SimplexList> groups;
+  for (int i = 0; i < n; ++i) groups[find(i)].push_back(simplices[i]);
+  std::vector<SimplexList> components;
+  for (auto &[root, members] : groups) components.push_back(std::move(members));
+  return components;
+}
+
+bool Cobordism::areIsomorphic(const SimplexList &a, const SimplexList &b) {
+  const Normalized A = normalize(a);
+  const Normalized B = normalize(b);
+  if (A.numVertices != B.numVertices) return false;
+  if (A.simplices.size() != B.simplices.size()) return false;
+  if (A.faceVertexCount != B.faceVertexCount) return false;
+  if (A.numVertices == 0) return true;  // both empty
+
+  const int nv = A.numVertices;
+  // Per-vertex degree = number of top simplices containing it.
+  auto degrees = [nv](const Normalized &x) {
+    std::vector<int> deg(nv, 0);
+    for (const auto &s : x.simplices)
+      for (int v : s) ++deg[v];
+    return deg;
+  };
+  const std::vector<int> degA = degrees(A);
+  const std::vector<int> degB = degrees(B);
+  {
+    std::vector<int> sa = degA, sb = degB;
+    std::sort(sa.begin(), sa.end());
+    std::sort(sb.begin(), sb.end());
+    if (sa != sb) return false;
+  }
+
+  // Which A-simplices contain each A-vertex (for incremental constraint checks).
+  std::vector<std::vector<const std::vector<int> *>> aSimplicesOf(nv);
+  for (const auto &s : A.simplices)
+    for (int v : s) aSimplicesOf[v].push_back(&s);
+
+  // Assign A-vertices (most-constrained first: highest degree) to B-vertices.
+  std::vector<int> order(nv);
+  std::iota(order.begin(), order.end(), 0);
+  std::sort(order.begin(), order.end(), [&](int x, int y) { return degA[x] > degA[y]; });
+
+  std::vector<int> mapAtoB(nv, -1);
+  std::vector<char> usedB(nv, 0);
+
+  std::function<bool(int)> backtrack = [&](int pos) -> bool {
+    if (pos == nv) return true;
+    const int u = order[pos];
+    for (int w = 0; w < nv; ++w) {
+      if (usedB[w] || degB[w] != degA[u]) continue;
+      mapAtoB[u] = w;
+      usedB[w] = 1;
+      bool consistent = true;
+      // Every A-simplex through u whose vertices are all assigned must map to a
+      // B-simplex.
+      for (const auto *simplex : aSimplicesOf[u]) {
+        std::vector<int> image;
+        image.reserve(simplex->size());
+        bool fullyAssigned = true;
+        for (int v : *simplex) {
+          if (mapAtoB[v] < 0) { fullyAssigned = false; break; }
+          image.push_back(mapAtoB[v]);
+        }
+        if (!fullyAssigned) continue;
+        std::sort(image.begin(), image.end());
+        if (!B.simplices.count(image)) { consistent = false; break; }
+      }
+      if (consistent && backtrack(pos + 1)) return true;
+      mapAtoB[u] = -1;
+      usedB[w] = 0;
+    }
+    return false;
+  };
+  return backtrack(0);
+}
+
+CobordismResult Cobordism::verify(const Spacetime &W, const Spacetime &M1,
+                                  const Spacetime &M2) {
+  const SimplexList boundary = boundaryFaces(W);
+  const std::vector<SimplexList> components = connectedComponents(boundary);
+
+  // The boundary of a manifold-with-boundary is itself closed: every
+  // codimension-one face of the boundary complex must belong to exactly two
+  // boundary simplices (boundary-of-boundary is empty).
+  if (!boundary.empty()) {
+    const std::size_t faceVertexCount = boundary.front().size();
+    if (faceVertexCount >= 1) {
+      std::map<Face, int> incidence;
+      for (const auto &simplex : boundary)
+        for (auto &facet : subfaces(simplex, faceVertexCount - 1)) ++incidence[facet];
+      for (auto &[facet, count] : incidence)
+        if (count != 2)
+          return {false, CobordismCheck::BoundaryChainNotClosed,
+                  "boundary is not a closed manifold (a codimension-one face of "
+                  "the boundary belongs to " + std::to_string(count) +
+                  " boundary simplices, expected 2)"};
+    }
+  }
+
+  // The expected boundary pieces are the non-empty manifolds among {M1, M2}.
+  std::vector<SimplexList> expected;
+  if (auto t = topSimplices(M1); !t.empty()) expected.push_back(std::move(t));
+  if (auto t = topSimplices(M2); !t.empty()) expected.push_back(std::move(t));
+
+  if (components.size() != expected.size())
+    return {false, CobordismCheck::WrongNumberOfBoundaryComponents,
+            "boundary has " + std::to_string(components.size()) +
+            " connected component(s), but M1 ⊔ M2 has " +
+            std::to_string(expected.size()) + " non-empty manifold(s)"};
+
+  // Match boundary components to the expected manifolds (each used once).
+  std::vector<char> expectedUsed(expected.size(), 0);
+  for (const auto &component : components) {
+    bool matched = false;
+    for (std::size_t e = 0; e < expected.size(); ++e) {
+      if (expectedUsed[e]) continue;
+      if (areIsomorphic(component, expected[e])) {
+        expectedUsed[e] = 1;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched)
+      return {false, CobordismCheck::BoundaryNotIsomorphic,
+              "a boundary component is not isomorphic to M1 or M2"};
+  }
+  return {true, CobordismCheck::Ok, "valid cobordism (boundary structure)"};
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_cobordism_verify_python.py
+++ b/tests/cobordism/test_cobordism_verify_python.py
@@ -1,0 +1,172 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Capability C: cobordism verification, boundary-structure increment (#66).
+
+A cobordism from M1 to M2 is a manifold W whose boundary is exactly M1 and M2
+side by side. We verify the boundary structure: that the boundary of W splits
+into connected pieces matching M1 and M2 as triangulations, and that the
+boundary is itself closed. Fixtures are built from solid simplices (balls) and
+simplicial products with an interval (cylinders M x I) / a ball (null-bordisms
+M x D^k). The PL-manifold link check and the orientation check are follow-ups.
+"""
+
+import unittest
+
+import tessera
+
+cobordism = tessera.cobordism
+
+
+def _build(topology):
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()
+    return spacetime
+
+
+def _empty():
+    return tessera.Spacetime()
+
+
+def _sphere(n):
+    return _build(tessera.SimplexBoundarySphere(n))
+
+
+def _interval():
+    return tessera.SolidSimplex(1)  # a single edge = the interval [0, 1]
+
+
+def _cylinder(sphere_dim):
+    # M x I, a cobordism from M to M.
+    return _build(tessera.SimplicialProduct(
+        tessera.SimplexBoundarySphere(sphere_dim), _interval()))
+
+
+Ok = cobordism.CobordismCheck.Ok
+
+
+class TestBoundaryFaces(unittest.TestCase):
+
+    def test_ball_boundary_is_a_sphere(self):
+        # The boundary of the solid n-simplex is its n+1 facets = S^{n-1}.
+        for n in range(2, 6):
+            with self.subTest(ball=n):
+                faces = cobordism.Cobordism.boundaryFaces(_build(tessera.SolidSimplex(n)))
+                self.assertEqual(len(faces), n + 1)
+
+    def test_closed_manifold_has_no_boundary(self):
+        for topology in (tessera.SimplexBoundarySphere(2),
+                         tessera.SimplexBoundarySphere(4),
+                         tessera.RealProjectivePlane()):
+            with self.subTest(manifold=type(topology).__name__):
+                self.assertEqual(cobordism.Cobordism.boundaryFaces(_build(topology)), [])
+
+    def test_cylinder_boundary_has_two_components(self):
+        faces = cobordism.Cobordism.boundaryFaces(_cylinder(2))
+        comps = cobordism.Cobordism.connectedComponents(faces)
+        self.assertEqual(len(comps), 2)
+
+
+class TestIsomorphism(unittest.TestCase):
+
+    def test_same_sphere_is_isomorphic(self):
+        s2a = cobordism.Cobordism.boundaryFaces(_build(tessera.SolidSimplex(3)))  # S^2
+        s2b = cobordism.Cobordism.boundaryFaces(_build(tessera.SolidSimplex(3)))
+        self.assertTrue(cobordism.Cobordism.areIsomorphic(s2a, s2b))
+
+    def test_relabeled_is_isomorphic(self):
+        a = [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]   # boundary of a tetra
+        b = [[10, 11, 12], [10, 11, 13], [10, 12, 13], [11, 12, 13]]
+        self.assertTrue(cobordism.Cobordism.areIsomorphic(a, b))
+
+    def test_different_spheres_not_isomorphic(self):
+        s2 = cobordism.Cobordism.boundaryFaces(_build(tessera.SolidSimplex(3)))   # S^2
+        s3 = cobordism.Cobordism.boundaryFaces(_build(tessera.SolidSimplex(4)))   # S^3
+        self.assertFalse(cobordism.Cobordism.areIsomorphic(s2, s3))
+
+    def test_empty_lists_are_isomorphic(self):
+        self.assertTrue(cobordism.Cobordism.areIsomorphic([], []))
+
+
+class TestVerifyValidCobordisms(unittest.TestCase):
+
+    def test_ball_caps_sphere(self):
+        # Solid n-simplex is a cobordism S^{n-1} -> empty (T0.2 / T3.1).
+        for n in range(2, 5):
+            with self.subTest(ball=n):
+                result = cobordism.Cobordism.verify(
+                    _build(tessera.SolidSimplex(n)),
+                    _sphere(n - 1), _empty())
+                self.assertTrue(result.ok, result.detail)
+                self.assertEqual(result.code, Ok)
+
+    def test_cylinders(self):
+        # M x I is a cobordism M -> M (T0.1, T0.4).
+        for dim in (1, 2):
+            with self.subTest(sphere=dim):
+                result = cobordism.Cobordism.verify(
+                    _cylinder(dim), _sphere(dim), _sphere(dim))
+                self.assertTrue(result.ok, result.detail)
+
+    def test_s1_cross_s2_null_bordism(self):
+        # S^1 x D^3 is a manifold whose boundary is S^1 x S^2: a cobordism
+        # S^1 x S^2 -> empty (T3.2 — S^1 x S^2 bounds).
+        w = _build(tessera.SimplicialProduct(tessera.SimplexBoundarySphere(1),
+                                             tessera.SolidSimplex(3)))
+        boundary = tessera.SimplicialProduct(tessera.SimplexBoundarySphere(1),
+                                             tessera.SimplexBoundarySphere(2))
+        result = cobordism.Cobordism.verify(w, _build(boundary), _empty())
+        self.assertTrue(result.ok, result.detail)
+
+    def test_empty_to_empty(self):
+        result = cobordism.Cobordism.verify(_empty(), _empty(), _empty())
+        self.assertTrue(result.ok, result.detail)
+
+
+class TestVerifyRejections(unittest.TestCase):
+
+    def test_wrong_boundary_manifold(self):
+        # Delta^4's boundary is S^3, not S^2.
+        result = cobordism.Cobordism.verify(
+            _build(tessera.SolidSimplex(4)), _sphere(2), _empty())
+        self.assertFalse(result.ok)
+        self.assertEqual(result.code, cobordism.CobordismCheck.BoundaryNotIsomorphic)
+
+    def test_wrong_number_of_components(self):
+        # A cylinder has two boundary circles/spheres, not one.
+        result = cobordism.Cobordism.verify(_cylinder(2), _sphere(2), _empty())
+        self.assertFalse(result.ok)
+        self.assertEqual(result.code,
+                         cobordism.CobordismCheck.WrongNumberOfBoundaryComponents)
+
+    def test_closed_manifold_is_not_a_cobordism_with_boundary(self):
+        # A closed 4-sphere has empty boundary; claiming it bounds S^3 fails.
+        result = cobordism.Cobordism.verify(_sphere(4), _sphere(3), _empty())
+        self.assertFalse(result.ok)
+        self.assertEqual(result.code,
+                         cobordism.CobordismCheck.WrongNumberOfBoundaryComponents)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First increment of #66 (epic #71): cobordism **verification** — does a triangulation `W` have boundary equal to `M1` disjoint-union `M2`?

## What

A static-only `Cobordism` class (per the subsystem convention), operating on `Spacetime`s:

- **`boundaryFaces(W)`** — the codimension-one faces belonging to exactly one top simplex (the boundary).
- **`connectedComponents(...)`** — facet-adjacency union-find, splitting the boundary into pieces.
- **`areIsomorphic(a, b)`** — simplicial isomorphism via a degree-pruned, most-constrained-first backtracking vertex bijection, so a boundary piece matches `M1`/`M2` regardless of vertex labels.
- **`verify(W, M1, M2)`** — matches the boundary components to the non-empty manifolds among `{M1, M2}` (either may be empty) and checks the boundary is itself **closed** (every codim-one face of the boundary is shared by exactly two boundary simplices — boundary-of-boundary is empty). Returns a `CobordismResult` (`ok`, machine code, human-readable `detail`).

Cobordism fixtures reuse the existing topologies: solid simplices (balls `Dⁿ`, boundary `Sⁿ⁻¹`) and simplicial products `M×I` (cylinders) / `M×Dᵏ` (null-bordisms).

## Tests (14)
- `Dⁿ` caps `Sⁿ⁻¹` (**T0.2 / T3.1**); cylinders `S¹→S¹`, `S²→S²` (**T0.1 / T0.4**); `S¹×D³` is a null-bordism of `S¹×S²` (**T3.2**, "S¹×S² bounds"); `∅→∅` (**T10.3**).
- boundary extraction / components / isomorphism units; rejections (wrong boundary manifold → `BoundaryNotIsomorphic`; wrong component count; closed manifold isn't a cobordism-with-boundary).

Full cobordism suite (55 tests / 135 subtests) green; core regression green.

## Scope / follow-ups
This is the **boundary-structure** half of Capability C (spec C2 + the boundary-closed part of C4). The **PL-manifold link check** (C1, e.g. T10.2 cone-on-a-torus) and the **orientation** check (C3) are separate follow-ups, as is the signature-distinguished **double-filling** (T5.1), which additionally needs the Kühnel `ℂP²` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)