### PR TITLE
cobordism: Stage 1 — quantum::ChoiJamiolkowski (map–state bending)

### DIFF
--- a/include/quantum/ChoiJamiolkowski.h
+++ b/include/quantum/ChoiJamiolkowski.h
@@ -1,0 +1,105 @@
+// Choi–Jamiołkowski map–state duality ("bending") over dense complex matrices.
+//
+// The Choi–Jamiołkowski isomorphism bends an operator into a state: a linear
+// map / matrix U on H_A → H_B becomes a vector |vec(U)⟩ in H_A ⊗ H_B. This
+// class is the pure-dense-linear-algebra realisation of that bend — Eigen
+// only, no ITensor, no MPS. It is the algebraic-layer (Stage 1) oracle for the
+// cobordism-correspondence experiment, where the "bending" of an operation
+// into a boundary state is checked against its transition amplitude.
+//
+// ─── Conventions (locked) ──────────────────────────────────────────────────
+//
+// Matrices are passed flat, ROW-MAJOR: a dA×dB matrix U has
+//   U_{ij} = U[i*dB + j],   i ∈ [0, dA),  j ∈ [0, dB).
+//
+// Vectorisation (row-major flatten = tensor index i*dB + j):
+//
+//   vec(U) = Σ_{ij} U_{ij} |i⟩_A ⊗ |j⟩_B.
+//
+// On a rank-one outer product this gives the separable state
+//
+//   vec(|a⟩⟨b|) = a ⊗ conj(b),
+//
+// which has Schmidt rank 1. More generally the Schmidt rank of vec(U) equals
+// the number of nonzero singular values of U (the SVD of U is the Schmidt
+// decomposition of vec(U)).
+//
+// The transition operator of two states is the rank-one map
+//
+//   U_T = |psiA⟩⟨psiB|        ((U_T)_{ij} = psiA_i · conj(psiB_j)),
+//
+// and the central map–state (Hilbert–Schmidt) duality identity is
+//
+//   ⟨psiA|U|psiB⟩ = ⟨vec(U_T)|vec(U)⟩ = Tr(U_T^H · U)
+//                 = Σ_{ij} conj(psiA_i) · U_{ij} · psiB_j.
+//
+// ─── References ─────────────────────────────────────────────────────────────
+//   Choi, *Completely positive linear maps on complex matrices*,
+//     Linear Algebra Appl. 10, 285 (1975).
+//   Jamiołkowski, *Linear transformations which preserve trace and positive
+//     semidefiniteness of operators*, Rep. Math. Phys. 3, 275 (1972).
+
+#pragma once
+
+#include <complex>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::graph {}
+namespace tessera::mesh {}
+namespace tessera::observables {}
+namespace tessera::simulations {}
+namespace tessera::spacetime {}
+namespace tessera::quantum {
+using namespace ::tessera::mesh;
+using namespace ::tessera::graph;
+using namespace ::tessera::spacetime;
+using namespace ::tessera::observables;
+using namespace ::tessera::simulations;
+
+/// Dense Choi–Jamiołkowski map–state duality ("bending").
+///
+/// A stateless static-only utility (the `cobordism::Cobordism` pattern): not
+/// instantiable, every operation is a static method. All matrices/vectors are
+/// flat, row-major `std::vector<std::complex<double>>` (see the file header for
+/// the locked conventions); Eigen is used internally for the SVD.
+class ChoiJamiolkowski {
+  public:
+    ChoiJamiolkowski() = delete;
+
+    /// Vectorise a dA×dB operator: vec(U) = Σ_{ij} U_{ij} |i⟩_A ⊗ |j⟩_B.
+    /// With the row-major convention the tensor index is i*dB + j, so vec(U) is
+    /// exactly the row-major flatten of U (length dA·dB). Throws
+    /// std::invalid_argument if U.size() != dA·dB or a dimension is non-positive.
+    [[nodiscard]] static std::vector<std::complex<double>> vectorize(
+        const std::vector<std::complex<double>> &U, int dA, int dB);
+
+    /// Singular values of the dA×dB operator U (Eigen JacobiSVD), in descending
+    /// order; min(dA, dB) of them. These are the Schmidt coefficients of vec(U).
+    [[nodiscard]] static std::vector<double> singularValues(
+        const std::vector<std::complex<double>> &U, int dA, int dB);
+
+    /// Schmidt rank of vec(U): the number of singular values of U that exceed
+    /// tol·σ_max (σ_max the largest singular value). Equals the operator rank of
+    /// U and the bipartite Schmidt rank of the state vec(U).
+    [[nodiscard]] static int schmidtRank(
+        const std::vector<std::complex<double>> &U, int dA, int dB,
+        double tol = 1e-10);
+
+    /// Transition operator U_T = |psiA⟩⟨psiB| (a rank-one dA×dB matrix,
+    /// (U_T)_{ij} = psiA_i · conj(psiB_j)), returned flat row-major. Throws
+    /// std::invalid_argument if psiA.size() != dA or psiB.size() != dB.
+    [[nodiscard]] static std::vector<std::complex<double>> transitionOperator(
+        const std::vector<std::complex<double>> &psiA,
+        const std::vector<std::complex<double>> &psiB, int dA, int dB);
+
+    /// Transition amplitude ⟨psiA|U|psiB⟩ = Σ_{ij} conj(psiA_i)·U_{ij}·psiB_j.
+    /// By the duality identity this equals ⟨vec(U_T)|vec(U)⟩ = Tr(U_T^H·U) for
+    /// U_T = |psiA⟩⟨psiB|. Throws std::invalid_argument on a dimension mismatch.
+    [[nodiscard]] static std::complex<double> transitionAmplitude(
+        const std::vector<std::complex<double>> &psiA,
+        const std::vector<std::complex<double>> &U,
+        const std::vector<std::complex<double>> &psiB, int dA, int dB);
+};
+
+}  // namespace tessera::quantum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ version = "0.1.0"
 description = "C++/pybind11 extension for lattice spacetime experiments"
 authors = [{ name = "Andrew Kelleher", email = "keats.kelleher@gmail.com" }]
 readme = "README.md"
