### PR TITLE
cobordism: oriented top-simplices + fundamental class

### DIFF
--- a/include/cobordism/ChainComplex.h
+++ b/include/cobordism/ChainComplex.h
@@ -82,6 +82,28 @@ class ChainComplex {
     /// \f$ \mathrm{torsion}(1) = \{2\} \f$.)
     [[nodiscard]] std::vector<long> torsion(int k) const;
 
+    /// The top simplices as sorted vertex-id tuples, in the canonical column
+    /// order of the top boundary matrix \f$ \partial_d \f$ (\f$ d = \f$
+    /// dimension()). This is the ordering the orientation signs from
+    /// fundamentalClass() refer to. Empty for the empty complex.
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> orientedTopSimplices() const;
+
+    /// The fundamental class \f$ [W] \in H_d \f$ of a closed oriented
+    /// \f$ d \f$-manifold: the per top-simplex orientation signs
+    /// \f$ \varepsilon_t = \pm 1 \f$ (indexed as orientedTopSimplices(), i.e. the
+    /// columns of \f$ \partial_d \f$) that make the top chain
+    /// \f$ \sum_t \varepsilon_t\, t \f$ a cycle
+    /// (\f$ \partial_d \sum_t \varepsilon_t\, t = 0 \f$, so each codimension-one
+    /// face's two incident top simplices cancel). It is the \f$ \pm 1 \f$
+    /// generator of \f$ \ker \partial_d \f$, which is one-dimensional
+    /// (\f$ b_d = 1 \f$) for a closed connected oriented manifold, hence unique
+    /// up to an overall sign; the sign is fixed deterministically by making the
+    /// first nonzero entry \f$ +1 \f$.
+    /// @throws std::runtime_error if no such class exists — the complex is not a
+    ///   closed connected oriented \f$ d \f$-manifold (\f$ \dim \ker \partial_d
+    ///   \neq 1 \f$) — or \f$ d < 1 \f$.
+    [[nodiscard]] std::vector<int> fundamentalClass() const;
+
     /// The symmetric intersection form \f$ Q_{ij} = \langle \alpha_i \cup
     /// \alpha_j, [K] \rangle \f$ on a basis \f$ \{\alpha_i\} \f$ of the free
     /// part of \f$ H^2 \f$, as a flat row-major \f$ b_2 \times b_2 \f$ matrix.

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -88,6 +88,16 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
       .def("bettiNumbersGF2", &ChainComplex::bettiNumbersGF2, "Betti numbers over GF(2).")
       .def("torsion", &ChainComplex::torsion, py::arg("k"),
            "Torsion coefficients of H_k (invariant factors > 1 of d_{k+1}).")
+      .def("orientedTopSimplices", &ChainComplex::orientedTopSimplices,
+           "Top simplices as sorted vertex-id tuples, in the canonical column "
+           "order of the top boundary matrix d_d (d = dimension()); the order "
+           "the fundamentalClass() signs refer to. Empty for the empty complex.")
+      .def("fundamentalClass", &ChainComplex::fundamentalClass,
+           "Fundamental class [W] in H_d: the per top-simplex orientation signs "
+           "eps_t = +/-1 (the +/-1 generator of ker d_d) making the top chain a "
+           "cycle (d_d applied to the signed top chain is 0). Sign-normalized so "
+           "the first nonzero entry is +1. Raises if the complex is not a closed "
+           "connected oriented manifold (dim ker d_d != 1) or dimension < 1.")
       .def("intersectionForm", &ChainComplex::intersectionForm,
            "Symmetric intersection form on free H^2 (flat b2 x b2), for a closed "
            "oriented 4-manifold; empty if n != 4 or b2 == 0.")

--- a/src/cobordism/ChainComplex.cpp
+++ b/src/cobordism/ChainComplex.cpp
@@ -194,6 +194,59 @@ std::vector<int> ChainComplex::bettiNumbersGF2() const {
   return b;
 }
 
+std::vector<std::vector<std::uint64_t>> ChainComplex::orientedTopSimplices() const {
+  if (dimension_ < 0) return {};  // empty complex: no top simplices
+  return faceVerts_[static_cast<std::size_t>(dimension_)];
+}
+
+std::vector<int> ChainComplex::fundamentalClass() const {
+  // [W] ∈ H_d is the ±1 generator of ker ∂_d: the orientation each top simplex
+  // must carry (relative to its increasing-vertex reference orientation) so the
+  // top chain Σ_t ε_t·t is a cycle. For a closed connected oriented d-manifold
+  // this kernel is one-dimensional (b_d = 1), so the generator is unique up to
+  // an overall sign.
+  const int d = dimension_;
+  if (d < 1)
+    throw std::runtime_error(
+        "ChainComplex::fundamentalClass: a closed oriented manifold of "
+        "dimension >= 1 is required");
+  const int rows = static_cast<int>(counts_[static_cast<std::size_t>(d - 1)]);
+  const int cols = static_cast<int>(counts_[static_cast<std::size_t>(d)]);
+  Eigen::MatrixXd topBoundary(rows, cols);
+  const auto &flat = boundary_[static_cast<std::size_t>(d)];
+  for (int r = 0; r < rows; ++r)
+    for (int c = 0; c < cols; ++c)
+      topBoundary(r, c) =
+          static_cast<double>(flat[static_cast<std::size_t>(r) * cols + c]);
+
+  const Eigen::MatrixXd kernel =
+      Eigen::FullPivLU<Eigen::MatrixXd>(topBoundary).kernel();
+  if (kernel.cols() != 1)
+    throw std::runtime_error(
+        "ChainComplex::fundamentalClass: a closed connected oriented " +
+        std::to_string(d) + "-manifold is required (dim ker ∂_" +
+        std::to_string(d) + " = b_" + std::to_string(d) +
+        " must be 1, so the fundamental class is unique up to sign)");
+
+  // Every entry of this generator has the same magnitude (one orientation per
+  // top simplex), so scaling by the first nonzero entry makes the entries
+  // exactly ±1; fixing that entry to +1 makes the overall sign deterministic.
+  Eigen::VectorXd generator = kernel.col(0);
+  const double scale = generator.cwiseAbs().maxCoeff();
+  const double threshold = 1e-9 * (scale > 0.0 ? scale : 1.0);
+  int firstNonzero = 0;
+  while (firstNonzero < generator.size() &&
+         std::abs(generator[firstNonzero]) <= threshold)
+    ++firstNonzero;
+  generator /= generator[firstNonzero];
+
+  std::vector<int> epsilon(static_cast<std::size_t>(cols), 0);
+  for (int i = 0; i < generator.size(); ++i)
+    epsilon[static_cast<std::size_t>(i)] =
+        static_cast<int>(std::lround(generator[i]));
+  return epsilon;
+}
+
 // The intersection form records how the two-dimensional surfaces sitting
 // inside a four-dimensional manifold cross one another: given two such
 // surfaces it returns an integer counting their (signed) crossing points. We
@@ -234,29 +287,13 @@ std::vector<double> ChainComplex::intersectionForm() const {
       boundaryMatrixAsEigen(2, numEdges, numTriangles);          // triangles -> edges
   const Eigen::MatrixXd tetrahedronBoundaries =
       boundaryMatrixAsEigen(3, numTriangles, numTetrahedra);     // tetrahedra -> triangles
-  const Eigen::MatrixXd fourSimplexBoundaries =
-      boundaryMatrixAsEigen(4, numTetrahedra, numFourSimplices); // 4-simplices -> tetrahedra
 
   // Fundamental class: the single way (up to sign) to orient all the
-  // four-simplices coherently so their boundaries cancel. Algebraically it is
-  // the one-dimensional null space of the four-simplex boundary map; its
-  // entries are +/-1, one orientation per four-simplex. A closed orientable
-  // 4-manifold has exactly this; anything else has no fundamental class and no
-  // well-defined signature.
-  const Eigen::MatrixXd topCycles =
-      Eigen::FullPivLU<Eigen::MatrixXd>(fourSimplexBoundaries).kernel();
-  if (topCycles.cols() != 1)
-    throw std::runtime_error(
-        "ChainComplex::intersectionForm: a closed orientable 4-manifold is "
-        "required (the space of top-dimensional cycles is not 1-dimensional, so "
-        "there is no fundamental class)");
-  Eigen::VectorXd orientationPerFourSimplex = topCycles.col(0);
-  int largestEntry = 0;
-  for (int i = 1; i < orientationPerFourSimplex.size(); ++i)
-    if (std::abs(orientationPerFourSimplex[i]) >
-        std::abs(orientationPerFourSimplex[largestEntry]))
-      largestEntry = i;
-  orientationPerFourSimplex /= orientationPerFourSimplex[largestEntry];  // -> entries +/-1
+  // four-simplices coherently so their boundaries cancel — the ±1 generator of
+  // ker ∂_4, one orientation per four-simplex (see fundamentalClass()). A closed
+  // orientable 4-manifold has exactly this; anything else has no fundamental
+  // class and no well-defined signature, and the call throws.
+  const std::vector<int> orientationPerFourSimplex = fundamentalClass();
 
   // Two-dimensional cohomology classes as triangle-cochains:
   //  - "closed" cochains are the null space of the transposed tetrahedron
@@ -309,7 +346,8 @@ std::vector<double> ChainComplex::intersectionForm() const {
         triangleIndexByVertices.at({vertices[0], vertices[1], vertices[2]});
     const int backTriangle =
         triangleIndexByVertices.at({vertices[2], vertices[3], vertices[4]});
-    const double orientation = orientationPerFourSimplex[s];
+    const double orientation =
+        static_cast<double>(orientationPerFourSimplex[static_cast<std::size_t>(s)]);
     for (int a = 0; a < numClasses; ++a)
       for (int b = 0; b < numClasses; ++b)
         intersectionMatrix[static_cast<std::size_t>(a) * numClasses + b] +=

--- a/tests/cobordism/test_oriented_tops_python.py
+++ b/tests/cobordism/test_oriented_tops_python.py
@@ -1,0 +1,148 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Oriented top-simplices and the fundamental class [W] = ε_t (#107).
+
+The Stage-2 Dijkgraaf–Witten weight ω(·)^{ε_t} needs each top simplex's
+orientation sign relative to a coherent orientation of the manifold W — the
+fundamental class [W] ∈ H_d. ``ChainComplex.fundamentalClass()`` returns those
+signs ε_t = ±1 (the generator of ker ∂_d), and
+``ChainComplex.orientedTopSimplices()`` returns the top simplices in the column
+order the signs refer to.
+
+We check on closed oriented manifolds (T³, T², S²) that the signed top chain is
+a cycle — applying ∂_d gives 0, i.e. every codimension-one face's two incident
+top simplices cancel — that the signs are ±1 and deterministically normalized,
+and that orientedTopSimplices() lines up with the boundary-matrix columns and
+the manifold's actual top simplices.
+"""
+
+import unittest
+
+import tessera
+
+cobordism = tessera.cobordism
+
+
+def _circle():
+    return tessera.SimplexBoundarySphere(1)  # S^1
+
+
+def _two_sphere():
+    return tessera.SimplexBoundarySphere(2)  # S^2
+
+
+def _torus():
+    return tessera.SimplicialProduct(_circle(), _circle())  # T^2 = S^1 x S^1
+
+
+def _three_torus():
+    return tessera.SimplicialProduct(_torus(), _circle())  # T^3 = T^2 x S^1
+
+
+def _build(topology):
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()
+    return spacetime
+
+
+def _top_tuples(spacetime):
+    """The top simplices of a Spacetime as sorted vertex-id tuples."""
+    tuples = [tuple(sorted(v.getId() for v in s.getVertices()))
+              for s in spacetime.getSimplices()]
+    top_size = max(len(t) for t in tuples)
+    return [t for t in tuples if len(t) == top_size]
+
+
+def _boundary_of_signed_top_chain(chain, d, epsilon):
+    """∂_d (Σ_t ε_t·t) as a list of coefficients over the (d-1)-simplices.
+
+    ∂_d is flat row-major with cols = |C_d| (= len(epsilon)); the chain
+    coefficient on row r is Σ_c ∂_d[r, c]·ε_c.
+    """
+    flat = chain.boundaryMatrix(d)
+    cols = len(epsilon)
+    rows = len(flat) // cols if cols else 0
+    return [sum(flat[r * cols + c] * epsilon[c] for c in range(cols))
+            for r in range(rows)]
+
+
+class TestFundamentalClass(unittest.TestCase):
+
+    def _check_closed_oriented(self, topology, expected_dimension):
+        spacetime = _build(topology)
+        chain = cobordism.ChainComplex.fromSpacetime(spacetime)
+        d = chain.dimension()
+        self.assertEqual(d, expected_dimension)
+
+        epsilon = list(chain.fundamentalClass())
+        tops = [tuple(t) for t in chain.orientedTopSimplices()]
+
+        # orientedTopSimplices length == number of top simplices == |ε|.
+        num_top = chain.numSimplices(d)
+        self.assertEqual(len(tops), num_top)
+        self.assertEqual(len(epsilon), num_top)
+
+        # The returned top simplices are exactly the manifold's top simplices,
+        # as sorted vertex-id tuples (the canonical ∂_d column order).
+        self.assertEqual(set(tops), set(_top_tuples(spacetime)))
+        self.assertEqual(len(set(tops)), len(tops))  # no duplicates
+        for t in tops:
+            self.assertEqual(list(t), sorted(t))
+
+        # ε_t ∈ {±1}, deterministically sign-normalized (first nonzero is +1).
+        self.assertTrue(all(e in (-1, 1) for e in epsilon))
+        self.assertEqual(next(e for e in epsilon if e != 0), 1)
+
+        # The signed top chain is a fundamental cycle: ∂_d (Σ ε_t·t) = 0, so
+        # every codimension-one face's two incident top simplices cancel.
+        self.assertTrue(
+            all(coefficient == 0
+                for coefficient in _boundary_of_signed_top_chain(chain, d, epsilon)))
+
+    def test_three_torus_is_a_fundamental_cycle(self):
+        # T^3 = S^1 x S^1 x S^1: a closed oriented 3-manifold (b_3 = 1).
+        self._check_closed_oriented(_three_torus(), 3)
+
+    def test_two_sphere_sanity_check(self):
+        # S^2: closed oriented surface (b_2 = 1).
+        self._check_closed_oriented(_two_sphere(), 2)
+
+    def test_two_torus_is_a_fundamental_cycle(self):
+        # T^2 = S^1 x S^1: another closed oriented surface (b_2 = 1).
+        self._check_closed_oriented(_torus(), 2)
+
+    def test_consistent_with_homology_top_betti(self):
+        # The fundamental class exists exactly when b_d = 1; cross-check that the
+        # closed oriented fixtures have a one-dimensional top homology.
+        for topology, dimension in ((_three_torus(), 3),
+                                    (_two_sphere(), 2),
+                                    (_torus(), 2)):
+            with self.subTest(dimension=dimension):
+                chain = cobordism.ChainComplex.fromSpacetime(_build(topology))
+                self.assertEqual(chain.bettiNumbers()[dimension], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Exposes the orientation data the Stage-2 Dijkgraaf–Witten weight ω(·)^{ε_t} needs: each top simplex's orientation sign relative to a coherent orientation of the manifold W — the fundamental class [W] ∈ H_d. `ChainComplex` already held this internally (the sorted `faceVerts_` and the signed top boundary matrix ∂_d) but exposed neither.

- `ChainComplex::orientedTopSimplices()` — the top simplices as sorted vertex-id tuples, in the canonical column order of ∂_d (the order the ε_t signs refer to).
- `ChainComplex::fundamentalClass()` — the per-top orientation signs ε_t = ±1, computed as the ±1 generator of `ker ∂_d` (Eigen `FullPivLU::kernel()`, the same primitive `intersectionForm` already used). For a closed connected oriented d-manifold `dim ker ∂_d = b_d = 1`, so the generator is unique up to overall sign; the sign is fixed deterministically (first nonzero entry +1). Raises if the complex is not a closed connected oriented manifold (`dim ker ∂_d ≠ 1`) or `d < 1`.
- Both bound in `src/cobordism/Bindings.cpp`, localized to the `ChainComplex` registration (minimizes conflict with #106).
- `intersectionForm` refactored to reuse `fundamentalClass()` for the 4-simplex orientation (removes the duplicated kernel-and-normalize block). The normalization is mathematically identical to the previous "largest entry" rule — every kernel entry shares one magnitude, so both resolve to "entry 0 = +1" — so the (orientation-dependent) signature is unchanged.

## Tests

New `tests/cobordism/test_oriented_tops_python.py` on closed oriented fixtures T³ (`SimplicialProduct(T², S¹)`), T² (`SimplicialProduct(S¹, S¹)`), and S² (`SimplexBoundarySphere(2)`):
- the signed top chain is a fundamental cycle — `∂_d (Σ_t ε_t·t) = 0` (every codimension-one face's two incident top simplices cancel);
- `orientedTopSimplices()` length equals the number of top simplices (= |ε| = `numSimplices(d)`), with no duplicates, sorted-tuple form, and matching the manifold's actual top simplices;
- ε_t ∈ {±1} and is sign-normalized (first nonzero entry +1);
- cross-check that each fixture has `b_d = 1`.

Results: new test file 4 passed (3 subtests); full `tests/cobordism/` suite 123 passed, 197 subtests — the `intersectionForm`/`signature` tests are unaffected by the refactor.

Closes #107.