### PR TITLE
cobordism: Stage 1 — wire cobordism spec + plan into the docs toctree

### DIFF
--- a/docs/source/quantum-experiments/cobordism-plan.md
+++ b/docs/source/quantum-experiments/cobordism-plan.md
@@ -1,0 +1,224 @@
+# Cobordism correspondence — Stage 1 (algebraic layer) implementation plan
+
+Implementation plan for **Stage 1** of the experiment specified in
+[`cobordism.md`](cobordism.md) (the State–Operation–Cobordism correspondence).
+Tracked under the **Cobordism Correspondence v0.1** milestone in the *Cobordism
+Extension* project.
+
+## Context
+
+The spec tests whether a quantum operation between two states can be realized as a
+**cobordism** whose boundary is the two states and whose TQFT value is their
+transition amplitude. **Stage 1** is the pure-linear-algebra "algebraic layer"
+(n=1): it validates the map–state correspondence and the gauge structure and, per
+the spec, is the **correctness oracle** that runs first, before any mesh dynamics.
+**This plan covers Stage 1 only**; Stage 2 (Dijkgraaf–Witten state-sum, interior
+bistellar moves, Lorentzian variant) is a follow-up milestone.
+
+Already built (the topological substrate, in `cobordism/`): `ChainComplex` (integer
+boundary maps, ℚ/GF(2) Betti, torsion, intersection form, signature), `Cobordism`
+(boundary verification), `Characteristic`/`CombinatorialDimension`, `IntegerLinalg`,
+and exact `Topology` fixtures. The mesh (`Spacetime`/`Edge`/`Vertex`), the
+`WilsonLoop` observable (curvature/causal holonomy on the dual graph), and a
+partly-built operator/state layer in `quantum/` (Choi via
+`ChoiState`/`InteractionSimulation`, Schmidt, von Neumann entropy) also exist.
+Unbuilt: the spec's Hermitian-weighted Laplacian, harmonic states, and the
+Choi–Jamiołkowski bending.
+
+## Architecture — reuse the two existing worlds, build the seam
+
+The experiment sits at the seam between the **mesh/topology** world (`Spacetime`,
+`Edge`, `ChainComplex`, `WilsonLoop`) and the **operator/state** world (`quantum/`).
+Work splits along that seam. All new code is class-organized and namespaced (no free
+functions), and reuses existing machinery rather than re-creating it.
+
+### Data model: the U(1) connection lives on `Edge`
+
+- **`Edge` gains one member** (`Edge.h` already anticipates "storing state on the
+  Edge"): `double phase` — the U(1) connection on the stored src→tgt orientation
+  (negated on reversal). Magnitude is the existing signed `squaredLength` (its sign
+  encodes signature, matching the spec and seeding the §5.6 Lorentzian variant). The
+  default (`phase = 0`) leaves every existing CDT edge unchanged.
+- **Complex weight** of an edge = `squaredLength · e^{i·phase}`. Assembly:
+  `A_ij = Σ squaredLength · e^{i·phase}`, `D_ii = Σ |squaredLength|` (magnitude
+  convention), `L = D − A`.
+- **No `ComplexEdge`, no side tables, no `EdgeList` refactor** (`EdgeList` stores
+  `Edge` by value → a subclass would slice; unnecessary once `phase` is a base
+  member).
+- **Deferred to Stage 2** (not exercised by Stage 1): `Edge::multiplicity`
+  (Δ-complex identifications on surface fixtures); `Spacetime::fromAdjacency`; and a
+  **U(1)-connection mode on `WilsonLoop`** (the general holonomy `Σ phase` around a
+  loop — needed by T4, "bulk holonomies = Stage-1 fluxes"). Stage-1 cycles are tiny
+  and known, so flux there is computed test-side, not via a library call.
+
+### `SpacetimeType::HERMITIAN_WEIGHTED`
+
+A new enum value. Unlike CDT (fixed edge lengths), this type carries variable
+complex edge weights — a real semantic distinction. Nothing branches on
+`SpacetimeType` today; this records intent and is the natural hook for future
+weight-aware behavior. Stage-1 fixtures are constructed with this type.
+
+### `cobordism::HodgeLaplacian` — operator on a `Spacetime`
+
+An operator object in the spirit of `ReggeSolver` (wraps a `Spacetime`, does the
+edge linear algebra), **degree-parameterized** so the same class serves Stage 1
+(`k=0`, assembled from edge weights) and Stage 2 (`L_k` from `ChainComplex` boundary
+matrices). Stage 1 implements `k=0`, reading `squaredLength`/`phase` off edges. It
+does **not** compute flux, cycle bases, or Betti numbers — those are
+`WilsonLoop`/`ChainComplex`'s job.
+
+```cpp
+namespace tessera::cobordism {
+class HodgeLaplacian {
+ public:
+  explicit HodgeLaplacian(std::shared_ptr<Spacetime> st);
+
+  std::vector<std::complex<double>> adjacency() const;     // N*N flat, Hermitian
+  std::vector<double>               degree()    const;     // magnitude convention
+  std::vector<std::complex<double>> laplacian(int k = 0) const;  // D - A at k=0
+
+  bool   isHermitian(double tol = 1e-12) const;
+  double unitarityResidual(double t = 1.0) const;          // ||e^{-iLt}(...)^H - I||
+
+  std::vector<double>               eigenvalues(int k = 0) const;   // real, ascending
+  std::vector<std::complex<double>> eigenvectors(int k = 0) const;  // columns
+  std::vector<std::complex<double>> harmonics(int k = 0, double tol = 1e-9) const;
+
+  HodgeLaplacian gauge(const std::vector<double>& alphas) const; // phase -> + a_i - a_j
+ private:
+  std::shared_ptr<Spacetime> st_;                          // lazy Eigen cache
+};
+}
+```
+
+Spectra via `Eigen::SelfAdjointEigenSolver<MatrixXcd>` (Hermitian ⇒ real
+eigenvalues, `e^{-iLt}` unitary by construction). `gauge` rephases edge phases;
+spectrum and every cycle flux must be invariant (C3). `b₁` and any flux are read
+from `ChainComplex::bettiNumbers()` and (test-side) `Σ phase` around the known
+cycle.
+
+### `cobordism::SpectralGap` / `HarmonicDimension` — scalar Observables
+
+The *scalar* spectral measurements are `Observable`s (`compute(spacetime) → double`),
+mirroring how `EulerCharacteristic`/`Signature` wrap `ChainComplex`
+(`Characteristic.cpp` delegates to `ChainComplex::fromSpacetime`). Because the
+connection lives on `Edge::phase`, a `Spacetime` carries everything they need.
+
+- **`SpectralGap`** — `λ₁ − λ₀` of the Hermitian Laplacian; collapses to 0 at
+  `Φ = π` on the triangle (C4).
+- **`HarmonicDimension`** — `dim ker L` (zero-mode count); the U(1) flux *lifts* the
+  zero-mode, so it drops 1 → 0 as `Φ` leaves 0, while the topological
+  `ChainComplex.bettiNumbers()` is unchanged (C4/C5).
+
+`HodgeLaplacian` itself stays a rich operator (returns matrices/eigenvectors, like
+`ChainComplex`), not an `Observable`.
+
+### `quantum::ChoiJamiolkowski` — map–state duality (bending)
+
+Bending *is* the Choi–Jamiołkowski construction, so it is a class in `quantum/`
+(beside `ChoiState`), reusing Eigen + the existing `vonNeumannEntropy` helper.
+
+```cpp
+namespace tessera::quantum {
+class ChoiJamiolkowski {
+ public:
+  ChoiJamiolkowski() = delete;  // static utility (cobordism::Cobordism pattern)
+  static std::vector<std::complex<double>> vectorize(const std::vector<std::complex<double>>& U, int dA, int dB);
+  static std::vector<double> singularValues(const std::vector<std::complex<double>>& U, int dA, int dB);
+  static int schmidtRank(const std::vector<std::complex<double>>& U, int dA, int dB, double tol = 1e-10);
+  static std::vector<std::complex<double>> transitionOperator(  // U_T = |psiA><psiB| (rank 1)
+      const std::vector<std::complex<double>>& psiA, const std::vector<std::complex<double>>& psiB, int dA, int dB);
+  static std::complex<double> transitionAmplitude(             // <psiA|U|psiB>
+      const std::vector<std::complex<double>>& psiA, const std::vector<std::complex<double>>& U,
+      const std::vector<std::complex<double>>& psiB, int dA, int dB);
+};
+}
+```
+
+**Locked conventions:** `vec(|a><b|) = a ⊗ conj(b)` (separable, Schmidt rank 1);
+**C1 is the HS/duality identity** `<psiA|U|psiB> = <vec(U_T)|vec(U)> = Tr(U_T^H U)`;
+Schmidt rank of `vec(U)` = #nonzero singular values of `U`. **The same class
+replaces `InteractionSimulation`'s inline 256-dim Choi.**
+
+## Fixtures (existing + inline; no new graph classes)
+
+| Fixture | Source | Laplacian spectrum (closed form) | Role |
+|------|------|------|------|
+| **triangle** = `SimplexBoundarySphere(1)` | existing `Topology` (`S¹ = ∂Δ²`, 3 verts/3 edges) | `λ_k = 2 − 2cos((Φ + 2πk)/3)` with flux Φ via `Edge::phase`; harmonic iff Φ≡0 | C4/C5 (b₁=1) |
+| **path** `0-1-2` | inline (`createVertex`/`createSimplex`) | `2 − 2cos(kπ/n)` (`{0,1,3}`); phase-independent (tree) | C5 tree (b₁=0) |
+| **testbed** square `00-01-11-10` + diag `00-11` | inline | numpy oracle; b₁=2 | C3 (spec's representative cyclic fixture) |
+
+**Provenance.** The triangle's flux spectrum is the tight-binding/Hückel
+**Aharonov–Bohm ring** result `E(k) = −2t·cos((2πk+φ)/N)` (here `L = 2I − A`, so
+`λ_k = 2 − 2cos((Φ+2πk)/N)`); see *Quantum rings for beginners*
+([arXiv:cond-mat/0310064](https://arxiv.org/abs/cond-mat/0310064)) and *Transport
+through quantum rings* ([arXiv:1403.1154](https://arxiv.org/abs/1403.1154)). The
+path/cycle Laplacian spectra are standard spectral graph theory. `b₁` for every
+fixture is cross-checked against `ChainComplex.bettiNumbers()[1]`.
+
+## Mapping to the spec checks (C1–C5)
+
+| Check | Fixture | Quantity | Expected | Tol | Refutes |
+|------|------|------|------|------|------|
+| **C1** value = amplitude | bare 2×2 `U`, unit `psiA,psiB` (seeded) | `transitionAmplitude` vs `<vec(U_T)|vec(U)>` & `Tr(U_T^H U)` | equal | `1e-12` | P1 (alg. half) |
+| **C2** rank=Schmidt=connectivity | `U_T=|psiA><psiB|`; `I₂` (cup); `σ_x` | `schmidtRank`, matrix rank | 1 ⇒ separable/disconnected; 2 ⇒ entangled/connected | `1e-10·σ_max` | P4 |
+| **C3** gauge invariance | testbed (b₁=2), random `w,θ,α` | `eigenvalues`, eigvec rephasing, `Σ phase` per cycle | spec(L) & all Φ_γ unchanged; `v→Gv` | `1e-12`/`1e-10` | P5 |
+| **C4** flux in spectrum | triangle = `SimplexBoundarySphere(1)`, flux sweep | `SpectralGap`, `HarmonicDimension` | `2−2cos((Φ+2πk)/3)`; harmonic iff Φ≡0; gap→0 at Φ=π | `1e-12` | P5 |
+| **C5** tree vs cycle | path (b₁=0); triangle/testbed (b₁≥1) | `SpectralGap`/`HarmonicDimension` over a θ sweep | tree θ-independent; cycle varies only through Φ_γ | `1e-12` | P5 |
+
+Pass criterion: **all C1–C5 pass** ⇒ P4, P5 supported and the amplitude half of P1.
+
+## Tickets (Cobordism Correspondence v0.1; issue-first, one per PR)
+
+- **[#88]** mesh/spacetime: `Edge::phase` + `SpacetimeType::HERMITIAN_WEIGHTED`.
+- **[#90]** cobordism: `HodgeLaplacian` (k=0) operator — assembly/spectra/harmonics/
+  `gauge` (+ bindings, + C3 + numpy-oracle spectrum tests; fixtures =
+  `SimplexBoundarySphere(1)` + inline).
+- **[#95]** cobordism: `SpectralGap` + `HarmonicDimension` Observables (delegate to
+  `HodgeLaplacian`; mirror `EulerCharacteristic`/`Signature` over `ChainComplex`) — C4/C5.
+- **[#91]** quantum: `ChoiJamiolkowski` class (+ bindings, + C1/C2 tests).
+- **[#92]** quantum: refactor `InteractionSimulation`'s inline Choi → `ChoiJamiolkowski`.
+- **[#93]** examples: `examples/cobordism/algebraic_correspondence.py` — C1–C5
+  pass/fail table + flux sweeps (§7/§8); figures not committed.
+- **[#94]** docs: wire `cobordism.md` + this plan into the quantum-experiments
+  toctree; clean `sphinx-build -E`.
+
+*(Closed: #89 graph-fixture classes — the triangle already exists as
+`SimplexBoundarySphere(1)`, and `CycleGraph`/`PathGraph`/`CompleteGraph` would
+duplicate `Spacetime`. Flux is a Wilson-loop quantity, handled test-side in Stage 1
+and via a `WilsonLoop` U(1) mode in Stage 2.)*
+
+## Build & verification
+
+- **Bindings:** `Edge::phase` in `src/mesh/Bindings.cpp`; enum in
+  `src/spacetime/Bindings.cpp`; `HodgeLaplacian` in `src/cobordism/Bindings.cpp`;
+  `ChoiJamiolkowski` in `src/quantum/Bindings.cpp`. `#include <pybind11/complex.h>`
+  where complex crosses. No CMake change (auto-glob; Eigen `PUBLIC` on `tessera_core`;
+  `quantum/` already links Eigen).
+- **Verify:** `pip install -e ".[dev]"`; `pytest tests/cobordism tests/quantum -v`
+  (C1–C5 green; `InteractionSimulation` tests unchanged); run the report; `sphinx-build
+  -E` 0 warnings. Heavier sweeps honor the 10-CPU cap (precautionary; Stage-1
+  matrices are tiny).
+
+## Risks
+
+1. **Convention bugs pass for the wrong reason** — assert against numpy, not the C++
+   output alone; lock `D_ii=Σ|w|`, `vec(|a><b|)=a⊗conj(b)`, the C1 HS form.
+2. **Kernel/degeneracy tolerance** — gap-ratio check; zero-count stable across
+   `tol∈[1e-6,1e-10]`; the triangle's Φ=π degeneracy is expected.
+3. **Complex over pybind** — `<pybind11/complex.h>`; round-trip test first.
+4. **Coordinate-free magnitudes** — ensure the `Metric` doesn't overwrite
+   explicitly-set squared lengths; set via `setSquaredLength` and assert.
+5. **`InteractionSimulation` refactor** — keep the 256-dim Choi byte-identical; gate
+   on its existing tests.
+
+## After Stage 1 (Stage 2 milestone)
+
+Stage 2 reuses the *same* `HodgeLaplacian` at `k≥1` (harmonic 1-forms on surface
+fixtures via `ChainComplex` boundary matrices), and is where `Edge::multiplicity`
+(Δ-complex identifications), `Spacetime::fromAdjacency`, and a **`WilsonLoop`
+U(1)-connection mode** (general `Σ phase` holonomy, for T4) finally earn their keep.
+It adds the Dijkgraaf–Witten ℤ₂ state-sum (T1/T3), interior bistellar moves for
+triangulation-independence (T2, make-or-break), gluing/functoriality (T5),
+cross-layer consistency (T4), and the Lorentzian variant (§5.6). Note **T3 must use
+T³, not S²×S¹** (the triple cup product vanishes on S²×S¹ — a negative control).

--- a/docs/source/quantum-experiments/cobordism.md
+++ b/docs/source/quantum-experiments/cobordism.md
@@ -1,0 +1,247 @@
+# Testing the State–Operation–Cobordism Correspondence in `tessera`
+
+## 0. Objective
+
+Test, numerically, whether a quantum operation between two states can be realized as a **cobordism** whose boundary is the two states and whose TQFT value is their transition amplitude — with all data (states, operation, signs/phases) determined by a **Hermitian-weighted simplicial complex**. The experiment has two layers: an algebraic layer that is pure linear algebra (validates the correspondence), and a topological layer built on `tessera`'s simplicial machinery (tests whether the sign/phase carries a genuine topological invariant).
+
+This document specifies the **mathematics only**. All data structures, language bindings, parallelism, and module layout are left to the implementer.
+
+---
+
+## 1. Hypothesis under test
+
+Let $\mathrm{geo}(\cdot)$ map a finite-dimensional Hilbert space to a simplicial complex carrying a Hermitian weighted adjacency, and map a state to a (weighted) subcomplex. The claim, for systems $A$ and $B$ with an operation $U:\mathcal{H}_B\to\mathcal{H}_A$:
+
+$$ W_{AB} = \mathrm{geo}(U) \quad\text{is an } n\text{-cobordism}, $$
+
+$$ \partial W_{AB} = \overline{\mathrm{geo}(\psi_B)}\ \sqcup\ \mathrm{geo}(\psi_A), $$
+
+$$ Z(W_{AB}) = \langle \psi_A \,|\, U \,|\, \psi_B \rangle . $$
+
+The manifold is the operation; the amplitude is the number it computes. The engine is map–state duality (Choi–Jamiołkowski / "bending"), under which
+
+$$ \operatorname{rank}(U) \;=\; \text{Schmidt rank of } \operatorname{vec}(U) \;=\; \text{connectivity of } W_{AB}. $$
+
+**Falsifiable core.** The hypothesis is *supported* iff (i) the cylinder cobordism reproduces the inner product, (ii) $Z(W)$ is invariant under interior re-triangulation, and (iii) the nontrivial sign class produces a $Z(W)$ distinct from the trivial one. It is *refuted* if any of these fails.
+
+---
+
+## 2. What to build on in `tessera`
+
+Reuse:
+
+- **Simplicial mesh** (oriented, with per-simplex vertex ordering / branching structure).
+- **All four Pachner moves** (add / remove / flip / shift) — the vehicle for the triangulation-independence test; map to the correct bistellar moves for the working dimension.
+- **`Cylinder` topology** $\Sigma\times[0,T]$ with open time boundaries — supplies boundary geometry and the **trivial** cobordism (the identity, $Z=\mathrm{id}$); the README notes it exists "for transition amplitudes." It is the $\mathrm{id}$ checkpoint, **not** the cobordism for a nontrivial operation — that is found by synthesis (§5.0).
+- **Lorentzian signature** and the CDT causal foliation (parameter $\alpha$ for the time/space edge-length-squared ratio) — supplies the indefinite-signature variant.
+- **Spectral tooling** already used for spectral dimension.
+
+New mathematics to add on top (no implementation prescription):
+
+1. A **Hermitian connection** on edges (complex weights with $A=A^\dagger$).
+2. **Hodge Laplacian** eigen-decomposition on $k$-cochains, and extraction of harmonic representatives.
+3. **Dijkgraaf–Witten** tetrahedron weights from a group cocycle, and the associated state-sum.
+
+---
+
+## 3. Notation
+
+- $V$, $E$ : vertex and edge sets; $N=|V|$ held fixed within a run.
+- $C^k$ : complex vector space of $k$-cochains; $d_k:C^k\to C^{k+1}$ the coboundary.
+- $A$ : weighted adjacency, $A_{ij}=w_{ij}\,e^{i\theta_{ij}}$, with $w_{ij}=w_{ji}\in\mathbb{R}$ (magnitudes; sign sets signature) and $\theta_{ij}=-\theta_{ji}$ (a $U(1)$ connection). Hermitian: $A=A^\dagger$.
+- $D$ : diagonal degree matrix. Use the **magnitude convention** $D_{ii}=\sum_j |A_{ij}|=\sum_j w_{ij}$ so that $L$ is Hermitian.
+- $L=D-A$ : graph (0-)Laplacian; $L_k$ : Hodge Laplacian on $k$-cochains, $L_k = d_{k-1}d_{k-1}^\dagger + d_k^\dagger d_k$.
+- $b_k=\dim\ker L_k$ : $k$-th Betti number (harmonic-cochain dimension).
+- $\Phi_\gamma=\sum_{(ij)\in\gamma}\theta_{ij}\ (\mathrm{mod}\ 2\pi)$ : holonomy (flux) around cycle $\gamma$.
+- $G=\operatorname{diag}(e^{i\alpha_v})$ : a vertex-phase gauge transformation, acting by $A\mapsto GAG^\dagger$.
+- $Z$ : the TQFT functor; $Z(W)$ the linear map / amplitude assigned to cobordism $W$.
+
+Two-qubit computational basis is written $\{00,01,10,11\}$, identifying $\mathbb{C}^4\cong\mathcal{H}_A\otimes\mathcal{H}_B$.
+
+---
+
+## 4. Stage 1 — Algebraic layer ($n=1$), pure linear algebra
+
+States live on vertices; the cobordism is an arc. This stage is fast, exact, and validates the correspondence and the gauge structure before any mesh is built.
+
+### 4.1 Hermitian-weighted complex
+
+Construct a Hermitian-weighted graph on $N$ vertices: choose magnitudes $w_{ij}=w_{ji}$ (allow negative for indefinite signature) and phases $\theta_{ij}=-\theta_{ji}$. Form $A$, then $D$ (magnitude convention), then $L=D-A$. Confirm $L=L^\dagger$ and that $e^{-iLt}$ is unitary.
+
+### 4.2 States as harmonic eigenvectors
+
+Eigendecompose $L=\sum_k \lambda_k\, v_k v_k^\dagger$, $\lambda_k\in\mathbb{R}$. A state is a chosen unit eigenvector $\psi=v_k$. Its geometric image $\mathrm{geo}(\psi)$ is the **weighted support**: the subcomplex of simplices on which $\psi$ is nonzero, decorated with the amplitudes. For $\mathrm{geo}(\psi)$ to be admissible as a closed boundary, require $\psi$ harmonic (a cycle): $\psi\in\ker L_{n-1}$.
+
+### 4.3 The operation and its bending
+
+The operation between $A$ and $B$ is the **entangling cross-cut coupling** — the both-bits-flip link $00\!\leftrightarrow\!11$, i.e. the off-diagonal block $\gamma_{AB}$ (the Weyl off-diagonal of $\gamma^0$) rendered geometrically. Compare it against the **transition operator** $U_T=|\psi_A\rangle\langle\psi_B|$.
+
+Bend (vectorize):
+
+$$ \operatorname{vec}(U) \;=\; \sum_{i,j} U_{ij}\,|i\rangle_A\otimes|j\rangle_B \;\in\; \mathcal{H}_A\otimes\mathcal{H}_B . $$
+
+Compute the Schmidt rank of $\operatorname{vec}(U)$ by SVD of the matrix $U$.
+
+### 4.4 The cobordism reading
+
+$W_{AB}$ is the support graph of $U$; its boundary components are $\mathrm{geo}(\psi_A)$ and $\mathrm{geo}(\psi_B)$. A rank-1 $U$ factors through the unit object,
+
+$$ \mathcal{H}_B \xrightarrow{\ \langle\psi_B|\ } \mathbb{C} \xrightarrow{\ |\psi_A\rangle\ } \mathcal{H}_A , $$
+
+so its cobordism is **disconnected** (a separable bent state); full-rank $U$ gives a **connected** cobordism (an entangled bent state, e.g. the cup $|00\rangle+|11\rangle$).
+
+### 4.5 Checks
+
+- **C1 (value = amplitude).** Verify numerically $\langle\psi_A|U|\psi_B\rangle$ equals the contraction of $\operatorname{vec}(U)$ with the bent boundary states.
+- **C2 (rank = Schmidt = connectivity).** Verify $\operatorname{rank}(U)$ equals the Schmidt rank of $\operatorname{vec}(U)$; confirm rank $1\Rightarrow$ separable/disconnected, rank $\ge 2\Rightarrow$ entangled/connected. Confirm $U_T$ is rank 1 and $\gamma_{AB}$ is full rank.
+- **C3 (gauge invariance).** Apply random $G=\operatorname{diag}(e^{i\alpha_v})$. Verify $\operatorname{spec}(L)$ is unchanged, eigenvectors are rephased $v_k\mapsto Gv_k$, and every cycle flux $\Phi_\gamma$ is unchanged.
+- **C4 (flux lives in the spectrum).** On a bigon — two parallel weighted edges between the $00$ and $11$ vertices, $b_1=1$ — the effective coupling is $z=e^{i\theta_1}+e^{i\theta_2}=2\cos(\Phi/2)\,e^{i\bar\theta}$ with $\Phi=\theta_1-\theta_2$. Verify the eigenvalue gap scales as $|z|=2|\cos(\Phi/2)|$ (a gauge-invariant interference signature) while the Bell relative phase $\bar\theta$ is gauge-dependent.
+- **C5 (tree vs cycle).** On a tree ($b_1=0$) verify the spectrum is independent of all $\theta$ (phases are pure gauge); on a graph with $b_1\ge1$ verify residual $\theta$-dependence through $\Phi_\gamma$.
+
+A representative cyclic testbed honoring both requirements: the square $00\text{–}01\text{–}11\text{–}10\text{–}00$ plus the diagonal $00\text{–}11$ ($|E|=5,\ b_1=2$); the diagonal is the entangling coupling, the cycles carry the flux.
+
+---
+
+## 4b. Boundary-state synthesis (inverse eigenvector problem)
+
+This builds $\mathrm{geo}(\psi_A)$ and $\mathrm{geo}(\psi_B)$ **independently** by solving the inverse problem: given a target state, find the *simplest* complex whose Laplacian has it as an eigenvector. Written here for the 0-Laplacian $L=D-A$ (vertex states); the same procedure runs at degree $k$ by replacing vertices with $k$-simplices and $L$ with $L_k$.
+
+### 4b.1 Target and embedding
+
+Draw a random unit target $\psi$. To keep it a **qubit** on $N\ge 2$ vertices, designate two **logical** vertices carrying the amplitudes $(c_0,c_1)$ and let the remaining **auxiliary** vertices carry zero amplitude — they exist only to supply combinatorial freedom:
+
+$$ \psi = (c_0,\ c_1,\ 0,\ \dots,\ 0),\qquad \|\psi\|=1 . $$
+
+(Alternatively treat the full $\mathbb{C}^N$ vector as an $N$-level state and drop "qubit." Decide which.)
+
+### 4b.2 Why auxiliary vertices are necessary
+
+Under the pure-edge constraint ($A_{ii}=0$, no on-site potentials) with the magnitude degree convention, a single edge between the two logical vertices has Laplacian
+
+$$ L=\begin{pmatrix} w & -w e^{i\theta}\\ -w e^{-i\theta} & w\end{pmatrix}, $$
+
+whose eigenvectors are $\tfrac{1}{\sqrt2}(e^{i\theta},\pm 1)$ — **balanced only** ($|c_0|=|c_1|$). A general-amplitude qubit ($|c_0|\ne|c_1|$) therefore cannot be a two-vertex eigenvector; it requires auxiliary scaffolding. The minimal number of auxiliary vertices is the state's **combinatorial complexity** — the quantity this stage measures.
+
+### 4b.3 Objective
+
+Solve for Hermitian edge weights on the current complex minimizing the eigenvalue-agnostic residual
+
+$$ r(A) = \big\|\,(I-\psi\psi^\dagger)\,L\,\psi\,\big\|^2 , $$
+
+with $A_{ii}=0$ and $D_{ii}=\sum_j w_{ij}$. Then $\psi$ is an eigenvector iff $r=0$ (i.e. $L\psi\parallel\psi$); the realized eigenvalue is the Rayleigh quotient $\lambda=\psi^\dagger L\psi$. The landscape is non-convex in $\{w_{ij},\theta_{ij}\}$; use multiple restarts.
+
+### 4b.4 Seed and the coning loop
+
+- **Seed.** Start each state on a single 4-simplex $\Delta^4$ — 5 vertices, 1-skeleton $K_5$.
+- **Cone-and-retry.** If no restart drives $r<\epsilon$ within budget, **cone in** one vertex and re-optimize. Use the topology-preserving stellar / Pachner-add operation (`tessera`'s `Spacetime` and `Simplex` expose coning methods): it adds an apex and its incident edges, enlarging the parameter space **without changing the homotopy type**. Add one vertex at a time.
+- **Stop / minimality.** Accept the first complex reaching $r<\epsilon$; record $(|V|,|E|)$ as the state's complexity. This is the simplest complex representing $\psi$.
+
+### 4b.5 Notes
+
+- **Coning vs the cone.** The growth move must be the topology-preserving subdivision (Pachner add), **not** the full cone $CX$ — a cone is contractible and would trivialize all harmonic/topological content. Confirm `tessera`'s coning primitive is the subdivision.
+- **Degree convention.** Keep the magnitude convention $D_{ii}=\sum_j|A_{ij}|$ (Hermitian $L$, unitary evolution). The signed convention restores the constant zero mode but breaks Hermiticity for complex weights — do not mix them.
+- **Feasibility.** On an unrestricted complete graph, parameters far outnumber constraints and a solution is generic; the search is nontrivial only because the complex must be a valid simplicial complex. Coning is the canonical simplicial way to add freedom, so the loop terminates.
+- **Output per state.** $\mathrm{geo}(\psi_A)$ and $\mathrm{geo}(\psi_B)$: their minimal complexes, edge weights, and realized $\lambda$. These are the boundary objects consumed by Stage 2.
+
+---
+
+## 5. Stage 2 — Topological layer ($n=3$), simplicial via `tessera`
+
+Now states live on closed 2-surfaces and the cobordism is a 3-manifold. This is where the sign becomes a topological invariant.
+
+### 5.0 Synthesis is the task
+
+Given the operation $U:\mathcal{H}_B\to\mathcal{H}_A$ (e.g. the entangling coupling $\gamma_{AB}$ relating the synthesized boundaries), **find a bulk** 3-manifold $W$ with $Z(W)=U$ — do not assume one. Bend $U$ to its target in $Z(\partial W)$ (Choi–Jamiołkowski), then search over bulk topologies and cocycle classes for a $W$ realizing it. The operation lives in the bulk topology, not in the cylinder.
+
+**Realizability is itself the test.** At $n=3$, $Z(W)$ is a topological invariant, so the realizable operators are constrained — generated by the mapping-class-group representation and handle operators, and required to respect the theory's symmetries; they are not arbitrary matrices. For $\mathbb{Z}_2$ DW on the torus, $Z(T^2)=\mathbb{C}^4$ and the invertible cobordism maps are generated by the modular $S,T$ matrices. So a generic $U$ may have **no** cobordism. The experiment must characterize the realizable set $\{Z(W)\}$ and decide whether the target $U$ lies in it — a genuine yes/no, and the sharpest form of the hypothesis.
+
+### 5.1 Cobordism and boundary surfaces
+
+A candidate $W$ is an oriented triangulated 3-manifold with
+
+$$ \partial W = \overline{\Sigma_B}\ \sqcup\ \Sigma_A , $$
+
+two closed oriented surfaces. The `Cylinder` topology $\Sigma\times[0,T]$ gives the **trivial** cobordism ($Z=\mathrm{id}$), used only as boundary geometry and the T1 checkpoint; nontrivial candidates come from gluings and other topologies ($S^2\times S^1$, $T^3$, lens spaces, mapping tori).
+
+### 5.2 States as harmonic 1-forms (qubits from $H_1$)
+
+Take $\Sigma$ a genus-$g$ surface. The real harmonic 1-cochains form $\ker L_1(\Sigma)$ of dimension $b_1=2g$. For the torus ($g=1$), $\dim\ker L_1=2$ — a **qubit**. Choose $\psi_A\in\ker L_1(\Sigma_A)$, $\psi_B\in\ker L_1(\Sigma_B)$ as the boundary states. (The discrete-gauge count of flat $\mathbb{Z}_2$ connections is $2^{\,b_1}$; keep the two countings distinct — continuous harmonic forms give the qubit dimension, flat connections index the state-sum.)
+
+### 5.3 The $\mathbb{Z}_2$ connection and Dijkgraaf–Witten weight
+
+Assign a $\mathbb{Z}_2$ gauge field $g\in C^1(W;\mathbb{Z}_2)$, $g_e\in\{0,1\}$, flat on every 2-simplex:
+
+$$ (d g)\big|_{\triangle} = g_{01}+g_{12}-g_{02} \equiv 0 \pmod 2 . $$
+
+Weight each oriented tetrahedron $[v_0v_1v_2v_3]$ by a 3-cocycle $\omega\in Z^3(\mathbb{Z}_2;U(1))$ raised to its orientation sign $\epsilon_t=\pm1$:
+
+$$ \omega\big(g_{01},g_{12},g_{23}\big)^{\epsilon_t}. $$
+
+Use the two classes: trivial $\omega\equiv 1$, and the nontrivial generator
+
+$$ \omega(a,b,c) = (-1)^{abc} \in H^3(\mathbb{Z}_2;U(1)) \cong \mathbb{Z}_2 . $$
+
+### 5.4 State-sum and cobordism map
+
+For a closed complex,
+
+$$ Z(W) = \frac{1}{|\mathbb{Z}_2|^{|V|}} \sum_{\text{flat } g}\ \prod_{\text{tetrahedra } t} \omega(t)^{\epsilon_t}. $$
+
+For $W$ with boundary, hold the boundary field $g|_{\partial W}$ fixed; summing over interior fields yields a vector indexed by boundary flat connections, i.e. an element of $Z(\partial W)$. Reading it as a map gives
+
+$$ Z(W) : Z(\Sigma_B)\to Z(\Sigma_A), \qquad \dim Z(\Sigma_g)=2^{\,b_1(\Sigma_g)} . $$
+
+The amplitude under test is $\langle\psi_A\,|\,Z(W)\,|\,\psi_B\rangle$ for the chosen boundary states.
+
+### 5.5 Checks
+
+- **T1 (cylinder = identity).** For $W=\Sigma\times[0,T]$ verify $Z(W)=\mathrm{id}_{Z(\Sigma)}$, hence $\langle\psi_A|Z(W)|\psi_B\rangle=\langle\psi_A|\psi_B\rangle$.
+- **T2 (triangulation independence — the central test).** Apply interior bistellar (Pachner) moves with $\partial W$ fixed; verify $Z(W)$ is invariant to machine precision. Failure here refutes the construction (or signals $\omega$ is not a cocycle).
+- **T3 (the sign carries an invariant).** On a 3-manifold with nontrivial topology, verify $Z_{\omega=(-1)^{abc}}(W)\ne Z_{\omega\equiv1}(W)$. Equality everywhere would refute "the sign carries an invariant" at $n=3$.
+- **T4 (cross-layer consistency).** Verify the bulk $\mathbb{Z}_2$ holonomies equal the Stage-1 cycle fluxes restricted to $\{0,\pi\}$.
+- **T5 (composition / functoriality).** Glue $W_1:\Sigma_A\to\Sigma_C$ and $W_2:\Sigma_C\to\Sigma_B$ along $\Sigma_C$; verify $Z(W_2\cup_{\Sigma_C} W_1)=Z(W_2)\,Z(W_1)$.
+
+### 5.6 Lorentzian variant
+
+Repeat the Hodge analysis in CDT's Lorentzian signature (parameter $\alpha$). The metric is indefinite, so $L_k$ becomes a discrete d'Alembertian and the clean identification $\ker L_k\cong H_k$ degrades to a pseudo-Hodge decomposition. Record where harmonic representatives become null and how the invariant (T2, T3) behaves relative to the Euclidean run. This is the signature in which $\gamma^0$ natively lives.
+
+---
+
+## 6. Falsifiable predictions
+
+- **P1.** Cylinder reproduces the inner product (T1, C1).
+- **P2.** $Z(W)$ invariant under interior Pachner moves (T2) — make-or-break.
+- **P3.** Nontrivial $\omega$ distinguishable from trivial on some $W$ (T3).
+- **P4.** $\operatorname{rank}(U)=$ Schmidt rank $=$ connectivity; transition operator separable, coupling entangling (C2).
+- **P5.** Flux is gauge-invariant and visible in the spectrum; only cycles ($b_1\ge1$) carry physical phase (C3, C4, C5).
+
+Hypothesis **supported** iff P1, P2, P3 hold; **refuted** if any of P1–P3 fails. P4, P5 are structural consistency conditions that should hold in every run.
+
+---
+
+## 7. Parameter sweeps
+
+- Flux $\Phi\in[0,2\pi)$: spectrum and amplitude versus flux (Stage 1).
+- Signature: Euclidean versus Lorentzian (CDT $\alpha$).
+- Boundary genus $g$: qubit dimension $b_1=2g$; state-sum dimension $2^{2g}$.
+- Cocycle class: trivial versus nontrivial $\mathbb{Z}_2$.
+- Bulk refinement / Pachner depth: invariance stress test (T2).
+- 3-manifold topology: $\Sigma\times S^1$, $T^3$, lens spaces.
+
+---
+
+## 8. Outputs
+
+- A pass/fail report on P1–P5 / C1–C5 / T1–T5, with residuals.
+- Tables of $Z(W)$ across triangulations at fixed boundary (demonstrating, or breaking, invariance).
+- Side-by-side $Z_{\text{nontrivial}}$ versus $Z_{\text{trivial}}$.
+- Spectrum-versus-flux and amplitude-versus-flux curves.
+- Cobordism mesh exports (the existing GIF / GraphML / DOT writers) for the worked $W$.
+
+---
+
+### Notes for the implementer
+
+- Stages are independent: Stage 1 needs no mesh and should run first as a correctness oracle for the bending/amplitude relations and the gauge structure.
+- The only nonstandard numerical objects are: the magnitude-convention Hermitian Laplacian, harmonic-cochain extraction (kernel of $L_k$), and the cocycle-weighted state-sum. Everything else is existing `tessera` machinery.
+- Keep the two notions of "dimension" separate throughout: the manifold dimension $n$ (here $1$ then $3$) versus the Hilbert-space dimension (here $2$ per qubit, $2^{b_1}$ for a boundary surface).

--- a/docs/source/quantum-experiments/index.md
+++ b/docs/source/quantum-experiments/index.md
@@ -14,6 +14,8 @@ experiments.
 overview/index
 earlier-work/index
 charged-cartan/index
+cobordism
+cobordism-plan
 ```
 
 ## Reproducing


### PR DESCRIPTION
Implements #94 — wires the cobordism spec and Stage-1 plan into the rendered docs.

- Adds `cobordism` (spec) and `cobordism-plan` (plan) to the quantum-experiments toctree.
- Removes the plan's `orphan` front-matter.
- The spec and plan were untracked in the tree; this commits both alongside the toctree edit (3 files).

Docs build: `sphinx-build -E` → 0 new warnings. (One pre-existing `quantum` autodoc warning comes from a stale compiled extension and is unrelated; it clears on a C++ rebuild.)

Follow-up on this branch: switch the plan doc's build commands from `pip` to `poetry`.

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)