### PR TITLE
cobordism: add Kühnel 9-vertex CP² fixture (#63)

### DIFF
--- a/include/spacetime/topologies/ComplexProjectivePlane.h
+++ b/include/spacetime/topologies/ComplexProjectivePlane.h
@@ -1,0 +1,72 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COMPLEXPROJECTIVEPLANE_H
+#define TESSERA_COMPLEXPROJECTIVEPLANE_H
+
+#include "Topology.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+class Spacetime;
+
+/// # Complex projective plane \f$ \mathbb{CP}^2 \f$ (minimal 9-vertex)
+///
+/// Kühnel's 9-vertex triangulation of \f$ \mathbb{CP}^2 \f$ — the unique
+/// minimal triangulation of any manifold that is neither a sphere nor a
+/// boundary of a simplex. A closed, orientable, smooth 4-manifold with
+/// f-vector \f$ (9, 36, 84, 90, 36) \f$, Euler characteristic
+/// \f$ \chi = 3 \f$, Betti numbers \f$ (1, 0, 1, 0, 1) \f$, and a definite
+/// intersection form of rank one — so the signature has absolute value one,
+/// \f$ |\sigma| = 1 \f$. Its symmetry group has order 54.
+///
+/// ## Construction
+///
+/// The 36 four-simplices are the orbits of twelve base simplices under the
+/// order-three permutation \f$ S = (1\,4\,7)(2\,5\,8)(3\,6\,9) \f$ of the nine
+/// vertices (each orbit has three members, \f$ 12 \times 3 = 36 \f$). The base
+/// list is the one tabulated by Kühnel and Banchoff and reproduced by Schwartz,
+/// "Trisecting the 9-vertex complex projective plane". Vertices are relabeled
+/// from the literature's \f$ 1\ldots 9 \f$ to tessera's \f$ 0\ldots 8 \f$, under
+/// which \f$ S \f$ becomes \f$ (0\,3\,6)(1\,4\,7)(2\,5\,8) \f$.
+///
+/// ## Orientation note
+///
+/// \f$ \mathbb{CP}^2 \f$ and its orientation reversal \f$ \overline{\mathbb{CP}}^2 \f$
+/// are the *same* simplicial complex; they differ only by a choice of
+/// fundamental class (which generator of \f$ \ker \partial_4 \f$). The
+/// signature's magnitude \f$ |\sigma| = 1 \f$ is the orientation-independent
+/// invariant; its sign is a convention fixed by how the fundamental class is
+/// selected.
+///
+/// Exact, fixed, pre-geometric (coordinate-free); ``build()`` ignores
+/// ``numSimplices``.
+class ComplexProjectivePlane : public Topology {
+  public:
+    ComplexProjectivePlane() = default;
+
+    /// Build the 9-vertex \f$ \mathbb{CP}^2 \f$. ``numSimplices`` is ignored.
+    void build(Spacetime *spacetime, int numSimplices) override;
+};
+
+} // namespace tessera::spacetime
+
+#endif // TESSERA_COMPLEXPROJECTIVEPLANE_H

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -33,6 +33,7 @@
 #include "spacetime/topologies/SimplexBoundarySphere.h"
 #include "spacetime/topologies/SolidSimplex.h"
 #include "spacetime/topologies/RealProjectivePlane.h"
+#include "spacetime/topologies/ComplexProjectivePlane.h"
 #include "spacetime/topologies/SimplicialProduct.h"
 #include "simulations/CDT.h"
 #include "spacetime/PachnerMove.h"
@@ -132,6 +133,16 @@ Pachner moves (add, remove, flip, iflip, shift).)doc")
       .def("build", &RealProjectivePlane::build, py::arg("spacetime"),
            py::arg("numSimplices") = 0,
            "Build the 6-vertex RP^2 (numSimplices ignored).");
