### PR TITLE
mesh: signature-aware simplex geometry + Simplex::volume()

### DIFF
--- a/examples/quantum/interaction_branching_simplex.py
+++ b/examples/quantum/interaction_branching_simplex.py
@@ -259,12 +259,13 @@ def assemble_cell(mi: dict, epsilon: float):
         return float("nan"), float("nan"), float("inf"), lengths
 
     simplex, _ = st.createSimplex([vert[n] for n in times])
-    gram = np.array(simplex.gramMatrix(), dtype=np.float64).reshape(4, 4)
+    gram = np.array(simplex.gramMatrix(wickRotate=True),
+                    dtype=np.float64).reshape(4, 4)
     with np.errstate(invalid="ignore"):
         det_gram = float(np.linalg.det(gram))
 
     spatial, _ = st.createSimplex([vert["A'"], vert["AB"], vert["B'"]])
-    spatial_area = float(spatial.area())
+    spatial_area = float(spatial.area(wickRotate=True))
 
     return det_gram, spatial_area, max(lengths.values()), lengths
 

--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -262,22 +262,49 @@ class Simplex {
 
     // ==================== Geometry ====================
 
-    /// Gram matrix of this simplex from its edge lengths (Wick-rotated).
+    /// Gram matrix of this simplex from its edge lengths.
     /// Returns a flat (d x d) row-major matrix where d = size() - 1.
-    /// Vertex 0 is the origin: G_ij = 1/2(|l^2(v0,vi)| + |l^2(v0,vj)| - |l^2(vi,vj)|).
-    [[nodiscard]] std::vector<double> gramMatrix() const;
+    /// Vertex 0 is the origin: G_ij = 1/2(s(v0,vi) + s(v0,vj) - s(vi,vj)),
+    /// where s(.,.) is the squared edge length.
+    ///
+    /// By default the geometry is **signature-aware**: the signed l^2 is kept,
+    /// so a timelike edge (l^2 < 0) carries its Lorentzian sign into G and
+    /// det(G) records the metric signature of the cell. Pass
+    /// ``wickRotate=true`` for the Euclidean/CDT convention that takes |l^2|
+    /// on every edge (det(G) > 0 for a valid cell). For a purely spacelike
+    /// (all l^2 > 0) simplex the two agree, so the toggle is a no-op there.
+    [[nodiscard]] std::vector<double> gramMatrix(bool wickRotate = false) const;
+
+    /// Cayley-Menger bordered matrix of this simplex: a flat (d+2) x (d+2)
+    /// row-major matrix with a zero corner, a border of ones, and the squared
+    /// edge-length matrix in the lower-right (d+1) x (d+1) block. Its cofactors
+    /// give the dihedral angles (see ``dihedralAngle``). ``wickRotate`` selects
+    /// signed (default) vs. |l^2| squared lengths, the same toggle as
+    /// ``gramMatrix``.
+    [[nodiscard]] std::vector<double> cayleyMengerMatrix(bool wickRotate = false) const;
 
     /// Dihedral angle at a hinge within this simplex.
     /// The hinge must be a (d-2)-subsimplex of this d-simplex.
-    [[nodiscard]] double dihedralAngle(SimplexPtr hinge) const;
+    /// ``wickRotate`` selects signed vs. |l^2| edge lengths (see ``gramMatrix``).
+    [[nodiscard]] double dihedralAngle(SimplexPtr hinge, bool wickRotate = false) const;
 
     /// Deficit angle at this hinge: 2*pi minus the sum of dihedral angles
     /// from all top-simplices containing this hinge.
     [[nodiscard]] double deficitAngle() const;
 
     /// Area of this simplex interpreted as a triangular hinge (3 vertices).
-    /// Uses Heron's formula on |l^2| of the three edges.
-    [[nodiscard]] double area() const;
+    /// Uses Heron's formula on the three edge squared lengths; ``wickRotate``
+    /// selects signed (default) vs. |l^2| (see ``gramMatrix``).
+    [[nodiscard]] double area(bool wickRotate = false) const;
+
+    /// Signed d-content (volume) of this simplex on the honest,
+    /// signature-respecting geometry: sign(det G) * sqrt(|det G|) / d!, with G
+    /// the non-Wick-rotated ``gramMatrix`` and d = size() - 1. For a Euclidean
+    /// (all-spacelike) simplex this is the ordinary positive volume; a
+    /// Lorentzian cell whose tangent metric has a negative Gram determinant
+    /// returns a negative content, recording the signature rather than
+    /// discarding it the way |l^2| would.
+    [[nodiscard]] double volume() const;
 
     /// Determinant of a square matrix (flat row-major, size n x n).
     [[nodiscard]] static double determinant(

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -302,14 +302,28 @@ facet.getCofaces() includes this simplex.)doc")
       .def("validate", &Simplex::validate,
            "Run internal consistency checks on this simplex.")
       .def("gramMatrix", &Simplex::gramMatrix,
-           "Gram matrix from edge lengths (flat d*d row-major, Wick-rotated).")
+           py::arg("wickRotate") = false,
+           "Gram matrix from edge lengths (flat d*d row-major). Signature-aware "
+           "(signed l^2) by default; pass wickRotate=True for the Euclidean/CDT "
+           "|l^2| convention.")
+      .def("cayleyMengerMatrix", &Simplex::cayleyMengerMatrix,
+           py::arg("wickRotate") = false,
+           "Cayley-Menger bordered matrix (flat (d+2)*(d+2) row-major) whose "
+           "cofactors give the dihedral angles. Signed l^2 by default; "
+           "wickRotate=True takes |l^2|.")
       .def("dihedralAngle", &Simplex::dihedralAngle,
-           py::arg("hinge"),
-           "Dihedral angle at a hinge within this simplex.")
+           py::arg("hinge"), py::arg("wickRotate") = false,
+           "Dihedral angle at a hinge within this simplex. Signed l^2 by "
+           "default; wickRotate=True takes |l^2| (the CDT/Regge convention).")
       .def("deficitAngle", &Simplex::deficitAngle,
            "Deficit angle at this hinge (2*pi - sum of dihedral angles).")
       .def("area", &Simplex::area,
-           "Area of this triangle (hinge) via Heron's formula.");
+           py::arg("wickRotate") = false,
+           "Area of this triangle (hinge) via Heron's formula. Signed l^2 by "
+           "default; wickRotate=True takes |l^2|.")
+      .def("volume", &Simplex::volume,
+           "Signed d-content sqrt(det G)/d! on the honest (non-Wick-rotated) "
+           "geometry; negative for a Lorentzian cell with timelike content.");
 
   py::class_<SimplexHash, std::shared_ptr<SimplexHash> >(m, "SimplexHash")
       .def(py::init<>());

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -671,17 +671,19 @@ std::vector<double> Simplex::cofactorMatrix(
     return C;
 }
 
