### PR TITLE
observables: WilsonLoop U(1) connection holonomy mode

### DIFF
--- a/include/observables/WilsonLoop.h
+++ b/include/observables/WilsonLoop.h
@@ -28,7 +28,8 @@ using namespace ::tessera::quantum;
 enum class WilsonMode : uint8_t {
     COMBINATORIAL,   ///< Dual-graph topology only (loop length, enclosed hinges)
     DEFICIT_ANGLE,   ///< Uses deficit angles: W = ((d-2)+2cos(ε))/d
-    CAUSAL           ///< CDT causal orientation changes around the loop
+    CAUSAL,          ///< CDT causal orientation changes around the loop
+    U1_CONNECTION    ///< U(1) connection holonomy: oriented Σ Edge::phase around a 1-skeleton cycle (mod 2π)
 };
 
 /// Which loop-shape generator to use.
@@ -56,10 +57,13 @@ struct WilsonResult {
 
 /// Wilson loop observable on a triangulated spacetime.
 ///
-/// Computes holonomy-like quantities around closed paths in the dual graph
-/// (top-simplices as nodes, shared facets as edges).  Three evaluation modes
-/// let users choose between purely combinatorial, curvature-based, and
-/// causal-structure analyses.
+/// Computes holonomy-like quantities around closed paths.  The dual-graph
+/// modes (top-simplices as nodes, shared facets as edges) let users choose
+/// between purely combinatorial, curvature-based, and causal-structure
+/// analyses.  The ``U1_CONNECTION`` mode instead accumulates the U(1)
+/// connection (``Edge::phase``) around a cycle on the primal 1-skeleton,
+/// returning the gauge-invariant holonomy (mod 2π) — the Wilson-loop view of
+/// the Stage-1 ``cobordism::HodgeLaplacian`` cycle flux.
 ///
 /// Usage:
 /// @code
@@ -82,6 +86,21 @@ class WilsonLoop {
     [[nodiscard]] WilsonResult evaluateCombinatorial(const LoopPath &loop) const;
     [[nodiscard]] WilsonResult evaluateDeficitAngle(const LoopPath &loop) const;
     [[nodiscard]] WilsonResult evaluateCausal(const LoopPath &loop) const;
+
+    /// U(1) connection holonomy around a closed cycle of vertices on the
+    /// primal 1-skeleton.  Accumulates ``Edge::phase`` oriented along the
+    /// stored source→target direction (``+phase`` forward, ``−phase`` on
+    /// reversal) and reduces the total into the principal interval (−π, π].
+    /// ``value`` carries the holonomy; ``loopSize`` the number of edges.
+    /// Returns an empty result if the cycle has fewer than two vertices or any
+    /// consecutive pair is not joined by an edge (an open path).
+    ///
+    /// This is the Wilson-loop counterpart of the Stage-1 cycle flux carried
+    /// by the Hermitian-weighted ``cobordism::HodgeLaplacian`` (the same
+    /// oriented phase sum); restricted to phases in {0, π} it reproduces the
+    /// ℤ₂ flux.
+    [[nodiscard]] WilsonResult evaluateU1Connection(
+        const std::vector<VertexPtr> &cycle) const;
 
     // ==================== Loop generators ====================
 
@@ -113,6 +132,12 @@ class WilsonLoop {
 
     /// Shared facet between two adjacent top-simplices (or nullptr).
     [[nodiscard]] SimplexPtr findSharedFacet(SimplexPtr a, SimplexPtr b) const;
+
+    /// Edge joining two vertices on the primal 1-skeleton (nullptr if none).
+    [[nodiscard]] EdgePtr edgeBetween(VertexPtr a, VertexPtr b) const;
+
+    /// Fold an angle into the principal holonomy interval (−π, π].
+    [[nodiscard]] static double principalAngle(double theta);
 
     /// Build a LoopPath from an ordered vector of simplices.
     [[nodiscard]] LoopPath buildLoopPath(

--- a/src/observables/Bindings.cpp
+++ b/src/observables/Bindings.cpp
@@ -242,7 +242,11 @@ multiple configurations for averaging.)doc")
       .value("DEFICIT_ANGLE", WilsonMode::DEFICIT_ANGLE,
              "Deficit-angle based: W = ((d-2)+2cos(epsilon))/d.")
       .value("CAUSAL", WilsonMode::CAUSAL,
-             "CDT causal orientation changes around the loop.");
+             "CDT causal orientation changes around the loop.")
+      .value("U1_CONNECTION", WilsonMode::U1_CONNECTION,
+             "U(1) connection holonomy: oriented sum of Edge.phase around a "
+             "1-skeleton vertex cycle, reduced mod 2*pi. The Wilson-loop view "
+             "of the Stage-1 cobordism.HodgeLaplacian cycle flux.");
 
   py::enum_<LoopType>(m, "LoopType",
       "Which loop-shape generator to use.")
@@ -283,7 +287,7 @@ tessera computes the Levi-Civita holonomy analogue: closed walks on the
 dual graph (top-simplices as nodes, shared facets as edges), with the
 loop value determined by the deficit angles of enclosed hinges.
 
-Three evaluation modes:
+Four evaluation modes:
 
 * ``COMBINATORIAL``  — dual-graph topology only. ``value`` is the loop
   length; ``enclosedHinges`` counts hinges contained in every loop
@@ -298,6 +302,13 @@ Three evaluation modes:
 * ``CAUSAL``  — CDT causal-orientation winding. ``causalWindingNumber``
   is the signed net change in foliation index around the loop; non-
   zero values mark loops that cross a CDT slice boundary.
+* ``U1_CONNECTION``  — U(1) connection holonomy. The oriented sum of the
+  ``Edge.phase`` carried on the primal 1-skeleton around a closed vertex
+  cycle (``+phase`` along the stored source->target orientation,
+  ``-phase`` reversed), reduced mod 2*pi. Evaluated via
+  ``evaluateU1Connection(cycle)`` (the connection is a primal-edge, not a
+  dual-graph, quantity); ``value`` carries the holonomy. This is the
+  Wilson-loop view of the Stage-1 ``cobordism.HodgeLaplacian`` cycle flux.
 
 Three loop-shape generators:
 
@@ -355,6 +366,23 @@ For multi-hinge loops the U(1) approximation:
 Walks the loop and accumulates a signed winding count from the
 final-time stamps of consecutive simplices. ``causalWindingNumber`` is
 the net winding; ``value`` carries the same number as a double.
+)doc")
+      .def("evaluateU1Connection", &WilsonLoop::evaluateU1Connection,
+           py::arg("cycle"),
+           R"doc(U(1) connection holonomy around a closed vertex cycle.
+
+``cycle`` is an ordered list of vertices on the primal 1-skeleton whose
+consecutive pairs (with wrap-around) are joined by edges. Accumulates each
+edge's ``phase`` along its stored source->target orientation (``+phase``
+forward, ``-phase`` reversed) and returns the total reduced into the
+principal interval ``(-pi, pi]`` in ``value``; ``loopSize`` is the number of
+edges. Returns an empty result (``loopSize == 0``) for a degenerate (fewer
+than two vertices) or open (a consecutive pair with no joining edge) cycle.
+
+This is the Wilson-loop counterpart of the Stage-1 cycle flux carried by the
+Hermitian-weighted ``cobordism.HodgeLaplacian`` — the same oriented phase
+sum. Restricted to phases in ``{0, pi}`` the holonomy lands in ``{0, pi}``
+and reproduces the Z2 flux.
 )doc")
       .def("hingeLoop", &WilsonLoop::hingeLoop,
            py::arg("hinge"),

--- a/src/observables/WilsonLoop.cpp
+++ b/src/observables/WilsonLoop.cpp
@@ -243,6 +243,11 @@ WilsonResult WilsonLoop::evaluate(const LoopPath &loop,
         case WilsonMode::COMBINATORIAL: return evaluateCombinatorial(loop);
         case WilsonMode::DEFICIT_ANGLE: return evaluateDeficitAngle(loop);
         case WilsonMode::CAUSAL:        return evaluateCausal(loop);
+        case WilsonMode::U1_CONNECTION:
+            // The U(1) connection lives on the primal 1-skeleton, so its
+            // holonomy is taken around a cycle of vertices rather than a
+            // dual-graph LoopPath. Call evaluateU1Connection(cycle) directly.
+            return {};
     }
     return {};
 }
