### PR TITLE
cobordism: Stage 1 — HodgeLaplacian (k=0) Hermitian-weighted Laplacian

### DIFF
--- a/include/cobordism/HodgeLaplacian.h
+++ b/include/cobordism/HodgeLaplacian.h
@@ -1,0 +1,143 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_HODGELAPLACIAN_H
+#define TESSERA_COBORDISM_HODGELAPLACIAN_H
+
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # HodgeLaplacian
+///
+/// The Hermitian-weighted Hodge Laplacian on a `Spacetime`. **Stage 1**
+/// implements the degree-zero case — the U(1)-weighted graph Laplacian
+/// \f$ L = D - A \f$ on the 1-skeleton — assembled directly from the complex
+/// edge weights \f$ \text{squaredLength}\cdot e^{i\,\text{phase}} \f$ carried by
+/// each `Edge`. The API is **degree-parameterized** (`int k`) so Stage 2 can add
+/// the cochain Laplacians \f$ L_k = d_{k-1}d_{k-1}^\dagger + d_k^\dagger d_k \f$
+/// without changing call sites; any \f$ k \neq 0 \f$ currently throws.
+///
+/// Vertices are indexed by a stable order: sorted vertex id \f$ \to 0..N-1 \f$,
+/// so the returned flat \f$ N\times N \f$ matrices (row-major) are reproducible.
+///
+/// ## Assembly (k = 0)
+///
+/// - Adjacency \f$ A_{ij} = \sum_{(i,j)} \text{squaredLength}\cdot e^{i\,\text{phase}} \f$,
+///   summed over edges between \f$ i \f$ and \f$ j \f$; the stored source→target
+///   orientation carries \f$ +\text{phase} \f$, the reverse carries
+///   \f$ -\text{phase} \f$, so \f$ A = A^\dagger \f$ (Hermitian).
+/// - Degree \f$ D_{ii} = \sum |\text{squaredLength}| \f$ over incident edges
+///   (the magnitude convention — keeps \f$ L \f$ Hermitian and \f$ e^{-iLt} \f$
+///   unitary for complex weights).
+/// - Laplacian \f$ L = D - A \f$.
+///
+/// This class is the *operator* only: it does not compute fluxes, cycle bases,
+/// or Betti numbers (those are `WilsonLoop` / `ChainComplex`'s job), and it does
+/// not gauge-transform the mesh (gauge invariance is exercised by rephasing the
+/// edges and rebuilding). The Hermitian eigendecomposition is lazily computed
+/// (Eigen `SelfAdjointEigenSolver<MatrixXcd>`) and cached.
+class HodgeLaplacian {
+  public:
+    /// Construct the operator over a triangulation. Edge weights/phases are read
+    /// lazily (at the first matrix/spectrum query), so the spacetime must
+    /// outlive the operator; the held `shared_ptr` keeps it alive.
+    explicit HodgeLaplacian(std::shared_ptr<Spacetime> st);
+
+    /// Weighted adjacency \f$ A \f$ as a flat row-major \f$ N\times N \f$ array
+    /// of complex entries. Hermitian by construction.
+    [[nodiscard]] std::vector<std::complex<double>> adjacency() const;
+
+    /// Degree vector \f$ (D_{00},\dots,D_{N-1,N-1}) \f$, real, length \f$ N \f$
+    /// (magnitude convention \f$ D_{ii} = \sum |\text{squaredLength}| \f$).
+    [[nodiscard]] std::vector<double> degree() const;
+
+    /// Laplacian \f$ L = D - A \f$ for \f$ k = 0 \f$, flat row-major
+    /// \f$ N\times N \f$ complex.
+    /// @throws std::runtime_error for \f$ k \neq 0 \f$ (Stage 2: \f$ L_k \f$ not
+    ///   yet implemented).
+    [[nodiscard]] std::vector<std::complex<double>> laplacian(int k = 0) const;
+
+    /// Whether \f$ \| L - L^\dagger \| \le \text{tol} \f$ (Frobenius norm) for
+    /// the \f$ k = 0 \f$ Laplacian. True by construction.
+    [[nodiscard]] bool isHermitian(double tol = 1e-12) const;
+
+    /// Unitarity residual of the time-evolution operator
+    /// \f$ U = e^{-iLt} = V\,\mathrm{diag}(e^{-i\lambda t})\,V^\dagger \f$ formed
+    /// from the eigendecomposition: returns \f$ \| U U^\dagger - I \| \f$
+    /// (Frobenius). ~0 for the Hermitian \f$ L \f$.
+    [[nodiscard]] double unitarityResidual(double t = 1.0) const;
+
+    /// Eigenvalues of \f$ L_k \f$ (real, ascending).
+    /// @throws std::runtime_error for \f$ k \neq 0 \f$.
+    [[nodiscard]] std::vector<double> eigenvalues(int k = 0) const;
+
+    /// Eigenvectors of \f$ L_k \f$ as a flat row-major \f$ N\times N \f$ array;
+    /// column \f$ j \f$ (entries at indices \f$ iN + j \f$) is the eigenvector
+    /// for the \f$ j \f$-th ascending eigenvalue.
+    /// @throws std::runtime_error for \f$ k \neq 0 \f$.
+    [[nodiscard]] std::vector<std::complex<double>> eigenvectors(int k = 0) const;
+
+    /// Harmonic representatives: the eigenvectors with \f$ |\lambda| < \text{tol} \f$
+    /// (a basis for \f$ \ker L_k \f$), as a flat row-major \f$ N\times M \f$
+    /// array whose \f$ M \f$ columns are the harmonics (so \f$ M = \f$
+    /// size/\f$ N \f$). \f$ M \f$ is the harmonic dimension.
+    /// @throws std::runtime_error for \f$ k \neq 0 \f$.
+    [[nodiscard]] std::vector<std::complex<double>> harmonics(int k = 0,
+                                                              double tol = 1e-9) const;
+
+  private:
+    std::shared_ptr<Spacetime> st_;
+
+    // Stable vertex order: ids_[idx] = vertex id, idToIndex_[id] = idx. Built
+    // once in the constructor (the vertex set is fixed for the operator's life;
+    // only the edge weights/phases are read lazily).
+    std::vector<std::uint64_t> ids_{};
+    std::unordered_map<std::uint64_t, std::size_t> idToIndex_{};
+    std::size_t order_{0};  // N = |V|
+
+    // Lazy, cached Hermitian eigendecomposition of the k=0 Laplacian.
+    mutable bool decomposed_{false};
+    mutable std::vector<double> evals_{};               // ascending, length N
+    mutable std::vector<std::complex<double>> evecs_{};  // flat N*N, columns
+
+    // Throw unless k == 0 (Stage 1 only implements the graph Laplacian).
+    static void requireStageOne(int k);
+
+    // Assemble the adjacency (flat row-major N*N) and degree (length N) from the
+    // current edge weights/phases, using the stable vertex order. Kept Eigen-free
+    // in its signature so the public header carries no Eigen dependency.
+    void assemble(std::vector<std::complex<double>> &A, std::vector<double> &D) const;
+
+    // Build and cache the eigendecomposition of L (k=0) if not already done.
+    void ensureDecomposition() const;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_HODGELAPLACIAN_H

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ version = "0.1.0"
 description = "C++/pybind11 extension for lattice spacetime experiments"
 authors = [{ name = "Andrew Kelleher", email = "keats.kelleher@gmail.com" }]
 readme = "README.md"
-requires-python = ">=3.11"
+# Upper-bounded so Poetry can resolve dev deps that cap Python at <4.0 (e.g.
+# pybind11-stubgen); pip resolves per-interpreter and is unaffected.
+requires-python = ">=3.11,<4.0"
 license = { text = "MIT" }
 dependencies = [
     "numpy>=2.0",
@@ -27,7 +29,15 @@ optional-dependencies.examples = [
     "tqdm>=4.66",
 ]
 optional-dependencies.dev = [
-    "tessera[examples]",
+    # The examples extra is inlined here (rather than referenced as
+    # "tessera[examples]") so Poetry can resolve `poetry install --all-extras`:
+    # Poetry 2.x rejects a PEP 621 self-referential extra as a self-dependency.
+    # pip's resolved dependency set is unchanged. Keep in sync with the
+    # optional-dependencies.examples list above.
+    "matplotlib>=3.8",
+    "networkx>=3.0",
+    "scipy>=1.11",
+    "tqdm>=4.66",
     "pytest",
     "scikit-build-core>=0.9",
     "cmake>=3.22",

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -24,6 +24,7 @@
 // in the Python dependency. This translation unit is always added to
 // _tessera's sources (see CMakeLists.txt, TESSERA_PYBIND_SOURCES).
 
+#include <pybind11/complex.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -31,6 +32,7 @@
 #include "cobordism/Characteristic.h"
 #include "cobordism/Cobordism.h"
 #include "cobordism/CombinatorialDimension.h"
+#include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
 
@@ -95,6 +97,48 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
            "Mod-2 Stiefel-Whitney numbers <w_{i1}..w_{ir}, [K]> keyed by "
            "monomial (e.g. 'w4', 'w2^2'); empty for the empty complex. Raises "
            "if a class needs a deferred higher Steenrod cup-i product (#65).");
+
+  // ----- Hermitian-weighted Hodge Laplacian (#90): the k=0 operator -----
+  py::class_<HodgeLaplacian>(m, "HodgeLaplacian",
+      R"doc(Hermitian-weighted Hodge Laplacian on a Spacetime.
+
+Stage 1 implements degree k=0 — the U(1)-weighted graph Laplacian L = D - A on
+the 1-skeleton, assembled from each edge's complex weight
+squaredLength * exp(i*phase). Vertices are indexed by sorted id (0..N-1), so the
+returned flat N*N row-major matrices are reproducible. Adjacency is Hermitian by
+construction (the reverse orientation negates the phase); the degree uses the
+magnitude convention D_ii = sum |squaredLength|. The eigendecomposition (Eigen
+SelfAdjointEigenSolver) is computed lazily and cached.
+
+The API is degree-parameterized (int k) for Stage 2's cochain Laplacians L_k;
+any k != 0 currently raises RuntimeError. This is the operator only — fluxes,
+cycle bases, and Betti numbers belong to WilsonLoop / ChainComplex.)doc")
+      .def(py::init<std::shared_ptr<Spacetime>>(), py::arg("spacetime"),
+           "Build the Hodge Laplacian operator over a triangulation.")
+      .def("adjacency", &HodgeLaplacian::adjacency,
+           "Weighted adjacency A as a flat row-major N*N complex array "
+           "(Hermitian; A_ij = sum squaredLength * exp(i*phase)).")
+      .def("degree", &HodgeLaplacian::degree,
+           "Degree vector (length N, real): D_ii = sum |squaredLength| over "
+           "incident edges (magnitude convention).")
+      .def("laplacian", &HodgeLaplacian::laplacian, py::arg("k") = 0,
+           "Laplacian L = D - A for k=0 as a flat row-major N*N complex array; "
+           "raises for k != 0 (Stage 2 not yet implemented).")
+      .def("isHermitian", &HodgeLaplacian::isHermitian, py::arg("tol") = 1e-12,
+           "True iff ||L - L^dagger|| <= tol (Frobenius) for the k=0 Laplacian.")
+      .def("unitarityResidual", &HodgeLaplacian::unitarityResidual,
+           py::arg("t") = 1.0,
+           "Residual ||U U^dagger - I|| of U = e^{-iLt} formed from the "
+           "eigendecomposition (~0 for the Hermitian L).")
+      .def("eigenvalues", &HodgeLaplacian::eigenvalues, py::arg("k") = 0,
+           "Eigenvalues of L_k (real, ascending); raises for k != 0.")
+      .def("eigenvectors", &HodgeLaplacian::eigenvectors, py::arg("k") = 0,
+           "Eigenvectors of L_k as a flat row-major N*N complex array (column j "
+           "is the eigenvector for the j-th ascending eigenvalue); raises for k != 0.")
+      .def("harmonics", &HodgeLaplacian::harmonics, py::arg("k") = 0,
+           py::arg("tol") = 1e-9,
+           "Harmonic representatives (eigenvectors with |lambda| < tol) as a flat "
+           "row-major N*M complex array whose M columns span ker L_k; raises for k != 0.");
 
   // Exact integer / GF(2) / inertia primitives (also exposed for direct
   // testing). Matrices are passed flat row-major with explicit dims.

--- a/src/cobordism/HodgeLaplacian.cpp
+++ b/src/cobordism/HodgeLaplacian.cpp
@@ -1,0 +1,216 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/HodgeLaplacian.h"
+
+#include <Eigen/Dense>
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Vertex.h"
+#include "mesh/VertexList.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+using cd = std::complex<double>;
+
+HodgeLaplacian::HodgeLaplacian(std::shared_ptr<Spacetime> st) : st_(std::move(st)) {
+  if (!st_) return;
+  // Stable vertex order: sort by id, then id -> 0..N-1.
+  const auto &verts = st_->getVertexList()->toVector();
+  ids_.reserve(verts.size());
+  for (const auto v : verts)
+    if (v != nullptr) ids_.push_back(v->getId());
+  std::sort(ids_.begin(), ids_.end());
+  order_ = ids_.size();
+  idToIndex_.reserve(order_);
+  for (std::size_t i = 0; i < order_; ++i) idToIndex_[ids_[i]] = i;
+}
+
+void HodgeLaplacian::requireStageOne(int k) {
+  if (k != 0)
+    throw std::runtime_error(
+        "HodgeLaplacian: Stage 2: L_k not yet implemented (only k=0, the graph "
+        "Laplacian, is available); requested k=" + std::to_string(k));
+}
+
+void HodgeLaplacian::assemble(std::vector<cd> &A, std::vector<double> &D) const {
+  const std::size_t N = order_;
+  A.assign(N * N, cd(0.0, 0.0));
+  D.assign(N, 0.0);
+  if (N == 0 || !st_) return;
+
+  for (const EdgePtr e : st_->getEdgeList()->toVector()) {
+    if (e == nullptr) continue;
+    const VertexPtr s = e->getSource();
+    const VertexPtr t = e->getTarget();
+    if (s == nullptr || t == nullptr) continue;
+    const auto is = idToIndex_.find(s->getId());
+    const auto it = idToIndex_.find(t->getId());
+    if (is == idToIndex_.end() || it == idToIndex_.end()) continue;
+    const std::size_t i = is->second;
+    const std::size_t j = it->second;
+    if (i == j) continue;  // a simplicial complex carries no self-loops
+
+    const double w = e->getSquaredLength();      // signed magnitude
+    const double phase = e->getPhase();          // U(1) connection on src->tgt
+
+    // Degree uses the magnitude convention D_ii = sum |squaredLength| over
+    // incident edges (phase-independent; keeps L Hermitian and e^{-iLt} unitary).
+    D[i] += std::abs(w);
+    D[j] += std::abs(w);
+
+    // A_ij = sum squaredLength * e^{i*phase}; the reverse orientation negates
+    // the phase, so A = A^dagger.
+    const cd z = w * std::exp(cd(0.0, phase));
+    A[i * N + j] += z;
+    A[j * N + i] += std::conj(z);
+  }
+}
+
+std::vector<cd> HodgeLaplacian::adjacency() const {
+  std::vector<cd> A;
+  std::vector<double> D;
+  assemble(A, D);
+  return A;
+}
+
+std::vector<double> HodgeLaplacian::degree() const {
+  std::vector<cd> A;
+  std::vector<double> D;
+  assemble(A, D);
+  return D;
+}
+
+std::vector<cd> HodgeLaplacian::laplacian(int k) const {
+  requireStageOne(k);
+  std::vector<cd> A;
+  std::vector<double> D;
+  assemble(A, D);
+  const std::size_t N = order_;
+  // L = D - A: off-diagonal entries are -A_ij; the diagonal carries D_ii (the
+  // adjacency has no diagonal in a complex without self-loops).
+  std::vector<cd> L(N * N, cd(0.0, 0.0));
+  for (std::size_t idx = 0; idx < A.size(); ++idx) L[idx] = -A[idx];
+  for (std::size_t i = 0; i < N; ++i) L[i * N + i] += D[i];
+  return L;
+}
+
+void HodgeLaplacian::ensureDecomposition() const {
+  if (decomposed_) return;
+  const int N = static_cast<int>(order_);
+  evals_.assign(static_cast<std::size_t>(N), 0.0);
+  evecs_.assign(static_cast<std::size_t>(N) * N, cd(0.0, 0.0));
+  if (N == 0) {
+    decomposed_ = true;
+    return;
+  }
+
+  std::vector<cd> A;
+  std::vector<double> D;
+  assemble(A, D);
+  Eigen::MatrixXcd L(N, N);
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j)
+      L(i, j) = -A[static_cast<std::size_t>(i) * N + j];
+  for (int i = 0; i < N; ++i) L(i, i) += D[static_cast<std::size_t>(i)];
+
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXcd> es(L);
+  // Eigen yields real eigenvalues in ascending order and orthonormal columns.
+  const Eigen::VectorXd &lam = es.eigenvalues();
+  const Eigen::MatrixXcd &V = es.eigenvectors();
+  for (int i = 0; i < N; ++i) evals_[static_cast<std::size_t>(i)] = lam[i];
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j)
+      evecs_[static_cast<std::size_t>(i) * N + j] = V(i, j);
+  decomposed_ = true;
+}
+
+bool HodgeLaplacian::isHermitian(double tol) const {
+  const int N = static_cast<int>(order_);
+  if (N == 0) return true;
+  const std::vector<cd> Lflat = laplacian(0);
+  Eigen::MatrixXcd L(N, N);
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j)
+      L(i, j) = Lflat[static_cast<std::size_t>(i) * N + j];
+  return (L - L.adjoint()).norm() <= tol;
+}
+
+double HodgeLaplacian::unitarityResidual(double t) const {
+  ensureDecomposition();
+  const int N = static_cast<int>(order_);
+  if (N == 0) return 0.0;
+
+  Eigen::MatrixXcd V(N, N);
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j)
+      V(i, j) = evecs_[static_cast<std::size_t>(i) * N + j];
+
+  Eigen::VectorXcd phases(N);
+  for (int k = 0; k < N; ++k)
+    phases[k] = std::exp(cd(0.0, -evals_[static_cast<std::size_t>(k)] * t));
+
+  // U = e^{-iLt} = V diag(e^{-i lambda t}) V^dagger.
+  const Eigen::MatrixXcd U = V * phases.asDiagonal() * V.adjoint();
+  const Eigen::MatrixXcd resid =
+      U * U.adjoint() - Eigen::MatrixXcd::Identity(N, N);
+  return resid.norm();
+}
+
+std::vector<double> HodgeLaplacian::eigenvalues(int k) const {
+  requireStageOne(k);
+  ensureDecomposition();
+  return evals_;
+}
+
+std::vector<cd> HodgeLaplacian::eigenvectors(int k) const {
+  requireStageOne(k);
+  ensureDecomposition();
+  return evecs_;
+}
+
+std::vector<cd> HodgeLaplacian::harmonics(int k, double tol) const {
+  requireStageOne(k);
+  ensureDecomposition();
+  const std::size_t N = order_;
+  if (N == 0) return {};
+
+  std::vector<std::size_t> cols;
+  for (std::size_t j = 0; j < N; ++j)
+    if (std::abs(evals_[j]) < tol) cols.push_back(j);
+
+  const std::size_t M = cols.size();
+  std::vector<cd> H(N * M, cd(0.0, 0.0));
+  for (std::size_t i = 0; i < N; ++i)
+    for (std::size_t jj = 0; jj < M; ++jj)
+      H[i * M + jj] = evecs_[i * N + cols[jj]];
+  return H;
+}
+
+}  // namespace tessera::cobordism

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -117,6 +117,12 @@ squaredLength * exp(i * phase) used by the Hermitian-weighted Laplacian.
 The default of 0 leaves an ordinary real-weighted CDT edge unchanged.)doc")
       .def("setPhase", &Edge::setPhase, py::arg("phase"),
            "Set the U(1) connection phase carried by this edge (radians).")
