### PR TITLE
spacetime: S²×S¹ fixture + T³ retriangulations

### DIFF
--- a/include/spacetime/topologies/SphereCircleProduct.h
+++ b/include/spacetime/topologies/SphereCircleProduct.h
@@ -1,0 +1,61 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_SPHERECIRCLEPRODUCT_H
+#define TESSERA_SPHERECIRCLEPRODUCT_H
+
+#include "Topology.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+class Spacetime;
+
+/// # Sphere–circle product \f$ S^2 \times S^1 \f$
+///
+/// The closed, oriented 3-manifold \f$ S^2 \times S^1 \f$, triangulated by the
+/// staircase (Eilenberg–Zilber) product of the minimal sphere triangulations
+/// \f$ S^2 = \partial\Delta^3 \f$ and \f$ S^1 = \partial\Delta^2 \f$ — i.e.
+/// exactly ``SimplicialProduct(SimplexBoundarySphere(2),
+/// SimplexBoundarySphere(1))``, exposed as a named topology for symmetry with
+/// :class:`Toroid`. The result has 12 vertices and 36 tetrahedra, Euler
+/// characteristic \f$ \chi = 0 \f$, and Betti numbers \f$ b = (1, 1, 1, 1) \f$.
+///
+/// It is the negative control for the triple cup product: \f$ H^1(S^2 \times
+/// S^1) \f$ is one-dimensional, so the cup-cube \f$ \alpha \cup \alpha \cup
+/// \alpha \f$ vanishes on it (unlike \f$ T^3 \f$, where the three independent
+/// 1-classes pair to the fundamental class). The Dijkgraaf–Witten state sum is
+/// therefore insensitive to the cup-product cocycle here, \f$ Z_\text{sign} =
+/// Z_\text{triv} \f$.
+///
+/// Exact, fixed, pre-geometric (coordinate-free); ``build()`` ignores
+/// ``numSimplices``.
+class SphereCircleProduct : public Topology {
+  public:
+    SphereCircleProduct() = default;
+
+    /// Build \f$ S^2 \times S^1 \f$ via the staircase product. ``numSimplices``
+    /// is ignored.
+    void build(Spacetime *spacetime, int numSimplices) override;
+};
+
+} // namespace tessera::spacetime
+
+#endif // TESSERA_SPHERECIRCLEPRODUCT_H

--- a/include/spacetime/topologies/StellarSubdivision.h
+++ b/include/spacetime/topologies/StellarSubdivision.h
@@ -1,0 +1,68 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_STELLARSUBDIVISION_H
+#define TESSERA_STELLARSUBDIVISION_H
+
+#include <memory>
+
+#include "Topology.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+class Spacetime;
+
+/// # Stellar subdivision of a triangulation
+///
+/// Wraps a base topology and refines it by a single **stellar subdivision**
+/// (a \f$ 1 \to (n+1) \f$ Pachner move): one top \f$ n \f$-simplex
+/// \f$ \tau = \{v_0, \ldots, v_n\} \f$ is starred at a fresh interior vertex
+/// \f$ c \f$ — \f$ \tau \f$ is removed and replaced by the \f$ n+1 \f$ simplices
+/// \f$ \{c\} \cup (\tau \setminus \{v_i\}) \f$. To keep the result deterministic
+/// the starred simplex is the lexicographically smallest top-simplex tuple.
+///
+/// Stellar moves are PL homeomorphisms, so the subdivided complex is the *same
+/// manifold* as the base with *identical homology*, yet it is a genuinely
+/// distinct labelled complex (one extra vertex, \f$ n \f$ extra top simplices),
+/// hence **not** isomorphic to the base. This makes it the canonical way to
+/// produce a second, inequivalent triangulation of a fixture — e.g. a retriangulated
+/// \f$ T^3 = \text{StellarSubdivision}(S^1 \times S^1 \times S^1) \f$ — for
+/// triangulation-invariance checks. Mirrors :class:`SimplicialProduct` as a
+/// composable wrapper over other topologies.
+///
+/// Exact and pre-geometric (coordinate-free); ``build()`` ignores
+/// ``numSimplices``.
+class StellarSubdivision : public Topology {
+  public:
+    explicit StellarSubdivision(std::shared_ptr<Topology> base)
+        : base_(std::move(base)) {}
+
+    /// Build the base topology and apply one stellar subdivision.
+    /// ``numSimplices`` is ignored.
+    void build(Spacetime *spacetime, int numSimplices) override;
+
+  private:
+    std::shared_ptr<Topology> base_;
+};
+
+} // namespace tessera::spacetime
+
+#endif // TESSERA_STELLARSUBDIVISION_H

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -35,6 +35,8 @@
 #include "spacetime/topologies/RealProjectivePlane.h"
 #include "spacetime/topologies/ComplexProjectivePlane.h"
 #include "spacetime/topologies/SimplicialProduct.h"
