### PR TITLE
cobordism: broaden Capability C verification tests (#66)

### DIFF
--- a/tests/cobordism/test_cobordism_verify_python.py
+++ b/tests/cobordism/test_cobordism_verify_python.py
@@ -63,6 +63,27 @@ def _cylinder(sphere_dim):
         tessera.SimplexBoundarySphere(sphere_dim), _interval()))
 
 
+def _product(*topologies):
+    """Left-nested SimplicialProduct of two or more factor topologies."""
+    result = topologies[0]
+    for factor in topologies[1:]:
+        result = tessera.SimplicialProduct(result, factor)
+    return result
+
+
+def _from_simplices(num_vertices, simplices):
+    """Build a Spacetime directly from explicit top-simplex vertex tuples
+    (vertices 0..num_vertices-1), for hand-crafted / pathological complexes."""
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, tessera.Toroid())
+    verts = [spacetime.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        spacetime.createSimplex([verts[i] for i in simplex])
+    return spacetime
+
+
 Ok = cobordism.CobordismCheck.Ok
 
 
@@ -166,6 +187,153 @@ class TestVerifyRejections(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertEqual(result.code,
                          cobordism.CobordismCheck.WrongNumberOfBoundaryComponents)
+
+    def test_book_of_three_triangles_has_non_closed_boundary(self):
+        # Three triangles sharing the edge {1,2} — a non-manifold "book". Its
+        # boundary edges meet 3-to-a-vertex at 1 and 2, so the boundary is not a
+        # closed manifold.
+        book = _from_simplices(5, [(0, 1, 2), (1, 2, 3), (1, 2, 4)])
+        result = cobordism.Cobordism.verify(book, _empty(), _empty())
+        self.assertFalse(result.ok)
+        self.assertEqual(result.code,
+                         cobordism.CobordismCheck.BoundaryChainNotClosed)
+
+
+# A solid disk's boundary edges DO form a closed circle, by contrast.
+class TestBallCapsSweep(unittest.TestCase):
+
+    def test_solid_simplex_caps_its_boundary_sphere(self):
+        # Delta^n is a cobordism S^{n-1} -> empty for a range of n.
+        for n in range(2, 7):
+            with self.subTest(ball=n):
+                result = cobordism.Cobordism.verify(
+                    _build(tessera.SolidSimplex(n)), _sphere(n - 1), _empty())
+                self.assertTrue(result.ok, f"Delta^{n}: {result.detail}")
+                self.assertEqual(result.code, Ok)
+
+
+class TestCylinderSweep(unittest.TestCase):
+
+    def test_sphere_cylinders(self):
+        # S^n x I is a cobordism S^n -> S^n.
+        for n in (1, 2, 3):
+            with self.subTest(sphere=n):
+                result = cobordism.Cobordism.verify(
+                    _cylinder(n), _sphere(n), _sphere(n))
+                self.assertTrue(result.ok, result.detail)
+
+    def test_real_projective_plane_cylinder(self):
+        # RP^2 x I is a (non-orientable) cobordism RP^2 -> RP^2.
+        rp2 = tessera.RealProjectivePlane()
+        w = _build(tessera.SimplicialProduct(rp2, _interval()))
+        result = cobordism.Cobordism.verify(w, _build(rp2), _build(rp2))
+        self.assertTrue(result.ok, result.detail)
+
+
+class TestNullBordisms(unittest.TestCase):
+    """W = M x D^k has boundary M x S^{k-1}, exhibiting M x S^{k-1} as bounding."""
+
+    def test_solid_torus_bounds_torus(self):
+        # S^1 x D^2 (solid torus) -> T^2 = S^1 x S^1.
+        w = _build(_product(tessera.SimplexBoundarySphere(1), tessera.SolidSimplex(2)))
+        torus = _product(tessera.SimplexBoundarySphere(1), tessera.SimplexBoundarySphere(1))
+        result = cobordism.Cobordism.verify(w, _build(torus), _empty())
+        self.assertTrue(result.ok, result.detail)
+
+    def test_s1_cross_s2_bounds(self):
+        # S^1 x D^3 -> S^1 x S^2 (T3.2).
+        w = _build(_product(tessera.SimplexBoundarySphere(1), tessera.SolidSimplex(3)))
+        boundary = _product(tessera.SimplexBoundarySphere(1), tessera.SimplexBoundarySphere(2))
+        result = cobordism.Cobordism.verify(w, _build(boundary), _empty())
+        self.assertTrue(result.ok, result.detail)
+
+    def test_s2_cross_s1_bounds(self):
+        # S^2 x D^2 -> S^2 x S^1.
+        w = _build(_product(tessera.SimplexBoundarySphere(2), tessera.SolidSimplex(2)))
+        boundary = _product(tessera.SimplexBoundarySphere(2), tessera.SimplexBoundarySphere(1))
+        result = cobordism.Cobordism.verify(w, _build(boundary), _empty())
+        self.assertTrue(result.ok, result.detail)
+
+    def test_t3_bounds(self):
+        # T^2 x D^2 -> T^3 = T^2 x S^1 (T3.3 — the 3-torus bounds).
+        torus = _product(tessera.SimplexBoundarySphere(1), tessera.SimplexBoundarySphere(1))
+        w = _build(tessera.SimplicialProduct(torus, tessera.SolidSimplex(2)))
+        t3 = tessera.SimplicialProduct(torus, tessera.SimplexBoundarySphere(1))
+        result = cobordism.Cobordism.verify(w, _build(t3), _empty())
+        self.assertTrue(result.ok, result.detail)
+
+
+class TestM1M2Order(unittest.TestCase):
+    """verify() matches the boundary to the *set* {M1, M2}, so the order is
+    irrelevant and either may be empty."""
+
+    def test_cap_order_irrelevant(self):
+        d4 = tessera.SolidSimplex(4)
+        forward = cobordism.Cobordism.verify(_build(d4), _sphere(3), _empty())
+        reversed_ = cobordism.Cobordism.verify(_build(d4), _empty(), _sphere(3))
+        self.assertTrue(forward.ok and reversed_.ok)
+
+    def test_cylinder_symmetric(self):
+        cyl = _cylinder(2)
+        self.assertTrue(cobordism.Cobordism.verify(cyl, _sphere(2), _sphere(2)).ok)
+
+
+class TestConnectedComponentsUnit(unittest.TestCase):
+
+    def test_single_sphere_is_connected(self):
+        faces = cobordism.Cobordism.boundaryFaces(_build(tessera.SolidSimplex(4)))
+        self.assertEqual(len(cobordism.Cobordism.connectedComponents(faces)), 1)
+
+    def test_two_disjoint_triangles_are_two_components(self):
+        comps = cobordism.Cobordism.connectedComponents(
+            [[0, 1, 2], [3, 4, 5]])
+        self.assertEqual(len(comps), 2)
+
+    def test_two_triangles_sharing_an_edge_are_one_component(self):
+        comps = cobordism.Cobordism.connectedComponents(
+            [[0, 1, 2], [1, 2, 3]])
+        self.assertEqual(len(comps), 1)
+
+    def test_empty_has_no_components(self):
+        self.assertEqual(cobordism.Cobordism.connectedComponents([]), [])
+
+
+class TestIsomorphismExtended(unittest.TestCase):
+
+    def _boundary_of(self, topology):
+        return cobordism.Cobordism.boundaryFaces(_build(topology))
+
+    def test_relabeling_preserves_isomorphism(self):
+        a = [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]            # boundary tetra
+        b = [[5, 6, 7], [5, 6, 8], [5, 7, 8], [6, 7, 8]]            # relabeled
+        self.assertTrue(cobordism.Cobordism.areIsomorphic(a, b))
+
+    def test_different_vertex_counts_not_isomorphic(self):
+        triangle_cycle = [[0, 1], [1, 2], [0, 2]]                   # S^1 on 3 verts
+        square_cycle = [[0, 1], [1, 2], [2, 3], [0, 3]]             # S^1 on 4 verts
+        self.assertFalse(cobordism.Cobordism.areIsomorphic(triangle_cycle, square_cycle))
+
+    def test_sphere_not_isomorphic_to_torus(self):
+        s2 = self._boundary_of(tessera.SolidSimplex(3))             # S^2
+        torus = _product(tessera.SimplexBoundarySphere(1),
+                         tessera.SimplexBoundarySphere(1))
+        # Hold the Spacetime in a variable: the Simplex handles from
+        # getSimplices() point into its storage, so it must outlive their use.
+        torus_st = _build(torus)
+        torus_tops = [list(sorted(v.getId() for v in s.getVertices()))
+                      for s in torus_st.getSimplices()
+                      if len(s.getVertices()) == 3]
+        self.assertFalse(cobordism.Cobordism.areIsomorphic(s2, torus_tops))
+
+    def test_same_manifold_two_constructions_isomorphic(self):
+        # The boundary of Delta^4 and the minimal S^3 are both the 5-vertex S^3.
+        boundary_of_ball = self._boundary_of(tessera.SolidSimplex(4))
+        minimal_s3 = [list(t) for t in (
+            (0, 1, 2, 3), (0, 1, 2, 4), (0, 1, 3, 4), (0, 2, 3, 4), (1, 2, 3, 4))]
+        self.assertTrue(cobordism.Cobordism.areIsomorphic(boundary_of_ball, minimal_s3))
+
+    def test_one_empty_one_nonempty_not_isomorphic(self):
+        self.assertFalse(cobordism.Cobordism.areIsomorphic([], [[0, 1, 2]]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #82, as requested — substantially more tests for cobordism verification (14 → **33 tests / 143 subtests** across the cobordism suite).

## Added coverage

- **Ball-cap sweep**: solid simplex `Δⁿ` caps `Sⁿ⁻¹` for `n = 2..6`.
- **Cylinder sweep**: `S¹/S²/S³ × I` (`M → M`), plus the **non-orientable** `RP² × I`.
- **Null-bordisms** `W = M × Dᵏ` (boundary `M × Sᵏ⁻¹`): solid torus → `T²`; `S¹×D³ → S¹×S²` (**T3.2**); `S²×D² → S²×S¹`; `T²×D² → T³` (**T3.3** — the 3-torus bounds, and this exercises the isomorphism check on a 27-vertex boundary).
- **M1/M2 order symmetry** (matching is to the *set* `{M1, M2}`; either may be empty).
- **`connectedComponents` units**: one sphere; two disjoint triangles; two sharing an edge; empty.
- **`areIsomorphic` extended**: relabeling; mismatched vertex counts; `S²` vs `T²`; two different constructions of `S³` (`∂Δ⁴` vs the minimal 5-vertex `S³`); empty vs non-empty.
- **Non-manifold "book"** (three triangles sharing an edge) → `BoundaryChainNotClosed`, covering the last result code.

## Note (a binding sharp edge, not an engine change)

`getSimplices()` returns `Simplex` handles that point into the `Spacetime`'s storage, so the `Spacetime` must outlive their use. One test holds it in a variable rather than iterating `_build(...).getSimplices()` on a temporary — the latter lets the `Spacetime` be destroyed immediately after the call, dangling the handles (it segfaulted before I fixed it). Worth a follow-up to add a `keep_alive` on that binding so the footgun can't bite; flagging rather than bundling.

Full cobordism suite (74 tests / 143 subtests) green; regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)