### PR TITLE
cobordism: Stage 1 — route InteractionSimulation Choi through ChoiJamiolkowski

### DIFF
--- a/include/quantum/ChoiJamiolkowski.h
+++ b/include/quantum/ChoiJamiolkowski.h
@@ -100,6 +100,22 @@ class ChoiJamiolkowski {
         const std::vector<std::complex<double>> &psiA,
         const std::vector<std::complex<double>> &U,
         const std::vector<std::complex<double>> &psiB, int dA, int dB);
+
+    /// Choi–Jamiołkowski *state* of a square d×d operator U: the maximally-
+    /// entangled bend |Φ_U⟩ = (U ⊗ I)|Φ⁺⟩ with |Φ⁺⟩ = (1/√d) Σ_k |k⟩|k⟩, which
+    /// in the row-major convention is the normalised vec, (1/√d)·vec(U) (length
+    /// d·d). For unitary U this is a unit vector. Throws std::invalid_argument
+    /// if U.size() != d·d or d is non-positive.
+    [[nodiscard]] static std::vector<std::complex<double>> choiState(
+        const std::vector<std::complex<double>> &U, int d);
+
+    /// Choi *matrix* J(U) = |Φ_U⟩⟨Φ_U| of a square d×d operator U: the
+    /// (d·d)×(d·d) density matrix of choiState(U, d), returned flat row-major
+    /// (J[i·d² + j] = state_i · conj(state_j)). This is the standard
+    /// (U ⊗ I)|Φ⁺⟩⟨Φ⁺|(U ⊗ I)^H Choi matrix; Tr J = 1 for unitary U. Throws
+    /// std::invalid_argument as choiState.
+    [[nodiscard]] static std::vector<std::complex<double>> choiMatrix(
+        const std::vector<std::complex<double>> &U, int d);
 };
 
 }  // namespace tessera::quantum

--- a/src/quantum/Bindings.cpp
+++ b/src/quantum/Bindings.cpp
@@ -817,7 +817,15 @@ flat row-major.)doc")
         .def_static("transitionAmplitude", &ChoiJamiolkowski::transitionAmplitude,
             py::arg("psiA"), py::arg("U"), py::arg("psiB"), py::arg("dA"), py::arg("dB"),
             R"doc(Transition amplitude ⟨psiA|U|psiB⟩ = Σ_{ij}
-conj(psiA_i)·U_{ij}·psiB_j.)doc");
+conj(psiA_i)·U_{ij}·psiB_j.)doc")
+        .def_static("choiState", &ChoiJamiolkowski::choiState,
+            py::arg("U"), py::arg("d"),
+            R"doc(Choi–Jamiołkowski state (U⊗I)|Φ⁺⟩ = (1/√d)·vec(U) of a square
+d×d operator (length d·d, row-major; a unit vector for unitary U).)doc")
+        .def_static("choiMatrix", &ChoiJamiolkowski::choiMatrix,
+            py::arg("U"), py::arg("d"),
+            R"doc(Choi matrix J(U) = |state⟩⟨state| of a square d×d operator
+(flat row-major (d·d)×(d·d); Tr J = 1 for unitary U).)doc");
 
     // ─── InteractionSimulation: interaction-history Monte Carlo ────────
     // See docs/source/interaction-history-monte-carlo.md.

--- a/src/quantum/ChoiJamiolkowski.cpp
+++ b/src/quantum/ChoiJamiolkowski.cpp
@@ -5,6 +5,7 @@
 
 #include <Eigen/Dense>
 
+#include <cmath>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -132,6 +133,29 @@ std::complex<double> ChoiJamiolkowski::transitionAmplitude(
     // ⟨psiA|U|psiB⟩ = Σ_{ij} conj(psiA_i)·U_{ij}·psiB_j. Eigen's complex dot()
     // conjugates its first argument: a.dot(M*b) = Σ_i conj(a_i) (M b)_i.
     return a.dot(M * b);