+      .def("setSquaredLength", &Edge::setSquaredLength, py::arg("squaredLength"),
+           R"doc(Set the squared edge length (the signed weight magnitude).
+
+Paired with the phase it gives the complex edge weight squaredLength * exp(i *
+phase) read by the Hermitian-weighted Laplacian; also used by the Regge solver
+to optimize geometry without rebuilding the mesh.)doc")
       .def("getTarget", &Edge::getTarget, py::return_value_policy::reference,
            "Return the target vertex of this edge.");
   // ========================================

--- a/tests/cobordism/test_hodge_laplacian_python.py
+++ b/tests/cobordism/test_hodge_laplacian_python.py
@@ -1,0 +1,429 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Hermitian-weighted Hodge Laplacian, k=0 operator (#90).
+
+Validates the U(1)-weighted graph Laplacian L = D - A assembled from edge
+weights (squaredLength * exp(i*phase)) against an independent numpy D-A oracle,
+plus the spec checks that live at degree 0: Hermiticity / unitary evolution,
+the Aharonov-Bohm flux spectrum on the triangle (C4/C5 anchors), gauge
+invariance (C3, computed test-side), and a b1 cross-check against ChainComplex.
+
+Fixtures (per the cobordism plan):
+  triangle = SimplexBoundarySphere(1)  (S^1 = boundary of a 2-simplex; b1=1)
+  path 0-1-2                            (a tree; b1=0)
+  testbed  square 00-01-11-10 + diag 00-11  (b1=2; the representative cyclic
+                                             fixture, ids 0=00,1=01,2=11,3=10)
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders
+# --------------------------------------------------------------------------- #
+def _build_topology(topology):
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, topology)
+    st.build()
+    return st
+
+
+def _from_simplices(num_vertices, simplices):
+    """Build a Spacetime directly from explicit simplex vertex tuples (vertices
+    0..num_vertices-1), the hand-crafted-complex idiom shared with the cobordism
+    verification tests."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    verts = [st.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        st.createSimplex([verts[i] for i in simplex])
+    return st
+
+
+def _set_uniform(st, squared_length=1.0, phase=0.0):
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(squared_length)
+        e.setPhase(phase)
+
+
+def _triangle():
+    """S^1 = boundary of a 2-simplex, with unit real edge weights (Φ = 0)."""
+    st = _build_topology(tessera.SimplexBoundarySphere(1))
+    _set_uniform(st, 1.0, 0.0)
+    return st
+
+
+def _path():
+    st = _from_simplices(3, [(0, 1), (1, 2)])
+    _set_uniform(st, 1.0, 0.0)
+    return st
+
+
+def _testbed():
+    # square 00-01-11-10-00 plus the entangling diagonal 00-11.
+    st = _from_simplices(4, [(0, 1), (1, 2), (2, 3), (3, 0), (0, 2)])
+    _set_uniform(st, 1.0, 0.0)
+    return st
+
+
+# --------------------------------------------------------------------------- #
+# numpy oracle and small helpers
+# --------------------------------------------------------------------------- #
+def _ordering(st):
+    ids = sorted(v.getId() for v in st.getVertexList().toVector())
+    return ids, {vid: i for i, vid in enumerate(ids)}
+
+
+def _np_laplacian(st):
+    """Independent D - A reference, built from the same edges with the same
+    stable (sorted-id) vertex order the operator uses."""
+    ids, idx = _ordering(st)
+    n = len(ids)
+    A = np.zeros((n, n), dtype=complex)
+    D = np.zeros(n)
+    for e in st.getEdgeList().toVector():
+        s = e.getSource().getId()
+        t = e.getTarget().getId()
+        if s == t:
+            continue
+        i, j = idx[s], idx[t]
+        w = e.getSquaredLength()
+        z = w * np.exp(1j * e.getPhase())
+        A[i, j] += z
+        A[j, i] += np.conj(z)
+        D[i] += abs(w)
+        D[j] += abs(w)
+    L = np.diag(D).astype(complex) - A
+    return n, ids, idx, A, D, L
+
+
+def _edge(st, a, b):
+    for e in st.getEdgeList().toVector():
+        if {e.getSource().getId(), e.getTarget().getId()} == {a, b}:
+            return e
+    raise KeyError((a, b))
+
+
+def _cycle_flux(st, cycle):
+    """Directed holonomy Σ phase around a closed vertex cycle, honoring each
+    edge's stored source->target orientation."""
+    total = 0.0
+    n = len(cycle)
+    for k in range(n):
+        a, b = cycle[k], cycle[(k + 1) % n]
+        e = _edge(st, a, b)
+        if e.getSource().getId() == a and e.getTarget().getId() == b:
+            total += e.getPhase()
+        else:
+            total -= e.getPhase()
+    return total
+
+
+def _matrix(flat, n):
+    return np.array(flat, dtype=complex).reshape(n, n)
+
+
+def _cluster_ranges(evals, tol=1e-6):
+    """Contiguous index ranges of (near-)equal ascending eigenvalues."""
+    ranges = []
+    start = 0
+    for i in range(1, len(evals) + 1):
+        if i == len(evals) or abs(evals[i] - evals[start]) > tol:
+            ranges.append((start, i))
+            start = i
+    return ranges
+
+
+# --------------------------------------------------------------------------- #
+# Assembly + spectrum vs numpy, and known-answer anchors
+# --------------------------------------------------------------------------- #
+class TestAssemblyAndSpectrum(unittest.TestCase):
+
+    def _check_against_numpy(self, st):
+        n, _ids, _idx, A, D, L = _np_laplacian(st)
+        hl = cob.HodgeLaplacian(st)
+        np.testing.assert_allclose(_matrix(hl.adjacency(), n), A, atol=1e-12)
+        np.testing.assert_allclose(np.array(hl.degree()), D, atol=1e-12)
+        np.testing.assert_allclose(_matrix(hl.laplacian(), n), L, atol=1e-12)
+        np.testing.assert_allclose(np.array(hl.laplacian(0)).reshape(n, n), L,
+                                   atol=1e-12)
+        np.testing.assert_allclose(np.array(hl.eigenvalues()),
+                                   np.linalg.eigvalsh(L), atol=1e-12)
+        return n
+
+    def test_triangle_is_three_vertices_three_edges(self):
+        st = _triangle()
+        self.assertEqual(st.getVertexCount(), 3)
+        self.assertEqual(len(st.getEdgeList().toVector()), 3)
+
+    def test_triangle_spectrum_matches_numpy(self):
+        self.assertEqual(self._check_against_numpy(_triangle()), 3)
+
+    def test_path_spectrum_matches_numpy(self):
+        self._check_against_numpy(_path())
+
+    def test_testbed_spectrum_matches_numpy(self):
+        self.assertEqual(self._check_against_numpy(_testbed()), 4)
+
+    def test_random_weighted_spectra_match_numpy(self):
+        # Generic complex Hermitian weights on each fixture: the operator must
+        # still equal the independent numpy D - A bit for bit (to tolerance).
+        rng = np.random.default_rng(20240601)
+        for name, st in (("triangle", _triangle()),
+                         ("path", _path()),
+                         ("testbed", _testbed())):
+            with self.subTest(fixture=name):
+                for e in st.getEdgeList().toVector():
+                    e.setSquaredLength(float(rng.uniform(0.5, 2.0)))
+                    e.setPhase(float(rng.uniform(-math.pi, math.pi)))
+                self._check_against_numpy(st)
+
+    def test_triangle_zero_phase_known_eigenvalues(self):
+        # Equal-weight S^1 with no flux: L = 2I - A(K3) -> {0, 3, 3}.
+        hl = cob.HodgeLaplacian(_triangle())
+        np.testing.assert_allclose(sorted(hl.eigenvalues()), [0.0, 3.0, 3.0],
+                                   atol=1e-12)
+
+    def test_path_known_eigenvalues(self):
+        # Open path 0-1-2 Laplacian -> {0, 1, 3}.
+        hl = cob.HodgeLaplacian(_path())
+        np.testing.assert_allclose(sorted(hl.eigenvalues()), [0.0, 1.0, 3.0],
+                                   atol=1e-12)
+
+    def test_complex_weight_round_trips_through_pybind(self):
+        # phase = pi/2 on a unit edge -> that adjacency entry is purely +i (and
+        # its mirror -i), confirming complex values cross the binding intact.
+        st = _path()
+        _ids, idx = _ordering(st)
+        e = _edge(st, 0, 1)
+        e.setSquaredLength(1.0)
+        e.setPhase(math.pi / 2.0)
+        s, t = e.getSource().getId(), e.getTarget().getId()
+        A = _matrix(cob.HodgeLaplacian(st).adjacency(), st.getVertexCount())
+        self.assertAlmostEqual(A[idx[s], idx[t]], 1j, places=12)
+        self.assertAlmostEqual(A[idx[t], idx[s]], -1j, places=12)
+
+
+# --------------------------------------------------------------------------- #
+# Hermiticity and unitary time evolution
+# --------------------------------------------------------------------------- #
+class TestHermiticityUnitarity(unittest.TestCase):
+
+    def _fixtures_with_random_weights(self):
+        rng = np.random.default_rng(7)
+        out = []
+        for name, st in (("triangle", _triangle()), ("testbed", _testbed())):
+            for e in st.getEdgeList().toVector():
+                e.setSquaredLength(float(rng.uniform(0.5, 2.0)))
+                e.setPhase(float(rng.uniform(-math.pi, math.pi)))
+            out.append((name, st))
+        return out
+
+    def test_laplacian_is_hermitian(self):
+        for name, st in self._fixtures_with_random_weights():
+            with self.subTest(fixture=name):
+                n = st.getVertexCount()
+                L = _matrix(cob.HodgeLaplacian(st).laplacian(), n)
+                self.assertLess(np.linalg.norm(L - L.conj().T), 1e-12)
+                self.assertTrue(cob.HodgeLaplacian(st).isHermitian(1e-12))
+
+    def test_time_evolution_is_unitary(self):
+        for name, st in self._fixtures_with_random_weights():
+            with self.subTest(fixture=name):
+                hl = cob.HodgeLaplacian(st)
+                self.assertLess(hl.unitarityResidual(), 1e-12)
+                self.assertLess(hl.unitarityResidual(2.5), 1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Flux in the spectrum (Aharonov-Bohm ring) — C4/C5 anchors
+# --------------------------------------------------------------------------- #
+class TestFluxSpectrum(unittest.TestCase):
+
+    @staticmethod
+    def _ring_eigs(phi):
+        return sorted(2.0 - 2.0 * math.cos((phi + 2.0 * math.pi * k) / 3.0)
+                      for k in range(3))
+
+    def _triangle_with_flux(self, phi):
+        # The spectrum depends only on the gauge-invariant total flux, so place
+        # all of Φ on a single edge; degree is phase-independent (= 2 each).
+        st = _triangle()
+        st.getEdgeList().toVector()[0].setPhase(phi)
+        return st
+
+    def test_flux_spectrum_matches_ring_formula(self):
+        for phi in (0.0, math.pi / 3, math.pi / 2, 2 * math.pi / 3, math.pi, 1.234):
+            with self.subTest(phi=phi):
+                hl = cob.HodgeLaplacian(self._triangle_with_flux(phi))
+                np.testing.assert_allclose(sorted(hl.eigenvalues()),
+                                           self._ring_eigs(phi), atol=1e-12)
+
+    def test_half_flux_quantum_gives_degenerate_pair(self):
+        # Φ = π -> {1, 1, 4}; the spectral gap λ1 - λ0 collapses to 0.
+        hl = cob.HodgeLaplacian(self._triangle_with_flux(math.pi))
+        eigs = sorted(hl.eigenvalues())
+        np.testing.assert_allclose(eigs, [1.0, 1.0, 4.0], atol=1e-12)
+        self.assertAlmostEqual(eigs[1] - eigs[0], 0.0, places=12)
+
+    def test_flux_lifts_the_zero_mode(self):
+        # No flux: one harmonic (the constant 0-cochain, b0 = 1). Any flux lifts
+        # it, so the harmonic dimension of L0 drops to 0.
+        n = 3
+        hl0 = cob.HodgeLaplacian(_triangle())
+        self.assertEqual(len(hl0.harmonics()) // n, 1)
+        hlpi = cob.HodgeLaplacian(self._triangle_with_flux(math.pi))
+        self.assertEqual(len(hlpi.harmonics()), 0)
+
+    def test_zero_mode_is_uniform(self):
+        # The Φ=0 harmonic is the uniform vector (equal magnitudes on every vertex).
+        n = 3
+        vec = np.array(cob.HodgeLaplacian(_triangle()).harmonics(), dtype=complex)
+        self.assertEqual(vec.size, n)  # one harmonic (M=1), length N
+        np.testing.assert_allclose(np.abs(vec), np.full(n, abs(vec[0])), atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# C3 — gauge invariance (computed test-side; the operator has no gauge() method)
+# --------------------------------------------------------------------------- #
+class TestGaugeInvariance(unittest.TestCase):
+
+    @staticmethod
+    def _apply_gauge(st, alpha):
+        # Rephase every edge: θ -> θ + α_src - α_tgt  (A -> G A G^†, L -> G L G^†).
+        for e in st.getEdgeList().toVector():
+            s, t = e.getSource().getId(), e.getTarget().getId()
+            e.setPhase(e.getPhase() + alpha[s] - alpha[t])
+
+    def test_testbed_spectrum_eigenvectors_and_flux_are_gauge_invariant(self):
+        rng = np.random.default_rng(2718)
+        st = _testbed()
+        # Random Hermitian weights + base phases (a generic point in the b1=2
+        # connection space).
+        for e in st.getEdgeList().toVector():
+            e.setSquaredLength(float(rng.uniform(0.5, 2.0)))
+            e.setPhase(float(rng.uniform(-math.pi, math.pi)))
+
+        ids, idx = _ordering(st)
+        n = len(ids)
+        hl_old = cob.HodgeLaplacian(st)
+        evals_old = np.array(hl_old.eigenvalues())
+        V_old = _matrix(hl_old.eigenvectors(), n)
+
+        # Two independent cycles of the testbed (b1 = 2).
+        cycles = ([0, 1, 2], [0, 2, 3])
+        flux_old = [_cycle_flux(st, c) for c in cycles]
+
+        # Random vertex-phase gauge.
+        alpha = {vid: float(rng.uniform(-math.pi, math.pi)) for vid in ids}
+        self._apply_gauge(st, alpha)
+
+        hl_new = cob.HodgeLaplacian(st)
+        evals_new = np.array(hl_new.eigenvalues())
+        V_new = _matrix(hl_new.eigenvectors(), n)
+
+        # (i) spectrum unchanged
+        np.testing.assert_allclose(evals_new, evals_old, atol=1e-12)
+
+        # (ii) eigenvectors rephased v -> G v: the spectral projector of every
+        # eigenvalue cluster transforms as P -> G P G^† (robust to the
+        # eigenvector phase/degeneracy ambiguity).
+        g = np.array([np.exp(1j * alpha[vid]) for vid in ids])
+        G = np.diag(g)
+        for (a, b) in _cluster_ranges(evals_old):
+            p_old = V_old[:, a:b] @ V_old[:, a:b].conj().T
+            p_new = V_new[:, a:b] @ V_new[:, a:b].conj().T
+            np.testing.assert_allclose(p_new, G @ p_old @ G.conj().T, atol=1e-9)
+
+        # (iii) every cycle flux unchanged
+        flux_new = [_cycle_flux(st, c) for c in cycles]
+        np.testing.assert_allclose(flux_new, flux_old, atol=1e-10)
+
+    def test_tree_eigenvectors_rephase_vectorwise(self):
+        # On the tree (non-degenerate {0,1,3}) the per-eigenvector statement
+        # v_k -> G v_k holds directly (up to a global phase).
+        rng = np.random.default_rng(99)
+        st = _path()
+        ids, idx = _ordering(st)
+        n = len(ids)
+        hl_old = cob.HodgeLaplacian(st)
+        V_old = _matrix(hl_old.eigenvectors(), n)
+
+        alpha = {vid: float(rng.uniform(-math.pi, math.pi)) for vid in ids}
+        TestGaugeInvariance._apply_gauge(st, alpha)
+        hl_new = cob.HodgeLaplacian(st)
+        np.testing.assert_allclose(np.array(hl_new.eigenvalues()),
+                                   np.array(hl_old.eigenvalues()), atol=1e-12)
+        V_new = _matrix(hl_new.eigenvectors(), n)
+
+        g = np.array([np.exp(1j * alpha[vid]) for vid in ids])
+        for k in range(n):
+            gv = g * V_old[:, k]
+            overlap = abs(np.vdot(gv, V_new[:, k]))  # parallel <=> |overlap| = 1
+            self.assertAlmostEqual(overlap, 1.0, places=8)
+
+
+# --------------------------------------------------------------------------- #
+# b1 cross-check against the topological oracle, and degree parameterization
+# --------------------------------------------------------------------------- #
+class TestBettiCrossCheck(unittest.TestCase):
+
+    def test_first_betti_numbers(self):
+        for name, st, expected in (("triangle", _triangle(), 1),
+                                   ("path", _path(), 0),
+                                   ("testbed", _testbed(), 2)):
+            with self.subTest(fixture=name):
+                cc = cob.ChainComplex.fromSpacetime(st)
+                self.assertEqual(cc.bettiNumbers()[1], expected)
+
+
+class TestDegreeParameterization(unittest.TestCase):
+
+    def test_nonzero_degree_not_implemented(self):
+        hl = cob.HodgeLaplacian(_triangle())
+        for call in (lambda: hl.laplacian(1),
+                     lambda: hl.eigenvalues(2),
+                     lambda: hl.eigenvectors(1),
+                     lambda: hl.harmonics(3)):
+            with self.subTest(call=call):
+                with self.assertRaises(RuntimeError):
+                    call()
+
+    def test_k_zero_is_the_default(self):
+        hl = cob.HodgeLaplacian(_triangle())
+        np.testing.assert_allclose(np.array(hl.eigenvalues()),
+                                   np.array(hl.eigenvalues(0)), atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #90 — `cobordism::HodgeLaplacian` (Stage 1, k=0): the Hermitian-weighted Hodge Laplacian operator on a `Spacetime`.

- `HodgeLaplacian.{h,cpp}`: `A_ij = Σ squaredLength·e^{i·phase}` (Hermitian; reverse orientation negates phase), `D_ii = Σ|squaredLength|`, `L = D − A`; `adjacency/degree/laplacian/isHermitian/unitarityResidual/eigenvalues/eigenvectors/harmonics` via Eigen `SelfAdjointEigenSolver<MatrixXcd>` (lazy-cached); `k≠0` throws (Stage 2). No flux/Betti/gauge — those are `ChainComplex`/`WilsonLoop` / test-side.
- Bindings: `tessera.cobordism.HodgeLaplacian` (+ `<pybind11/complex.h>`); bound `Edge.setSquaredLength` (was unbound in Python, needed by the tests).
- Tests: 19 tests / 20 subtests; full `tests/cobordism` regression **110 passed**, 0 regressions. Verified against an independent numpy `D−A` oracle, the Aharonov–Bohm flux spectrum `2−2cos((Φ+2πk)/3)` (Φ=π → `{1,1,4}`, gap collapse, zero-mode lift), C3 gauge invariance, and the `b₁` cross-check via `ChainComplex`.
- `pyproject.toml`: two poetry-resolution fixes (inline the `examples` extra into `dev` — Poetry rejects PEP 621 self-extras; bound `requires-python` to `>=3.11,<4.0`). Behavior-preserving for pip/CI.

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)