+
+  py::class_<ComplexProjectivePlane, Topology,
+             std::shared_ptr<ComplexProjectivePlane> >(m, "ComplexProjectivePlane",
+      "Minimal 9-vertex CP^2 (Kühnel): f=(9,36,84,90,36), χ=3, "
+      "Betti (1,0,1,0,1), orientable with |signature|=1. Exact and "
+      "pre-geometric; build() ignores numSimplices.")
+      .def(py::init<>())
+      .def("build", &ComplexProjectivePlane::build, py::arg("spacetime"),
+           py::arg("numSimplices") = 0,
+           "Build the 9-vertex CP^2 (numSimplices ignored).");
 
   py::class_<SimplicialProduct, Topology, std::shared_ptr<SimplicialProduct> >(
       m, "SimplicialProduct",

--- a/src/spacetime/topologies/ComplexProjectivePlane.cpp
+++ b/src/spacetime/topologies/ComplexProjectivePlane.cpp
@@ -1,0 +1,64 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "spacetime/topologies/ComplexProjectivePlane.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <set>
+#include <vector>
+
+namespace tessera::spacetime {
+
+void ComplexProjectivePlane::build(Spacetime *spacetime, int /*numSimplices*/) {
+  // Kühnel's 9-vertex CP^2. The twelve base 4-simplices below (vertices
+  // 0..8) are the literature list of Kühnel & Banchoff with vertex labels
+  // shifted down by one. The full set of 36 is closed under the order-three
+  // symmetry S = (0 3 6)(1 4 7)(2 5 8) — applying S twice to each base
+  // simplex yields its three-member orbit, and 12 * 3 = 36.
+  const std::array<std::array<std::uint64_t, 5>, 12> base{{
+      {0, 4, 1, 7, 8}, {0, 1, 2, 7, 8}, {0, 2, 5, 7, 8}, {3, 4, 1, 7, 8},
+      {3, 1, 2, 7, 8}, {3, 2, 5, 7, 8}, {0, 3, 1, 4, 5}, {0, 3, 2, 4, 5},
+      {0, 3, 1, 4, 8}, {0, 3, 2, 5, 7}, {0, 3, 6, 1, 5}, {0, 3, 6, 5, 7}}};
+
+  // S as a lookup: vertex -> image. The three 3-cycles (0 3 6), (1 4 7),
+  // (2 5 8).
+  const std::array<std::uint64_t, 9> permute{3, 4, 5, 6, 7, 8, 0, 1, 2};
+
+  // Generate the orbit of every base simplex and collect the distinct ones
+  // (a std::set keyed on the sorted vertex tuple deduplicates and orders them).
+  std::set<std::vector<std::uint64_t>> simplices;
+  for (const auto &simplex : base) {
+    std::vector<std::uint64_t> current(simplex.begin(), simplex.end());
+    for (int step = 0; step < 3; ++step) {
+      std::vector<std::uint64_t> sorted = current;
+      std::sort(sorted.begin(), sorted.end());
+      simplices.insert(std::move(sorted));
+      for (auto &vertex : current) vertex = permute[vertex];
+    }
+  }
+
+  std::vector<std::vector<std::uint64_t>> tops(simplices.begin(), simplices.end());
+  buildExplicit(spacetime, 9, tops);
+}
+
+} // namespace tessera::spacetime

--- a/tests/cobordism/test_fixtures_python.py
+++ b/tests/cobordism/test_fixtures_python.py
@@ -212,12 +212,61 @@ class TestRealProjectivePlane(unittest.TestCase):
         self.assertTrue(all(c == 2 for c in edge_count.values()))
 
 
+class TestComplexProjectivePlane(unittest.TestCase):
+    """Kühnel's minimal 9-vertex CP^2: f=(9,36,84,90,36), χ=3,
+    Betti (1,0,1,0,1), orientable with a rank-1 definite intersection form
+    (|signature| = 1)."""
+
+    F_VECTOR = [9, 36, 84, 90, 36]
+
+    def test_f_vector_and_euler(self):
+        st = _build(tessera.ComplexProjectivePlane())
+        tops = _top_tuples(st)
+        self.assertEqual(len(tops), 36)
+        self.assertEqual(_f_vector_from_tops(tops), self.F_VECTOR)
+        self.assertEqual(_materialized_face_counts(st), self.F_VECTOR)
+        self.assertEqual(_euler(self.F_VECTOR), 3)
+        self.assertEqual(cobordism.CombinatorialDimension().compute(st), 4.0)
+
+    def test_closed_pseudomanifold(self):
+        # Every codimension-one face (a tetrahedron, 4 vertices) lies in exactly
+        # two of the 36 four-simplices — the hallmark of a closed manifold.
+        tops = _top_tuples(_build(tessera.ComplexProjectivePlane()))
+        tet_count = {}
+        for t in tops:
+            for tet in itertools.combinations(t, 4):
+                tet_count[tet] = tet_count.get(tet, 0) + 1
+        self.assertEqual(len(tet_count), 90)
+        self.assertTrue(all(c == 2 for c in tet_count.values()))
+
+    def test_homology_and_signature(self):
+        st = _build(tessera.ComplexProjectivePlane())
+        cc = cobordism.ChainComplex.fromSpacetime(st)
+        self.assertEqual(cc.fVector(), self.F_VECTOR)
+        self.assertTrue(cc.boundaryComposesToZero())
+        # Betti numbers of CP^2 agree over Q and GF(2) (the homology is
+        # torsion-free), so there is no 2-torsion to split them apart.
+        self.assertEqual(cc.bettiNumbers(), [1, 0, 1, 0, 1])
+        self.assertEqual(cc.bettiNumbersGF2(), [1, 0, 1, 0, 1])
+        self.assertEqual(cc.eulerCharacteristic(), 3)
+        self.assertEqual(cc.torsion(2), [])
+        self.assertEqual(cc.torsion(3), [])
+        # H^2 is rank one with a definite, unimodular intersection form: the
+        # 1x1 matrix [±1]. |signature| = 1 is the orientation-independent fact
+        # (the sign is a convention fixed by the choice of fundamental class).
+        form = cc.intersectionForm()
+        self.assertEqual(len(form), 1)
+        self.assertEqual(abs(form[0]), 1.0)
+        self.assertEqual(abs(cc.signature()), 1)
+
+
 class TestPreGeometric(unittest.TestCase):
 
     def test_vertices_are_coordinate_free(self):
         for topology in (tessera.SimplexBoundarySphere(3),
                          tessera.SolidSimplex(4),
-                         tessera.RealProjectivePlane()):
+                         tessera.RealProjectivePlane(),
+                         tessera.ComplexProjectivePlane()):
             with self.subTest(topology=type(topology).__name__):
                 st = _build(topology)
                 for v in st.getVertexList().toVector():