+}
+
+std::vector<std::complex<double>> ChoiJamiolkowski::choiState(
+    const std::vector<std::complex<double>> &U, int d) {
+    requirePositiveDims(d, d, "ChoiJamiolkowski::choiState");
+    asMatrix(U, d, d, "ChoiJamiolkowski::choiState");  // validates U.size() == d*d
+    // |Φ_U⟩ = (U ⊗ I)|Φ⁺⟩ with |Φ⁺⟩ = (1/√d) Σ_k |k⟩|k⟩  ==  (1/√d) · vec(U).
+    const double inv = 1.0 / std::sqrt(static_cast<double>(d));
+    std::vector<std::complex<double>> state = U;
+    for (auto &z : state) z *= inv;
+    return state;
+}
+
+std::vector<std::complex<double>> ChoiJamiolkowski::choiMatrix(
+    const std::vector<std::complex<double>> &U, int d) {
+    const std::vector<std::complex<double>> v = choiState(U, d);
+    const std::size_t n = v.size();  // d*d
+    // J = |v⟩⟨v|, row-major: J[i*n + j] = v_i · conj(v_j).
+    std::vector<std::complex<double>> J(n * n);
+    for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t j = 0; j < n; ++j)
+            J[i * n + j] = v[i] * std::conj(v[j]);
+    return J;
 }
 
 }  // namespace tessera::quantum

--- a/src/simulations/InteractionSimulation.cpp
+++ b/src/simulations/InteractionSimulation.cpp
@@ -14,6 +14,7 @@
 #include "mesh/SimplexFilter.h"
 #include "mesh/Vertex.h"
 #include "observables/MIUnits.hpp"
+#include "quantum/ChoiJamiolkowski.h"
 #include "quantum/Holography.hpp"
 #include "spacetime/Metric.h"
 #include "spacetime/Spacetime.h"
@@ -446,22 +447,20 @@ InteractionSimulation::InteractionSimulation(InteractionConfig config)
         config_.featureChoiSigmaAB = false;
     }
     if (config_.featureChoiSigmaAB) {
-        // |Ω⟩ = (1/4) Σ_{i,j} |i,j⟩_A |i,j⟩_B' on the doubled
-        // ququart space; J(U) = (U ⊗ I_16) |Ω⟩⟨Ω| (U† ⊗ I_16).
-        // We construct |Ω⟩ as a 256-dim column vector with 1/4 at
-        // every "diagonal" (i,j;i,j) index, then apply U on the
-        // first 16-dim subsystem.
-        Eigen::VectorXcd omega = Eigen::VectorXcd::Zero(256);
-        for (int k = 0; k < 16; ++k)
-            omega(k * 16 + k) = cd(0.25, 0.0);   // (1/4) (i,j) (i,j)
-        // Apply U on the first 16-dim factor: reshape omega as 16×16
-        // (rows = first factor, cols = second), multiply by U from
-        // the left, reshape back.
-        Eigen::Map<Eigen::MatrixXcd> omega_mat(omega.data(), 16, 16);
-        Eigen::MatrixXcd shaped = quditInteractionU_ * omega_mat;
-        Eigen::VectorXcd uOmega = Eigen::Map<Eigen::VectorXcd>(
-            shaped.data(), 256);
-        quditChoiU_ = uOmega * uOmega.adjoint();
+        // J(U) = (U ⊗ I_16) |Φ⁺⟩⟨Φ⁺| (U ⊗ I_16)^H, the Choi matrix of the
+        // qudit-pair unitary on the doubled ququart space (|Φ⁺⟩ = (1/4) Σ_k
+        // |k,k⟩). Delegated to quantum::ChoiJamiolkowski::choiMatrix so the
+        // vec(U) convention (standard, row-major) is canonical across the
+        // codebase and shared with the Stage-1 bending oracle.
+        std::vector<cd> uFlat(256);
+        for (int i = 0; i < 16; ++i)
+            for (int j = 0; j < 16; ++j)
+                uFlat[static_cast<std::size_t>(i) * 16 + j] =
+                    quditInteractionU_(i, j);
+        const std::vector<cd> jFlat = ChoiJamiolkowski::choiMatrix(uFlat, 16);
+        quditChoiU_ = Eigen::Map<const Eigen::Matrix<
+            cd, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>(
+            jFlat.data(), 256, 256);
     }
 
     buildInitialLayer();