@@ -345,6 +350,48 @@ WilsonResult WilsonLoop::evaluateCausal(const LoopPath &loop) const {
     }
     r.causalWindingNumber = winding;
     r.value = static_cast<double>(winding);
+    return r;
+}
+
+// ---- U(1) connection holonomy ----
+
+EdgePtr WilsonLoop::edgeBetween(VertexPtr a, VertexPtr b) const {
+    if (!a || !b || a->getId() == b->getId()) return nullptr;
+    // a->getEdges() already contains only edges incident to a, so it is enough
+    // to find the one that also touches b.
+    for (const auto &e : a->getEdges()) {
+        if (e->hasVertex(b->getId())) return e;
+    }
+    return nullptr;
+}
+
+double WilsonLoop::principalAngle(double theta) {
+    constexpr double twoPi = 2.0 * std::numbers::pi;
+    double r = std::remainder(theta, twoPi);   // [-π, π]
+    if (r <= -std::numbers::pi) r += twoPi;     // fold the −π endpoint up to π
+    return r;
+}
+
+WilsonResult WilsonLoop::evaluateU1Connection(
+    const std::vector<VertexPtr> &cycle) const {
+    const int n = static_cast<int>(cycle.size());
+    if (n < 2) return {};  // need at least one edge
+
+    double total = 0.0;
+    for (int i = 0; i < n; ++i) {
+        VertexPtr a = cycle[i];
+        VertexPtr b = cycle[(i + 1) % n];
+        EdgePtr e = edgeBetween(a, b);
+        if (!e) return {};  // open path — not a closed 1-skeleton cycle
+        // +phase along the stored source→target orientation, −phase reversed.
+        const bool forward = (e->getSource()->getId() == a->getId() &&
+                              e->getTarget()->getId() == b->getId());
+        total += forward ? e->getPhase() : -e->getPhase();
+    }
+
+    WilsonResult r;
+    r.loopSize = n;
+    r.value = principalAngle(total);  // holonomy mod 2π, principal value (−π, π]
     return r;
 }
 

