### PR TITLE
cobordism: DijkgraafWitten closed-W ℤ₂ state-sum (T3)

### DIFF
--- a/include/cobordism/ChainComplex.h
+++ b/include/cobordism/ChainComplex.h
@@ -82,6 +82,15 @@ class ChainComplex {
     /// \f$ \mathrm{torsion}(1) = \{2\} \f$.)
     [[nodiscard]] std::vector<long> torsion(int k) const;
 
+    /// The k-simplices as sorted vertex-id tuples, in the canonical order of
+    /// \f$ C_k \f$ — the column order of \f$ \partial_{k+1} \f$ and, equally, the
+    /// row order of \f$ \partial_k \f$. For \f$ k = \f$ dimension() this is
+    /// orientedTopSimplices(); for \f$ k = 1 \f$ it is the edge ordering the
+    /// rows of boundaryMatrix(2) refer to, which is needed to read a
+    /// \f$ \mathbb{Z}_2 \f$ connection \f$ g \in C^1 \f$ on a simplex's edges.
+    /// Empty when \f$ k \f$ is out of range.
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> kSimplexVertices(int k) const;
+
     /// The top simplices as sorted vertex-id tuples, in the canonical column
     /// order of the top boundary matrix \f$ \partial_d \f$ (\f$ d = \f$
     /// dimension()). This is the ordering the orientation signs from

--- a/include/cobordism/DijkgraafWitten.h
+++ b/include/cobordism/DijkgraafWitten.h
@@ -1,0 +1,104 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_DIJKGRAAFWITTEN_H
+#define TESSERA_COBORDISM_DIJKGRAAFWITTEN_H
+
+#include <complex>
+#include <memory>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// The two normalized classes of \f$ Z^3(\mathbb{Z}_2; U(1)) \f$ used as the
+/// Dijkgraaf–Witten weight: the trivial cocycle \f$ \omega \equiv 1 \f$ and the
+/// nontrivial sign cocycle \f$ \omega(a,b,c) = (-1)^{abc} \f$ (the generator of
+/// \f$ H^3(\mathbb{Z}_2; U(1)) \cong \mathbb{Z}_2 \f$, the cochain-level cup
+/// cube \f$ t^3 \f$).
+enum class Cocycle {
+  Trivial,  ///< \f$ \omega \equiv 1 \f$ (untwisted state sum).
+  Sign,     ///< \f$ \omega(a,b,c) = (-1)^{abc} \f$.
+};
+
+/// # DijkgraafWitten
+///
+/// The Dijkgraaf–Witten partition function of a closed oriented triangulated
+/// 3-manifold \f$ W \f$ with gauge group \f$ \mathbb{Z}_2 \f$ and a 3-cocycle
+/// \f$ \omega \in Z^3(\mathbb{Z}_2; U(1)) \f$:
+/// \f[
+///   Z(W) = \frac{1}{2^{|V|}} \sum_{\text{flat } g}
+///          \prod_{\text{tetrahedra } t}
+///          \omega(g_{01}, g_{12}, g_{23})^{\varepsilon_t}.
+/// \f]
+/// Here \f$ g \in C^1(W; \mathbb{Z}_2) \f$ is a **flat** connection — a value
+/// \f$ g_e \in \{0,1\} \f$ on each edge with \f$ (dg)|_\triangle = g_{01} +
+/// g_{12} - g_{02} \equiv 0 \pmod 2 \f$ on every triangle — i.e. an element of
+/// \f$ \ker(d_1 \bmod 2) \f$, where the coboundary \f$ d_1 = \partial_2^\top \f$
+/// is the transpose of `ChainComplex::boundaryMatrix(2)`. \f$ \varepsilon_t =
+/// \pm 1 \f$ is each tetrahedron's orientation sign from the fundamental class
+/// (`ChainComplex::fundamentalClass()`), and on an ordered tetrahedron
+/// \f$ [v_0 < v_1 < v_2 < v_3] \f$ the weight reads the connection on its three
+/// "consecutive" edges \f$ (v_0,v_1), (v_1,v_2), (v_2,v_3) \f$ — the
+/// Alexander–Whitney faces — mapped to their \f$ C_1 \f$ (edge) indices.
+///
+/// The sum is the gauge-redundant enumeration over the whole flat space
+/// \f$ \ker(d_1) \f$ (\f$ 2^{\text{nullity}} \f$ connections, materialized via
+/// `gf2Span`); the division by \f$ 2^{|V|} \f$ is the gauge volume, leaving the
+/// topological invariant. This brute-force enumeration is intended for the
+/// small triangulations on which the invariant is checked by hand; the
+/// underlying `gf2Span` refuses a nullity too large to materialize.
+class DijkgraafWitten {
+  public:
+    /// Build the state sum over a triangulation \f$ W \f$ with the chosen
+    /// cocycle. \f$ W \f$ is read at `partitionFunction()` time; the held
+    /// `shared_ptr` keeps it alive.
+    DijkgraafWitten(std::shared_ptr<Spacetime> W, Cocycle w);
+
+    /// The partition function \f$ Z(W) \in \mathbb{C} \f$.
+    /// @throws std::runtime_error if \f$ W \f$ is null or not a closed oriented
+    ///   3-manifold (dimension \f$ \neq 3 \f$, or no fundamental class), or
+    ///   `std::invalid_argument` (from `gf2Span`) if the flat space is too large
+    ///   to enumerate.
+    [[nodiscard]] std::complex<double> partitionFunction() const;
+
+    /// Whether the cocycle \f$ \omega \f$ for the given choice satisfies the
+    /// normalized 3-cocycle (pentagon) identity over \f$ \mathbb{Z}_2 \f$:
+    /// \f$ \omega(b,c,d)\,\omega(a, b{+}c, d)\,\omega(a,b,c) =
+    /// \omega(a{+}b, c, d)\,\omega(a, b, c{+}d) \f$ for every
+    /// \f$ (a,b,c,d) \in \mathbb{Z}_2^4 \f$ (brute-forced over all 16 tuples).
+    /// Both `Trivial` and `Sign` are genuine cocycles, so both return true;
+    /// it is the prerequisite that makes the state sum a topological invariant.
+    [[nodiscard]] static bool isCocycle(Cocycle w);
+
+  private:
+    std::shared_ptr<Spacetime> W_;
+    Cocycle cocycle_;
+
+    /// Evaluate \f$ \omega(a,b,c) \f$ for a cocycle choice, \f$ a,b,c \in
+    /// \{0,1\} \f$.
+    [[nodiscard]] static std::complex<double> omega(Cocycle w, int a, int b, int c);
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_DIJKGRAAFWITTEN_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -32,6 +32,7 @@
 #include "cobordism/Characteristic.h"
 #include "cobordism/Cobordism.h"
 #include "cobordism/CombinatorialDimension.h"
+#include "cobordism/DijkgraafWitten.h"
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
@@ -88,6 +89,11 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
       .def("bettiNumbersGF2", &ChainComplex::bettiNumbersGF2, "Betti numbers over GF(2).")
       .def("torsion", &ChainComplex::torsion, py::arg("k"),
            "Torsion coefficients of H_k (invariant factors > 1 of d_{k+1}).")
+      .def("kSimplexVertices", &ChainComplex::kSimplexVertices, py::arg("k"),
+           "k-simplices as sorted vertex-id tuples in C_k order (the column "
+           "order of d_{k+1} / row order of d_k). k=1 gives the edge ordering "
+           "the rows of boundaryMatrix(2) refer to; k=dimension() equals "
+           "orientedTopSimplices(). Empty when k is out of range.")
       .def("orientedTopSimplices", &ChainComplex::orientedTopSimplices,
            "Top simplices as sorted vertex-id tuples, in the canonical column "
            "order of the top boundary matrix d_d (d = dimension()); the order "
@@ -247,4 +253,36 @@ cycle bases, and Betti numbers belong to WilsonLoop / ChainComplex.)doc")
       .def_static("verify", &Cobordism::verify, py::arg("W"), py::arg("M1"),
                   py::arg("M2"),
                   "Verify W is a cobordism from M1 to M2 (boundary structure).");
+
+  // ----- Capability T3 (#108): Dijkgraaf-Witten Z_2 state sum -----
+  py::enum_<Cocycle>(m, "Cocycle",
+      "The two normalized classes of Z^3(Z_2; U(1)) used as the "
+      "Dijkgraaf-Witten weight: Trivial (omega == 1) and Sign "
+      "(omega(a,b,c) = (-1)^{abc}, the generator of H^3(Z_2; U(1)) = Z_2).")
+      .value("Trivial", Cocycle::Trivial)
+      .value("Sign", Cocycle::Sign);
+
+  py::class_<DijkgraafWitten>(m, "DijkgraafWitten",
+      R"doc(Dijkgraaf-Witten Z_2 state sum of a closed oriented 3-manifold.
+
+Z(W) = (1/2^|V|) sum_{flat g} prod_t omega(g_01, g_12, g_23)^{eps_t}, summed over
+the flat Z_2 connections g in C^1 (the GF(2) nullspace of the coboundary
+d_1 = boundaryMatrix(2)^T), with each tetrahedron's orientation sign eps_t from
+the fundamental class. For connected W the untwisted value is Z_Trivial(W) =
+2^{b_1(W;Z_2) - 1}; the Sign cocycle twists it by (-1)^{<g cup g cup g, [W]>},
+which differs from the trivial value exactly when the mod-2 cup cube is nonzero
+on W (e.g. RP^3), and agrees with it when the cube vanishes (e.g. T^3, S^2xS^1).
+Enumerates the whole flat space (gauge-redundant), so it is intended for small
+triangulations; a flat space too large to materialize is refused.)doc")
+      .def(py::init<std::shared_ptr<Spacetime>, Cocycle>(), py::arg("W"),
+           py::arg("cocycle"),
+           "Build the state sum over a closed oriented 3-manifold W with the "
+           "chosen cocycle.")
+      .def("partitionFunction", &DijkgraafWitten::partitionFunction,
+           "The partition function Z(W) as a complex number. Raises if W is not "
+           "a closed oriented 3-manifold or the flat space is too large.")
+      .def_static("isCocycle", &DijkgraafWitten::isCocycle, py::arg("cocycle"),
+                  "Whether omega satisfies the normalized 3-cocycle (pentagon) "
+                  "identity over Z_2 (brute-forced over all 16 tuples of "
+                  "Z_2^4). True for both Trivial and Sign.");
 }

--- a/src/cobordism/ChainComplex.cpp
+++ b/src/cobordism/ChainComplex.cpp
@@ -194,9 +194,13 @@ std::vector<int> ChainComplex::bettiNumbersGF2() const {
   return b;
 }
 
+std::vector<std::vector<std::uint64_t>> ChainComplex::kSimplexVertices(int k) const {
+  if (k < 0 || k > dimension_) return {};  // out of range: no such simplices
+  return faceVerts_[static_cast<std::size_t>(k)];
+}
+
 std::vector<std::vector<std::uint64_t>> ChainComplex::orientedTopSimplices() const {
-  if (dimension_ < 0) return {};  // empty complex: no top simplices
-  return faceVerts_[static_cast<std::size_t>(dimension_)];
+  return kSimplexVertices(dimension_);  // empty complex (d < 0) yields {}
 }
 
 std::vector<int> ChainComplex::fundamentalClass() const {

--- a/src/cobordism/DijkgraafWitten.cpp
+++ b/src/cobordism/DijkgraafWitten.cpp
@@ -1,0 +1,164 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/DijkgraafWitten.h"
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "cobordism/ChainComplex.h"
+#include "cobordism/IntegerLinalg.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+DijkgraafWitten::DijkgraafWitten(std::shared_ptr<Spacetime> W, Cocycle w)
+    : W_(std::move(W)), cocycle_(w) {}
+
+std::complex<double> DijkgraafWitten::omega(Cocycle w, int a, int b, int c) {
+  switch (w) {
+    case Cocycle::Trivial:
+      return {1.0, 0.0};
+    case Cocycle::Sign:
+      // (-1)^{abc}: the sign flips only when all three edge values are 1.
+      return ((a & b & c) & 1) ? std::complex<double>{-1.0, 0.0}
+                               : std::complex<double>{1.0, 0.0};
+  }
+  return {1.0, 0.0};  // unreachable; silences a maybe-no-return warning
+}
+
+bool DijkgraafWitten::isCocycle(Cocycle w) {
+  // Normalized 3-cocycle (pentagon) identity over Z_2, written multiplicatively:
+  //   ω(b,c,d) · ω(a, b⊕c, d) · ω(a,b,c)  ==  ω(a⊕b, c, d) · ω(a, b, c⊕d)
+  // must hold for every (a,b,c,d) ∈ Z_2^4 (⊕ is addition mod 2). Brute-force all
+  // 16 tuples. This is the prerequisite that makes the state sum gauge-invariant
+  // (hence a topological invariant), so the partition function relies on it.
+  const double tolerance = 1e-12;
+  for (int a = 0; a < 2; ++a)
+    for (int b = 0; b < 2; ++b)
+      for (int c = 0; c < 2; ++c)
+        for (int d = 0; d < 2; ++d) {
+          const std::complex<double> left =
+              omega(w, b, c, d) * omega(w, a, b ^ c, d) * omega(w, a, b, c);
+          const std::complex<double> right =
+              omega(w, a ^ b, c, d) * omega(w, a, b, c ^ d);
+          if (std::abs(left - right) > tolerance) return false;
+        }
+  return true;
+}
+
+std::complex<double> DijkgraafWitten::partitionFunction() const {
+  if (W_ == nullptr)
+    throw std::runtime_error(
+        "DijkgraafWitten::partitionFunction: the spacetime is null");
+
+  const ChainComplex chain = ChainComplex::fromSpacetime(*W_);
+  if (chain.dimension() != 3)
+    throw std::runtime_error(
+        "DijkgraafWitten::partitionFunction: a closed oriented 3-manifold is "
+        "required (dimension must be 3)");
+
+  const int numVertices = static_cast<int>(chain.numSimplices(0));
+  const int numEdges = static_cast<int>(chain.numSimplices(1));
+  const int numTriangles = static_cast<int>(chain.numSimplices(2));
+
+  // The flat Z_2 connections g ∈ C^1 are ker(d_1 mod 2), where the coboundary
+  // d_1 = ∂_2^T acts on edge-cochains. ∂_2 = boundaryMatrix(2) is
+  // rows = |C_1| (edges) × cols = |C_2| (triangles); its transpose d_1 is
+  // triangles × edges. A flat g (length numEdges) satisfies, on every triangle,
+  // (d_1 g)|_△ = g_01 + g_12 - g_02 ≡ 0 (mod 2).
+  const std::vector<long> &boundaryTwo = chain.boundaryMatrix(2);
+  std::vector<int> coboundaryOne(
+      static_cast<std::size_t>(numTriangles) * numEdges, 0);
+  for (int edge = 0; edge < numEdges; ++edge)
+    for (int triangle = 0; triangle < numTriangles; ++triangle)
+      coboundaryOne[static_cast<std::size_t>(triangle) * numEdges + edge] =
+          static_cast<int>(
+              boundaryTwo[static_cast<std::size_t>(edge) * numTriangles +
+                          triangle] &
+              1L);
+
+  const std::vector<std::vector<int>> flatBasis =
+      gf2Nullspace(coboundaryOne, numTriangles, numEdges);
+
+  // Orientation / flatness verification: every basis cocycle must satisfy
+  // d_1 · g ≡ 0 (mod 2) on each triangle ((dg)|_△ = g_01 + g_12 - g_02 ≡ 0).
+  // This holds by construction of the nullspace; assert it so a mis-transposed
+  // coboundary or inconsistent edge ordering is caught loudly rather than
+  // silently producing a wrong invariant.
+  for (const std::vector<int> &basisVector : flatBasis)
+    for (int triangle = 0; triangle < numTriangles; ++triangle) {
+      int parity = 0;
+      for (int edge = 0; edge < numEdges; ++edge)
+        parity ^=
+            coboundaryOne[static_cast<std::size_t>(triangle) * numEdges + edge] &
+            basisVector[static_cast<std::size_t>(edge)];
+      if (parity != 0)
+        throw std::runtime_error(
+            "DijkgraafWitten::partitionFunction: a flat-connection basis vector "
+            "violates d_1·g ≡ 0 (mod 2) — the coboundary/edge indexing is "
+            "inconsistent");
+    }
+
+  const std::vector<std::vector<int>> flatConnections =
+      gf2Span(flatBasis, numEdges);
+
+  // Map a sorted vertex pair (v_i, v_j) to its C_1 (edge) index. The edge
+  // ordering kSimplexVertices(1) returns is exactly the row order of ∂_2 (both
+  // are faceVerts_[1]), so g — indexed by ∂_2's rows — is read consistently.
+  const std::vector<std::vector<std::uint64_t>> edges = chain.kSimplexVertices(1);
+  std::map<std::pair<std::uint64_t, std::uint64_t>, int> edgeIndex;
+  for (int e = 0; e < static_cast<int>(edges.size()); ++e)
+    edgeIndex[{edges[e][0], edges[e][1]}] = e;
+
+  // Each tetrahedron's ordered (sorted) vertices and its orientation sign ε_t,
+  // both indexed in the column order of ∂_3 (orientedTopSimplices()).
+  const std::vector<std::vector<std::uint64_t>> tetrahedra =
+      chain.orientedTopSimplices();
+  const std::vector<int> epsilon = chain.fundamentalClass();
+
+  // Z(W) = (1/2^{|V|}) Σ_{flat g} Π_t ω(g_01, g_12, g_23)^{ε_t}.
+  std::complex<double> total{0.0, 0.0};
+  for (const std::vector<int> &g : flatConnections) {
+    std::complex<double> weight{1.0, 0.0};
+    for (int t = 0; t < static_cast<int>(tetrahedra.size()); ++t) {
+      const std::vector<std::uint64_t> &v = tetrahedra[t];  // v0 < v1 < v2 < v3
+      const int g01 = g[static_cast<std::size_t>(edgeIndex.at({v[0], v[1]}))];
+      const int g12 = g[static_cast<std::size_t>(edgeIndex.at({v[1], v[2]}))];
+      const int g23 = g[static_cast<std::size_t>(edgeIndex.at({v[2], v[3]}))];
+      std::complex<double> tetWeight = omega(cocycle_, g01, g12, g23);
+      // ω^{ε_t}: ε_t = +1 leaves it, ε_t = -1 inverts it. For a U(1) phase the
+      // inverse is the conjugate (a no-op for the real ±1 values of Trivial and
+      // Sign, but kept so the formula is faithful for any U(1) cocycle).
+      if (epsilon[static_cast<std::size_t>(t)] < 0) tetWeight = std::conj(tetWeight);
+      weight *= tetWeight;
+    }
+    total += weight;
+  }
+  total /= std::pow(2.0, static_cast<double>(numVertices));
+  return total;
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_dijkgraaf_witten_python.py
+++ b/tests/cobordism/test_dijkgraaf_witten_python.py
@@ -1,0 +1,333 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Dijkgraaf–Witten ℤ₂ state sum (#108).
+
+The closed-W state sum
+
+    Z(W) = (1/2^|V|) Σ_{flat g} ∏_t ω(g_01, g_12, g_23)^{ε_t}
+
+over the flat ℤ₂ connections g ∈ C¹ (the GF(2) nullspace of the coboundary
+d₁ = ∂₂ᵀ), each tetrahedron weighted by a 3-cocycle ω raised to its orientation
+sign ε_t (the fundamental class). ω is either Trivial (ω≡1) or Sign
+(ω(a,b,c) = (-1)^{abc}), the two classes of Z³(ℤ₂; U(1)).
+
+Acceptance, in dependency order:
+
+1. **3-cocycle (pentagon) identity — first.** ω must be a genuine 3-cocycle, or
+   the state sum is not gauge-invariant and the rest is meaningless. Checked with
+   an independent Python oracle (with a deliberately non-cocycle cochain as a
+   negative control so the oracle has teeth) against ``DijkgraafWitten.isCocycle``.
+
+2. **Convention anchor.** For a connected closed oriented 3-manifold the
+   untwisted partition function is ``Z_Trivial(W) = 2^{b_1(W;ℤ₂) - 1}``. Verified
+   exactly on S³ (b₁=0 → ½) and S²×S¹ (b₁=1 → 1), with b₁ read from the chain
+   complex, and cross-checked against an independent numpy reimplementation of the
+   whole state sum (a true oracle for the edge-indexing/orientation wiring).
+
+3. **The Sign twist.** ``Z_Sign(W)`` twists the untwisted value by
+   ``(-1)^{⟨g∪g∪g, [W]⟩}``, the mod-2 cup cube. It therefore differs from
+   ``Z_Trivial(W)`` **iff the cup cube is nonzero on W**.
+
+   NOTE — correction to the ticket's worked example. Ticket #108 proposed T³ as
+   the manifold where the sign cocycle distinguishes. That is mathematically
+   incorrect: H*(T³;ℤ₂) is the exterior algebra Λ(x,y,z), in which every
+   degree-one class squares to zero, so the cup cube g³ vanishes for *every*
+   g ∈ H¹(T³;ℤ₂) and ``Z_Sign(T³) = Z_Trivial(T³)``. The same vanishing holds on
+   S²×S¹ and S³ (so those are negative controls, asserted below). The cobordism
+   design note (``docs/.../cobordism.md`` §6, P3) states the requirement
+   correctly — "nontrivial ω distinguishable from trivial on **some** W", with
+   "Σ×S¹, T³, lens spaces" as candidate topologies; the distinguishers are the
+   **lens spaces** (RP³ = L(2,1) and friends), whose cup cube t³ ≠ 0.
+
+   The positive control is therefore deferred: the only closed oriented
+   3-manifold with t³ ≠ 0 that is small enough for this brute-force state sum
+   (gf2Span enumerates the full flat space, so nullity = |V| must stay ≲ 24) is
+   the vertex-minimal RP³, and tessera ships no RP³/lens-space fixture yet (the
+   named S²×S¹ fixture is itself a separate, unmerged ticket). Per #108's own
+   guidance for unavailable fixtures, this control is noted as deferred; the
+   expected values (Z_Trivial(RP³)=1, Z_Sign(RP³)=0) are pinned in
+   ``test_lens_space_distinction_is_deferred`` so the follow-up fixture has a
+   target.
+
+4. **Negative control.** On S²×S¹ (and S³) the sign cocycle does **not**
+   distinguish: ``Z_Sign == Z_Trivial``. A wrong edge map, transpose, or ω would
+   generically break this, so it doubles as a correctness check on the twist.
+"""
+
+import itertools
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cobordism = tessera.cobordism
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures: closed oriented 3-manifolds small enough for the brute-force sum.
+# --------------------------------------------------------------------------- #
+def _build(topology, dimensions=4):
+    signature = tessera.Signature(dimensions, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()
+    return spacetime
+
+
+def _three_sphere():
+    # S³ = ∂Δ⁴: 5 vertices, betti (1,0,0,1).
+    return _build(tessera.SimplexBoundarySphere(3))
+
+
+def _s2_cross_s1():
+    # S²×S¹ via the simplicial (Eilenberg–Zilber) product: 12 vertices,
+    # betti (1,1,1,1). The named fixture is a separate ticket; compose it inline.
+    return _build(tessera.SimplicialProduct(tessera.SimplexBoundarySphere(2),
+                                            tessera.SimplexBoundarySphere(1)))
+
+
+def _two_sphere():
+    # S²: a closed 2-manifold, used to check the dimension guard.
+    return _build(tessera.SimplexBoundarySphere(2))
+
+
+def _first_betti_gf2(spacetime):
+    chain = cobordism.ChainComplex.fromSpacetime(spacetime)
+    return chain.bettiNumbersGF2()[1]
+
+
+# --------------------------------------------------------------------------- #
+# Pure-Python 3-cocycle oracle (group cohomology of ℤ₂, multiplicative U(1)).
+# --------------------------------------------------------------------------- #
+def _omega(kind, a, b, c):
+    """ω(a,b,c) for a cochain ``kind`` ∈ {trivial, sign, broken}."""
+    if kind == "trivial":
+        return 1
+    if kind == "sign":  # the nontrivial generator (-1)^{abc}
+        return -1 if (a & b & c) else 1
+    if kind == "broken":  # NOT a 3-cocycle — only here to give the oracle teeth
+        return -1 if (a & b) else 1
+    raise ValueError(kind)
+
+
+def _satisfies_pentagon(kind):
+    """Normalized 3-cocycle (pentagon) identity over ℤ₂, brute-forced over ℤ₂⁴:
+    ω(b,c,d)·ω(a,b⊕c,d)·ω(a,b,c) == ω(a⊕b,c,d)·ω(a,b,c⊕d)."""
+    for a, b, c, d in itertools.product((0, 1), repeat=4):
+        left = _omega(kind, b, c, d) * _omega(kind, a, b ^ c, d) * _omega(kind, a, b, c)
+        right = _omega(kind, a ^ b, c, d) * _omega(kind, a, b, c ^ d)
+        if left != right:
+            return False
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Independent numpy reimplementation of the whole state sum (oracle for C++).
+# --------------------------------------------------------------------------- #
+def _gf2_nullspace(matrix):
+    """Basis of {x : matrix·x ≡ 0 (mod 2)} as rows, via RREF (pure numpy)."""
+    a = (np.asarray(matrix, dtype=np.int64) & 1).copy()
+    rows, cols = a.shape
+    pivots, r = [], 0
+    for col in range(cols):
+        if r >= rows:
+            break
+        piv = next((i for i in range(r, rows) if a[i, col] & 1), None)
+        if piv is None:
+            continue
+        a[[r, piv]] = a[[piv, r]]
+        for i in range(rows):
+            if i != r and (a[i, col] & 1):
+                a[i] ^= a[r]
+        pivots.append(col)
+        r += 1
+    is_pivot = [False] * cols
+    for c in pivots:
+        is_pivot[c] = True
+    basis = []
+    for free in range(cols):
+        if is_pivot[free]:
+            continue
+        x = np.zeros(cols, dtype=np.int64)
+        x[free] = 1
+        for t, pc in enumerate(pivots):
+            x[pc] = a[t, free] & 1
+        basis.append(x)
+    return basis
+
+
+def _dw_partition_oracle(spacetime, kind):
+    """Recompute Z(W) independently from the chain complex (numpy GF(2))."""
+    chain = cobordism.ChainComplex.fromSpacetime(spacetime)
+    num_vertices = chain.numSimplices(0)
+    num_edges = chain.numSimplices(1)
+    num_triangles = chain.numSimplices(2)
+
+    boundary2 = (np.asarray(chain.boundaryMatrix(2), dtype=np.int64)
+                 .reshape(num_edges, num_triangles)) & 1   # edges × triangles
+    coboundary1 = boundary2.T                              # triangles × edges
+    basis = _gf2_nullspace(coboundary1)
+
+    edges = [tuple(e) for e in chain.kSimplexVertices(1)]
+    edge_index = {e: i for i, e in enumerate(edges)}
+    tets = [tuple(t) for t in chain.orientedTopSimplices()]
+    epsilon = list(chain.fundamentalClass())
+
+    total = 0.0
+    k = len(basis)
+    for mask in range(1 << k):
+        g = np.zeros(num_edges, dtype=np.int64)
+        for b in range(k):
+            if (mask >> b) & 1:
+                g ^= basis[b]
+        weight = 1
+        for tet, sign in zip(tets, epsilon):
+            g01 = int(g[edge_index[(tet[0], tet[1])]])
+            g12 = int(g[edge_index[(tet[1], tet[2])]])
+            g23 = int(g[edge_index[(tet[2], tet[3])]])
+            value = _omega(kind, g01, g12, g23)
+            # value**sign is a no-op for the real ±1 values of these cocycles.
+            weight *= value
+        total += weight
+    return total / (2.0 ** num_vertices)
+
+
+class TestThreeCocycleIdentity(unittest.TestCase):
+    """Run first: ω must satisfy the pentagon identity (topological-invariance
+    prerequisite). Establish the oracle's validity, then check C++ against it."""
+
+    def test_python_oracle_accepts_the_two_cocycles(self):
+        self.assertTrue(_satisfies_pentagon("trivial"))
+        self.assertTrue(_satisfies_pentagon("sign"))
+
+    def test_python_oracle_rejects_a_non_cocycle(self):
+        # Teeth: a cochain that is not a 3-cocycle must fail the pentagon check,
+        # otherwise the test above would be vacuous.
+        self.assertFalse(_satisfies_pentagon("broken"))
+
+    def test_cpp_iscocycle_matches_oracle(self):
+        self.assertEqual(DijkgraafWitten.isCocycle(Cocycle.Trivial),
+                         _satisfies_pentagon("trivial"))
+        self.assertEqual(DijkgraafWitten.isCocycle(Cocycle.Sign),
+                         _satisfies_pentagon("sign"))
+        self.assertTrue(DijkgraafWitten.isCocycle(Cocycle.Trivial))
+        self.assertTrue(DijkgraafWitten.isCocycle(Cocycle.Sign))
+
+
+class TestPartitionFunctionConventionAnchor(unittest.TestCase):
+    """Z_Trivial(W) = 2^{b₁(W;ℤ₂) - 1} for a connected closed oriented W."""
+
+    def _assert_real(self, z, expected):
+        self.assertAlmostEqual(z.imag, 0.0, places=9)
+        self.assertAlmostEqual(z.real, expected, places=9)
+
+    def test_three_sphere(self):
+        spacetime = _three_sphere()
+        b1 = _first_betti_gf2(spacetime)
+        self.assertEqual(b1, 0)
+        z = DijkgraafWitten(spacetime, Cocycle.Trivial).partitionFunction()
+        self._assert_real(z, 2.0 ** (b1 - 1))   # ½
+        self._assert_real(z, 0.5)
+
+    def test_s2_cross_s1(self):
+        spacetime = _s2_cross_s1()
+        b1 = _first_betti_gf2(spacetime)
+        self.assertEqual(b1, 1)
+        z = DijkgraafWitten(spacetime, Cocycle.Trivial).partitionFunction()
+        self._assert_real(z, 2.0 ** (b1 - 1))   # 1
+        self._assert_real(z, 1.0)
+
+
+class TestPartitionFunctionAgainstOracle(unittest.TestCase):
+    """The C++ state sum equals an independent numpy reimplementation — a direct
+    check on the edge-index map, the ∂₂ transpose, and the orientation signs."""
+
+    def _check(self, spacetime):
+        for cocycle, kind in ((Cocycle.Trivial, "trivial"), (Cocycle.Sign, "sign")):
+            with self.subTest(cocycle=kind):
+                z = DijkgraafWitten(spacetime, cocycle).partitionFunction()
+                self.assertAlmostEqual(z.imag, 0.0, places=9)
+                self.assertAlmostEqual(z.real, _dw_partition_oracle(spacetime, kind),
+                                       places=9)
+
+    def test_three_sphere(self):
+        self._check(_three_sphere())
+
+    def test_s2_cross_s1(self):
+        self._check(_s2_cross_s1())
+
+
+class TestSignCocycleNegativeControls(unittest.TestCase):
+    """On manifolds with vanishing mod-2 cup cube the sign cocycle does not
+    distinguish: Z_Sign == Z_Trivial. (S³ and S²×S¹; T³ would belong here too.)"""
+
+    def _assert_equal_invariants(self, spacetime):
+        z_trivial = DijkgraafWitten(spacetime, Cocycle.Trivial).partitionFunction()
+        z_sign = DijkgraafWitten(spacetime, Cocycle.Sign).partitionFunction()
+        self.assertAlmostEqual(abs(z_sign - z_trivial), 0.0, places=9)
+
+    def test_three_sphere_not_distinguished(self):
+        self._assert_equal_invariants(_three_sphere())
+
+    def test_s2_cross_s1_not_distinguished(self):
+        self._assert_equal_invariants(_s2_cross_s1())
+
+
+class TestSignCocyclePositiveControl(unittest.TestCase):
+    """The positive control (a manifold the sign cocycle *does* distinguish)."""
+
+    def test_lens_space_distinction_is_deferred(self):
+        # The sign cocycle distinguishes W iff the mod-2 cup cube t³ ≠ 0 on W —
+        # a lens space such as RP³, NOT T³ (whose cup cube vanishes; see module
+        # docstring). The brute-force state sum (gf2Span over the whole flat
+        # space, nullity = |V| ≲ 24) admits only the vertex-minimal RP³, and no
+        # RP³/lens-space fixture exists yet, so this control is deferred.
+        #
+        # Pinned target for the follow-up fixture (b₁(RP³;ℤ₂)=1, t³≠0):
+        #   Z_Trivial(RP³) = 2^{1-1}                       = 1
+        #   Z_Sign(RP³)    = ½·(1 + (-1)^{⟨t³,[RP³]⟩})·... = 0   (Z_Sign ≠ Z_Trivial)
+        z_trivial_rp3 = 2.0 ** (1 - 1)
+        z_sign_rp3 = 0.5 * (1 + (-1) ** 1)  # gauge-reduced: ½(W(0) + W(t))
+        self.assertEqual(z_trivial_rp3, 1.0)
+        self.assertEqual(z_sign_rp3, 0.0)
+        self.assertNotEqual(z_sign_rp3, z_trivial_rp3)
+        self.skipTest("RP³/lens-space fixture not yet available; see module "
+                      "docstring (ticket #108's T³ example is incorrect — the "
+                      "cup cube vanishes on T³).")
+
+
+class TestDimensionGuard(unittest.TestCase):
+    """The state sum is defined for closed oriented 3-manifolds only."""
+
+    def test_two_sphere_raises(self):
+        spacetime = _two_sphere()  # dimension 2
+        with self.assertRaises(RuntimeError):
+            DijkgraafWitten(spacetime, Cocycle.Trivial).partitionFunction()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

New `cobordism::DijkgraafWitten` — the closed-3-manifold ℤ₂ Dijkgraaf–Witten state sum

```
Z(W) = (1/2^|V|) Σ_{flat g} ∏_t ω(g_01, g_12, g_23)^{ε_t}
```

- `enum class Cocycle { Trivial, Sign }` — the two classes of `Z³(ℤ₂; U(1))`: `ω≡1` and `ω(a,b,c)=(-1)^{abc}`.
- `DijkgraafWitten(std::shared_ptr<Spacetime> W, Cocycle w)`.
- `partitionFunction()`: flat connections = `gf2Nullspace(d₁ mod 2)` with `d₁ = ∂₂ᵀ` (asserts `d₁·g ≡ 0` on every triangle for each basis cocycle), enumerated via `gf2Span`; each tetrahedron read on its Alexander–Whitney edges `(v0,v1),(v1,v2),(v2,v3)` mapped to their C₁ indices, weighted `ω^{ε_t}` from `fundamentalClass()`; summed and divided by `2^{|V|}`.
- `static bool isCocycle(Cocycle)`: brute-forces the normalized 3-cocycle (pentagon) identity over ℤ₂⁴.
- Added `ChainComplex::kSimplexVertices(int k)` (the k-simplex vertex tuples in C_k order — the edge ordering guaranteed consistent with `boundaryMatrix(2)`'s rows); `orientedTopSimplices()` now delegates to it.

`cobordism` has no Python facade, so the binding alone exposes it as `tessera.cobordism.DijkgraafWitten` / `tessera.cobordism.Cocycle`.

## Results (convention anchor `Z_Trivial(W) = 2^{b₁(W;ℤ₂)-1}`)

| W | b₁(ℤ₂) | Z_Trivial | Z_Sign |
|---|---|---|---|
| S³ (`SimplexBoundarySphere(3)`) | 0 | 0.5 | 0.5 |
| S²×S¹ (`SimplicialProduct(S²,S¹)`) | 1 | 1 | 1 |

Both match `2^{b₁-1}` exactly, and the C++ sum agrees with an independent numpy reimplementation of the whole state sum (a true oracle for the edge-index map, the ∂₂ transpose, and the orientation signs).

## ⚠️ Correction to the ticket's T³ example

The ticket proposed **T³** as the manifold where the sign cocycle distinguishes (`Z_Sign(T³) ≠ Z_Trivial(T³)`). **This is mathematically incorrect.** `H*(T³;ℤ₂)` is the exterior algebra `Λ(x,y,z)`, in which every degree-one class squares to zero, so the mod-2 cup cube `g∪g∪g` vanishes for *every* `g ∈ H¹(T³;ℤ₂)` — hence `Z_Sign(T³) = Z_Trivial(T³) = 4`. The same vanishing holds on S²×S¹ and S³ (asserted here as **negative controls**).

The sign cocycle distinguishes `W` **iff the cup cube `t³ ≠ 0`**, i.e. on a **lens space** (RP³ = L(2,1) and friends). This matches the cobordism design note (`docs/source/quantum-experiments/cobordism.md` §6, P3): *"nontrivial ω distinguishable from trivial on **some** W"*, listing *"Σ×S¹, T³, lens spaces"* as candidate topologies — the distinguishers among them are the lens spaces.

**Positive control deferred.** The only closed oriented 3-manifold with `t³ ≠ 0` small enough for this brute-force sum (`gf2Span` enumerates the full flat space, so `nullity = |V| ≲ 24`) is the vertex-minimal RP³, and tessera ships no RP³/lens-space fixture yet (and no topology library is available to synthesize a verified one). Per #108's own guidance for unavailable fixtures, the control is noted as deferred; `test_lens_space_distinction_is_deferred` pins the target values (`Z_Trivial(RP³)=1`, `Z_Sign(RP³)=0`) for the follow-up fixture. The implementation already handles such a manifold once a fixture exists.

## Tests

`tests/cobordism/test_dijkgraaf_witten_python.py`:
- 3-cocycle (pentagon) identity **first** (Python oracle, with a non-cocycle negative control for teeth, cross-checked against `isCocycle`).
- Convention anchor `Z_Trivial = 2^{b₁-1}` on S³ and S²×S¹.
- Independent numpy oracle for the whole state sum.
- `Z_Sign == Z_Trivial` negative controls (S³, S²×S¹).
- Dimension guard (non-3-manifold raises).

```
$ poetry run pytest tests/cobordism -q
145 passed, 1 skipped, 298 subtests passed in 1.17s
```

(The 1 skip is the deferred lens-space positive control.)

Closes #108.