--- a/tests/quantum/test_choi_jamiolkowski_python.py
+++ b/tests/quantum/test_choi_jamiolkowski_python.py
@@ -138,5 +138,53 @@ class TestSchmidtRankAndSingularValues(unittest.TestCase):
         self.assertEqual(ChoiJamiolkowski.schmidtRank(sx, 2, 2), 2)
 
 
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without the quantum subsystem")
+class TestChoiStateAndMatrix(unittest.TestCase):
+    """Choi state (U⊗I)|Φ⁺⟩ = (1/√d) vec(U) and matrix J(U) = |state⟩⟨state|."""
+
+    def test_choi_state_of_identity_is_maximally_entangled(self) -> None:
+        # (1/√d) vec(I_d) = (1/√d) Σ_k |k,k⟩ — the maximally entangled |Φ⁺⟩.
+        for d in (2, 3, 4):
+            with self.subTest(d=d):
+                state = np.array(ChoiJamiolkowski.choiState(_flat(np.eye(d)), d))
+                np.testing.assert_allclose(
+                    state, np.eye(d).flatten() / np.sqrt(d), atol=1e-12)
+                self.assertAlmostEqual(np.linalg.norm(state), 1.0, delta=1e-12)
+
+    def test_choi_state_is_normalised_vec(self) -> None:
+        rng = np.random.default_rng(11)
+        for d in (2, 3):
+            with self.subTest(d=d):
+                U = _rand_complex(rng, d, d)
+                state = np.array(ChoiJamiolkowski.choiState(_flat(U), d))
+                np.testing.assert_allclose(
+                    state, U.flatten() / np.sqrt(d), atol=1e-12)
+
+    def test_choi_matrix_is_pure_unit_trace_for_unitary(self) -> None:
+        # J(U) = |Φ_U⟩⟨Φ_U|: Hermitian, Tr = 1, rank 1 for unitary U; equals
+        # the outer product of choiState with itself.
+        rng = np.random.default_rng(3)
+        d, n = 2, 4
+        Q, _ = np.linalg.qr(_rand_complex(rng, d, d))   # a unitary
+        J = np.array(ChoiJamiolkowski.choiMatrix(_flat(Q), d)).reshape(n, n)
+        np.testing.assert_allclose(J, J.conj().T, atol=1e-12)        # Hermitian
+        self.assertAlmostEqual(np.trace(J).real, 1.0, delta=1e-12)   # Tr = 1
+        evals = np.linalg.eigvalsh(J)
+        self.assertAlmostEqual(evals[-1], 1.0, delta=1e-12)          # rank 1
+        np.testing.assert_allclose(evals[:-1], 0.0, atol=1e-12)
+        state = np.array(ChoiJamiolkowski.choiState(_flat(Q), d))
+        np.testing.assert_allclose(J, np.outer(state, state.conj()), atol=1e-12)
+
+    def test_choi_matrix_marginal_is_maximally_mixed_for_unitary(self) -> None:
+        # Tracing out the second factor of J(unitary U) gives I/d — the
+        # convention-independent fact behind InteractionSimulation's Q-bookkeeping.
+        rng = np.random.default_rng(5)
+        d = 4
+        Q, _ = np.linalg.qr(_rand_complex(rng, d, d))
+        J4 = np.array(ChoiJamiolkowski.choiMatrix(_flat(Q), d)).reshape(d, d, d, d)
+        rho_A = np.einsum("ijkj->ik", J4)               # trace over factor B
+        np.testing.assert_allclose(rho_A, np.eye(d) / d, atol=1e-12)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements #92 — deduplicate the Choi construction by routing `InteractionSimulation`'s inline 256-dim Choi through `quantum::ChoiJamiolkowski`, and canonicalize the vec convention across the codebase.

**Convention canonicalized.** The standard Choi state is `(U⊗I)|Φ⁺⟩ = Σ_jk U_jk|j⟩|k⟩` = row-major `vec(U)` — already what `ChoiJamiolkowski` uses. `InteractionSimulation`'s column-major left-multiply was the transposed `(I⊗U)` variant; it now uses the canonical convention (its `(U⊗I)` comment is finally accurate).

- `ChoiJamiolkowski` gains **`choiState(U,d)`** = `(U⊗I)|Φ⁺⟩ = (1/√d)·vec(U)` and **`choiMatrix(U,d)`** = `J(U) = |state⟩⟨state|` (Tr=1 for unitary U) — the Choi state/matrix the class is named for — with pybind bindings + numpy-oracle unit tests.
- `InteractionSimulation`'s `quditChoiU_` now delegates to `ChoiJamiolkowski::choiMatrix`.

**Physics preserved (verified, not just asserted byte-identical).** The reduction `reduceChoiAgainstPartner` traces `J(U)` to `rho_AB = UU† = I/16` — U-independent for unitary U, and `Iᵀ = I` — so the transpose flip cannot change it. Confirmed:
- cpp `test_sigma_ab_choi_state` (Q-conservation across 12 seeds): **PASS**
- `test_charged_cartan_python.py` (InteractionSimulation, Choi on by default): **PASS**
- `test_choi_jamiolkowski_python.py` incl. new `choiState`/`choiMatrix`: **PASS** (22 passed)

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)