### PR TITLE
Fix use-after-free: keep Spacetime alive behind its simplex/vertex handles

### DIFF
--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -310,9 +310,28 @@ probability. Sits next to ``modularityOnSkeleton``.
 Uses the topology's builder (e.g. Toroid staircase triangulation) to
 create the initial simplicial complex.  The actual number of simplices
 may differ slightly due to slab quantization.)doc")
-      .def("getSimplices", &Spacetime::getSimplices, py::return_value_policy::copy,
+      // The returned Simplex handles point into this Spacetime's storage, so
+      // each one must keep the Spacetime alive — otherwise
+      // `Spacetime(...).getSimplices()` on a temporary frees the storage before
+      // the handles are used (a use-after-free / segfault). A blanket
+      // keep_alive on the result list does not work (a Python list cannot be a
+      // keep-alive target), so we cast each element with reference_internal,
+      // which ties its lifetime to the Spacetime (self).
+      .def("getSimplices",
+           [](py::object self) {
+             py::list out;
+             for (const auto &s : py::cast<Spacetime &>(self).getSimplices())
+               out.append(py::cast(s, py::return_value_policy::reference_internal, self));
+             return out;
+           },
            "Return all top-dimensional simplices in the complex.")
-      .def("getExternalSimplices", &Spacetime::getExternalSimplices, py::return_value_policy::copy,
+      .def("getExternalSimplices",
+           [](py::object self) {
+             py::list out;
+             for (const auto &s : py::cast<Spacetime &>(self).getExternalSimplices())
+               out.append(py::cast(s, py::return_value_policy::reference_internal, self));
+             return out;
+           },
            "Return simplices on the boundary of the complex.")
       .def("createEdge",
            static_cast<EdgePtr (Spacetime::*)(const VertexPtr &, const VertexPtr &) const>(&
@@ -394,10 +413,13 @@ This is the volume-fixing target per [RU] eq. 6.)doc")
       .def("getN32", &Spacetime::getN32,
            "Return N32: the count of (d-1,2) + (2,d-1) type simplices.")
       .def("getRandomSimplex", &Spacetime::getRandomSimplex, py::return_value_policy::reference,
+           py::keep_alive<0, 1>(),  // single handle (weak-referenceable) keeps the Spacetime alive
            "Return a uniformly random simplex from the complex (any dimension).")
       .def("getRandomTopSimplex", &Spacetime::getRandomTopSimplex, py::return_value_policy::reference,
+           py::keep_alive<0, 1>(),
            "Return a uniformly random top-dimensional simplex.")
       .def("getRandomVertex", &Spacetime::getRandomVertex, py::return_value_policy::reference,
+           py::keep_alive<0, 1>(),
            "Return a uniformly random vertex.")
       .def("removeSimplex", &Spacetime::removeSimplex, py::arg("simplex"),
            "Remove a top-dimensional simplex from the complex.")

--- a/tests/test_spacetime.py
+++ b/tests/test_spacetime.py
@@ -19,8 +19,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import gc
 import unittest
 
+import tessera
 from tessera import Spacetime, Edge, Vertex
 
 class TestSpacetime(unittest.TestCase):
@@ -353,6 +355,66 @@ class TestCreateSimplexVertexCap(unittest.TestCase):
         self.assertEqual(raised, 10)
         self.assertEqual(len([s for s in st.getSimplices()
                               if len(s.getVertices()) == 9]), 0)
+
+
+class TestHandleLifetime(unittest.TestCase):
+    """Simplex/Vertex handles returned by the query methods point into the
+    Spacetime's storage, so the Spacetime must stay alive while they are used.
+    The bindings enforce this (keep_alive), so the handles remain valid even
+    after the Spacetime variable goes out of scope. Each helper builds a
+    Spacetime in a local, returns handles, and lets the local drop — without
+    the keep_alive these accesses are use-after-free (segfault).
+    """
+
+    def _sphere_spacetime(self, n=2):
+        sig = tessera.Signature(4, tessera.Lorentzian)
+        metric = tessera.Metric(True, sig)
+        st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                               tessera.PREFERRED, tessera.SimplexBoundarySphere(n))
+        st.build()
+        return st
+
+    def test_getSimplices_outlives_spacetime_local(self):
+        def handles():
+            return self._sphere_spacetime(2).getSimplices()  # temporary Spacetime
+        simplices = handles()
+        gc.collect()
+        # S^2 = boundary of a tetrahedron has 4 triangles; accessing them must
+        # not touch freed storage.
+        self.assertEqual(len(simplices), 4)
+        self.assertTrue(all(len(s.getVertices()) == 3 for s in simplices))
+
+    def test_getExternalSimplices_outlives_spacetime_local(self):
+        def handles():
+            sig = tessera.Signature(4, tessera.Lorentzian)
+            metric = tessera.Metric(True, sig)
+            st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                   tessera.PREFERRED, tessera.SolidSimplex(4))
+            st.build()
+            return st.getExternalSimplices()
+        external = handles()
+        gc.collect()
+        self.assertGreater(len(external), 0)
+        for s in external:
+            _ = s.getVertices()  # no crash
+
+    def test_getRandomVertex_outlives_spacetime_local(self):
+        v = self._sphere_spacetime(2).getRandomVertex()
+        gc.collect()
+        self.assertIsNotNone(v)
+        _ = v.getId()  # no crash
+
+    def test_getRandomTopSimplex_outlives_spacetime_local(self):
+        def handle():
+            sig = tessera.Signature(4, tessera.Lorentzian)
+            metric = tessera.Metric(True, sig)
+            st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                   tessera.PREFERRED, tessera.Toroid())
+            st.build(50)
+            return st.getRandomTopSimplex()
+        s = handle()
+        gc.collect()
+        self.assertEqual(len(s.getVertices()), 5)  # 4D top simplex
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The footgun surfaced while writing the #83 cobordism tests: `getSimplices()` (and friends) return `Simplex`/`Vertex` handles that point into the `Spacetime`'s storage, but nothing tied the `Spacetime`'s lifetime to those handles. So `Spacetime(...).getSimplices()` **on a temporary** freed the storage the moment the call returned, dangling the handles — a use-after-free that segfaults on access.

## Fix
- **`getSimplices` / `getExternalSimplices`**: a blanket `keep_alive` on the result doesn't work — pybind can't use a plain Python `list` as a keep-alive target (lists aren't weak-referenceable). Instead each element is cast with `return_value_policy::reference_internal`, tying every returned handle's lifetime to the `Spacetime`.
- **`getRandomSimplex` / `getRandomTopSimplex` / `getRandomVertex`**: single handle, so `keep_alive<0,1>` works directly.

## Test
`tests/test_spacetime.py::TestHandleLifetime` — each helper builds a `Spacetime` in a local, returns handles, lets the local drop, then accesses the handles after `gc.collect()`. Use-after-free before this fix; valid now.

## Verification
`TestHandleLifetime` green; `getSimplices`-heavy suites (spacetime/simplex/cdt/cobordism — 112) green; full non-slow suite passes apart from one **pre-existing, RNG-order-flaky** Pachner flip-stress test (unrelated to this binding-only change — passes 5/5 in isolation; it's the same `_top_size`-picks-first-simplex fragility as the one fixed in #81, in another test file, and I'll harden it next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)