-requires-python = ">=3.11"
+# Upper-bounded so Poetry can resolve dev deps that cap Python at <4.0 (e.g.
+# pybind11-stubgen); pip resolves per-interpreter and is unaffected.
+requires-python = ">=3.11,<4.0"
 license = { text = "MIT" }
 dependencies = [
     "numpy>=2.0",
@@ -27,7 +29,15 @@ optional-dependencies.examples = [
     "tqdm>=4.66",
 ]
 optional-dependencies.dev = [
-    "tessera[examples]",
+    # The examples extra is inlined here (rather than referenced as
+    # "tessera[examples]") so Poetry can resolve `poetry install --all-extras`:
+    # Poetry 2.x rejects a PEP 621 self-referential extra as a self-dependency.
+    # pip's resolved dependency set is unchanged. Keep in sync with the
+    # optional-dependencies.examples list above.
+    "matplotlib>=3.8",
+    "networkx>=3.0",
+    "scipy>=1.11",
+    "tqdm>=4.66",
     "pytest",
     "scikit-build-core>=0.9",
     "cmake>=3.22",

--- a/src/quantum/Bindings.cpp
+++ b/src/quantum/Bindings.cpp
@@ -24,6 +24,7 @@
 
 #include "quantum/CausalCompare.hpp"
 #include "quantum/CausetChain.hpp"
+#include "quantum/ChoiJamiolkowski.h"
 #include "quantum/ChoiState.hpp"
 #include "quantum/DMRGRunner.hpp"
 #include "quantum/Holography.hpp"
@@ -37,6 +38,7 @@
 #include "quantum/TDVPRunner.hpp"
 #include "spacetime/Spacetime.h"  // full type needed for py::cast<Spacetime*>()
 
+#include <pybind11/complex.h>
 #include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
@@ -781,6 +783,41 @@ joint reduced density matrices).
             &MutualInformation::edgeLength,
             py::arg("I"), py::arg("epsilon") = 1e-10,
             R"doc(ℓ = -log(I) with infinity floor at -log(epsilon).)doc");