--- a/tests/observables/test_wilson_u1_holonomy_python.py
+++ b/tests/observables/test_wilson_u1_holonomy_python.py
@@ -1,0 +1,315 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""U(1) connection holonomy mode of observables::WilsonLoop (#114, T4).
+
+WilsonMode.U1_CONNECTION accumulates the U(1) connection (``Edge.phase``)
+around a closed cycle on the primal 1-skeleton, honoring each edge's stored
+source->target orientation (``+phase`` forward, ``-phase`` reversed), and
+returns the total holonomy mod 2*pi.
+
+Validated against two independent references:
+
+  * a numpy/hand oracle of the oriented phase sum (``_cycle_flux``), the same
+    helper the Hodge-Laplacian tests use; and
+  * the Stage-1 cycle flux carried by ``cobordism.HodgeLaplacian`` — recovered
+    from the complex adjacency ``A[i,j] = squaredLength * exp(i*phase)`` it
+    assembles (``_hodge_flux``), the cross-layer consistency T4 asserts.
+
+The Z2 case (phases restricted to {0, pi}) checks that the bulk holonomy lands
+in {0, pi} and matches the Stage-1 flux there.
+
+Fixtures (shared idiom with tests/cobordism): build a HERMITIAN_WEIGHTED
+spacetime directly from explicit simplex vertex tuples.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+TWO_PI = 2.0 * math.pi
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders
+# --------------------------------------------------------------------------- #
+def _from_simplices(num_vertices, simplices):
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    verts = [st.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        st.createSimplex([verts[i] for i in simplex])
+    return st
+
+
+def _triangle():
+    """S^1: the 1-skeleton cycle 0-1-2-0 (b1 = 1)."""
+    return _from_simplices(3, [(0, 1), (1, 2), (2, 0)])
+
+
+def _testbed():
+    """Square 0-1-2-3-0 plus the diagonal 0-2 (b1 = 2)."""
+    return _from_simplices(4, [(0, 1), (1, 2), (2, 3), (3, 0), (0, 2)])
+
+
+def _vertices_by_id(st):
+    return {v.getId(): v for v in st.getVertexList().toVector()}
+
+
+def _edge(st, a, b):
+    for e in st.getEdgeList().toVector():
+        if {e.getSource().getId(), e.getTarget().getId()} == {a, b}:
+            return e
+    raise KeyError((a, b))
+
+
+def _set_phases(st, phases):
+    """Assign edge phases from a {frozenset({a, b}): phi} map; unit positive
+    weights everywhere, phase 0 on edges not in the map."""
+    for e in st.getEdgeList().toVector():
+        key = frozenset({e.getSource().getId(), e.getTarget().getId()})
+        e.setSquaredLength(1.0)
+        e.setPhase(phases.get(key, 0.0))
+
+
+# --------------------------------------------------------------------------- #
+# Oracles and mod-2*pi helpers
+# --------------------------------------------------------------------------- #
+def _cycle_flux(st, cycle):
+    """Hand oracle: directed holonomy sum of phase around a closed vertex-id
+    cycle, honoring each edge's stored source->target orientation."""
+    total = 0.0
+    n = len(cycle)
+    for k in range(n):
+        a, b = cycle[k], cycle[(k + 1) % n]
+        e = _edge(st, a, b)
+        if e.getSource().getId() == a and e.getTarget().getId() == b:
+            total += e.getPhase()
+        else:
+            total -= e.getPhase()
+    return total
+
+
+def _hodge_flux(st, cycle):
+    """Stage-1 cycle flux read off cobordism.HodgeLaplacian's complex
+    adjacency: arg(A[i,j]) is +phase along source->target and -phase reversed
+    (unit weights), so the directed sum around the cycle is the same oriented
+    holonomy the operator encodes in L = D - A."""
+    ids = sorted(v.getId() for v in st.getVertexList().toVector())
+    idx = {vid: i for i, vid in enumerate(ids)}
+    n = len(ids)
+    A = np.array(cob.HodgeLaplacian(st).adjacency(), dtype=complex).reshape(n, n)
+    total = 0.0
+    m = len(cycle)
+    for k in range(m):
+        a, b = cycle[k], cycle[(k + 1) % m]
+        total += np.angle(A[idx[a], idx[b]])
+    return float(total)
+
+
+def _wrap(theta):
+    """Principal value in (-pi, pi] (matches WilsonLoop::principalAngle)."""
+    r = math.remainder(theta, TWO_PI)
+    if r <= -math.pi:
+        r += TWO_PI
+    return r
+
+
+def _close_mod_2pi(a, b, tol=1e-9):
+    """True iff a == b modulo 2*pi (robust to the +-pi boundary)."""
+    return abs(math.remainder(a - b, TWO_PI)) < tol
+
+
+def _holonomy(st, cycle):
+    wl = tessera.WilsonLoop(st)
+    by_id = _vertices_by_id(st)
+    return wl.evaluateU1Connection([by_id[c] for c in cycle])
+
+
+# --------------------------------------------------------------------------- #
+# Holonomy vs the hand oracle, and total flux Phi (mod 2*pi)
+# --------------------------------------------------------------------------- #
+class TestHolonomyVsOracle(unittest.TestCase):
+
+    def test_zero_phase_is_trivial(self):
+        st = _triangle()
+        _set_phases(st, {})
+        r = _holonomy(st, [0, 1, 2])
+        self.assertEqual(r.loopSize, 3)
+        self.assertAlmostEqual(r.value, 0.0, places=12)
+
+    def test_matches_hand_oracle_single_edge(self):
+        # All of Phi on one edge of the triangle; the holonomy equals the
+        # oriented oracle sum exactly (both honor the stored orientation).
+        for phi in (0.3, 1.0, 2.0, -0.7, math.pi / 2):
+            with self.subTest(phi=phi):
+                st = _triangle()
+                _set_phases(st, {frozenset({0, 1}): phi})
+                r = _holonomy(st, [0, 1, 2])
+                self.assertEqual(r.loopSize, 3)
+                self.assertTrue(_close_mod_2pi(r.value, _cycle_flux(st, [0, 1, 2])))
+
+    def test_equals_total_flux_mod_2pi(self):
+        # Orient the cycle to hit the phased edge forward, so the holonomy is
+        # exactly +Phi (mod 2*pi). Covers Phi outside (-pi, pi] to exercise the
+        # mod-2*pi reduction.
+        for phi in (0.0, 1.0, math.pi, 4.0, 2 * math.pi, -5.0, 3 * math.pi):
+            with self.subTest(phi=phi):
+                st = _triangle()
+                _set_phases(st, {frozenset({0, 1}): phi})
+                e01 = _edge(st, 0, 1)
+                s, t = e01.getSource().getId(), e01.getTarget().getId()
+                third = ({0, 1, 2} - {s, t}).pop()
+                r = _holonomy(st, [s, t, third])
+                self.assertTrue(_close_mod_2pi(r.value, phi),
+                                f"holonomy {r.value} != Phi {phi} (mod 2pi)")
+                # Reduced into the principal interval (-pi, pi].
+                self.assertGreater(r.value, -math.pi - 1e-12)
+                self.assertLessEqual(r.value, math.pi + 1e-12)
+
+    def test_distributed_phases_sum(self):
+        # Distinct phases on every edge of a testbed cycle; the holonomy is the
+        # oriented sum over the three traversed edges.
+        st = _testbed()
+        _set_phases(st, {
+            frozenset({0, 1}): 0.4,
+            frozenset({1, 2}): -1.1,
+            frozenset({0, 2}): 0.9,   # the (2, 0) leg of the cycle
+        })
+        r = _holonomy(st, [0, 1, 2])
+        self.assertEqual(r.loopSize, 3)
+        self.assertTrue(_close_mod_2pi(r.value, _cycle_flux(st, [0, 1, 2])))
+
+    def test_orientation_reversal_negates(self):
+        st = _testbed()
+        _set_phases(st, {
+            frozenset({0, 1}): 0.4,
+            frozenset({1, 2}): -1.1,
+            frozenset({0, 2}): 0.9,
+        })
+        fwd = _holonomy(st, [0, 1, 2]).value
+        rev = _holonomy(st, [2, 1, 0]).value
+        self.assertTrue(_close_mod_2pi(fwd, -rev))
+
+
+# --------------------------------------------------------------------------- #
+# Cross-layer: equals the Stage-1 HodgeLaplacian cycle flux
+# --------------------------------------------------------------------------- #
+class TestMatchesHodgeStageOneFlux(unittest.TestCase):
+
+    def test_triangle_random_phase_matches_hodge(self):
+        rng = np.random.default_rng(114)
+        for _ in range(8):
+            st = _triangle()
+            _set_phases(st, {
+                frozenset({0, 1}): float(rng.uniform(-math.pi, math.pi)),
+                frozenset({1, 2}): float(rng.uniform(-math.pi, math.pi)),
+                frozenset({2, 0}): float(rng.uniform(-math.pi, math.pi)),
+            })
+            r = _holonomy(st, [0, 1, 2])
+            self.assertTrue(_close_mod_2pi(r.value, _hodge_flux(st, [0, 1, 2])))
+            self.assertTrue(_close_mod_2pi(r.value, _cycle_flux(st, [0, 1, 2])))
+
+    def test_testbed_both_cycles_match_hodge(self):
+        # The b1 = 2 testbed has two independent cycles; each holonomy matches
+        # the operator's Stage-1 flux for that signed-edge cycle.
+        rng = np.random.default_rng(2024)
+        st = _testbed()
+        _set_phases(st, {
+            frozenset({0, 1}): float(rng.uniform(-math.pi, math.pi)),
+            frozenset({1, 2}): float(rng.uniform(-math.pi, math.pi)),
+            frozenset({2, 3}): float(rng.uniform(-math.pi, math.pi)),
+            frozenset({3, 0}): float(rng.uniform(-math.pi, math.pi)),
+            frozenset({0, 2}): float(rng.uniform(-math.pi, math.pi)),
+        })
+        for cycle in ([0, 1, 2], [0, 2, 3]):
+            with self.subTest(cycle=cycle):
+                r = _holonomy(st, cycle)
+                self.assertTrue(_close_mod_2pi(r.value, _hodge_flux(st, cycle)))
+                self.assertTrue(_close_mod_2pi(r.value, _cycle_flux(st, cycle)))
+
+
+# --------------------------------------------------------------------------- #
+# Z2 case: phases in {0, pi} -> holonomy in {0, pi}, matching Stage-1 flux
+# --------------------------------------------------------------------------- #
+class TestZ2Holonomy(unittest.TestCase):
+
+    def test_parity_lands_in_zero_or_pi(self):
+        # k edges at phase pi; the bulk holonomy is pi for odd k, 0 for even k
+        # (a pi edge contributes +-pi == pi mod 2*pi regardless of orientation).
+        edges = [frozenset({0, 1}), frozenset({1, 2}), frozenset({2, 0})]
+        saw_zero = saw_pi = False
+        for k in range(len(edges) + 1):
+            with self.subTest(num_pi_edges=k):
+                st = _triangle()
+                _set_phases(st, {e: math.pi for e in edges[:k]})
+                r = _holonomy(st, [0, 1, 2])
+                expected = math.pi if (k % 2 == 1) else 0.0
+
+                # Holonomy restricted to {0, pi}.
+                self.assertTrue(
+                    abs(r.value) < 1e-9 or abs(r.value - math.pi) < 1e-9,
+                    f"Z2 holonomy {r.value} not in {{0, pi}}")
+                self.assertTrue(_close_mod_2pi(r.value, expected))
+
+                # Cross-layer: matches the Stage-1 flux there.
+                self.assertTrue(_close_mod_2pi(r.value, _hodge_flux(st, [0, 1, 2])))
+                self.assertTrue(_close_mod_2pi(r.value, _cycle_flux(st, [0, 1, 2])))
+
+                saw_zero |= (expected == 0.0)
+                saw_pi |= (expected == math.pi)
+        self.assertTrue(saw_zero and saw_pi)  # both Z2 classes exercised
+
+
+# --------------------------------------------------------------------------- #
+# Degenerate / open cycles return an empty result
+# --------------------------------------------------------------------------- #
+class TestDegenerateCycles(unittest.TestCase):
+
+    def test_too_few_vertices_is_empty(self):
+        st = _triangle()
+        _set_phases(st, {})
+        by_id = _vertices_by_id(st)
+        wl = tessera.WilsonLoop(st)
+        self.assertEqual(wl.evaluateU1Connection([]).loopSize, 0)
+        self.assertEqual(wl.evaluateU1Connection([by_id[0]]).loopSize, 0)
+
+    def test_open_path_is_empty(self):
+        # On the testbed, vertices 1 and 3 are not adjacent (no edge 1-3), so a
+        # cycle through that pair is open and yields an empty result.
+        st = _testbed()
+        _set_phases(st, {})
+        with self.assertRaises(KeyError):
+            _edge(st, 1, 3)  # confirm the gap exists
+        r = _holonomy(st, [0, 1, 3])
+        self.assertEqual(r.loopSize, 0)
+        self.assertEqual(r.value, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a connection-holonomy mode to `observables::WilsonLoop` (ticket #114, T4).

- New `WilsonMode::U1_CONNECTION` enum value and `WilsonLoop::evaluateU1Connection(cycle)`: around a closed cycle of vertices on the primal 1-skeleton, accumulates the U(1) connection `Edge::phase` oriented along the stored source→target direction (`+phase` forward, `-phase` on reversal) and returns the total holonomy reduced into the principal interval `(-pi, pi]`. The connection is a primal-edge quantity, so it takes a vertex cycle rather than a dual-graph `LoopPath`; the unified `evaluate(LoopPath, mode)` documents this and the dual-graph switch stays focused on the existing modes.
- Bindings (`src/observables/Bindings.cpp`): registers the `U1_CONNECTION` enum value and the `evaluateU1Connection` method alongside the existing `WilsonMode`/`WilsonLoop` registration; class docstring updated to four modes.

This is the Wilson-loop counterpart of the Stage-1 cycle flux carried by the Hermitian-weighted `cobordism::HodgeLaplacian` (the same oriented sum of `Edge::phase`).

## Acceptance

Tests in `tests/observables/test_wilson_u1_holonomy_python.py` with a numpy/hand oracle:

- On small fixtures (triangle S^1, b1=2 testbed) with assigned edge phases forming a cycle of total flux Φ, the `U1_CONNECTION` holonomy equals Φ (mod 2π) and equals the hand oracle (`_cycle_flux`).
- Cross-layer: the holonomy equals the Stage-1 flux recovered from `cobordism.HodgeLaplacian`'s complex adjacency (`arg` of `squaredLength·e^{i·phase}`) for the same signed-edge cycle — both triangle and both independent testbed cycles.
- ℤ₂ case: with phases restricted to `{0, π}` the bulk holonomy lands in `{0, π}` by parity and matches the Stage-1 flux there.
- Plus orientation-reversal (negation), distributed-phase summation, and degenerate/open-cycle (empty result) checks.

## Test results

- `tests/observables/test_wilson_u1_holonomy_python.py`: 10 passed, 18 subtests passed.
- No regressions: `tests/test_wilson_loop.py` + `tests/cobordism/test_hodge_laplacian_python.py`: 31 passed, 20 subtests passed.

Closes #114.