+#include "spacetime/topologies/SphereCircleProduct.h"
+#include "spacetime/topologies/StellarSubdivision.h"
 #include "simulations/CDT.h"
 #include "spacetime/PachnerMove.h"
 #include "spacetime/pachner/AddMove.h"
@@ -154,6 +156,28 @@ Pachner moves (add, remove, flip, iflip, shift).)doc")
       .def("build", &SimplicialProduct::build, py::arg("spacetime"),
            py::arg("numSimplices") = 0,
            "Build the product complex (numSimplices ignored).");
+
+  py::class_<SphereCircleProduct, Topology,
+             std::shared_ptr<SphereCircleProduct> >(m, "SphereCircleProduct",
+      "S^2 x S^1: the closed oriented 3-manifold ∂Δ^3 × ∂Δ^2 (12 vertices, "
+      "36 tetrahedra), χ=0, Betti (1,1,1,1). The triple-cup negative control "
+      "for T^3. Exact and pre-geometric; build() ignores numSimplices.")
+      .def(py::init<>())
+      .def("build", &SphereCircleProduct::build, py::arg("spacetime"),
+           py::arg("numSimplices") = 0,
+           "Build S^2 x S^1 (numSimplices ignored).");
+
+  py::class_<StellarSubdivision, Topology,
+             std::shared_ptr<StellarSubdivision> >(m, "StellarSubdivision",
+      "Refines a base topology by one stellar 1->(n+1) subdivision (star the "
+      "lexicographically smallest top simplex at a fresh vertex). Same manifold "
+      "and homology as the base, but a genuinely distinct (non-isomorphic) "
+      "labelled complex — e.g. StellarSubdivision(T^3) retriangulates T^3. "
+      "Exact and pre-geometric; build() ignores numSimplices.")
+      .def(py::init<std::shared_ptr<Topology> >(), py::arg("base"))
+      .def("build", &StellarSubdivision::build, py::arg("spacetime"),
+           py::arg("numSimplices") = 0,
+           "Build the subdivided complex (numSimplices ignored).");
   // ========================================
   // Metric
   // ========================================

--- a/src/spacetime/topologies/SphereCircleProduct.cpp
+++ b/src/spacetime/topologies/SphereCircleProduct.cpp
@@ -1,0 +1,38 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "spacetime/topologies/SphereCircleProduct.h"
+
+#include <memory>
+
+#include "spacetime/topologies/SimplexBoundarySphere.h"
+#include "spacetime/topologies/SimplicialProduct.h"
+
+namespace tessera::spacetime {
+
+void SphereCircleProduct::build(Spacetime *spacetime, int /*numSimplices*/) {
+  // S^2 x S^1 = ∂Δ^3 × ∂Δ^2, triangulated by the staircase product.
+  SimplicialProduct product(std::make_shared<SimplexBoundarySphere>(2),
+                            std::make_shared<SimplexBoundarySphere>(1));
+  product.build(spacetime, 0);
+}
+
+} // namespace tessera::spacetime