+
+    // ─── ChoiJamiolkowski: dense map–state duality ("bending") ─────────
+    py::class_<ChoiJamiolkowski>(m, "ChoiJamiolkowski",
+            R"doc(Static utility for the dense Choi–Jamiołkowski map–state
+duality ("bending"). Not instantiable; call the methods on the class.
+
+Operators and states are flat, ROW-MAJOR lists of complex numbers: a dA×dB
+operator U has ``U[i*dB + j] = U_{ij}``. Locked conventions:
+
+* ``vec(U) = Σ_{ij} U_{ij} |i⟩_A ⊗ |j⟩_B`` (the row-major flatten);
+* ``vec(|a⟩⟨b|) = a ⊗ conj(b)`` (separable, Schmidt rank 1);
+* ``⟨psiA|U|psiB⟩ = ⟨vec(U_T)|vec(U)⟩ = Tr(U_T^H·U)`` with
+  ``U_T = |psiA⟩⟨psiB|``;
+* Schmidt rank of ``vec(U)`` = number of nonzero singular values of U.
+)doc")
+        .def_static("vectorize", &ChoiJamiolkowski::vectorize,
+            py::arg("U"), py::arg("dA"), py::arg("dB"),
+            R"doc(Vectorise a dA×dB operator: vec(U) = Σ_{ij} U_{ij} |i⟩⊗|j⟩,
+the length-(dA·dB) row-major flatten.)doc")
+        .def_static("singularValues", &ChoiJamiolkowski::singularValues,
+            py::arg("U"), py::arg("dA"), py::arg("dB"),
+            R"doc(Singular values of the dA×dB operator U (descending); the
+Schmidt coefficients of vec(U).)doc")
+        .def_static("schmidtRank", &ChoiJamiolkowski::schmidtRank,
+            py::arg("U"), py::arg("dA"), py::arg("dB"), py::arg("tol") = 1e-10,
+            R"doc(Schmidt rank of vec(U): the number of singular values of U
+exceeding tol·σ_max.)doc")
+        .def_static("transitionOperator", &ChoiJamiolkowski::transitionOperator,
+            py::arg("psiA"), py::arg("psiB"), py::arg("dA"), py::arg("dB"),
+            R"doc(Transition operator U_T = |psiA⟩⟨psiB| (rank one), returned
+flat row-major.)doc")
+        .def_static("transitionAmplitude", &ChoiJamiolkowski::transitionAmplitude,
+            py::arg("psiA"), py::arg("U"), py::arg("psiB"), py::arg("dA"), py::arg("dB"),
+            R"doc(Transition amplitude ⟨psiA|U|psiB⟩ = Σ_{ij}
+conj(psiA_i)·U_{ij}·psiB_j.)doc");
 
     // ─── InteractionSimulation: interaction-history Monte Carlo ────────
     // See docs/source/interaction-history-monte-carlo.md.

