### PR TITLE
cobordism: IntegerLinalg::gf2Nullspace — GF(2) kernel basis

### DIFF
--- a/include/cobordism/IntegerLinalg.h
+++ b/include/cobordism/IntegerLinalg.h
@@ -51,6 +51,31 @@ struct SmithNormalForm {
 /// Rank over GF(2) of a 0/1 matrix (flat row-major). Entries are read mod 2.
 [[nodiscard]] int gf2Rank(std::vector<int> M, int rows, int cols);
 
+/// Basis of the GF(2) kernel (nullspace) of a 0/1 matrix M (rows x cols, flat
+/// row-major; entries read mod 2). Each returned vector x has length `cols` and
+/// satisfies M·x ≡ 0 (mod 2); the vectors are linearly independent over GF(2)
+/// and there are exactly nullity = cols - gf2Rank(M) of them, so the whole
+/// kernel is their GF(2) span. The basis is returned as a list of length-`cols`
+/// vectors (one per free column of the reduced row echelon form), the form that
+/// reads naturally for a collection of independent vectors; the count is just
+/// the size of the returned list. Empty when M has full column rank.
+///
+/// This is the cocycle space Z¹ = ker(∂₂ᵀ mod 2) of flat ℤ₂ gauge fields in the
+/// Dijkgraaf–Witten state sum; pair with gf2Span to enumerate the connections.
+[[nodiscard]] std::vector<std::vector<int>> gf2Nullspace(std::vector<int> M,
+                                                         int rows, int cols);
+
+/// All 2^k GF(2) linear combinations of a `basis` of k length-`cols` vectors,
+/// each combination a length-`cols` vector (entries read mod 2). The first
+/// element is always the zero vector (empty combination); `cols` is taken
+/// explicitly so the trivial connection has the right length even when the
+/// basis is empty (k = 0 → a single zero vector). For a cocycle basis from
+/// gf2Nullspace this enumerates the 2^nullity flat ℤ₂ connections. Enumeration
+/// is exponential in k; intended for the small nullities of tiny complexes, it
+/// rejects k large enough to be unmaterializable.
+[[nodiscard]] std::vector<std::vector<int>> gf2Span(
+    const std::vector<std::vector<int>> &basis, int cols);
+
 /// Inertia of a symmetric integer matrix Q (n x n): the counts of positive,
 /// negative, and zero eigenvalues by Sylvester's law of inertia. The signature
 /// is nPos - nNeg.

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -151,6 +151,14 @@ cycle bases, and Betti numbers belong to WilsonLoop / ChainComplex.)doc")
         "Rank over Q of an integer matrix.");
   m.def("gf2_rank", &gf2Rank, py::arg("matrix"), py::arg("rows"), py::arg("cols"),
         "Rank over GF(2) of a 0/1 matrix.");
+  m.def("gf2_nullspace", &gf2Nullspace, py::arg("matrix"), py::arg("rows"),
+        py::arg("cols"),
+        "Basis of the GF(2) kernel of a 0/1 matrix, as a list of nullity "
+        "length-cols vectors (each x with matrix·x == 0 mod 2; independent over "
+        "GF(2); nullity == cols - gf2_rank). The cocycles Z1 = ker(d2^T mod 2).");
+  m.def("gf2_span", &gf2Span, py::arg("basis"), py::arg("cols"),
+        "All 2^k GF(2) combinations of a basis of k length-cols vectors (first "
+        "is the zero vector). For a gf2_nullspace basis, the flat Z2 connections.");
 
   py::class_<Inertia>(m, "Inertia")
       .def_readonly("n_pos", &Inertia::nPos)