--- a/src/spacetime/topologies/StellarSubdivision.cpp
+++ b/src/spacetime/topologies/StellarSubdivision.cpp
@@ -1,0 +1,84 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "spacetime/topologies/StellarSubdivision.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "mesh/Simplex.h"
+#include "mesh/Vertex.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::spacetime {
+
+void StellarSubdivision::build(Spacetime *spacetime, int /*numSimplices*/) {
+  // Build the base into a scratch spacetime; its fixture vertices are numbered
+  // 0..|V|-1 (see SimplicialProduct / buildExplicit), so |V| = getVertexCount().
+  auto scratch = std::make_shared<Spacetime>();
+  base_->build(scratch.get(), 0);
+  const std::uint64_t numVertices = scratch->getVertexCount();
+
+  // Collect the top (highest-dimensional) simplices as sorted vertex tuples.
+  std::size_t topSize = 0;
+  for (const auto &s : scratch->getSimplices())
+    topSize = std::max(topSize, static_cast<std::size_t>(s->size()));
+
+  std::vector<std::vector<std::uint64_t>> tops;
+  for (const auto &s : scratch->getSimplices()) {
+    if (static_cast<std::size_t>(s->size()) != topSize) continue;
+    std::vector<std::uint64_t> ids;
+    ids.reserve(topSize);
+    for (const auto &v : s->getVertices()) ids.push_back(v->getId());
+    std::sort(ids.begin(), ids.end());
+    tops.push_back(std::move(ids));
+  }
+
+  // Nothing to refine (e.g. an empty complex): rebuild the base verbatim.
+  if (tops.empty()) {
+    buildExplicit(spacetime, static_cast<std::size_t>(numVertices), tops);
+    return;
+  }
+
+  // Deterministic choice: star the lexicographically smallest top simplex so
+  // the subdivision is reproducible regardless of getSimplices() order.
+  std::sort(tops.begin(), tops.end());
+  const std::vector<std::uint64_t> starred = tops.front();
+  tops.erase(tops.begin());
+
+  // Stellar 1 -> (n+1) move: replace `starred` with the cones from a fresh
+  // interior vertex `center` over each of its facets.
+  const std::uint64_t center = numVertices;
+  for (std::size_t omit = 0; omit < starred.size(); ++omit) {
+    std::vector<std::uint64_t> cell;
+    cell.reserve(starred.size());
+    for (std::size_t i = 0; i < starred.size(); ++i)
+      if (i != omit) cell.push_back(starred[i]);
+    cell.push_back(center);
+    tops.push_back(std::move(cell));
+  }
+
+  buildExplicit(spacetime, static_cast<std::size_t>(numVertices) + 1, tops);
+}
+
+} // namespace tessera::spacetime