--- a/src/quantum/ChoiJamiolkowski.cpp
+++ b/src/quantum/ChoiJamiolkowski.cpp
@@ -1,0 +1,137 @@
+// Dense Choi–Jamiołkowski map–state duality ("bending"). See
+// include/quantum/ChoiJamiolkowski.h for the locked conventions and the math.
+
+#include "quantum/ChoiJamiolkowski.h"
+
+#include <Eigen/Dense>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::graph {}
+namespace tessera::mesh {}
+namespace tessera::observables {}
+namespace tessera::simulations {}
+namespace tessera::spacetime {}
+namespace tessera::quantum {
+using namespace ::tessera::mesh;
+using namespace ::tessera::graph;
+using namespace ::tessera::spacetime;
+using namespace ::tessera::observables;
+using namespace ::tessera::simulations;
+
+namespace {
+
+// A complex matrix laid out the way callers pass them: row-major, so that the
+// flat index i*cols + j is the (i, j) entry — i.e. the vec(·) tensor index.
+using RowMajorXcd =
+    Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic,
+                  Eigen::RowMajor>;
+
+void requirePositiveDims(int dA, int dB, const char *who) {
+    if (dA <= 0 || dB <= 0) {
+        throw std::invalid_argument(std::string(who) +
+                                    ": dimensions dA, dB must be positive");
+    }
+}
+
+// Validate length and view a flat vector as an Eigen column vector (no copy).
+Eigen::Map<const Eigen::VectorXcd> asVector(
+    const std::vector<std::complex<double>> &v, int n, const char *who,
+    const char *name) {
+    if (static_cast<long long>(v.size()) != static_cast<long long>(n)) {
+        throw std::invalid_argument(std::string(who) + ": " + name +
+                                    " must have length " + std::to_string(n) +
+                                    " (got " + std::to_string(v.size()) + ")");
+    }
+    return Eigen::Map<const Eigen::VectorXcd>(v.data(), n);
+}
+
+// Validate length and view a flat row-major buffer as a dA×dB Eigen matrix.
+Eigen::Map<const RowMajorXcd> asMatrix(
+    const std::vector<std::complex<double>> &m, int dA, int dB,
+    const char *who) {
+    const long long expected = static_cast<long long>(dA) * dB;
+    if (static_cast<long long>(m.size()) != expected) {
+        throw std::invalid_argument(
+            std::string(who) + ": operator must have dA*dB = " +
+            std::to_string(dA) + "*" + std::to_string(dB) + " = " +
+            std::to_string(expected) + " entries row-major (got " +
+            std::to_string(m.size()) + ")");
+    }
+    return Eigen::Map<const RowMajorXcd>(m.data(), dA, dB);
+}
+
+}  // namespace
+
+std::vector<std::complex<double>> ChoiJamiolkowski::vectorize(
+    const std::vector<std::complex<double>> &U, int dA, int dB) {
+    requirePositiveDims(dA, dB, "ChoiJamiolkowski::vectorize");
+    // vec(U) = Σ_{ij} U_{ij} |i⟩_A ⊗ |j⟩_B. With the row-major layout the
+    // tensor index i*dB + j coincides with U's own flat index, so the
+    // vectorisation is exactly U's buffer — validated and returned as the
+    // length-(dA·dB) state vector.
+    asMatrix(U, dA, dB, "ChoiJamiolkowski::vectorize");
+    return U;
+}
+
+std::vector<double> ChoiJamiolkowski::singularValues(
+    const std::vector<std::complex<double>> &U, int dA, int dB) {
+    requirePositiveDims(dA, dB, "ChoiJamiolkowski::singularValues");
+    const Eigen::MatrixXcd M =
+        asMatrix(U, dA, dB, "ChoiJamiolkowski::singularValues");
+    // No U/V requested: JacobiSVD computes the singular values alone, already
+    // sorted in descending order.
+    Eigen::JacobiSVD<Eigen::MatrixXcd> svd(M);
+    const Eigen::VectorXd &sv = svd.singularValues();
+    return std::vector<double>(sv.data(), sv.data() + sv.size());
+}
+
+int ChoiJamiolkowski::schmidtRank(const std::vector<std::complex<double>> &U,
+                                  int dA, int dB, double tol) {
+    const std::vector<double> sv = singularValues(U, dA, dB);
+    if (sv.empty()) return 0;
+    const double sigmaMax = sv.front();  // descending ⇒ first is the largest
+    if (sigmaMax <= 0.0) return 0;       // zero operator ⇒ rank 0
+    const double threshold = tol * sigmaMax;
+    int rank = 0;
+    for (const double s : sv) {
+        if (s > threshold) ++rank;
+    }
+    return rank;
+}
+
+std::vector<std::complex<double>> ChoiJamiolkowski::transitionOperator(
+    const std::vector<std::complex<double>> &psiA,
+    const std::vector<std::complex<double>> &psiB, int dA, int dB) {
+    requirePositiveDims(dA, dB, "ChoiJamiolkowski::transitionOperator");
+    const auto a =
+        asVector(psiA, dA, "ChoiJamiolkowski::transitionOperator", "psiA");
+    const auto b =
+        asVector(psiB, dB, "ChoiJamiolkowski::transitionOperator", "psiB");
+    // U_T = |psiA⟩⟨psiB|, so (U_T)_{ij} = psiA_i · conj(psiB_j); written out
+    // row-major into the returned flat buffer.
+    std::vector<std::complex<double>> out(static_cast<std::size_t>(dA) *
+                                          static_cast<std::size_t>(dB));
+    Eigen::Map<RowMajorXcd>(out.data(), dA, dB) = a * b.adjoint();
+    return out;
+}
+
+std::complex<double> ChoiJamiolkowski::transitionAmplitude(
+    const std::vector<std::complex<double>> &psiA,
+    const std::vector<std::complex<double>> &U,
+    const std::vector<std::complex<double>> &psiB, int dA, int dB) {
+    requirePositiveDims(dA, dB, "ChoiJamiolkowski::transitionAmplitude");
+    const auto a =
+        asVector(psiA, dA, "ChoiJamiolkowski::transitionAmplitude", "psiA");
+    const auto b =
+        asVector(psiB, dB, "ChoiJamiolkowski::transitionAmplitude", "psiB");
+    const auto M = asMatrix(U, dA, dB, "ChoiJamiolkowski::transitionAmplitude");
+    // ⟨psiA|U|psiB⟩ = Σ_{ij} conj(psiA_i)·U_{ij}·psiB_j. Eigen's complex dot()
+    // conjugates its first argument: a.dot(M*b) = Σ_i conj(a_i) (M b)_i.
+    return a.dot(M * b);
+}
+
+}  // namespace tessera::quantum