### PR DESCRIPTION
## What

Adds `ComplexProjectivePlane`, a `Topology` subclass that builds **Kühnel's minimal 9-vertex triangulation of ℂP²** — the canonical closed, orientable 4-manifold fixture the cobordism capabilities need (signature, Pontryagin/Stiefel–Whitney validation). It's the unique minimal triangulation of any manifold that is neither a sphere nor a simplex boundary.

## Construction

The 36 four-simplices are the size-three orbits of **twelve base simplices** under the order-three symmetry `S = (0 3 6)(1 4 7)(2 5 8)`. The base list is the Kühnel–Banchoff tabulation (reproduced by Schwartz, *Trisecting the 9-vertex complex projective plane*), relabeled from the literature's `1..9` to tessera's `0..8`. Exact, fixed, pre-geometric (coordinate-free), consistent with the other fixtures.

## Validation

Built end-to-end and checked against the homology+signature oracle (`ChainComplex.fromSpacetime`):

| invariant | expected | got |
|---|---|---|
| f-vector | (9, 36, 84, 90, 36) | ✅ |
| χ | 3 | ✅ |
| Betti (ℚ) | (1, 0, 1, 0, 1) | ✅ |
| Betti (GF(2)) | (1, 0, 1, 0, 1) | ✅ |
| torsion H₂, H₃ | none | ✅ |
| ∂² = 0 | true | ✅ |
| closed pseudomanifold | every tetrahedron in exactly 2 four-simplices | ✅ |
| intersection form | rank-1 definite `[±1]` | ✅ |
| \|signature\| | 1 | ✅ |

### Orientation note
ℂP² and its reversal ℂP̄² are the *same* simplicial complex; they differ only by a choice of fundamental class (which generator of `ker ∂₄`). `|signature| = 1` is the orientation-independent invariant; the sign is a convention. The test asserts `|signature| = 1` and that the intersection form is the 1×1 matrix `[±1]`.

## Tests

`TestComplexProjectivePlane` (f-vector/Euler, closed-pseudomanifold, homology+signature) plus inclusion in the pre-geometric coordinate-free sweep. Full cobordism suite: **77 passed**.

Part of the cobordism epic #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)