-std::vector<double> Simplex::gramMatrix() const {
+std::vector<double> Simplex::gramMatrix(bool wickRotate) const {
     int dPlus1 = static_cast<int>(vertices.size());
     int d = dPlus1 - 1;
     if (d < 1) return {};
 
-    // Build squared-distance lookup using Wick-rotated (absolute) values.
+    // Squared-distance lookup. Honor the signed l^2 so the Lorentzian sign of
+    // timelike edges survives into G; wickRotate takes |l^2| (Euclidean/CDT).
     std::unordered_map<std::uint64_t, double> sqMap;
     for (const auto &e : edges) {
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
-        sqMap[fp] = std::abs(e->getSquaredLength());
+        sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
+                               : e->getSquaredLength();
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -699,7 +701,37 @@ std::vector<double> Simplex::gramMatrix() const {
     return G;
 }
 
-double Simplex::dihedralAngle(SimplexPtr hinge) const {
+std::vector<double> Simplex::cayleyMengerMatrix(bool wickRotate) const {
+    int dPlus1 = static_cast<int>(vertices.size());
+    if (dPlus1 < 1) return {};
+
+    // Squared-distance lookup; signed by default, |l^2| under wickRotate.
+    std::unordered_map<std::uint64_t, double> sqMap;
+    for (const auto &e : edges) {
+        auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
+                  Fingerprint::mix64(e->getTarget()->getId());
+        sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
+                               : e->getSquaredLength();
+    }
+    auto getSq = [&](int i, int j) -> double {
+        if (i == j) return 0.0;
+        auto fp = Fingerprint::mix64(vertices[i]->getId()) ^
+                  Fingerprint::mix64(vertices[j]->getId());
+        auto it = sqMap.find(fp);
+        return it != sqMap.end() ? it->second : 0.0;
+    };
+
+    // Bordered matrix: zero corner, a border of ones, squared distances inside.
+    int n = dPlus1 + 1;
+    std::vector<double> B(n * n, 0.0);
+    for (int k = 1; k < n; ++k) { B[k] = 1.0; B[k * n] = 1.0; }
+    for (int i = 0; i < dPlus1; ++i)
+        for (int j = 0; j < dPlus1; ++j)
+            B[(i + 1) * n + (j + 1)] = getSq(i, j);
+    return B;
+}
+
+double Simplex::dihedralAngle(SimplexPtr hinge, bool wickRotate) const {
     int dPlus1 = static_cast<int>(vertices.size());
 
     // Find the two vertices in this simplex but not in the hinge.
@@ -714,28 +746,9 @@ double Simplex::dihedralAngle(SimplexPtr hinge) const {
     if (opposite.size() != 2) return 0.0;
     int vi = opposite[0], vj = opposite[1];
 
-    // Cayley-Menger bordered matrix approach.
-    std::unordered_map<std::uint64_t, double> sqMap;
-    for (const auto &e : edges) {
-        auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
-                  Fingerprint::mix64(e->getTarget()->getId());
-        sqMap[fp] = std::abs(e->getSquaredLength());
-    }
-    auto getSq = [&](int i, int j) -> double {
-        if (i == j) return 0.0;
-        auto fp = Fingerprint::mix64(vertices[i]->getId()) ^
-                  Fingerprint::mix64(vertices[j]->getId());
-        auto it = sqMap.find(fp);
-        return it != sqMap.end() ? it->second : 0.0;
-    };
-
+    // Cayley-Menger bordered matrix; its cofactors give the dihedral angle.
     int n = dPlus1 + 1;
-    std::vector<double> B(n * n, 0.0);
-    for (int k = 1; k < n; ++k) { B[k] = 1.0; B[k * n] = 1.0; }
-    for (int i = 0; i < dPlus1; ++i)
-        for (int j = 0; j < dPlus1; ++j)
-            B[(i + 1) * n + (j + 1)] = getSq(i, j);
-
+    auto B = cayleyMengerMatrix(wickRotate);
     auto cof = cofactorMatrix(B, n);
     int bi = vi + 1, bj = vj + 1;
     double Cij = cof[bi * n + bj];
@@ -762,20 +775,45 @@ double Simplex::deficitAngle() const {
         for (std::size_t i = 1; i < vertices.size(); ++i)
             if (!sigma->hasVertex(vertices[i])) { containsAll = false; break; }
         if (containsAll)
-            sum += sigma->dihedralAngle(const_cast<Simplex*>(this));
+            // Deficit angles drive the CDT/Regge action, which is defined on
+            // the Wick-rotated (Euclidean) geometry — request |l^2| explicitly.
+            sum += sigma->dihedralAngle(const_cast<Simplex*>(this), /*wickRotate=*/true);
     }
     return 2.0 * std::numbers::pi - sum;
 }
 
-double Simplex::area() const {
+double Simplex::area(bool wickRotate) const {
     if (edges.size() < 3) return 0.0;
-    double a2 = std::abs(edges[0]->getSquaredLength());
-    double b2 = std::abs(edges[1]->getSquaredLength());
-    double c2 = std::abs(edges[2]->getSquaredLength());
+    auto sq = [&](std::size_t k) -> double {
+        return wickRotate ? std::abs(edges[k]->getSquaredLength())
+                          : edges[k]->getSquaredLength();
+    };
+    double a2 = sq(0);
+    double b2 = sq(1);
+    double c2 = sq(2);
     double val = 2.0 * (a2 * b2 + b2 * c2 + c2 * a2)
                  - (a2 * a2 + b2 * b2 + c2 * c2);
     if (val <= 0.0) return 0.0;
     return std::sqrt(val) / 4.0;
+}
+
+double Simplex::volume() const {
+    int d = static_cast<int>(vertices.size()) - 1;
+    if (d < 1) return 0.0;
+
+    // Honest, signature-respecting Gram matrix: timelike edges keep l^2 < 0,
+    // so det(G) can be negative for a Lorentzian cell.
+    const std::vector<double> G = gramMatrix(/*wickRotate=*/false);
+    if (static_cast<int>(G.size()) != d * d) return 0.0;
+
+    const double detG = determinant(G, d);
+    double factorial = 1.0;
+    for (int i = 2; i <= d; ++i) factorial *= static_cast<double>(i);
+
+    // Signed d-content: sqrt(det G)/d! with the sign of det(G) carried out so
+    // the result stays real and records the signature instead of |det G|.
+    const double sign = (detG < 0.0) ? -1.0 : 1.0;
+    return sign * std::sqrt(std::abs(detG)) / factorial;
 }
 
 }

--- a/src/mesh/SimplexFilter.cpp
+++ b/src/mesh/SimplexFilter.cpp
@@ -30,9 +30,11 @@ bool PositiveGramDeterminantFilter::accept(SimplexPtr const& simplex) const {
     // Vertex 0 is the origin; G is positive-definite for a non-degenerate
     // Euclidean k-simplex, so det(G) > 0 is the validity criterion. (The
     // simplex's k-volume is √(det(G) / k!²); det(G) > 0 ⇔ real positive
-    // volume.) Any NaN / inf in edge lengths propagates through the Gram
-    // build and we reject the simplex defensively.
-    std::vector<double> gram = simplex->gramMatrix();
+    // volume.) This is a Euclidean validity test, so request the Wick-rotated
+    // (|l^2|) Gram — a Lorentzian cell with timelike edges would otherwise have
+    // a sign-indefinite det(G). Any NaN / inf in edge lengths propagates
+    // through the Gram build and we reject the simplex defensively.
+    std::vector<double> gram = simplex->gramMatrix(/*wickRotate=*/true);
     const int d = static_cast<int>(k1) - 1;
     if (static_cast<int>(gram.size()) != d * d) return false;
 

--- a/src/simulations/InteractionSimulation.cpp
+++ b/src/simulations/InteractionSimulation.cpp
@@ -385,7 +385,7 @@ double cellHingeAction(const double edgeSq[10]) {
     for (SimplexPtr facet : cell->getFacets())
         for (SimplexPtr hinge : facet->getFacets())
             if (hinge->getVertices().size() == 3)
-                s += hinge->area() * hinge->deficitAngle();
+                s += hinge->area(/*wickRotate=*/true) * hinge->deficitAngle();
     return s;
 }
 
@@ -991,7 +991,7 @@ bool InteractionSimulation::interact() {
     for (SimplexPtr facet : cell->getFacets())
         for (SimplexPtr hinge : facet->getFacets())
             if (hinge->getVertices().size() == 3)
-                hingeAction_[hinge] = hinge->area() * hinge->deficitAngle();
+                hingeAction_[hinge] = hinge->area(/*wickRotate=*/true) * hinge->deficitAngle();
 
     stateOf_[xp] = res.statePrimeX;
     stateOf_[ab] = res.stateAB;

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -58,7 +58,8 @@ ReggeSolver::ReggeSolver(std::shared_ptr<Spacetime> spacetime,
 
 double ReggeSolver::dihedralAngle(SimplexPtr sigma,
                                    SimplexPtr hinge) const {
-    return sigma->dihedralAngle(hinge);
+    // Regge calculus runs on the Wick-rotated (Euclidean) geometry.
+    return sigma->dihedralAngle(hinge, /*wickRotate=*/true);
 }
 
 double ReggeSolver::deficitAngle(SimplexPtr hinge) const {
@@ -66,7 +67,8 @@ double ReggeSolver::deficitAngle(SimplexPtr hinge) const {
 }
 
 double ReggeSolver::hingeArea(SimplexPtr hinge) {
-    return hinge->area();
+    // Regge calculus runs on the Wick-rotated (Euclidean) geometry.
+    return hinge->area(/*wickRotate=*/true);
 }
 
 // =====================================================================

--- a/tests/mesh/test_simplex_geometry.py
+++ b/tests/mesh/test_simplex_geometry.py
@@ -1,0 +1,267 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Signature-aware Simplex geometry: volume(), gramMatrix(), and the extracted
+cayleyMengerMatrix().
+
+The geometry is honest (signature-respecting) by default: a timelike edge keeps
+its negative squared length, so a Lorentzian cell reports a signed content. The
+Wick-rotated (|l^2|) behaviour the CDT/Regge path relies on is still available
+via ``wickRotate=True`` and is exercised here too.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+from tessera import Spacetime
+
+
+def _make_simplex(st, vertex_ids, squared_by_pair):
+    """Build a simplex on ``st`` with full control of vertex order and of every
+    edge's signed squared length.
+
+    ``vertex_ids`` fixes the vertex order (so vertex 0 -- the Gram origin -- is
+    ``vertex_ids[0]``); ``squared_by_pair`` maps ``frozenset({i, j})`` to the
+    signed l^2 of that edge. Returns ``(simplex, verts, edges)``.
+    """
+    verts = {i: st.createVertex(i) for i in vertex_ids}
+    edges = {}
+    for pair, l2 in squared_by_pair.items():
+        a, b = tuple(pair)
+        edges[pair] = st.createEdge(verts[a], verts[b], float(l2))
+    simplex, _ = st.createSimplex([verts[i] for i in vertex_ids],
+                                  list(edges.values()))
+    return simplex, verts, edges
+
+
+def _expected_gram(simplex, squared_by_pair, wick):
+    """Independent reconstruction of the (d x d) Gram matrix from the signed (or
+    |l^2| when ``wick``) squared lengths, in the simplex's own vertex order."""
+    vids = [v.getId() for v in simplex.getVertices()]
+    d = len(vids) - 1
+
+    def s(i, j):
+        if i == j:
+            return 0.0
+        l2 = squared_by_pair[frozenset({vids[i], vids[j]})]
+        return abs(l2) if wick else float(l2)
+
+    G = np.zeros((d, d))
+    for i in range(d):
+        for j in range(d):
+            G[i, j] = 0.5 * (s(0, i + 1) + s(0, j + 1) - s(i + 1, j + 1))
+    return G
+
+
+def _cofactor(M):
+    """Cofactor matrix, mirroring Simplex::cofactorMatrix exactly."""
+    n = M.shape[0]
+    C = np.zeros((n, n))
+    for i in range(n):
+        for j in range(n):
+            minor = np.delete(np.delete(M, i, axis=0), j, axis=1)
+            C[i, j] = ((-1) ** (i + j)) * np.linalg.det(minor)
+    return C
+
+
+def _dihedral_from_cm(B, bi, bj):
+    """Dihedral angle from a Cayley-Menger matrix, mirroring the C++ cofactor
+    formula (including the abs under the sqrt and the cos clamp)."""
+    C = _cofactor(B)
+    denom = math.sqrt(abs(C[bi, bi] * C[bj, bj]))
+    if denom < 1e-15:
+        return 0.0
+    cos = max(-1.0, min(1.0, -C[bi, bj] / denom))
+    return math.acos(cos)
+
+
+class TestSimplexVolume(unittest.TestCase):
+    def setUp(self):
+        self.st = Spacetime()
+
+    def test_euclidean_triangle_volume_matches_hand_value(self):
+        # Right isosceles triangle, legs 1 and 1, hypotenuse^2 = 2. Area = 1/2.
+        sq = {
+            frozenset({0, 1}): 1.0,
+            frozenset({0, 2}): 1.0,
+            frozenset({1, 2}): 2.0,
+        }
+        simplex, _, _ = _make_simplex(self.st, [0, 1, 2], sq)
+        self.assertAlmostEqual(simplex.volume(), 0.5, places=9)
+
+    def test_euclidean_tetrahedron_volume_matches_hand_value(self):
+        # Corner tetrahedron with three unit legs along orthogonal axes:
+        # vertices (0,0,0),(1,0,0),(0,1,0),(0,0,1). Volume = 1/6.
+        sq = {
+            frozenset({0, 1}): 1.0,
+            frozenset({0, 2}): 1.0,
+            frozenset({0, 3}): 1.0,
+            frozenset({1, 2}): 2.0,
+            frozenset({1, 3}): 2.0,
+            frozenset({2, 3}): 2.0,
+        }
+        simplex, _, _ = _make_simplex(self.st, [0, 1, 2, 3], sq)
+        self.assertAlmostEqual(simplex.volume(), 1.0 / 6.0, places=9)
+
+    def test_lorentzian_triangle_volume_is_signed(self):
+        # One timelike edge (l^2 < 0). In coordinates (t, x):
+        # v0=(0,0), v1=(1,0) timelike from v0 -> l^2 = -1,
+        # v2=(0,2) spacelike -> l^2 = 4, edge v1-v2 -> l^2 = -1 + 4 = 3.
+        # Honest Gram = [[-1, 0], [0, 4]], det = -4, signed content = -1.
+        sq = {
+            frozenset({0, 1}): -1.0,
+            frozenset({0, 2}): 4.0,
+            frozenset({1, 2}): 3.0,
+        }
+        simplex, _, _ = _make_simplex(self.st, [0, 1, 2], sq)
+
+        vol = simplex.volume()
+        # The honest content is signed (negative), recording the signature.
+        self.assertLess(vol, 0.0)
+        self.assertAlmostEqual(vol, -1.0, places=9)
+
+        # It must NOT be the |l^2| (Wick-rotated) value, which is positive.
+        gram_wick = _expected_gram(simplex, sq, wick=True)
+        wick_content = math.sqrt(np.linalg.det(gram_wick)) / 2.0
+        self.assertGreater(wick_content, 0.0)
+        self.assertFalse(math.isclose(vol, wick_content, abs_tol=1e-6))
+
+    def test_volume_matches_signed_gram_determinant(self):
+        sq = {
+            frozenset({0, 1}): -1.0,
+            frozenset({0, 2}): 4.0,
+            frozenset({1, 2}): 3.0,
+        }
+        simplex, _, _ = _make_simplex(self.st, [0, 1, 2], sq)
+        gram = _expected_gram(simplex, sq, wick=False)
+        det = np.linalg.det(gram)
+        expected = math.copysign(math.sqrt(abs(det)), det) / math.factorial(2)
+        self.assertAlmostEqual(simplex.volume(), expected, places=9)
+
+
+class TestSimplexGramSignatureAware(unittest.TestCase):
+    def setUp(self):
+        self.st = Spacetime()
+
+    def test_gram_honest_keeps_timelike_sign(self):
+        sq = {
+            frozenset({0, 1}): -1.0,
+            frozenset({0, 2}): 4.0,
+            frozenset({1, 2}): 3.0,
+        }
+        simplex, _, _ = _make_simplex(self.st, [0, 1, 2], sq)
+        honest = np.array(simplex.gramMatrix()).reshape(2, 2)          # default
+        honest_explicit = np.array(
+            simplex.gramMatrix(wickRotate=False)).reshape(2, 2)
+        np.testing.assert_allclose(honest, honest_explicit)
+        np.testing.assert_allclose(honest, _expected_gram(simplex, sq, False))
+        # Honest != Wick-rotated for a Lorentzian cell.
+        wick = np.array(simplex.gramMatrix(wickRotate=True)).reshape(2, 2)
+        np.testing.assert_allclose(wick, _expected_gram(simplex, sq, True))
+        self.assertFalse(np.allclose(honest, wick))
+
+    def test_gram_euclidean_toggle_is_noop(self):
+        # All-spacelike (l^2 > 0): dropping the abs changes nothing.
+        sq = {
+            frozenset({0, 1}): 1.0,
+            frozenset({0, 2}): 1.0,
+            frozenset({1, 2}): 2.0,
+        }
+        simplex, _, _ = _make_simplex(self.st, [0, 1, 2], sq)
+        honest = np.array(simplex.gramMatrix(wickRotate=False)).reshape(2, 2)
+        wick = np.array(simplex.gramMatrix(wickRotate=True)).reshape(2, 2)
+        np.testing.assert_allclose(honest, wick)
+
+
+class TestCayleyMengerMatrix(unittest.TestCase):
+    def setUp(self):
+        self.st = Spacetime()
+
+    def _tetra(self):
+        # Unit-edge tetra under Wick rotation, but with edge (0,1) timelike so
+        # honest and |l^2| geometries differ.
+        sq = {
+            frozenset({0, 1}): -1.0,
+            frozenset({0, 2}): 1.0,
+            frozenset({0, 3}): 1.0,
+            frozenset({1, 2}): 1.0,
+            frozenset({1, 3}): 1.0,
+            frozenset({2, 3}): 1.0,
+        }
+        simplex, verts, edges = _make_simplex(self.st, [0, 1, 2, 3], sq)
+        return simplex, verts, edges, sq
+
+    def _expected_inner(self, simplex, sq, wick):
+        vids = [v.getId() for v in simplex.getVertices()]
+        n = len(vids)
+        inner = np.zeros((n, n))
+        for i in range(n):
+            for j in range(n):
+                if i == j:
+                    continue
+                l2 = sq[frozenset({vids[i], vids[j]})]
+                inner[i, j] = abs(l2) if wick else float(l2)
+        return inner
+
+    def test_structure_border_and_inner_block(self):
+        simplex, _, _, sq = self._tetra()
+        n = len(simplex.getVertices()) + 1  # d + 2 == 5 for a tetrahedron
+        for wick in (True, False):
+            B = np.array(simplex.cayleyMengerMatrix(wickRotate=wick)).reshape(n, n)
+            self.assertEqual(B[0, 0], 0.0)
+            np.testing.assert_allclose(B[0, 1:], np.ones(n - 1))
+            np.testing.assert_allclose(B[1:, 0], np.ones(n - 1))
+            np.testing.assert_allclose(B[1:, 1:],
+                                       self._expected_inner(simplex, sq, wick))
+
+    def test_wick_and_honest_inner_blocks_differ(self):
+        simplex, _, _, _ = self._tetra()
+        n = len(simplex.getVertices()) + 1
+        wick = np.array(simplex.cayleyMengerMatrix(wickRotate=True)).reshape(n, n)
+        honest = np.array(
+            simplex.cayleyMengerMatrix(wickRotate=False)).reshape(n, n)
+        self.assertFalse(np.allclose(wick, honest))
+
+    def test_reproduces_dihedral_angle(self):
+        """The extracted matrix is exactly what dihedralAngle consumes: feeding
+        cayleyMengerMatrix through the cofactor formula reproduces
+        dihedralAngle(hinge) for both the Wick-rotated and honest geometries."""
+        simplex, verts, edges, _ = self._tetra()
+        # Hinge = edge (2,3); the two opposite vertices are 0 and 1.
+        hinge, _ = self.st.createSimplex([verts[2], verts[3]],
+                                         [edges[frozenset({2, 3})]])
+        vids = [v.getId() for v in simplex.getVertices()]
+        n = len(vids) + 1
+        bi = vids.index(0) + 1
+        bj = vids.index(1) + 1
+
+        for wick in (True, False):
+            B = np.array(
+                simplex.cayleyMengerMatrix(wickRotate=wick)).reshape(n, n)
+            reconstructed = _dihedral_from_cm(B, bi, bj)
+            actual = simplex.dihedralAngle(hinge, wickRotate=wick)
+            self.assertAlmostEqual(actual, reconstructed, places=7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The metric Hodge weights for Stage 2 need honest, signature-respecting
simplex volumes. Previously `mesh::Simplex` Wick-rotated unconditionally —
`gramMatrix()`, `dihedralAngle()`, and `area()` all took `|l^2|`, discarding
the Lorentzian sign of timelike edges (`l^2 < 0`).

This PR makes the geometry **signature-aware** and makes the Wick rotation an
explicit, opt-in choice:

- `gramMatrix()`, `dihedralAngle()`, and `area()` now take a `bool wickRotate`
  (default `false` = honest, signed geometry). Passing `wickRotate=true` keeps
  the historical `|l^2|` Euclidean/CDT behaviour. For a purely spacelike
  (Euclidean, `l^2 > 0`) simplex the toggle is a no-op.
- The Cayley–Menger bordered-matrix construction inlined in `dihedralAngle()`
  is extracted into a reusable `Simplex::cayleyMengerMatrix(bool wickRotate)`;
  `dihedralAngle()` now consumes it, producing the identical matrix it built
  before.
- New `Simplex::volume()` returns the signed d-content `sqrt(det G)/d!` from
  the honest (non-rotated) Gram — `sign(det G) * sqrt(|det G|) / d!`, so a
  Lorentzian cell reports a negative content rather than the abs value. Bound
  to Python alongside `cayleyMengerMatrix()`.

## How non-regression is guaranteed

Every existing caller that relied on the Wick rotation now requests it
explicitly, so its numerical result is byte-for-byte unchanged:

- `mesh/SimplexFilter.cpp` (Gram determinant validity) → `gramMatrix(true)`
- `simulations/ReggeSolver.cpp` `dihedralAngle` / `hingeArea` → `…(true)`
- `Simplex::deficitAngle` → `dihedralAngle(…, true)`
- `simulations/InteractionSimulation.cpp` (×2) → `area(true)`
- `examples/quantum/interaction_branching_simplex.py` → `gramMatrix(wickRotate=True)`, `area(wickRotate=True)`

The CUDA Regge path (`src/cuda/regge_cuda.cu`) is a self-contained,
independently Wick-rotated implementation and is intentionally left untouched.

## Tests

New `tests/mesh/test_simplex_geometry.py`:
- Euclidean triangle (`0.5`) and corner tetrahedron (`1/6`) `volume()` vs
  hand-computed values.
- A Lorentzian triangle with one timelike edge yields the **signed** content
  (`-1.0`), distinct from the positive `|l^2|` value.
- `cayleyMengerMatrix()` border/inner-block structure, Wick-vs-honest
  divergence, and a cofactor-formula reconstruction that reproduces
  `dihedralAngle()` for both modes.

Results: `tests/mesh` 9 passed. Regression set (`test_simplex`,
`test_regge_solver`, `test_spacetime_skeleton_spectral_python`) green; the
three `test_interaction_simulation*` C++ tests pass; `tests/cobordism` +
`tests/quantum` 359 passed. The only failure is
`test_regge_solver::…::test_solver_reduces_gradient_norm`, which fails with a
CUDA out-of-memory error under GPU contention — the known flaky resource
issue, not a regression (the CUDA path is unchanged).

Closes #103.