--- a/tessera/quantum/__init__.py
+++ b/tessera/quantum/__init__.py
@@ -189,7 +189,7 @@ _EXPORTS = (
     "PeakRadialMajorization",
     # Coarse-grained workflow classes
     "SchwingerModel", "SchwingerQuench", "InteractionSimulation",
-    "Majorization", "Causet", "MutualInformation",
+    "Majorization", "Causet", "MutualInformation", "ChoiJamiolkowski",
     # KI + QuantumSimplex (Van Raamsdonk-metric simplex factory)
     "QuantumSimplex", "QuantumSimplexPosition", "QuantumVertex",
     "createQuantumVertex",

--- a/tests/quantum/test_choi_jamiolkowski_python.py
+++ b/tests/quantum/test_choi_jamiolkowski_python.py
@@ -1,0 +1,142 @@
+"""Python acceptance tests for the C++ ChoiJamiolkowski utility class.
+
+The Choi–Jamiołkowski "bending" maps an operator U to a bipartite state
+vec(U). numpy is used as the independent oracle for every claim:
+
+* C1 — the map–state (Hilbert–Schmidt) duality identity
+        ⟨psiA|U|psiB⟩ = ⟨vec(U_T)|vec(U)⟩ = Tr(U_T^H·U),  U_T = |psiA⟩⟨psiB|.
+* C2 — Schmidt rank = number of nonzero singular values: the rank-one
+        transition operator is separable (rank 1); the identity bends to the
+        cup |00⟩+|11⟩ and σ_x to |01⟩+|10⟩, both rank 2 (entangled).
+
+Conventions (locked): operators are flat ROW-MAJOR, so a dA×dB matrix U has
+U[i*dB + j] = U_{ij}; vec(U) = Σ_{ij} U_{ij} |i⟩⊗|j⟩ is that flatten; and
+vec(|a⟩⟨b|) = a ⊗ conj(b).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+try:
+    from tessera.quantum import ChoiJamiolkowski
+    HAVE_QUANTUM = True
+except ImportError:
+    HAVE_QUANTUM = False
+
+
+def _rand_complex(rng: "np.random.Generator", *shape: int) -> np.ndarray:
+    """A complex array of the given shape with iid standard-normal parts."""
+    return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+
+def _unit(v: np.ndarray) -> np.ndarray:
+    return v / np.linalg.norm(v)
+
+
+def _flat(matrix) -> list:
+    """Row-major (C-order) flatten as a list of Python complex numbers."""
+    return np.asarray(matrix, dtype=complex).flatten().tolist()
+
+
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without the quantum subsystem")
+class TestTransitionAmplitudeDuality(unittest.TestCase):
+    """C1: ⟨psiA|U|psiB⟩ = ⟨vec(U_T)|vec(U)⟩ = Tr(U_T^H·U), vs a numpy oracle."""
+
+    def test_duality_identity_matches_numpy(self) -> None:
+        for seed in (0, 1, 7, 12345):
+            with self.subTest(seed=seed):
+                rng = np.random.default_rng(seed)
+                U = _rand_complex(rng, 2, 2)
+                psiA = _unit(_rand_complex(rng, 2))
+                psiB = _unit(_rand_complex(rng, 2))
+
+                # Independent numpy oracle ------------------------------------
+                amp_ref = psiA.conj() @ U @ psiB
+                U_T = np.outer(psiA, psiB.conj())          # |psiA><psiB|
+                vecU = U.flatten()                          # row-major
+                vecUT = U_T.flatten()
+                inner_ref = np.vdot(vecUT, vecU)            # <vec(U_T)|vec(U)>
+                trace_ref = np.trace(U_T.conj().T @ U)      # Tr(U_T^H U)
+                # The oracle must itself be self-consistent.
+                self.assertAlmostEqual(abs(amp_ref - inner_ref), 0.0, delta=1e-12)
+                self.assertAlmostEqual(abs(amp_ref - trace_ref), 0.0, delta=1e-12)
+
+                # C++ under test ----------------------------------------------
+                amp = ChoiJamiolkowski.transitionAmplitude(
+                    psiA.tolist(), _flat(U), psiB.tolist(), 2, 2)
+                UT_cpp = ChoiJamiolkowski.transitionOperator(
+                    psiA.tolist(), psiB.tolist(), 2, 2)
+                vecU_cpp = ChoiJamiolkowski.vectorize(_flat(U), 2, 2)
+                vecUT_cpp = ChoiJamiolkowski.vectorize(UT_cpp, 2, 2)
+
+                inner_cpp = np.vdot(np.array(vecUT_cpp), np.array(vecU_cpp))
+                UT_mat = np.array(UT_cpp).reshape(2, 2)
+                trace_cpp = np.trace(UT_mat.conj().T @ U)
+
+                # transitionAmplitude == <vec(U_T)|vec(U)> == Tr(U_T^H U),
+                # each equal to the independent numpy amplitude, to 1e-12.
+                self.assertAlmostEqual(abs(amp - amp_ref), 0.0, delta=1e-12)
+                self.assertAlmostEqual(abs(amp - inner_cpp), 0.0, delta=1e-12)
+                self.assertAlmostEqual(abs(amp - trace_cpp), 0.0, delta=1e-12)
+
+                # Building blocks match their definitions.
+                np.testing.assert_allclose(UT_mat, U_T, atol=1e-12)        # |psiA><psiB|
+                np.testing.assert_allclose(np.array(vecU_cpp), vecU, atol=1e-12)  # flatten
+
+
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without the quantum subsystem")
+class TestSchmidtRankAndSingularValues(unittest.TestCase):
+    """C2: Schmidt rank = #nonzero singular values; separable vs entangled."""
+
+    def test_transition_operator_is_separable_rank_one(self) -> None:
+        rng = np.random.default_rng(2024)
+        psiA = _unit(_rand_complex(rng, 2))
+        psiB = _unit(_rand_complex(rng, 2))
+
+        U_T = ChoiJamiolkowski.transitionOperator(
+            psiA.tolist(), psiB.tolist(), 2, 2)
+        sv = ChoiJamiolkowski.singularValues(U_T, 2, 2)
+
+        # |psiA><psiB| with unit psiA, psiB has singular values (1, 0).
+        self.assertEqual(len(sv), 2)
+        self.assertAlmostEqual(sv[0], 1.0, delta=1e-12)
+        self.assertAlmostEqual(sv[1], 0.0, delta=1e-12)
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(U_T, 2, 2), 1)
+
+        # Cross-check the spectrum against a numpy SVD of |psiA><psiB|.
+        sv_ref = np.linalg.svd(np.outer(psiA, psiB.conj()), compute_uv=False)
+        np.testing.assert_allclose(
+            sorted(sv, reverse=True), sorted(sv_ref, reverse=True), atol=1e-12)
+
+    def test_identity_bends_to_cup_rank_two(self) -> None:
+        I2 = _flat(np.eye(2))
+
+        # vec(I_2) = |00> + |11> (the cup / unnormalized Bell state).
+        vec = ChoiJamiolkowski.vectorize(I2, 2, 2)
+        np.testing.assert_allclose(
+            np.array(vec), np.array([1, 0, 0, 1], dtype=complex), atol=1e-12)
+
+        sv = ChoiJamiolkowski.singularValues(I2, 2, 2)
+        np.testing.assert_allclose(
+            sorted(sv, reverse=True), [1.0, 1.0], atol=1e-12)
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(I2, 2, 2), 2)
+
+    def test_pauli_x_is_entangled_rank_two(self) -> None:
+        sx = _flat(np.array([[0, 1], [1, 0]]))
+
+        # vec(σ_x) = |01> + |10>.
+        vec = ChoiJamiolkowski.vectorize(sx, 2, 2)
+        np.testing.assert_allclose(
+            np.array(vec), np.array([0, 1, 1, 0], dtype=complex), atol=1e-12)
+
+        sv = ChoiJamiolkowski.singularValues(sx, 2, 2)
+        np.testing.assert_allclose(
+            sorted(sv, reverse=True), [1.0, 1.0], atol=1e-12)
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(sx, 2, 2), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #91 — `quantum::ChoiJamiolkowski`, the dense Choi–Jamiołkowski (map–state duality / "bending") utility for Stage 1.

- `ChoiJamiolkowski.{h,cpp}` (static utility): `vectorize`, `singularValues`, `schmidtRank`, `transitionOperator`, `transitionAmplitude` (Eigen). Conventions: `vec(|a><b|) = a ⊗ conj(b)`; HS/duality identity `<a|U|b> = <vec(U_T)|vec(U)> = Tr(U_T^H U)`; Schmidt rank = #nonzero singular values of U.
- Bindings: `tessera.quantum.ChoiJamiolkowski` — C++ registration in `register_quantum`, plus the name added to the `tessera/quantum/__init__.py` facade `_EXPORTS` (the quantum submodule re-exports a curated list).
- Tests (C1/C2): **4 passed** — amplitude == HS contraction == `Tr(U_T^H U)` to 1e-12; `U_T` separable (rank/Schmidt 1), identity/`σ_x` entangled (rank/Schmidt 2).
- `pyproject.toml`: the same poetry-resolution fixes as #90 (needed for `poetry install` to resolve; identical change, merges cleanly).

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)