### PR TITLE
cobordism: Stage 1 — Edge U(1) phase + SpacetimeType::HERMITIAN_WEIGHTED

### DIFF
--- a/include/mesh/Edge.h
+++ b/include/mesh/Edge.h
@@ -104,6 +104,14 @@ class Edge {
     /// @return The square of the length of the edge.
     [[nodiscard]] double getSquaredLength() const noexcept;
 
+    /// The U(1) connection phase carried on this edge's stored source->target orientation (and
+    /// negated on reversal). With the signed `squaredLength` magnitude it forms the complex edge
+    /// weight \f$ \text{squaredLength}\cdot e^{i\,\text{phase}} \f$ read by the Hermitian-weighted
+    /// Laplacian. The default (`phase = 0`) leaves an ordinary real-weighted CDT edge unchanged.
+    ///
+    /// @return The U(1) connection phase, in radians.
+    [[nodiscard]] double getPhase() const noexcept;
+
 #ifdef TESSERA_VERBOSE
     [[nodiscard]] std::string toString() const noexcept;
 #else
@@ -154,6 +162,10 @@ class Edge {
     /// the geometry without rebuilding the mesh.
     void setSquaredLength(double sq) noexcept { squaredLength = sq; }
 
+    /// Set the U(1) connection phase (radians).  Used by the Hermitian-weighted
+    /// Laplacian and its gauge transform to rephase the edge without rebuilding the mesh.
+    void setPhase(double p) noexcept { phase = p; }
+
     /// Index into EdgeList::liveVec_ (maintained by EdgeList).
     std::uint32_t liveIdx_{UINT32_MAX};
 
@@ -186,6 +198,7 @@ class Edge {
     VertexPtr target = nullptr;
 
     double squaredLength;
+    double phase = 0.0;
 
     Simplices simplices_{};
 };

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -59,7 +59,10 @@ enum class SpacetimeType : uint8_t {
   COSET = 2,
   REGGE_PACHNER = 3,
   GFT_SPIN_FOAM = 4,
-  RICCI_FLOW_DISCRETIZATION = 5
+  RICCI_FLOW_DISCRETIZATION = 5,
+  // Variable complex edge weights (squaredLength * e^{i*phase}) for a
+  // Hermitian-weighted complex, unlike CDT's fixed real edge lengths.
+  HERMITIAN_WEIGHTED = 6
 };
 
 ///

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -109,6 +109,14 @@ endpoint vertex IDs, so Edge(v1, v2) == Edge(v2, v1).)doc")
 Positive = spacelike, negative = timelike, zero = lightlike.
 We work in squared lengths to avoid complex arithmetic for
 timelike (imaginary-length) edges.)doc")
+      .def("getPhase", &Edge::getPhase,
+           R"doc(Return the U(1) connection phase carried by this edge (radians).
+
+Paired with the signed squared length it gives the complex edge weight
+squaredLength * exp(i * phase) used by the Hermitian-weighted Laplacian.
+The default of 0 leaves an ordinary real-weighted CDT edge unchanged.)doc")
+      .def("setPhase", &Edge::setPhase, py::arg("phase"),
+           "Set the U(1) connection phase carried by this edge (radians).")
       .def("getTarget", &Edge::getTarget, py::return_value_policy::reference,
            "Return the target vertex of this edge.");
   // ========================================

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -49,13 +49,13 @@ class Simplex;
       const VertexPtr &source_,
       const VertexPtr &target_,
       double squaredLength_
-    ) : source(source_), target(target_), squaredLength(squaredLength_), fingerprint({source_->getId(), target_->getId()}) {
+    ) : source(source_), target(target_), squaredLength(squaredLength_), phase(0.0), fingerprint({source_->getId(), target_->getId()}) {
     }
 
     Edge::Edge(
       const VertexPtr &source_,
       const VertexPtr &target_
-    ) : source(source_), target(target_), fingerprint({source_->getId(), target_->getId()}) {
+    ) : source(source_), target(target_), phase(0.0), fingerprint({source_->getId(), target_->getId()}) {
       // Set squaredLength to a random value between -1 and 1
       squaredLength = random_uniform(); // Fallback: CDT always provides explicit edge lengths.
     }
@@ -70,6 +70,10 @@ class Simplex;
 
     [[nodiscard]] double Edge::getSquaredLength() const noexcept {
       return squaredLength;
+    }
+
+    [[nodiscard]] double Edge::getPhase() const noexcept {
+      return phase;
     }
 
 #ifdef TESSERA_VERBOSE

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -204,6 +204,7 @@ Args:
       .value("CDT", SpacetimeType::CDT)
       .value("REGGE", SpacetimeType::REGGE)
       .value("COSET", SpacetimeType::COSET)
+      .value("HERMITIAN_WEIGHTED", SpacetimeType::HERMITIAN_WEIGHTED)
       .export_values();
   // ========================================
   // Spacetime

--- a/tests/test_edge.py
+++ b/tests/test_edge.py
@@ -21,6 +21,7 @@
 
 import unittest
 
+import tessera
 from tessera import Edge, Vertex, Spacetime
 
 
@@ -75,6 +76,42 @@ class TestEdge(unittest.TestCase):
         self.assertEqual(e1, e3)
         e4 = Edge(v2, v3)
         self.assertNotEqual(e1, e4)
+
+
+class TestEdgePhase(unittest.TestCase):
+
+    def test_default_phase_is_zero(self):
+        v1 = Vertex(1, [0, 0, 0, 0])
+        v2 = Vertex(2, [1, 1, 1, 1])
+        edge = Edge(v1, v2)
+        self.assertEqual(edge.getPhase(), 0.0)
+
+    def test_default_phase_is_zero_with_explicit_squared_length(self):
+        v1 = Vertex(1, [0, 0, 0, 0])
+        v2 = Vertex(2, [1, 1, 1, 1])
+        edge = Edge(v1, v2, 1.0)
+        self.assertEqual(edge.getPhase(), 0.0)
+
+    def test_set_phase_round_trip(self):
+        v1 = Vertex(1, [0, 0, 0, 0])
+        v2 = Vertex(2, [1, 1, 1, 1])
+        edge = Edge(v1, v2)
+        for value in (0.5, -1.25, 3.14159, 0.0):
+            edge.setPhase(value)
+            self.assertEqual(edge.getPhase(), value)
+
+
+class TestHermitianWeightedSpacetimeType(unittest.TestCase):
+
+    def test_hermitian_weighted_value_exists(self):
+        self.assertTrue(hasattr(tessera, "HERMITIAN_WEIGHTED"))
+
+    def test_spacetime_constructs_with_hermitian_weighted(self):
+        signature = tessera.Signature(4, tessera.Lorentzian)
+        metric = tessera.Metric(True, signature)
+        spacetime = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                                      tessera.PREFERRED, tessera.Toroid())
+        self.assertIsInstance(spacetime, tessera.Spacetime)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements #88 — the Hermitian-weighted-complex mesh primitives for Stage 1 of the cobordism correspondence (plan: `docs/source/quantum-experiments/cobordism-plan.md`).

- `Edge::phase` — the U(1) connection on an edge (default `0.0`, preserving CDT) + `getPhase`/`setPhase` + pybind binding.
- `SpacetimeType::HERMITIAN_WEIGHTED` (+ binding) — variable complex edge weights, unlike CDT's fixed lengths.
- Tests: phase default/round-trip; enum exists and a `Spacetime` constructs with it.

Tests: `tests/test_edge.py tests/test_spacetime.py` → 25 passed, 1 skipped (pre-existing, unrelated), no regressions.

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)