### PR TITLE
cobordism: Capability A — Stiefel–Whitney numbers via Wu classes (#65)

### DIFF
--- a/include/cobordism/ChainComplex.h
+++ b/include/cobordism/ChainComplex.h
@@ -23,6 +23,8 @@
 #define TESSERA_COBORDISM_CHAINCOMPLEX_H
 
 #include <cstdint>
+#include <map>
+#include <string>
 #include <vector>
 
 // === tessera subsystem ns fwd-decls ===
@@ -94,6 +96,32 @@ class ChainComplex {
     /// Signature \f$ \sigma = b_+ - b_- \f$ of the intersection form
     /// (Sylvester inertia). 0 when \f$ n \neq 4 \f$ or \f$ b_2 = 0 \f$.
     [[nodiscard]] int signature() const;
+
+    /// Mod-2 Stiefel–Whitney numbers of a closed PL \f$ n \f$-manifold:
+    /// \f$ \langle w_{i_1}\cdots w_{i_r}, [K] \rangle \in \mathbb{Z}/2 \f$ for
+    /// every partition \f$ (i_1,\dots,i_r) \f$ of \f$ n \f$ into positive parts,
+    /// keyed by the monomial (e.g. ``"w4"``, ``"w2^2"``, ``"w1^2"``,
+    /// ``"w1w3"``). Empty when the complex is empty.
+    ///
+    /// Computed combinatorially: the mod-2 cohomology \f$ H^*(K;\mathbb{Z}/2) \f$
+    /// (from the boundary maps reduced mod 2), the Alexander–Whitney cup product
+    /// on cochains, and the Wu classes \f$ v_k \f$ — defined by
+    /// \f$ \langle v_k \cup x, [K]\rangle = \langle \mathrm{Sq}^k x, [K]\rangle \f$
+    /// for all \f$ x \in H^{n-k} \f$ — from which the total Stiefel–Whitney class
+    /// is \f$ w = \mathrm{Sq}(v) \f$. The fundamental class \f$ [K] \f$ over
+    /// \f$ \mathbb{Z}/2 \f$ is the sum of all top simplices, and evaluation on it
+    /// is the mod-2 sum of a top-degree cochain over those simplices.
+    ///
+    /// Only the Steenrod squares expressible through the ordinary
+    /// (\f$ \cup_0 \f$) product are implemented: \f$ \mathrm{Sq}^k \f$ on a
+    /// class of degree \f$ k \f$ (the squaring) and the degree-forced zeros.
+    /// These suffice for surfaces and for closed orientable 4-manifolds with
+    /// \f$ b_1 = 0 \f$ (so \f$ \mathbb{RP}^2 \f$, \f$ \mathbb{CP}^2 \f$,
+    /// \f$ S^4 \f$, \f$ S^2\times S^2 \f$, and their disjoint unions).
+    /// @throws std::runtime_error if a required Wu or Stiefel–Whitney class
+    ///   genuinely needs a higher cup-\f$ i \f$ product (\f$ i>0 \f$) — the
+    ///   general Steenrod squares are deferred (see issue #65).
+    [[nodiscard]] std::map<std::string, int> stiefelWhitneyNumbers() const;
 
   private:
     int dimension_{-1};

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -90,7 +90,11 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
            "Symmetric intersection form on free H^2 (flat b2 x b2), for a closed "
            "oriented 4-manifold; empty if n != 4 or b2 == 0.")
       .def("signature", &ChainComplex::signature,
-           "Signature b+ - b- of the intersection form (0 if n != 4 or b2 == 0).");
+           "Signature b+ - b- of the intersection form (0 if n != 4 or b2 == 0).")
+      .def("stiefelWhitneyNumbers", &ChainComplex::stiefelWhitneyNumbers,
+           "Mod-2 Stiefel-Whitney numbers <w_{i1}..w_{ir}, [K]> keyed by "
+           "monomial (e.g. 'w4', 'w2^2'); empty for the empty complex. Raises "
+           "if a class needs a deferred higher Steenrod cup-i product (#65).");
 
   // Exact integer / GF(2) / inertia primitives (also exposed for direct
   // testing). Matrices are passed flat row-major with explicit dims.

--- a/src/cobordism/ChainComplex.cpp
+++ b/src/cobordism/ChainComplex.cpp
@@ -27,8 +27,11 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
+#include <functional>
 #include <map>
 #include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -361,6 +364,323 @@ std::vector<long> ChainComplex::torsion(int k) const {
   for (long d : snf.invariantFactors)
     if (d > 1) out.push_back(d);
   return out;