--- a/tests/cobordism/test_three_manifold_fixtures_python.py
+++ b/tests/cobordism/test_three_manifold_fixtures_python.py
@@ -1,0 +1,147 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Stage-2 closed 3-manifold fixtures (#110).
+
+Two deliverables, checked here with cobordism homology:
+
+  * ``SphereCircleProduct`` — the closed oriented S^2 x S^1, the negative
+    control for the triple cup product (b = (1, 1, 1, 1));
+  * two genuinely distinct triangulations of T^3 — the staircase product
+    S^1 x S^1 x S^1 and its single stellar subdivision (``StellarSubdivision``).
+    They are **non-isomorphic** as labelled complexes yet **homologically
+    equal** (b = (1, 3, 3, 1)), the input pair for the T2 retriangulation-
+    invariance check.
+"""
+
+import itertools
+import unittest
+
+import tessera
+
+cobordism = tessera.cobordism
+
+
+def _build(topology):
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, topology)
+    st.build()  # delegates to topology.build(); numSimplices ignored
+    return st
+
+
+def _betti(topology):
+    return cobordism.ChainComplex.fromSpacetime(_build(topology)).bettiNumbers()
+
+
+def _top_simplices(topology):
+    """Top-simplex vertex-id tuples of the built complex, as plain ints.
+
+    The Spacetime is held in a local for the duration of the extraction (the
+    Simplex handles from getSimplices() point into its storage); only the
+    decoupled int tuples escape, so the result is safe to use afterwards.
+    """
+    st = _build(topology)
+    by_size = {}
+    for s in st.getSimplices():
+        t = tuple(sorted(v.getId() for v in s.getVertices()))
+        by_size.setdefault(len(t), []).append(t)
+    return [list(t) for t in by_size[max(by_size)]]
+
+
+def _circle():
+    return tessera.SimplexBoundarySphere(1)  # S^1
+
+
+def _t3_product():
+    """T^3 = S^1 x S^1 x S^1 via the (left-nested) staircase product."""
+    return tessera.SimplicialProduct(
+        tessera.SimplicialProduct(_circle(), _circle()), _circle())
+
+
+def _t3_subdivided():
+    """A second, inequivalent triangulation of T^3: one stellar subdivision."""
+    return tessera.StellarSubdivision(_t3_product())
+
+
+def _is_closed_manifold(tops):
+    """Every codimension-one face of a top cell is shared by exactly two top
+    cells (the defining property of a closed pseudomanifold)."""
+    facet_counts = {}
+    for top in tops:
+        for facet in itertools.combinations(sorted(top), len(top) - 1):
+            facet_counts[facet] = facet_counts.get(facet, 0) + 1
+    return all(count == 2 for count in facet_counts.values())
+
+
+class TestSphereCircleProduct(unittest.TestCase):
+    """S^2 x S^1 — the T^3 triple-cup negative control."""
+
+    def test_betti_numbers(self):
+        self.assertEqual(_betti(tessera.SphereCircleProduct()), [1, 1, 1, 1])
+
+    def test_is_closed_three_manifold(self):
+        tops = _top_simplices(tessera.SphereCircleProduct())
+        self.assertTrue(all(len(t) == 4 for t in tops))   # tetrahedra => 3-manifold
+        self.assertTrue(_is_closed_manifold(tops))
+
+    def test_minimal_face_counts(self):
+        # ∂Δ^3 (4 verts) x ∂Δ^2 (3 verts): 12 vertices, 4*3*C(3,1) = 36 tets.
+        tops = _top_simplices(tessera.SphereCircleProduct())
+        self.assertEqual(len({v for t in tops for v in t}), 12)
+        self.assertEqual(len(tops), 36)
+
+
+class TestT3Retriangulations(unittest.TestCase):
+    """Two distinct triangulations of T^3 for the T2 invariance check."""
+
+    def test_both_have_three_torus_homology(self):
+        self.assertEqual(_betti(_t3_product()), [1, 3, 3, 1])
+        self.assertEqual(_betti(_t3_subdivided()), [1, 3, 3, 1])
+
+    def test_triangulations_are_non_isomorphic(self):
+        product = _top_simplices(_t3_product())
+        subdivided = _top_simplices(_t3_subdivided())
+        self.assertFalse(cobordism.Cobordism.areIsomorphic(product, subdivided))
+
+    def test_homologically_equal_but_combinatorially_distinct(self):
+        # Same manifold (equal Betti) ...
+        self.assertEqual(_betti(_t3_product()), _betti(_t3_subdivided()))
+        # ... yet the stellar move grows the complex by one vertex and three
+        # tetrahedra, so it cannot be a relabeling of the product.
+        product = _top_simplices(_t3_product())
+        subdivided = _top_simplices(_t3_subdivided())
+        self.assertEqual(len({v for t in subdivided for v in t}),
+                         len({v for t in product for v in t}) + 1)
+        self.assertEqual(len(subdivided), len(product) + 3)
+
+    def test_each_triangulation_self_isomorphic(self):
+        # Sanity guard on the negative result above: areIsomorphic is reflexive.
+        product = _top_simplices(_t3_product())
+        self.assertTrue(cobordism.Cobordism.areIsomorphic(product, product))
+
+    def test_subdivision_remains_a_closed_manifold(self):
+        self.assertTrue(_is_closed_manifold(_top_simplices(_t3_subdivided())))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_three_manifold_fixtures_python.py
+++ b/tests/cobordism/test_three_manifold_fixtures_python.py
@@ -143,5 +143,65 @@ class TestT3Retriangulations(unittest.TestCase):
         self.assertTrue(_is_closed_manifold(_top_simplices(_t3_subdivided())))
 
 
+class TestStellarSubdivisionPreservesTopology(unittest.TestCase):
+    """A stellar (1->d+1) Pachner move changes the triangulation but not the
+    homotopy type. The T^3 case above checks this once; here it is exercised on
+    a different base manifold and under iteration -- the depth axis of the T2
+    Pachner-invariance sweep (#112)."""
+
+    def test_preserves_sphere_circle_product_homology(self):
+        base = tessera.SphereCircleProduct()
+        sub = tessera.StellarSubdivision(base)
+        self.assertEqual(_betti(sub), [1, 1, 1, 1])          # still S^2 x S^1
+        self.assertTrue(_is_closed_manifold(_top_simplices(sub)))
+        b, s = _top_simplices(base), _top_simplices(sub)
+        # the 1->4 move: +1 vertex, +3 tetrahedra ...
+        self.assertEqual(len(s), len(b) + 3)
+        self.assertEqual(len({v for t in s for v in t}),
+                         len({v for t in b for v in t}) + 1)
+        # ... a genuine retriangulation, not a relabeling.
+        self.assertFalse(cobordism.Cobordism.areIsomorphic(b, s))
+
+    def test_iterated_subdivision_preserves_three_torus(self):
+        once = _t3_subdivided()
+        twice = tessera.StellarSubdivision(once)
+        self.assertEqual(_betti(twice), [1, 3, 3, 1])        # still T^3
+        self.assertTrue(_is_closed_manifold(_top_simplices(twice)))
+        o, t = _top_simplices(once), _top_simplices(twice)
+        self.assertEqual(len(t), len(o) + 3)                 # one further move
+        self.assertFalse(cobordism.Cobordism.areIsomorphic(o, t))
+
+
+class TestClosedThreeManifoldInvariants(unittest.TestCase):
+    """Euler-Poincare and orientability -- the properties the Dijkgraaf-Witten
+    state-sum (#108) relies on for these fixtures."""
+
+    @staticmethod
+    def _chain(topology):
+        return cobordism.ChainComplex.fromSpacetime(_build(topology))
+
+    def test_euler_characteristic_zero(self):
+        # A closed odd-dimensional manifold has chi = 0, and Euler-Poincare ties
+        # the face-count chi (from |C_k|) to the homological one (the alternating
+        # Betti sum) -- an independent cross-check of each triangulation.
+        for topo in (tessera.SphereCircleProduct(), _t3_product(), _t3_subdivided()):
+            cc = self._chain(topo)
+            self.assertEqual(cc.eulerCharacteristic(), 0)
+            betti = cc.bettiNumbers()
+            self.assertEqual(sum((-1) ** k * b for k, b in enumerate(betti)), 0)
+
+    def test_orientable_with_unique_fundamental_class(self):
+        # b_3 = 1 and a +/-1 coefficient on every top cell => closed, connected,
+        # oriented: the precondition for the orientation signs eps_t in the DW
+        # weight.
+        for topo in (tessera.SphereCircleProduct(), _t3_product()):
+            cc = self._chain(topo)
+            fundamental = cc.fundamentalClass()
+            tops = cc.orientedTopSimplices()
+            self.assertEqual(cc.bettiNumbers()[3], 1)
+            self.assertEqual(len(fundamental), len(tops))
+            self.assertTrue(all(abs(coeff) == 1 for coeff in fundamental))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stage-2 closed 3-manifold fixtures: the **T3 negative control** and the input pair for the **T2** retriangulation-invariance check.

## What
- **`SphereCircleProduct`** (`include`/`src/spacetime/topologies/`) — the closed oriented **S²×S¹**, built as the staircase product `∂Δ³ × ∂Δ²` (delegates to `SimplicialProduct(SimplexBoundarySphere(2), SimplexBoundarySphere(1))`), exposed as a named `Topology` for symmetry with `Toroid`. 12 vertices, 36 tetrahedra, χ=0. It is the triple-cup negative control: `H¹` is one-dimensional, so `α∪α∪α` vanishes (`Z_sign = Z_triv`).
- **`StellarSubdivision`** — a composable wrapper (mirrors `SimplicialProduct`) that refines a base topology by one stellar `1→(n+1)` move (stars the lexicographically-smallest top simplex at a fresh vertex). Same manifold/homology, but a genuinely distinct, non-isomorphic labelled complex. Used to produce the second `T³` triangulation: `StellarSubdivision(S¹×S¹×S¹)`.
- Bound both in `src/spacetime/Bindings.cpp` (auto-exported as `tessera.SphereCircleProduct` / `tessera.StellarSubdivision`).
- Tests in `tests/cobordism/test_three_manifold_fixtures_python.py`.

## Acceptance (all verified)
- Betti `S²×S¹` → **(1,1,1,1)**; `T³` (both triangulations) → **(1,3,3,1)**.
- The two `T³` triangulations are **non-isomorphic** (`Cobordism.areIsomorphic` is `False`: product = 27 verts/162 tets vs subdivided = 28 verts/165 tets) but **homologically equal**.
- Both new fixtures verified as closed pseudomanifolds (every codim-1 face in exactly two top cells).

## Tests
`pytest tests/cobordism/` → **143 passed, 294 subtests** (8 new). Branch rebased onto current `main` and rebuilt/retested.

Closes #110.