--- a/src/cobordism/IntegerLinalg.cpp
+++ b/src/cobordism/IntegerLinalg.cpp
@@ -26,6 +26,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <stdexcept>
+#include <string>
 
 namespace tessera::cobordism {
 
@@ -135,6 +137,70 @@ int gf2Rank(std::vector<int> M, int rows, int cols) {
     ++rank;
   }
   return rank;
+}
+
+std::vector<std::vector<int>> gf2Nullspace(std::vector<int> M, int rows, int cols) {
+  auto idx = [cols](int i, int j) { return static_cast<std::size_t>(i) * cols + j; };
+  for (auto &v : M) v &= 1;
+  // Reduce to RREF (mirroring gf2Rank), recording each pivot's column.
+  std::vector<int> pivotCol;  // pivotCol[r] == pivot column of reduced row r
+  int rank = 0;
+  for (int col = 0; col < cols && rank < rows; ++col) {
+    int piv = -1;
+    for (int i = rank; i < rows; ++i)
+      if (M[idx(i, col)] & 1) { piv = i; break; }
+    if (piv < 0) continue;
+    if (piv != rank)
+      for (int j = 0; j < cols; ++j) std::swap(M[idx(rank, j)], M[idx(piv, j)]);
+    // Eliminate this column from every other row (above and below).
+    for (int i = 0; i < rows; ++i) {
+      if (i != rank && (M[idx(i, col)] & 1))
+        for (int j = col; j < cols; ++j) M[idx(i, j)] ^= M[idx(rank, j)];
+    }
+    pivotCol.push_back(col);
+    ++rank;
+  }
+
+  // Free columns are the non-pivot columns; one kernel vector per free column.
+  std::vector<char> isPivot(static_cast<std::size_t>(cols), 0);
+  for (int c : pivotCol) isPivot[static_cast<std::size_t>(c)] = 1;
+
+  std::vector<std::vector<int>> basis;
+  basis.reserve(static_cast<std::size_t>(cols - rank));
+  for (int f = 0; f < cols; ++f) {
+    if (isPivot[static_cast<std::size_t>(f)]) continue;
+    // Set the free variable to 1; back-substitute each pivot variable to the
+    // (already reduced) coefficient tying it to this free column.
+    std::vector<int> x(static_cast<std::size_t>(cols), 0);
+    x[static_cast<std::size_t>(f)] = 1;
+    for (int r = 0; r < rank; ++r)
+      x[static_cast<std::size_t>(pivotCol[r])] = M[idx(r, f)] & 1;
+    basis.push_back(std::move(x));
+  }
+  return basis;
+}
+
+std::vector<std::vector<int>> gf2Span(const std::vector<std::vector<int>> &basis,
+                                      int cols) {
+  const int k = static_cast<int>(basis.size());
+  // 2^k vectors are materialized; refuse a count that cannot fit in memory (and
+  // would also overflow the shift below).
+  if (k > 24)
+    throw std::invalid_argument(
+        "gf2Span: basis too large to enumerate (2^" + std::to_string(k) +
+        " combinations)");
+  const std::size_t count = std::size_t{1} << k;
+  std::vector<std::vector<int>> out;
+  out.reserve(count);
+  for (std::size_t mask = 0; mask < count; ++mask) {
+    std::vector<int> v(static_cast<std::size_t>(cols), 0);
+    for (int b = 0; b < k; ++b)
+      if (mask & (std::size_t{1} << b))
+        for (int j = 0; j < cols; ++j) v[static_cast<std::size_t>(j)] ^=
+            basis[static_cast<std::size_t>(b)][static_cast<std::size_t>(j)] & 1;
+    out.push_back(std::move(v));
+  }
+  return out;
 }
 
 Inertia symmetricInertia(std::vector<long> Q, int n, double tol) {

--- a/tests/cobordism/test_gf2_nullspace_python.py
+++ b/tests/cobordism/test_gf2_nullspace_python.py
@@ -1,0 +1,204 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""GF(2) nullspace and span (#106): cocycles Z1 = ker(d2^T mod 2) and the flat
+Z2 connections enumerated from them, validated against an independent numpy
+GF(2) oracle on random binary matrices plus a handful of hand fixtures.
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+def _flat(M):
+    """Flatten a 2D array-like to a flat row-major list of python ints."""
+    return [int(v) for v in np.asarray(M, dtype=np.int64).reshape(-1)]
+
+
+def _gf2_rank_np(M):
+    """Independent GF(2) rank oracle (Gaussian elimination, pure numpy)."""
+    A = (np.asarray(M, dtype=np.int64) & 1).copy()
+    if A.ndim == 1:
+        A = A.reshape(1, -1) if A.size else A.reshape(0, 0)
+    rows, cols = A.shape
+    rank = 0
+    for col in range(cols):
+        if rank >= rows:
+            break
+        piv = next((i for i in range(rank, rows) if A[i, col] & 1), None)
+        if piv is None:
+            continue
+        A[[rank, piv]] = A[[piv, rank]]
+        for i in range(rows):
+            if i != rank and (A[i, col] & 1):
+                A[i] ^= A[rank]
+        rank += 1
+    return rank
+
+
+def _assert_kernel_basis(test, A, rows, cols):
+    """Run every nullspace acceptance property for matrix A (rows x cols)."""
+    A = np.asarray(A, dtype=np.int64).reshape(rows, cols) if rows else \
+        np.zeros((0, cols), dtype=np.int64)
+    basis = cob.gf2_nullspace(_flat(A) if rows else [], rows, cols)
+    basis = [list(v) for v in basis]
+    nullity = len(basis)
+
+    # rank-nullity over GF(2): gf2_rank + nullity == cols.
+    rank = cob.gf2_rank(_flat(A) if rows else [], rows, cols)
+    test.assertEqual(rank, _gf2_rank_np(A))
+    test.assertEqual(rank + nullity, cols)
+
+    for x in basis:
+        test.assertEqual(len(x), cols)
+        test.assertTrue(set(x) <= {0, 1})
+        # A . x == 0 (mod 2).
+        if rows:
+            prod = (A @ np.asarray(x, dtype=np.int64)) % 2
+            test.assertTrue(np.all(prod == 0), f"A.x != 0 for x={x}")
+
+    # The basis vectors are linearly independent over GF(2).
+    test.assertEqual(_gf2_rank_np(basis) if nullity else 0, nullity)
+    return basis
+
+
+class TestGf2NullspaceFixtures(unittest.TestCase):
+
+    def test_full_rank_has_empty_kernel(self):
+        # 2x2 identity: trivial kernel.
+        self.assertEqual(cob.gf2_nullspace([1, 0, 0, 1], 2, 2), [])
+
+    def test_single_relation(self):
+        # [1 1] x = 0  ->  kernel spanned by (1, 1).
+        basis = cob.gf2_nullspace([1, 1], 1, 2)
+        self.assertEqual([list(v) for v in basis], [[1, 1]])
+
+    def test_two_relations_three_cols(self):
+        # [[1,1,0],[0,1,1]] x = 0  ->  kernel spanned by (1, 1, 1).
+        basis = cob.gf2_nullspace([1, 1, 0, 0, 1, 1], 2, 3)
+        self.assertEqual([list(v) for v in basis], [[1, 1, 1]])
+
+    def test_zero_matrix_is_whole_space(self):
+        # 2x2 zero matrix: nullity 2, kernel == all of GF(2)^2.
+        basis = [list(v) for v in cob.gf2_nullspace([0, 0, 0, 0], 2, 2)]
+        self.assertEqual(len(basis), 2)
+        self.assertEqual(_gf2_rank_np(basis), 2)
+
+    def test_rank_one_all_ones(self):
+        # 3x3 all-ones: rank 1, nullity 2; every kernel vector has even weight.
+        basis = _assert_kernel_basis(self, np.ones((3, 3), dtype=int), 3, 3)
+        self.assertEqual(len(basis), 2)
+        for x in basis:
+            self.assertEqual(sum(x) % 2, 0)
+
+    def test_entries_reduced_mod_two(self):
+        # Odd entries read as 1: [3, 3] behaves like [1, 1].
+        self.assertEqual([list(v) for v in cob.gf2_nullspace([3, 3], 1, 2)],
+                         [[1, 1]])
+
+
+class TestGf2NullspaceOracle(unittest.TestCase):
+
+    def test_random_binary_matrices(self):
+        rng = np.random.default_rng(20251106)
+        shapes = [(1, 1), (2, 3), (3, 2), (4, 4), (5, 8), (8, 5),
+                  (6, 6), (7, 10), (10, 7), (3, 12)]
+        for rows, cols in shapes:
+            for trial in range(8):
+                with self.subTest(rows=rows, cols=cols, trial=trial):
+                    A = rng.integers(0, 2, size=(rows, cols))
+                    _assert_kernel_basis(self, A, rows, cols)
+
+    def test_random_low_rank_matrices(self):
+        # Force a large kernel by building rank-deficient matrices (outer-product
+        # sums of r < cols binary vectors), stressing the free-column logic.
+        rng = np.random.default_rng(424242)
+        for cols in (6, 9, 12):
+            for r in range(0, 4):
+                with self.subTest(cols=cols, r=r):
+                    rows = cols
+                    A = np.zeros((rows, cols), dtype=np.int64)
+                    for _ in range(r):
+                        u = rng.integers(0, 2, size=(rows, 1))
+                        v = rng.integers(0, 2, size=(1, cols))
+                        A = (A + u @ v) % 2
+                    _assert_kernel_basis(self, A, rows, cols)
+
+    def test_empty_matrix_zero_rows(self):
+        # No equations: the kernel is the whole space (nullity == cols).
+        basis = [list(v) for v in cob.gf2_nullspace([], 0, 4)]
+        self.assertEqual(len(basis), 4)
+        self.assertEqual(_gf2_rank_np(basis), 4)
+
+
+class TestGf2Span(unittest.TestCase):
+
+    def _expected_span(self, basis, cols):
+        """All GF(2) combinations of `basis`, computed independently in numpy."""
+        out = set()
+        k = len(basis)
+        for mask in range(1 << k):
+            v = np.zeros(cols, dtype=np.int64)
+            for b in range(k):
+                if mask & (1 << b):
+                    v ^= np.asarray(basis[b], dtype=np.int64) & 1
+            out.add(tuple(int(x) for x in v))
+        return out
+
+    def test_empty_basis_yields_single_zero_vector(self):
+        # k == 0: the only combination is the zero vector, of length cols.
+        self.assertEqual([list(v) for v in cob.gf2_span([], 3)], [[0, 0, 0]])
+
+    def test_span_matches_numpy_oracle(self):
+        rng = np.random.default_rng(98765)
+        for rows, cols in [(2, 4), (3, 6), (1, 5), (4, 7), (5, 5)]:
+            A = rng.integers(0, 2, size=(rows, cols))
+            basis = [list(v) for v in cob.gf2_nullspace(_flat(A), rows, cols)]
+            span = [list(v) for v in cob.gf2_span(basis, cols)]
+            with self.subTest(rows=rows, cols=cols):
+                # 2^nullity combinations, all distinct, first is the zero vector.
+                self.assertEqual(len(span), 2 ** len(basis))
+                self.assertEqual(span[0], [0] * cols)
+                self.assertEqual(len(set(map(tuple, span))), len(span))
+                # Set equality with the independent oracle.
+                self.assertEqual(set(map(tuple, span)),
+                                 self._expected_span(basis, cols))
+                # Every connection in the span is itself a cocycle (A.v == 0).
+                for v in span:
+                    prod = (A @ np.asarray(v, dtype=np.int64)) % 2
+                    self.assertTrue(np.all(prod == 0))
+
+    def test_span_rejects_unmaterializable_basis(self):
+        # 1x25 zero matrix -> nullity 25; enumerating 2^25 is refused.
+        basis = cob.gf2_nullspace([0] * 25, 1, 25)
+        self.assertEqual(len(basis), 25)
+        with self.assertRaises(ValueError):
+            cob.gf2_span(basis, 25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the GF(2) kernel-basis routine the Stage-2 Dijkgraaf–Witten state sum needs to enumerate flat ℤ₂ gauge fields (cocycles `Z¹ = ker(∂₂ᵀ mod 2)`). `cobordism::IntegerLinalg` already had `gf2Rank` but no nullspace.

- **`gf2Nullspace(matrix, rows, cols)`** — basis of the GF(2) kernel of a 0/1 matrix (flat row-major, entries read mod 2). Gaussian elimination over GF(2): row-reduce to RREF (mirroring `gf2Rank`'s elimination), identify free columns, back-substitute one kernel vector per free column. Returned as `std::vector<std::vector<int>>` — a list of `nullity` length-`cols` vectors, matching the subsystem's nested-vector idiom (`SimplexList`); the count is just the list size. Empty when the matrix has full column rank.
- **`gf2Span(basis, cols)`** — the optional helper: all `2^k` GF(2) linear combinations of a basis (first element the zero vector). `cols` is explicit so the trivial connection has the right length when the basis is empty. Enumeration is exponential, so it rejects an unmaterializable `k` (> 24) with `ValueError`. For a `gf2Nullspace` basis this enumerates the `2^nullity` flat ℤ₂ connections.
- Bound as `gf2_nullspace` / `gf2_span` in `src/cobordism/Bindings.cpp`, localized to the `IntegerLinalg` registration block (minimizes conflict with #107).

Follows the existing `IntegerLinalg` convention (free functions in `tessera::cobordism`, flat row-major dims passed explicitly, mirroring `gf2Rank`'s signature). `poetry.lock` (generated locally, untracked upstream) deliberately left out of the commit.

## Tests

New `tests/cobordism/test_gf2_nullspace_python.py` with an independent numpy GF(2) oracle on random binary matrices (varied shapes + forced low-rank cases) asserting, for every returned basis vector: `A·x ≡ 0 (mod 2)`, basis linear independence over GF(2), and `gf2Rank + nullity == cols`. Plus hand fixtures (identity → empty kernel, `[1 1]` → `(1,1)`, `[[1,1,0],[0,1,1]]` → `(1,1,1)`, zero matrix, all-ones, mod-2 reduction) and `gf2_span` checks (set-equality vs numpy oracle, `2^nullity` count, zero-vector first, every span element a cocycle, the `k > 24` guard).

```
$ poetry run pytest tests/cobordism/test_gf2_nullspace_python.py -q
12 passed, 97 subtests passed in 0.15s
```

Existing `test_chaincomplex_python.py` (IntegerLinalg primitives) + `test_smoke_python.py` still green (13 passed). Clean editable build (`poetry run pip install -e .`, exit 0).

Closes #106.