+}
+
+// ===========================================================================
+// Stiefel–Whitney numbers (mod-2 characteristic numbers)
+// ===========================================================================
+//
+// These are read off the mod-2 cohomology ring. The pipeline is:
+//
+//   1. Mod-2 cohomology H^k(K; Z/2): cocycles modulo coboundaries, with the
+//      coboundary operator being the transpose of the (mod-2) boundary map.
+//   2. Cup product on cochains via the Alexander–Whitney recipe — the same
+//      front/back-face rule used by the integral intersection form, now mod 2
+//      and for arbitrary degrees.
+//   3. Wu classes v_k, defined by <v_k ∪ x, [K]> = <Sq^k x, [K]> for every
+//      x in H^{n-k}. Solving this small linear system (its matrix is the
+//      nondegenerate Poincaré-duality pairing) gives each v_k.
+//   4. The total Stiefel–Whitney class w = Sq(v); then each Stiefel–Whitney
+//      number is a degree-n monomial in the w_i evaluated on the fundamental
+//      class [K] (the mod-2 sum of all top simplices).
+//
+// Only the Steenrod squares expressible through the ordinary cup product are
+// implemented (Sq^k on a degree-k class is the cup square; Sq^k on a lower
+// degree class is zero). The general Sq^i needs higher cup-i products and is
+// deferred (#65); a class that genuinely requires it raises an exception.
+namespace {
+
+using Gf2Vector = std::vector<std::uint8_t>;  // dense vector over GF(2), entries 0/1
+using Gf2Matrix = std::vector<Gf2Vector>;     // a list of rows, each the same length
+
+// Reduce `rows` to reduced row-echelon form in place. Returns the pivot column
+// of each surviving (nonzero) row; its size is the rank.
+std::vector<int> gf2ReduceRows(Gf2Matrix &rows, int numColumns) {
+  std::vector<int> pivotColumns;
+  int pivotRow = 0;
+  for (int column = 0; column < numColumns && pivotRow < static_cast<int>(rows.size());
+       ++column) {
+    int found = -1;
+    for (int r = pivotRow; r < static_cast<int>(rows.size()); ++r)
+      if (rows[r][column]) { found = r; break; }
+    if (found < 0) continue;
+    std::swap(rows[pivotRow], rows[found]);
+    for (int r = 0; r < static_cast<int>(rows.size()); ++r)
+      if (r != pivotRow && rows[r][column])
+        for (int c = 0; c < numColumns; ++c) rows[r][c] ^= rows[pivotRow][c];
+    pivotColumns.push_back(column);
+    ++pivotRow;
+  }
+  return pivotColumns;
+}
+
+// Basis of the null space {x : matrix·x = 0} of a GF(2) matrix with `numColumns`
+// columns (rows may be empty, in which case every standard basis vector is a
+// kernel vector).
+Gf2Matrix gf2Kernel(Gf2Matrix matrix, int numColumns) {
+  const std::vector<int> pivotColumns = gf2ReduceRows(matrix, numColumns);
+  std::vector<char> isPivot(numColumns, 0);
+  for (int p : pivotColumns) isPivot[p] = 1;
+  Gf2Matrix basis;
+  for (int freeColumn = 0; freeColumn < numColumns; ++freeColumn) {
+    if (isPivot[freeColumn]) continue;
+    Gf2Vector x(numColumns, 0);
+    x[freeColumn] = 1;
+    for (int t = 0; t < static_cast<int>(pivotColumns.size()); ++t)
+      x[pivotColumns[t]] = matrix[t][freeColumn];
+    basis.push_back(std::move(x));
+  }
+  return basis;
+}
+
+// Incrementally maintained spanning set (kept in echelon form). add() returns
+// true iff `candidate` was linearly independent of everything added so far
+// (and then records it). Used to split cocycles into cohomology classes.
+struct Gf2Span {
+  Gf2Matrix echelonRows;
+  std::vector<int> leadingColumn;
+  int numColumns;
+  explicit Gf2Span(int columns) : numColumns(columns) {}
+  bool add(Gf2Vector candidate) {
+    for (int t = 0; t < static_cast<int>(echelonRows.size()); ++t)
+      if (candidate[leadingColumn[t]])
+        for (int c = 0; c < numColumns; ++c) candidate[c] ^= echelonRows[t][c];
+    int lead = -1;
+    for (int c = 0; c < numColumns; ++c)
+      if (candidate[c]) { lead = c; break; }
+    if (lead < 0) return false;  // already in the span
+    echelonRows.push_back(std::move(candidate));
+    leadingColumn.push_back(lead);
+    return true;
+  }
+};
+
+// Solve matrix·x = rhs over GF(2) for a square, invertible matrix (the
+// duality pairing). Throws if the system is not uniquely solvable.
+Gf2Vector gf2Solve(const Gf2Matrix &matrix, const Gf2Vector &rhs) {
+  const int n = static_cast<int>(rhs.size());
+  Gf2Matrix augmented(matrix.size(), Gf2Vector(n + 1, 0));
+  for (int r = 0; r < static_cast<int>(matrix.size()); ++r) {
+    for (int c = 0; c < n; ++c) augmented[r][c] = matrix[r][c];
+    augmented[r][n] = rhs[r];
+  }
+  const std::vector<int> pivotColumns = gf2ReduceRows(augmented, n + 1);
+  if (static_cast<int>(pivotColumns.size()) != n || pivotColumns.back() == n)
+    throw std::runtime_error(
+        "ChainComplex::stiefelWhitneyNumbers: the Poincaré-duality pairing is "
+        "not invertible (the complex is not a closed manifold)");
+  Gf2Vector x(n, 0);
+  for (int t = 0; t < n; ++t) x[pivotColumns[t]] = augmented[t][n];
+  return x;
+}
+
+bool isZeroVector(const Gf2Vector &v) {
+  for (std::uint8_t e : v)
+    if (e) return false;
+  return true;
+}
+
+}  // namespace
+
+std::map<std::string, int> ChainComplex::stiefelWhitneyNumbers() const {
+  std::map<std::string, int> numbers;
+  const int n = dimension_;
+  if (n < 0) return numbers;  // empty complex: no characteristic numbers
+
+  const auto countAt = [&](int k) {
+    return (k < 0 || k > n) ? 0 : static_cast<int>(counts_[static_cast<std::size_t>(k)]);
+  };
+
+  // Mod-2 boundary entry ∂_k[row][col] (k-simplex col -> its (k-1)-faces).
+  const auto boundaryBit = [&](int k, int row, int col) -> std::uint8_t {
+    const auto &flat = boundary_[static_cast<std::size_t>(k)];
+    const int cols = countAt(k);
+    return static_cast<std::uint8_t>(
+        std::abs(flat[static_cast<std::size_t>(row) * cols + col]) & 1);
+  };
+
+  // Index of a k-simplex from its sorted vertex ids (for cup-product faces).
+  std::vector<std::map<Face, int>> indexOfFace(n + 1);
+  for (int k = 0; k <= n; ++k)
+    for (int i = 0; i < countAt(k); ++i)
+      indexOfFace[k][faceVerts_[k][static_cast<std::size_t>(i)]] = i;
+
+  // ---- mod-2 cohomology bases, one representative cocycle per class ----
+  // H^k = ker(δ^k) / im(δ^{k-1}); δ^k = (∂_{k+1})^T, coboundaries = rows of ∂_k.
+  std::vector<Gf2Matrix> cohomology(n + 1);  // cohomology[k] = basis cochains in C^k
+  for (int k = 0; k <= n; ++k) {
+    const int dim = countAt(k);
+    // Coboundary operator δ^k as a matrix on length-`dim` cochains, with one
+    // row per (k+1)-simplex: (δ^k α)(τ) = α(∂τ).
+    Gf2Matrix coboundaryOperator;
+    if (k + 1 <= n) {
+      const int higher = countAt(k + 1);
+      coboundaryOperator.assign(higher, Gf2Vector(dim, 0));
+      for (int tau = 0; tau < higher; ++tau)
+        for (int face = 0; face < dim; ++face)
+          coboundaryOperator[tau][face] = boundaryBit(k + 1, face, tau);
+    }
+    const Gf2Matrix cocycles = gf2Kernel(std::move(coboundaryOperator), dim);
+
+    // Span seeded with the coboundaries (rows of ∂_k); cocycles independent of
+    // them are the cohomology generators.
+    Gf2Span span(dim);
+    for (int row = 0; row < countAt(k - 1); ++row) {
+      Gf2Vector coboundary(dim, 0);
+      for (int col = 0; col < dim; ++col) coboundary[col] = boundaryBit(k, row, col);
+      span.add(std::move(coboundary));
+    }
+    for (const Gf2Vector &cocycle : cocycles)
+      if (span.add(cocycle)) cohomology[k].push_back(cocycle);
+  }
+
+  // ---- Alexander–Whitney cup product on cochains (mod 2) ----
+  // (α ∪ β) on a (p+q)-simplex [v0..v_{p+q}] = α(v0..vp) · β(vp..v_{p+q}).
+  const auto cup = [&](const Gf2Vector &alpha, int p, const Gf2Vector &beta,
+                       int q) -> Gf2Vector {
+    const int degree = p + q;
+    const int dim = countAt(degree);
+    Gf2Vector product(dim, 0);
+    if (degree > n) return product;
+    for (int s = 0; s < dim; ++s) {
+      const Face &vertices = faceVerts_[degree][static_cast<std::size_t>(s)];
+      const Face front(vertices.begin(), vertices.begin() + (p + 1));
+      const Face back(vertices.begin() + p, vertices.end());
+      product[s] = static_cast<std::uint8_t>(
+          alpha[indexOfFace[p].at(front)] & beta[indexOfFace[q].at(back)]);
+    }
+    return product;
+  };
+
+  // Evaluate a top-degree cochain on the fundamental class [K]: the mod-2 sum
+  // over all top simplices.
+  const auto evaluateOnFundamentalClass = [&](const Gf2Vector &topCochain) -> int {
+    int total = 0;
+    for (std::uint8_t e : topCochain) total ^= e;
+    return total;
+  };
+
+  // ---- Wu classes v_k (1 ≤ k ≤ n/2; the rest vanish for degree reasons) ----
+  // v_k is the element of H^k with <v_k ∪ x, [K]> = <Sq^k x, [K]> for all
+  // x in H^{n-k}. Sq^k on a degree-(n-k) class is the cup square when k = n-k,
+  // zero when k > n-k, and (deferred) a higher cup-i product when k < n-k.
+  std::vector<Gf2Vector> wuClass(n + 1);
+  for (int k = 0; k <= n; ++k) wuClass[k].assign(countAt(k), 0);
+  for (int k = 1; 2 * k <= n; ++k) {
+    const int complement = n - k;
+    const auto &basisK = cohomology[k];
+    const auto &basisComplement = cohomology[complement];
+    if (basisK.empty()) continue;  // H^k = 0 ⇒ v_k = 0
+    if (basisK.size() != basisComplement.size())
+      throw std::runtime_error(
+          "ChainComplex::stiefelWhitneyNumbers: mod-2 Poincaré duality fails "
+          "(dim H^" + std::to_string(k) + " != dim H^" + std::to_string(complement) +
+          "); the complex is not a closed manifold");
+
+    // Pairing matrix P[j][i] = <e_i ∪ x_j, [K]> and right-hand side
+    // r[j] = <Sq^k x_j, [K]>.
+    Gf2Matrix pairing(basisComplement.size(), Gf2Vector(basisK.size(), 0));
+    Gf2Vector rightHandSide(basisComplement.size(), 0);
+    for (int j = 0; j < static_cast<int>(basisComplement.size()); ++j) {
+      for (int i = 0; i < static_cast<int>(basisK.size()); ++i)
+        pairing[j][i] = static_cast<std::uint8_t>(
+            evaluateOnFundamentalClass(cup(basisK[i], k, basisComplement[j], complement)));
+      if (k == complement)  // Sq^k on a degree-k class is the cup square
+        rightHandSide[j] = static_cast<std::uint8_t>(evaluateOnFundamentalClass(
+            cup(basisComplement[j], complement, basisComplement[j], complement)));
+      // k < complement would need a higher cup-i product; but H^k ≠ 0 with
+      // k < n-k cannot occur for the supported manifolds (it requires a
+      // nonzero low-degree cohomology paired against a higher one). Guard it.
+      else
+        throw std::runtime_error(
+            "ChainComplex::stiefelWhitneyNumbers: Wu class v_" + std::to_string(k) +
+            " requires a higher Steenrod cup-i product (i>0), which is deferred "
+            "(see issue #65)");
+    }
+    const Gf2Vector coefficients = gf2Solve(pairing, rightHandSide);
+    Gf2Vector v(countAt(k), 0);
+    for (int i = 0; i < static_cast<int>(coefficients.size()); ++i)
+      if (coefficients[i])
+        for (int c = 0; c < countAt(k); ++c) v[c] ^= basisK[i][c];
+    wuClass[k] = std::move(v);
+  }
+
+  // ---- Stiefel–Whitney classes w_i = Σ_j Sq^j(v_{i-j}) ----
+  // Sq^0(v_i) = v_i; Sq^j(v_{i-j}) for j ≥ 1 is the cup square when 2j = i
+  // (degree i-j = j) and zero when the Wu class vanishes; anything else is a
+  // deferred higher square. Computed lazily so a deferred term is only hit if
+  // it is actually needed (and nonzero).
+  std::vector<bool> haveW(n + 1, false);
+  std::vector<Gf2Vector> wClass(n + 1);
+  const auto stiefelWhitney = [&](int i) -> const Gf2Vector & {
+    if (haveW[i]) return wClass[i];
+    Gf2Vector w(countAt(i), 0);
+    if (i <= n - i)  // Sq^0(v_i): v_i itself (zero unless 1 ≤ i ≤ n/2)
+      for (int c = 0; c < countAt(i); ++c) w[c] ^= wuClass[i][c];
+    for (int j = 1; j <= i; ++j) {
+      const int m = i - j;  // degree of the Wu class being squared
+      if (isZeroVector(wuClass[m])) continue;  // Sq^j(0) = 0
+      if (j > m) continue;                      // Sq^j on degree m < j is 0
+      if (j == m) {                             // Sq^j on degree j is the square
+        const Gf2Vector square = cup(wuClass[m], m, wuClass[m], m);
+        for (int c = 0; c < countAt(i); ++c) w[c] ^= square[c];
+        continue;
+      }
+      throw std::runtime_error(
+          "ChainComplex::stiefelWhitneyNumbers: Stiefel–Whitney class w_" +
+          std::to_string(i) + " requires a higher Steenrod cup-i product (i>0), "
+          "which is deferred (see issue #65)");
+    }
+    haveW[i] = true;
+    wClass[i] = std::move(w);
+    return wClass[i];
+  };
+
+  // ---- Stiefel–Whitney numbers: every partition of n into positive parts ----
+  // The monomial w_{i_1}···w_{i_r} (parts ascending) cupped together and
+  // evaluated on [K]. Parts are processed smallest-first so a zero factor (e.g.
+  // w_1 = 0 on an orientable manifold) short-circuits before a deferred,
+  // would-be-higher-square factor is ever requested.
+  std::function<void(int, int, std::vector<int> &)> forEachPartition =
+      [&](int remaining, int minimumPart, std::vector<int> &parts) {
+        if (remaining == 0) {
+          // Build a readable monomial key, e.g. {1,1,2} -> "w1^2w2".
+          std::string key;
+          for (int p = 0; p < static_cast<int>(parts.size());) {
+            int q = p;
+            while (q < static_cast<int>(parts.size()) && parts[q] == parts[p]) ++q;
+            const int multiplicity = q - p;
+            key += "w" + std::to_string(parts[p]);
+            if (multiplicity > 1) key += "^" + std::to_string(multiplicity);
+            p = q;
+          }
+          // Evaluate the cup-product monomial, short-circuiting on a zero factor.
+          Gf2Vector accumulator;
+          int accumulatorDegree = 0;
+          bool zero = false;
+          for (int idx = 0; idx < static_cast<int>(parts.size()); ++idx) {
+            const Gf2Vector &factor = stiefelWhitney(parts[idx]);
+            if (idx == 0) {
+              accumulator = factor;
+              accumulatorDegree = parts[idx];
+            } else {
+              accumulator = cup(accumulator, accumulatorDegree, factor, parts[idx]);
+              accumulatorDegree += parts[idx];
+            }
+            if (isZeroVector(accumulator)) { zero = true; break; }
+          }
+          numbers[key] = zero ? 0 : evaluateOnFundamentalClass(accumulator);
+          return;
+        }
+        for (int part = minimumPart; part <= remaining; ++part) {
+          parts.push_back(part);
+          forEachPartition(remaining - part, part, parts);
+          parts.pop_back();
+        }
+      };
+  std::vector<int> parts;
+  forEachPartition(n, 1, parts);
+  return numbers;
 }
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/Characteristic.cpp
+++ b/src/cobordism/Characteristic.cpp
@@ -39,11 +39,10 @@ double Signature::compute(const std::shared_ptr<Spacetime> &spacetime) {
 }
 
 CharacteristicNumbers CharacteristicNumbers::of(const Spacetime &K, bool oriented) {
-  (void)oriented;  // gates Stiefel–Whitney (unoriented) vs oriented numbers once SW lands
   const ChainComplex cc = ChainComplex::fromSpacetime(K);
   CharacteristicNumbers out;
   out.euler = cc.eulerCharacteristic();
-  if (cc.dimension() == 4) {
+  if (oriented && cc.dimension() == 4) {
     try {
       const int signatureValue = cc.signature();
       out.signature = signatureValue;
@@ -54,7 +53,14 @@ CharacteristicNumbers CharacteristicNumbers::of(const Spacetime &K, bool oriente
       // Non-orientable / no fundamental class: signature (hence p1) undefined.
     }
   }
-  // Stiefel–Whitney numbers: pending the Wu-class / Steenrod-square work.
+  // Stiefel–Whitney numbers are unoriented invariants — computed regardless of
+  // the `oriented` flag. A class genuinely needing a deferred higher Steenrod
+  // square (issue #65) leaves the family empty rather than failing the call.
+  try {
+    out.stiefelWhitneyNumbers = cc.stiefelWhitneyNumbers();
+  } catch (const std::exception &) {
+    // Higher cup-i square required (deferred) or not a closed manifold.
+  }
   return out;
 }
 

--- a/tests/cobordism/test_characteristic_python.py
+++ b/tests/cobordism/test_characteristic_python.py
@@ -23,10 +23,17 @@
 
 Euler characteristic and signature (as Observables) plus the aggregate
 CharacteristicNumbers. The signature is validated on the intersection form:
-the 4-sphere gives the empty form, and S^2 x S^2 gives the hyperbolic form
+the 4-sphere gives the empty form, S^2 x S^2 gives the hyperbolic form
 (signature 0 but rank 2 -- which only happens if the cup product is computed
-correctly). The signature = +1 case (the complex projective plane) and the
-Stiefel-Whitney numbers are pending follow-ups.
+correctly), and CP^2 gives a rank-1 definite form (|signature| = 1).
+
+Stiefel-Whitney numbers are validated against their textbook values:
+w1^2[RP^2] = 1, w2[RP^2] = 1, w2^2[CP^2] = w4[CP^2] = 1, every number of S^4
+and S^2 x S^2 vanishes, and RP^2 ⊔ RP^2 has all numbers ≡ 0 (mod 2).
+
+Orientation note: CP^2 and its reversal are the same simplicial complex, so the
+signature comes out with a fixed but convention-dependent sign; the tests assert
+the orientation-independent facts (|signature| = 1, p1 = 3*signature).
 """
 
 import unittest
@@ -34,6 +41,11 @@ import unittest
 import tessera
 
 cobordism = tessera.cobordism
+
+# The 10 triangles of the minimal 6-vertex RP^2, as a vertex-tuple template we
+# can stamp out at a vertex offset to build disjoint unions by hand.
+_RP2_TRIANGLES = [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5), (0, 1, 5),
+                  (1, 2, 4), (2, 3, 5), (1, 3, 4), (1, 3, 5), (2, 4, 5)]
 
 
 def _build(topology):
@@ -43,6 +55,28 @@ def _build(topology):
                                   tessera.PREFERRED, topology)
     spacetime.build()
     return spacetime
+
+
+def _empty_spacetime():
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, tessera.Toroid())
+
+
+def _two_disjoint_rp2():
+    """RP^2 ⊔ RP^2, built by hand on two disjoint 6-vertex blocks."""
+    spacetime = _empty_spacetime()
+    vertices = [spacetime.createVertex(i) for i in range(12)]
+    for triangle in _RP2_TRIANGLES:
+        spacetime.createSimplex([vertices[i] for i in triangle])
+        spacetime.createSimplex([vertices[i + 6] for i in triangle])
+    return spacetime
+
+
+def _stiefel_whitney(spacetime):
+    return dict(cobordism.ChainComplex.fromSpacetime(
+        spacetime).stiefelWhitneyNumbers())
 
 
 def _sphere(n):
@@ -137,6 +171,18 @@ class TestSignature(unittest.TestCase):
         self.assertGreater(abs(off01), 1e-6)                  # nonzero crossing
         self.assertLess(diag0 * diag1 - off01 * off10, 0.0)   # det < 0 (indefinite)
 
+    def test_complex_projective_plane_is_definite_rank_one(self):
+        # CP^2 has b2 = 1 and a unimodular definite intersection form [±1], so
+        # |signature| = 1. (The sign is a convention; see the module docstring.)
+        spacetime = _build(tessera.ComplexProjectivePlane())
+        chain = cobordism.ChainComplex.fromSpacetime(spacetime)
+        self.assertEqual(chain.bettiNumbers()[2], 1)
+        form = list(chain.intersectionForm())
+        self.assertEqual(len(form), 1)
+        self.assertAlmostEqual(abs(form[0]), 1.0, places=6)
+        self.assertEqual(abs(chain.signature()), 1)
+        self.assertEqual(abs(cobordism.Signature().compute(spacetime)), 1.0)
+
     def test_intersection_form_is_symmetric_and_sized_by_b2(self):
         spacetime = _build(_s2_cross_s2())
         chain = cobordism.ChainComplex.fromSpacetime(spacetime)
@@ -158,12 +204,27 @@ class TestSignature(unittest.TestCase):
 class TestCharacteristicNumbers(unittest.TestCase):
 
     def test_four_manifolds_have_signature_and_pontryagin(self):
-        for topology in (_sphere(4), _s2_cross_s2()):
+        for topology in (_sphere(4), _s2_cross_s2(),
+                         tessera.ComplexProjectivePlane()):
             with self.subTest(manifold=type(topology).__name__):
                 numbers = cobordism.CharacteristicNumbers.of(_build(topology))
                 self.assertIsNotNone(numbers.signature)
-                # Hirzebruch signature theorem: p1 = 3 * signature.
+                # Hirzebruch signature theorem (cross-validation V1): the only
+                # Pontryagin number in dimension four is p1 = 3 * signature.
                 self.assertEqual(numbers.pontryagin_numbers["p1"], 3 * numbers.signature)
+
+    def test_complex_projective_plane_pontryagin(self):
+        # p1(CP^2) = 3*signature with |signature| = 1, so |p1| = 3.
+        numbers = cobordism.CharacteristicNumbers.of(
+            _build(tessera.ComplexProjectivePlane()))
+        self.assertEqual(abs(numbers.signature), 1)
+        self.assertEqual(numbers.pontryagin_numbers["p1"], 3 * numbers.signature)
+        self.assertEqual(abs(numbers.pontryagin_numbers["p1"]), 3)
+
+    def test_four_sphere_pontryagin_vanishes(self):
+        numbers = cobordism.CharacteristicNumbers.of(_build(_sphere(4)))
+        self.assertEqual(numbers.signature, 0)
+        self.assertEqual(numbers.pontryagin_numbers["p1"], 0)
 
     def test_euler_agrees_with_observable(self):
         euler = cobordism.EulerCharacteristic()
@@ -181,10 +242,147 @@ class TestCharacteristicNumbers(unittest.TestCase):
                 self.assertIsNone(numbers.signature)
                 self.assertEqual(dict(numbers.pontryagin_numbers), {})
 
-    def test_stiefel_whitney_numbers_pending(self):
-        # Documented as not-yet-computed; the map is currently empty.
-        numbers = cobordism.CharacteristicNumbers.of(_build(_s2_cross_s2()))
-        self.assertEqual(dict(numbers.stiefel_whitney_numbers), {})
+    def test_stiefel_whitney_numbers_exposed(self):
+        # CharacteristicNumbers.of surfaces the same numbers as the ChainComplex.
+        spacetime = _build(tessera.ComplexProjectivePlane())
+        numbers = cobordism.CharacteristicNumbers.of(spacetime)
+        self.assertEqual(dict(numbers.stiefel_whitney_numbers),
+                         _stiefel_whitney(spacetime))
+        self.assertEqual(numbers.stiefel_whitney_numbers["w2^2"], 1)
+
+
+class TestStiefelWhitneyNumbers(unittest.TestCase):
+    """Mod-2 Stiefel-Whitney numbers against their textbook values."""
+
+    def test_real_projective_plane(self):
+        # w(RP^2) = (1 + a)^3 = 1 + a + a^2, so w1 = a, w2 = a^2. The two SW
+        # numbers w1^2[RP^2] and w2[RP^2] both evaluate to 1.
+        numbers = _stiefel_whitney(_build(tessera.RealProjectivePlane()))
+        self.assertEqual(numbers, {"w1^2": 1, "w2": 1})
+
+    def test_complex_projective_plane(self):
+        # w(CP^2) = (1 + x)^3 = 1 + x + x^2 with |x| = 2, so w2 = x, w4 = x^2.
+        # The dimension-4 numbers w2^2 and w4 are 1; everything containing w1
+        # vanishes because CP^2 is orientable (w1 = 0).
+        numbers = _stiefel_whitney(_build(tessera.ComplexProjectivePlane()))
+        self.assertEqual(numbers["w2^2"], 1)
+        self.assertEqual(numbers["w4"], 1)
+        self.assertEqual(numbers["w1w3"], 0)
+        self.assertEqual(numbers["w1^2w2"], 0)
+        self.assertEqual(numbers["w1^4"], 0)
+
+    def test_spheres_have_vanishing_numbers(self):
+        # Every Stiefel-Whitney number of a sphere is zero (spheres bound disks).
+        for n in (2, 4):
+            with self.subTest(sphere=n):
+                numbers = _stiefel_whitney(_build(tessera.SimplexBoundarySphere(n)))
+                self.assertTrue(all(value == 0 for value in numbers.values()))
+
+    def test_product_of_spheres_vanishes(self):
+        # S^2 x S^2 bounds, so all its Stiefel-Whitney numbers vanish.
+        numbers = _stiefel_whitney(_build(_s2_cross_s2()))
+        self.assertTrue(all(value == 0 for value in numbers.values()))
+
+    def test_top_number_is_euler_characteristic_mod_two(self):
+        # The top Stiefel-Whitney number w_n[M] equals chi(M) mod 2.
+        euler = cobordism.EulerCharacteristic()
+        cases = [(tessera.RealProjectivePlane(), "w2"),
+                 (tessera.SimplexBoundarySphere(2), "w2"),
+                 (tessera.ComplexProjectivePlane(), "w4"),
+                 (tessera.SimplexBoundarySphere(4), "w4")]
+        for topology, top_key in cases:
+            with self.subTest(manifold=type(topology).__name__):
+                spacetime = _build(topology)
+                chi = int(euler.compute(spacetime))
+                numbers = _stiefel_whitney(spacetime)
+                self.assertEqual(numbers[top_key], chi % 2)
+
+    def test_disjoint_union_is_additive_and_vanishes(self):
+        # SW numbers are additive over disjoint union, so RP^2 ⊔ RP^2 has
+        # w1^2 = 1 + 1 = 0 and w2 = 1 + 1 = 0 (mod 2).
+        numbers = _stiefel_whitney(_two_disjoint_rp2())
+        self.assertEqual(numbers, {"w1^2": 0, "w2": 0})
+
+    def test_empty_complex_has_no_numbers(self):
+        numbers = _stiefel_whitney(_empty_spacetime())
+        self.assertEqual(numbers, {})
+
+    def test_torus_numbers_vanish(self):
+        # The 2-torus is parallelizable (a Lie group), hence bounds, hence all
+        # of its Stiefel-Whitney numbers vanish.
+        self.assertEqual(_stiefel_whitney(_build(_torus())), {"w1^2": 0, "w2": 0})
+
+    def test_higher_steenrod_squares_are_deferred(self):
+        # A manifold with b1 > 0 needs a higher cup-i Steenrod square to find
+        # the Wu class v_1; the general Sq^i is deferred (#65). The low-level
+        # call raises, and the aggregate CharacteristicNumbers.of degrades
+        # gracefully by leaving the Stiefel-Whitney family empty.
+        deferred = [
+            ("S^1 x S^3", tessera.SimplicialProduct(_sphere(1), _sphere(3))),
+            ("RP^2 x S^1",
+             tessera.SimplicialProduct(tessera.RealProjectivePlane(), _sphere(1))),
+        ]
+        for label, topology in deferred:
+            with self.subTest(manifold=label):
+                spacetime = _build(topology)
+                with self.assertRaises(Exception):
+                    cobordism.ChainComplex.fromSpacetime(
+                        spacetime).stiefelWhitneyNumbers()
+                numbers = cobordism.CharacteristicNumbers.of(spacetime)
+                self.assertEqual(dict(numbers.stiefel_whitney_numbers), {})
+
+
+# (label, topology factory, expected Betti numbers) for a spread of manifolds
+# whose homology is textbook. Products are assembled from the sphere and
+# real/complex projective-plane fixtures via SimplicialProduct.
+_KNOWN_MANIFOLDS = [
+    ("S^1", lambda: _sphere(1), [1, 1]),
+    ("S^2", lambda: _sphere(2), [1, 0, 1]),
+    ("S^3", lambda: _sphere(3), [1, 0, 0, 1]),
+    ("S^4", lambda: _sphere(4), [1, 0, 0, 0, 1]),
+    ("RP^2", tessera.RealProjectivePlane, [1, 0, 0]),
+    ("T^2", _torus, [1, 2, 1]),
+    ("S^1 x S^2", _s1_cross_s2, [1, 1, 1, 1]),
+    ("S^1 x S^3", lambda: tessera.SimplicialProduct(_sphere(1), _sphere(3)),
+     [1, 1, 0, 1, 1]),
+    ("T^3", lambda: tessera.SimplicialProduct(_torus(), _sphere(1)), [1, 3, 3, 1]),
+    ("S^2 x S^2", _s2_cross_s2, [1, 0, 2, 0, 1]),
+    ("CP^2", tessera.ComplexProjectivePlane, [1, 0, 1, 0, 1]),
+]
+
+
+class TestKnownManifoldHomology(unittest.TestCase):
+    """Betti numbers (over Q) of a spread of known manifolds, cross-checked
+    against chi = sum (-1)^k b_k and the boundary^2 = 0 chain-complex axiom."""
+
+    def test_betti_numbers_and_euler(self):
+        for label, make, betti in _KNOWN_MANIFOLDS:
+            with self.subTest(manifold=label):
+                chain = cobordism.ChainComplex.fromSpacetime(_build(make()))
+                self.assertTrue(chain.boundaryComposesToZero())
+                self.assertEqual(chain.bettiNumbers(), betti)
+                expected_euler = sum((-1) ** k * b for k, b in enumerate(betti))
+                self.assertEqual(chain.eulerCharacteristic(), expected_euler)
+
+
+class TestKnownFourManifoldSignatures(unittest.TestCase):
+    """Signature and middle Betti number of the closed oriented 4-manifold
+    fixtures. (CP^2's signature sign is a convention; |signature| = 1.)"""
+
+    def test_signatures(self):
+        # (label, factory, |signature|, b2)
+        cases = [
+            ("S^4", lambda: _sphere(4), 0, 0),
+            ("S^1 x S^3", lambda: tessera.SimplicialProduct(_sphere(1), _sphere(3)),
+             0, 0),
+            ("S^2 x S^2", _s2_cross_s2, 0, 2),
+            ("CP^2", tessera.ComplexProjectivePlane, 1, 1),
+        ]
+        for label, make, abs_signature, b2 in cases:
+            with self.subTest(manifold=label):
+                chain = cobordism.ChainComplex.fromSpacetime(_build(make()))
+                self.assertEqual(chain.bettiNumbers()[2], b2)
+                self.assertEqual(abs(chain.signature()), abs_signature)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Completes **Capability A** (#65) by computing the mod-2 **Stiefel–Whitney numbers** — the last characteristic-number family still pending. Euler characteristic, signature, and the Pontryagin number `p1 = 3σ` already landed; this adds `ChainComplex::stiefelWhitneyNumbers()` and wires the family into `CharacteristicNumbers::of`.

> **Stacked on #86** (the ℂP² fixture, which the SW validations need). Based on `cobordism/fixtures-cp2`; GitHub will retarget this to `main` automatically once #86 merges. Review #86 first.

## How

Reads the numbers off the mod-2 cohomology ring, combinatorially:

1. **`H^*(K; ℤ/2)`** from the boundary maps reduced mod 2 — a small hand-rolled GF(2) toolkit (kernel, incremental span, linear solve).
2. **Alexander–Whitney cup product** on cochains, generalizing the front/back-face rule already used by the integral intersection form to arbitrary degrees, mod 2.
3. **Wu classes** `v_k`, defined by `⟨v_k ∪ x, [K]⟩ = ⟨Sq^k x, [K]⟩` for all `x ∈ H^{n-k}`, solved against the nondegenerate Poincaré-duality pairing.
4. Total class `w = Sq(v)`, then each degree-`n` monomial cupped and evaluated on the ℤ/2 fundamental class (the sum of all top simplices).

### Scope of the Steenrod squares
Only squares expressible through the ordinary (`cup_0`) product are implemented: `Sq^k` on a degree-`k` class (the cup square) and the degree-forced zeros. These cover **surfaces** and **closed orientable 4-manifolds with `b₁ = 0`** (ℝP², ℂP², S⁴, S²×S², disjoint unions). A class that genuinely needs a higher `cup_i` (`i>0`) — e.g. any 4-manifold with `b₁ > 0` — raises a documented exception; `CharacteristicNumbers::of` catches it and leaves the family empty. General `Sq^i` is deferred per the ticket.

## Validation

| check | result |
|---|---|
| `w₁²[ℝP²]`, `w₂[ℝP²]` | 1, 1 ✅ |
| `w₂²[ℂP²]`, `w₄[ℂP²]` | 1, 1 ✅ |
| all numbers of S⁴, S²×S², T² | 0 ✅ |
| ℝP²⊔ℝP² (additivity) | all 0 ✅ |
| top number `wₙ[M]` | `= χ(M) mod 2` ✅ |
| `\|σ(ℂP²)\|`, `p₁ = 3σ` | 1, holds ✅ |
| `b₁>0` deferral (S¹×S³, ℝP²×S¹) | raises cleanly; `.of` family empty ✅ |

Plus a known-manifold homology/signature table (spheres, T², T³, S¹×S², S¹×S³, S²×S², ℂP²) checked against textbook Betti numbers. Cobordism suite: **91 passed**.

Part of the cobordism epic #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)