### PR TITLE
cobordism: HodgeLaplacian Lorentzian d'Alembertian (§5.6)

### DIFF
--- a/include/cobordism/HodgeLaplacian.h
+++ b/include/cobordism/HodgeLaplacian.h
@@ -60,6 +60,28 @@ using namespace ::tessera::spacetime;
 /// a same-kernel cross-check. A negative \f$ k \f$ throws; a \f$ k \f$ beyond the
 /// top dimension has no \f$ k \f$-cells and yields empty results.
 ///
+/// ## Lorentzian d'Alembertian (§5.6)
+///
+/// The `lorentzian = true` path keeps the same metric-Hodge construction but
+/// weights \f$ W_k \f$ with the **signed** `Simplex::volume()` — the honest,
+/// signature-respecting content in which a timelike edge (\f$ l^2 < 0 \f$) carries
+/// a *negative* volume — instead of \f$ |\text{volume}| \f$. The inner product
+/// then goes **indefinite**: the symmetric \f$ W_k^{1/2} \f$ similarity breaks
+/// (the square root of a negative weight is imaginary), so the operator
+/// \f$ L_k = \partial_k^*\partial_k + \partial_{k+1}\partial_{k+1}^* \f$ with the
+/// *signed* metric adjoint \f$ \partial_k^* = W_k^{-1}\partial_k^{\top}W_{k-1} \f$
+/// is assembled **directly** — \f$ L_k = W_k^{-1}\partial_k^{\top}W_{k-1}\partial_k
+/// + \partial_{k+1}W_{k+1}^{-1}\partial_{k+1}^{\top}W_k \f$ — and is generally
+/// **non-self-adjoint** (a discrete d'Alembertian). It is diagonalized with a
+/// general `Eigen::EigenSolver`, so eigenvalues may be negative or complex. The
+/// clean \f$ \ker L_k \cong H_k \f$ degrades to a pseudo-Hodge decomposition:
+/// "harmonic" becomes the small-\f$ |\lambda| \f$ near-kernel, and a near-kernel
+/// representative \f$ h \f$ may be **null** in the indefinite metric
+/// (\f$ \langle h,h\rangle_W = \sum_i W_{k,i}|h_i|^2 \approx 0 \f$). When every
+/// \f$ l^2 > 0 \f$ the signed content equals \f$ |\text{volume}| \f$ and this path
+/// reproduces the Euclidean spectrum/kernel above. The Euclidean
+/// (`lorentzian = false`) path is untouched.
+///
 /// For \f$ k = 0 \f$ vertices are indexed by a stable order (sorted vertex id
 /// \f$ \to 0..N-1 \f$); for \f$ k \geq 1 \f$ the \f$ k \f$-cells follow the
 /// canonical `ChainComplex` column order (sorted vertex-id tuples), so the
@@ -104,15 +126,22 @@ class HodgeLaplacian {
     /// weights (the combinatorial Laplacian); `metric` is ignored at \f$ k = 0 \f$.
     /// @throws std::runtime_error for \f$ k < 0 \f$. Empty for \f$ k \f$ above the
     ///   top dimension.
+    /// With `lorentzian = true` (and `metric`, \f$ k \geq 1 \f$) it is instead the
+    /// **signed-weight d'Alembertian** assembled directly (generally
+    /// non-symmetric; the imaginary parts of the returned entries are still zero,
+    /// the operator being real).
     [[nodiscard]] std::vector<std::complex<double>> laplacian(int k = 0,
-                                                             bool metric = true) const;
+                                                             bool metric = true,
+                                                             bool lorentzian = false) const;
 
     /// Diagonal inner-product weights \f$ W_k \f$ (length \f$ |C_k| \f$) in the
     /// canonical `ChainComplex` column order: the per-\f$ k \f$-simplex Euclidean
     /// volume (`Simplex::volume`, magnitude; degenerate cells fall back to 1 to
     /// keep \f$ W_k \f$ positive). \f$ W_0 = I \f$ (all ones). Empty for \f$ k < 0 \f$
-    /// or \f$ k \f$ above the top dimension.
-    [[nodiscard]] std::vector<double> weights(int k) const;
+    /// or \f$ k \f$ above the top dimension. With `lorentzian = true` the entries
+    /// are the **signed** `Simplex::volume()` (timelike cells negative; degenerate
+    /// cells still fall back to \f$ +1 \f$ so \f$ W_k \f$ stays invertible).
+    [[nodiscard]] std::vector<double> weights(int k, bool lorentzian = false) const;
 
     /// Whether \f$ \| L - L^\dagger \| \le \text{tol} \f$ (Frobenius norm) for
     /// the \f$ k = 0 \f$ Laplacian. True by construction.
@@ -149,6 +178,44 @@ class HodgeLaplacian {
                                                               double tol = 1e-9,
                                                               bool metric = true) const;
 
+    /// === Lorentzian (signed-weight) d'Alembertian, \f$ k \geq 1 \f$ (§5.6) ===
+    ///
+    /// Eigenvalues of the signed-weight \f$ L_k \f$ (the non-self-adjoint
+    /// d'Alembertian), as **complex** numbers sorted ascending by
+    /// \f$ (\mathrm{Re},\mathrm{Im}) \f$ — they may be negative or come in complex
+    /// conjugate pairs. `metric = false` falls back to unit weights (positive, so
+    /// the spectrum is the real combinatorial one). On an all-spacelike complex
+    /// the spectrum reproduces `eigenvalues(k, metric)` (real). For \f$ k = 0 \f$
+    /// this is the signed graph Laplacian \f$ \partial_1 W_1^{-1}\partial_1^\top \f$
+    /// (\f$ W_0 = I \f$), distinct from the Hermitian \f$ k = 0 \f$ path above.
+    /// @throws std::runtime_error for \f$ k < 0 \f$. Empty above the top dimension.
+    [[nodiscard]] std::vector<std::complex<double>> lorentzianEigenvalues(
+        int k, bool metric = true) const;
+
+    /// Eigenvectors of the signed-weight \f$ L_k \f$ as a flat row-major
+    /// \f$ M\times M \f$ complex array; column \f$ j \f$ (entries \f$ iM + j \f$)
+    /// is the eigenvector for the \f$ j \f$-th eigenvalue of
+    /// `lorentzianEigenvalues(k, metric)` (same order). @throws for \f$ k < 0 \f$.
+    [[nodiscard]] std::vector<std::complex<double>> lorentzianEigenvectors(
+        int k, bool metric = true) const;
+
+    /// Near-kernel ("harmonic") representatives of the d'Alembertian: the
+    /// eigenvectors with \f$ |\lambda| < \text{tol} \f$, as a flat row-major
+    /// \f$ M\times H \f$ complex array (\f$ H \f$ columns). For an all-spacelike
+    /// complex \f$ H = b_k \f$; with genuine timelike cells the count can differ
+    /// (the pseudo-Hodge decomposition). @throws for \f$ k < 0 \f$.
+    [[nodiscard]] std::vector<std::complex<double>> lorentzianHarmonics(
+        int k, double tol = 1e-9, bool metric = true) const;
+
+    /// The indefinite norms \f$ \langle h,h\rangle_W = \sum_i W_{k,i}|h_i|^2 \f$
+    /// (signed \f$ W_k \f$) of the near-kernel representatives, one per column of
+    /// `lorentzianHarmonics(k, tol, metric)` and in the same order. A value
+    /// \f$ \approx 0 \f$ flags a **null** harmonic (a lightlike kernel direction);
+    /// all entries are positive on an all-spacelike complex. @throws for
+    /// \f$ k < 0 \f$.
+    [[nodiscard]] std::vector<double> lorentzianNullNorms(
+        int k, double tol = 1e-9, bool metric = true) const;
+
   private:
     std::shared_ptr<Spacetime> st_;
 
@@ -174,12 +241,27 @@ class HodgeLaplacian {
     };
     mutable std::unordered_map<long long, MetricSpectrum> metricCache_{};
 
+    // General (non-symmetric) eigendecomposition of the signed-weight d'Alembertian
+    // L_k, cached per (k, metric). Eigenvalues/eigenvectors are complex and sorted
+    // ascending by (Re, Im); `wk` is the signed weight diagonal kept for the
+    // indefinite null-norm <h,h>_W = sum_i wk[i] |h_i|^2.
+    struct LorentzianSpectrum {
+      int dim{0};
+      std::vector<std::complex<double>> evals{};         // sorted, length |C_k|
+      std::vector<std::complex<double>> evecs{};         // flat |C_k|*|C_k|, columns
+      std::vector<double> wk{};                          // signed W_k, length |C_k|
+    };
+    mutable std::unordered_map<long long, LorentzianSpectrum> lorentzianCache_{};
+
     // Throw for k < 0 (no negative-degree chains).
     static void requireNonNegativeDegree(int k);
 
     // Build/fetch the cached symmetric spectrum of L_k^sym (k >= 1). Key folds in
     // `metric` so the metric and combinatorial spectra are cached separately.
     const MetricSpectrum &ensureMetricSpectrum(int k, bool metric) const;
+
+    // Build/fetch the cached general spectrum of the signed-weight d'Alembertian.
+    const LorentzianSpectrum &ensureLorentzianSpectrum(int k, bool metric) const;
 
     // Assemble the adjacency (flat row-major N*N) and degree (length N) from the
     // current edge weights/phases, using the stable vertex order. Kept Eigen-free

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -130,7 +130,15 @@ d_{k+1} d_{k+1}^T) as a same-kernel cross-check. k-cells follow the canonical
 ChainComplex column order, so the matrices align with boundaryMatrix(k) and
 weights(k). Negative k raises; k above the top dimension yields empty results.
 Spectra are computed lazily and cached. This is the operator only — fluxes,
-cycle bases, and Betti numbers belong to WilsonLoop / ChainComplex.)doc")
+cycle bases, and Betti numbers belong to WilsonLoop / ChainComplex.
+
+Lorentzian d'Alembertian (§5.6): the lorentzian* methods weight W_k with the
+SIGNED Simplex.volume (timelike l^2 < 0 ⇒ negative volumes), so the inner product
+goes indefinite and L_k = d_k* d_k + d_{k+1} d_{k+1}* is assembled directly and is
+generally non-self-adjoint — eigenvalues may be negative or complex. ker L_k ~= H_k
+degrades: 'harmonic' becomes the small-|lambda| near-kernel and a representative h
+can be null (<h,h>_W = sum_i W_{k,i}|h_i|^2 ~= 0). All-spacelike ⇒ reproduces the
+Euclidean spectrum/kernel.)doc")
       .def(py::init<std::shared_ptr<Spacetime>>(), py::arg("spacetime"),
            "Build the Hodge Laplacian operator over a triangulation.")
       .def("adjacency", &HodgeLaplacian::adjacency,
@@ -140,15 +148,19 @@ cycle bases, and Betti numbers belong to WilsonLoop / ChainComplex.)doc")
            "Degree vector (length N, real): D_ii = sum |squaredLength| over "
            "incident edges (magnitude convention).")
       .def("laplacian", &HodgeLaplacian::laplacian, py::arg("k") = 0,
-           py::arg("metric") = true,
+           py::arg("metric") = true, py::arg("lorentzian") = false,
            "Laplacian L_k as a flat row-major complex array: N*N for k=0 "
            "(L = D - A), else |C_k|*|C_k| (the symmetric metric Laplacian; "
            "imag 0). metric=False uses unit weights (combinatorial) for k>=1 and "
-           "is ignored at k=0. Raises for k<0; empty above the top dimension.")
+           "is ignored at k=0. lorentzian=True (k>=1) assembles the signed-weight "
+           "d'Alembertian directly (generally non-symmetric; still real). Raises "
+           "for k<0; empty above the top dimension.")
       .def("weights", &HodgeLaplacian::weights, py::arg("k"),
+           py::arg("lorentzian") = false,
            "Diagonal inner-product weights W_k (length |C_k|) in ChainComplex "
-           "column order: per-k-simplex |volume| (W_0 = I). Empty for k<0 or k "
-           "above the top dimension.")
+           "column order: per-k-simplex |volume| (W_0 = I). lorentzian=True returns "
+           "the signed volume (timelike cells negative). Empty for k<0 or k above "
+           "the top dimension.")
       .def("isHermitian", &HodgeLaplacian::isHermitian, py::arg("tol") = 1e-12,
            "True iff ||L - L^dagger|| <= tol (Frobenius) for the k=0 Laplacian.")
       .def("unitarityResidual", &HodgeLaplacian::unitarityResidual,
@@ -171,7 +183,31 @@ cycle bases, and Betti numbers belong to WilsonLoop / ChainComplex.)doc")
            "Harmonic representatives (eigenvectors with |lambda| < tol) as a flat "
            "row-major M*H complex array whose H columns span ker L_k ~= H_k "
            "(H = b_k). metric selects volume vs. unit weights for k>=1. Raises "
-           "for k<0; empty above the top dimension.");
+           "for k<0; empty above the top dimension.")
+      // ----- Lorentzian (signed-weight) d'Alembertian (#105, spec §5.6) -----
+      .def("lorentzianEigenvalues", &HodgeLaplacian::lorentzianEigenvalues,
+           py::arg("k"), py::arg("metric") = true,
+           "Eigenvalues of the signed-weight d'Alembertian L_k (k>=1) as complex "
+           "numbers sorted ascending by (Re, Im): may be negative or complex-"
+           "conjugate pairs (the indefinite metric ⇒ non-self-adjoint operator). "
+           "On an all-spacelike complex they reproduce eigenvalues(k). Raises for "
+           "k<0; empty above the top dimension.")
+      .def("lorentzianEigenvectors", &HodgeLaplacian::lorentzianEigenvectors,
+           py::arg("k"), py::arg("metric") = true,
+           "Eigenvectors of the signed-weight L_k as a flat row-major M*M complex "
+           "array; column j is the eigenvector for lorentzianEigenvalues(k)[j].")
+      .def("lorentzianHarmonics", &HodgeLaplacian::lorentzianHarmonics,
+           py::arg("k"), py::arg("tol") = 1e-9, py::arg("metric") = true,
+           "Near-kernel ('harmonic') representatives of the d'Alembertian "
+           "(eigenvectors with |lambda| < tol) as a flat row-major M*H complex "
+           "array. H = b_k on an all-spacelike complex; with timelike cells the "
+           "count can differ (pseudo-Hodge decomposition).")
+      .def("lorentzianNullNorms", &HodgeLaplacian::lorentzianNullNorms,
+           py::arg("k"), py::arg("tol") = 1e-9, py::arg("metric") = true,
+           "Indefinite W-norms <h,h>_W = sum_i W_{k,i} |h_i|^2 of the near-kernel "
+           "representatives, one per column of lorentzianHarmonics (same order). "
+           "A value ~0 flags a NULL (lightlike) harmonic; all positive on an "
+           "all-spacelike complex.");
 
   // Exact integer / GF(2) / inertia primitives (also exposed for direct
   // testing). Matrices are passed flat row-major with explicit dims.

--- a/src/cobordism/HodgeLaplacian.cpp
+++ b/src/cobordism/HodgeLaplacian.cpp
@@ -87,15 +87,19 @@ std::vector<std::vector<SimplexPtr>> orderedFaces(const Spacetime &K) {
 // Diagonal weights W_k (length `count`) in ChainComplex column order: the
 // per-k-simplex |volume| (Euclidean content via Simplex::volume), or all ones for
 // k == 0 or the combinatorial path. A degenerate (zero) cell falls back to 1 so
-// W_k stays positive-definite (W_k^{-1/2} is finite).
+// W_k stays positive-definite (W_k^{-1/2} is finite). With `lorentzian` the
+// **signed** volume is used (timelike cells negative ⇒ W_k indefinite); degenerate
+// cells still fall back to +1 so W_k stays invertible (W_k^{-1} is finite).
 std::vector<double> simplexWeights(const std::vector<std::vector<SimplexPtr>> &faces,
-                                   int k, int count, bool metric) {
+                                   int k, int count, bool metric,
+                                   bool lorentzian = false) {
   std::vector<double> w(static_cast<std::size_t>(std::max(count, 0)), 1.0);
   if (!metric || k == 0 || k < 0 || k >= static_cast<int>(faces.size())) return w;
   const auto &fk = faces[static_cast<std::size_t>(k)];
   for (int j = 0; j < count && j < static_cast<int>(fk.size()); ++j) {
-    const double vol = std::abs(fk[static_cast<std::size_t>(j)]->volume());
-    w[static_cast<std::size_t>(j)] = (vol > 0.0) ? vol : 1.0;
+    const double signedVol = fk[static_cast<std::size_t>(j)]->volume();
+    const double vol = lorentzian ? signedVol : std::abs(signedVol);
+    w[static_cast<std::size_t>(j)] = (std::abs(vol) > 0.0) ? vol : 1.0;
   }
   return w;
 }
@@ -149,6 +153,63 @@ Eigen::MatrixXd metricLaplacian(const Spacetime &K, int k, bool metric) {
     const Eigen::MatrixXd Bkp1 =
         wk.sqrt().matrix().asDiagonal() * dkp1 * invSqrtWkp1.matrix().asDiagonal();
     L.noalias() += Bkp1 * Bkp1.transpose();
+  }
+  return L;
+}
+
+// Signed-weight (Lorentzian) metric Hodge Laplacian for k >= 0 — the discrete
+// d'Alembertian. With W indefinite the symmetric W^{1/2} similarity breaks, so the
+// operator is assembled directly from the signed metric adjoint
+// d_k* = W_k^{-1} d_k^T W_{k-1}:
+//   L_k = W_k^{-1} d_k^T W_{k-1} d_k + d_{k+1} W_{k+1}^{-1} d_{k+1}^T W_k.
+// This is similar to the symmetric metricLaplacian when every weight is positive
+// (W_k^{-1/2} L_k W_k^{1/2} = L_k^sym), so the spectrum/kernel coincide there; with
+// signed weights it is generally NON-symmetric (a true d'Alembertian). Returns a
+// |C_k| x |C_k| real matrix (0 x 0 if no k-cells). `metric == false` ⇒ unit weights
+// (the positive combinatorial operator, no Lorentzian content).
+Eigen::MatrixXd signedLaplacian(const Spacetime &K, int k, bool metric) {
+  const ChainComplex cc = ChainComplex::fromSpacetime(K);
+  const int n = cc.dimension();
+  const int nk = static_cast<int>(cc.numSimplices(k));
+  Eigen::MatrixXd L = Eigen::MatrixXd::Zero(nk, nk);
+  if (nk == 0) return L;
+
+  const std::vector<std::vector<SimplexPtr>> faces = orderedFaces(K);
+  const auto weightArr = [&](int kk) {
+    const std::vector<double> wv = simplexWeights(
+        faces, kk, static_cast<int>(cc.numSimplices(kk)), metric, /*lorentzian=*/true);
+    Eigen::ArrayXd a(static_cast<Eigen::Index>(wv.size()));
+    for (std::size_t i = 0; i < wv.size(); ++i) a[static_cast<Eigen::Index>(i)] = wv[i];
+    return a;
+  };
+  const auto boundary = [&](int kk, int rows, int cols) {
+    const std::vector<long> &flat = cc.boundaryMatrix(kk);
+    Eigen::MatrixXd d(rows, cols);
+    for (int r = 0; r < rows; ++r)
+      for (int c = 0; c < cols; ++c)
+        d(r, c) = static_cast<double>(flat[static_cast<std::size_t>(r) * cols + c]);
+    return d;
+  };
+
+  const Eigen::ArrayXd wk = weightArr(k);
+  const Eigen::ArrayXd invWk = wk.inverse();
+
+  // Term 1: W_k^{-1} d_k^T W_{k-1} d_k (present once there are (k-1)-faces).
+  const int rows = static_cast<int>(cc.numSimplices(k - 1));
+  if (k >= 1 && rows > 0) {
+    const Eigen::MatrixXd dk = boundary(k, rows, nk);
+    const Eigen::ArrayXd wkm1 = weightArr(k - 1);
+    L.noalias() += invWk.matrix().asDiagonal() * dk.transpose() *
+                   wkm1.matrix().asDiagonal() * dk;
+  }
+
+  // Term 2: d_{k+1} W_{k+1}^{-1} d_{k+1}^T W_k (absent when there are no (k+1)-cells).
+  const int cols = (k + 1 <= n) ? static_cast<int>(cc.numSimplices(k + 1)) : 0;
+  if (cols > 0) {
+    const Eigen::MatrixXd dkp1 = boundary(k + 1, nk, cols);
+    const Eigen::ArrayXd invWkp1 = weightArr(k + 1).inverse();
+    L.noalias() += dkp1 * invWkp1.matrix().asDiagonal() * dkp1.transpose() *
+                   wk.matrix().asDiagonal();
   }
   return L;
 }
@@ -223,8 +284,20 @@ std::vector<double> HodgeLaplacian::degree() const {
   return D;
 }
 
-std::vector<cd> HodgeLaplacian::laplacian(int k, bool metric) const {
+std::vector<cd> HodgeLaplacian::laplacian(int k, bool metric, bool lorentzian) const {
   requireNonNegativeDegree(k);
+  if (lorentzian && k >= 1) {
+    // The signed-weight d'Alembertian (generally non-symmetric); real operator
+    // returned complex (imag 0) for type parity with the other paths.
+    if (!st_) return {};
+    const Eigen::MatrixXd L = signedLaplacian(*st_, k, metric);
+    const int nk = static_cast<int>(L.rows());
+    std::vector<cd> out(static_cast<std::size_t>(nk) * nk, cd(0.0, 0.0));
+    for (int i = 0; i < nk; ++i)
+      for (int j = 0; j < nk; ++j)
+        out[static_cast<std::size_t>(i) * nk + j] = cd(L(i, j), 0.0);
+    return out;
+  }
   if (k == 0) {
     // k = 0 (unchanged): L = D - A. Off-diagonal entries are -A_ij; the diagonal
     // carries D_ii (the adjacency has no diagonal in a complex without self-loops).
@@ -250,13 +323,13 @@ std::vector<cd> HodgeLaplacian::laplacian(int k, bool metric) const {
   return out;
 }
 
-std::vector<double> HodgeLaplacian::weights(int k) const {
+std::vector<double> HodgeLaplacian::weights(int k, bool lorentzian) const {
   if (k < 0 || !st_) return {};
   const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
   if (k > cc.dimension()) return {};
   const int m = static_cast<int>(cc.numSimplices(k));
   if (k == 0) return std::vector<double>(static_cast<std::size_t>(m), 1.0);
-  return simplexWeights(orderedFaces(*st_), k, m, /*metric=*/true);
+  return simplexWeights(orderedFaces(*st_), k, m, /*metric=*/true, lorentzian);
 }
 
 const HodgeLaplacian::MetricSpectrum &HodgeLaplacian::ensureMetricSpectrum(
@@ -283,6 +356,45 @@ const HodgeLaplacian::MetricSpectrum &HodgeLaplacian::ensureMetricSpectrum(
     }
   }
   return metricCache_.emplace(key, std::move(sp)).first->second;
+}
+
+const HodgeLaplacian::LorentzianSpectrum &HodgeLaplacian::ensureLorentzianSpectrum(
+    int k, bool metric) const {
+  const long long key = static_cast<long long>(k) * 2 + (metric ? 1 : 0);
+  const auto cached = lorentzianCache_.find(key);
+  if (cached != lorentzianCache_.end()) return cached->second;
+
+  LorentzianSpectrum sp;
+  if (st_) {
+    const Eigen::MatrixXd L = signedLaplacian(*st_, k, metric);
+    const int nk = static_cast<int>(L.rows());
+    sp.dim = nk;
+    sp.evals.assign(static_cast<std::size_t>(nk), cd(0.0, 0.0));
+    sp.evecs.assign(static_cast<std::size_t>(nk) * nk, cd(0.0, 0.0));
+    sp.wk = weights(k, /*lorentzian=*/true);
+    if (nk > 0) {
+      // Indefinite metric ⇒ the operator is non-self-adjoint; a general solver is
+      // needed (eigenvalues may be negative or complex-conjugate pairs).
+      Eigen::EigenSolver<Eigen::MatrixXd> es(L);
+      const Eigen::VectorXcd lam = es.eigenvalues();
+      const Eigen::MatrixXcd V = es.eigenvectors();
+
+      // Stable, reproducible order: ascending by (Re, Im) of the eigenvalue.
+      std::vector<int> order(static_cast<std::size_t>(nk));
+      for (int i = 0; i < nk; ++i) order[static_cast<std::size_t>(i)] = i;
+      std::sort(order.begin(), order.end(), [&](int a, int b) {
+        if (lam[a].real() != lam[b].real()) return lam[a].real() < lam[b].real();
+        return lam[a].imag() < lam[b].imag();
+      });
+      for (int c = 0; c < nk; ++c) {
+        const int src = order[static_cast<std::size_t>(c)];
+        sp.evals[static_cast<std::size_t>(c)] = lam[src];
+        for (int r = 0; r < nk; ++r)
+          sp.evecs[static_cast<std::size_t>(r) * nk + c] = V(r, src);
+      }
+    }
+  }
+  return lorentzianCache_.emplace(key, std::move(sp)).first->second;
 }
 
 void HodgeLaplacian::ensureDecomposition() const {
@@ -396,6 +508,57 @@ std::vector<cd> HodgeLaplacian::harmonics(int k, double tol, bool metric) const 
     for (std::size_t jj = 0; jj < M; ++jj)
       H[i * M + jj] = (*evecs)[i * N + cols[jj]];
   return H;
+}
+
+std::vector<cd> HodgeLaplacian::lorentzianEigenvalues(int k, bool metric) const {
+  requireNonNegativeDegree(k);
+  return ensureLorentzianSpectrum(k, metric).evals;
+}
+
+std::vector<cd> HodgeLaplacian::lorentzianEigenvectors(int k, bool metric) const {
+  requireNonNegativeDegree(k);
+  return ensureLorentzianSpectrum(k, metric).evecs;
+}
+
+std::vector<cd> HodgeLaplacian::lorentzianHarmonics(int k, double tol,
+                                                    bool metric) const {
+  requireNonNegativeDegree(k);
+  const LorentzianSpectrum &sp = ensureLorentzianSpectrum(k, metric);
+  const std::size_t N = static_cast<std::size_t>(sp.dim);
+  if (N == 0) return {};
+
+  std::vector<std::size_t> cols;
+  for (std::size_t j = 0; j < N; ++j)
+    if (std::abs(sp.evals[j]) < tol) cols.push_back(j);
+
+  const std::size_t H = cols.size();
+  std::vector<cd> out(N * H, cd(0.0, 0.0));
+  for (std::size_t i = 0; i < N; ++i)
+    for (std::size_t jj = 0; jj < H; ++jj)
+      out[i * H + jj] = sp.evecs[i * N + cols[jj]];
+  return out;
+}
+
+std::vector<double> HodgeLaplacian::lorentzianNullNorms(int k, double tol,
+                                                        bool metric) const {
+  requireNonNegativeDegree(k);
+  const LorentzianSpectrum &sp = ensureLorentzianSpectrum(k, metric);
+  const std::size_t N = static_cast<std::size_t>(sp.dim);
+  if (N == 0) return {};
+
+  std::vector<double> norms;
+  for (std::size_t j = 0; j < N; ++j) {
+    if (std::abs(sp.evals[j]) >= tol) continue;
+    // Indefinite W-norm <h,h>_W = sum_i W_{k,i} |h_i|^2 (real; signed W_k). A
+    // value ≈ 0 marks a null (lightlike) harmonic direction.
+    double nrm = 0.0;
+    for (std::size_t i = 0; i < N; ++i) {
+      const cd hi = sp.evecs[i * N + j];
+      nrm += sp.wk[i] * std::norm(hi);  // std::norm = |hi|^2
+    }
+    norms.push_back(nrm);
+  }
+  return norms;
 }
 
 }  // namespace tessera::cobordism

--- a/tests/cobordism/test_hodge_laplacian_lorentzian_python.py
+++ b/tests/cobordism/test_hodge_laplacian_lorentzian_python.py
@@ -1,0 +1,460 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Lorentzian (signed-weight) Hodge Laplacian — the discrete d'Alembertian (#105).
+
+#104 gave the Euclidean metric Hodge Laplacian L_k (k>=1) with positive
+|volume| weights: symmetric, PSD, ker L_k ~= H_k. This suite exercises the
+Lorentzian variant, in which the inner-product weights W_k are the *signed*
+Simplex.volume() — timelike edges (l^2 < 0) carry negative k-volumes, so W goes
+indefinite and L_k = d_k* d_k + d_{k+1} d_{k+1}* (d_k* = W_k^-1 d_k^T W_{k-1}) is
+the non-self-adjoint d'Alembertian, diagonalized with a general eigensolver.
+
+Primary fixture — the 3-cycle S^1 (b_1 = 1) with one edge made timelike — admits
+a closed-form answer that pins the implementation exactly:
+
+  * edges (0,1),(0,2) spacelike (l^2 = 1 -> signed volume +1); edge (1,2) timelike
+    (l^2 = -alpha^2 -> signed volume -alpha), so W_1 = diag(1, 1, -alpha);
+  * L_1 = W_1^-1 d_1^T d_1 has eigenvalues  {0, 3, 1 - 2/alpha}  (derived below):
+      - the 0 mode is the 1-cycle (the kernel of d_1 is untouched by W_1^-1);
+      - 1 - 2/alpha < 0 for alpha < 2  =>  L_1 is NOT positive-semidefinite
+        (a genuine d'Alembertian), reaches 0 at alpha = 2 (a defective crossing),
+        and is positive again for alpha > 2;
+  * the harmonic (the cycle, |h_i|^2 = 1/3 each) has indefinite norm
+      <h,h>_W = (1 + 1 - alpha)/3 = (2 - alpha)/3,
+    which is POSITIVE for alpha < 2, NULL at alpha = 2, NEGATIVE for alpha > 2 —
+    i.e. the harmonic representative becomes null exactly at the alpha=2 crossing
+    (spec sec 5.6, "record where harmonic representatives become null").
+
+What is *recorded* (vs. hard-asserted) for the larger / CDT fixtures, where the
+geometry is not closed-form, is the spectrum's departure from the nonneg-real
+axis (indefiniteness), the near-kernel count vs. b_k (the pseudo-Hodge
+decomposition), and which near-kernel representatives are null.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+TOL = 1e-7  # near-kernel threshold (|lambda| < TOL counts as harmonic)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders
+# --------------------------------------------------------------------------- #
+def _from_simplices(num_vertices, simplices):
+    """Build a Spacetime from explicit simplex vertex tuples (vertices
+    0..num_vertices-1). createSimplex auto-creates every sub-edge."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    verts = [st.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        st.createSimplex([verts[i] for i in simplex])
+    return st
+
+
+def _edge(st, a, b):
+    for e in st.getEdgeList().toVector():
+        if {e.getSource().getId(), e.getTarget().getId()} == {a, b}:
+            return e
+    raise KeyError((a, b))
+
+
+def _set_all_spacelike(st, l2=1.0):
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(l2)
+        e.setPhase(0.0)
+    return st
+
+
+def _triangle_cycle():
+    """S^1 as the 3-cycle 0-1-2-0 (b_1 = 1); all-spacelike unit edges."""
+    return _set_all_spacelike(_from_simplices(3, [(0, 1), (1, 2), (2, 0)]), 1.0)
+
+
+def _triangle_one_timelike(alpha):
+    """The 3-cycle with edge (1,2) timelike: l^2 = -alpha^2 (signed volume
+    -alpha); edges (0,1),(0,2) spacelike (l^2 = 1)."""
+    st = _triangle_cycle()
+    _edge(st, 1, 2).setSquaredLength(-(alpha ** 2))
+    return st
+
+
+def _path():
+    """Open path 0-1-2 (a tree; b_1 = 0)."""
+    return _set_all_spacelike(_from_simplices(3, [(0, 1), (1, 2)]), 1.0)
+
+
+def _testbed():
+    """Square 0-1-2-3 + diagonal 0-2 (1-complex; b_1 = 2)."""
+    return _set_all_spacelike(
+        _from_simplices(4, [(0, 1), (1, 2), (2, 3), (3, 0), (0, 2)]), 1.0)
+
+
+def _filled_square():
+    """Square 0-1-2-3 with the triangle (0,1,2) FILLED as a 2-cell and (0,2,3)
+    left open: b_1 = 1, and the 2-cell makes the k=1 operator carry BOTH the d_1
+    and d_2 terms (unlike the pure 1-complexes above)."""
+    return _set_all_spacelike(
+        _from_simplices(4, [(0, 1, 2), (0, 2), (2, 3), (3, 0)]), 1.0)
+
+
+def _filled_square_timelike(alpha):
+    """The filled square with its shared diagonal (0,2) timelike — exercises the
+    indefinite d'Alembertian on a both-terms (d_1 and d_2) k=1 operator."""
+    st = _filled_square()
+    _edge(st, 0, 2).setSquaredLength(-(alpha ** 2))
+    return st
+
+
+def _torus_raw():
+    """T^2 = S^1 x S^1 via the proven SimplicialProduct + CDT path (b = [1,2,1]),
+    edges left at their CDT-assigned lengths (a Lorentzian time structure)."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    topology = tessera.SimplicialProduct(tessera.SimplexBoundarySphere(1),
+                                         tessera.SimplexBoundarySphere(1))
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0, tessera.PREFERRED,
+                           topology)
+    st.build()
+    return st
+
+
+def _torus():
+    """All-spacelike T^2 (unit edges), the #104 Euclidean fixture."""
+    return _set_all_spacelike(_torus_raw(), 1.0)
+
+
+def _torus_lorentzian(alpha):
+    """T^2 with genuine timelike edges. The SimplicialProduct(S^1,S^1) build is
+    geometrically flat (a single time slice), so we declare a deterministic third
+    of the edges timelike (l^2 = -alpha^2) by their sorted (src,tgt) order — the
+    ticket's "set some edges' squaredLength < 0 via setSquaredLength" on a real
+    (CDT-built), both-d_1-and-d_2-terms complex. Returns (spacetime, num_timelike)."""
+    st = _torus_raw()
+    edges = sorted(st.getEdgeList().toVector(),
+                   key=lambda e: tuple(sorted((e.getSource().getId(),
+                                               e.getTarget().getId()))))
+    n_time = 0
+    for i, e in enumerate(edges):
+        e.setPhase(0.0)
+        if i % 3 == 0:  # every third edge is timelike
+            e.setSquaredLength(-(alpha ** 2))
+            n_time += 1
+        else:
+            e.setSquaredLength(1.0)
+    return st, n_time
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _betti(st, k):
+    return cob.ChainComplex.fromSpacetime(st).bettiNumbers()[k]
+
+
+def _nk(st, k):
+    return cob.ChainComplex.fromSpacetime(st).numSimplices(k)
+
+
+def _lor_matrix(st, k, metric=True):
+    nk = _nk(st, k)
+    flat = cob.HodgeLaplacian(st).laplacian(k, metric, True)  # lorentzian=True
+    return np.array(flat, dtype=complex).reshape(nk, nk)
+
+
+def _lor_eigs(st, k, metric=True):
+    return np.array(cob.HodgeLaplacian(st).lorentzianEigenvalues(k, metric),
+                    dtype=complex)
+
+
+def _near_kernel_count(st, k, metric=True, tol=TOL):
+    return int(np.sum(np.abs(_lor_eigs(st, k, metric)) < tol))
+
+
+def _null_norms(st, k, metric=True, tol=1e-9):
+    return np.array(cob.HodgeLaplacian(st).lorentzianNullNorms(k, tol, metric),
+                    dtype=float)
+
+
+def _is_not_psd(eigs, tol=1e-6):
+    """A genuine d'Alembertian: some eigenvalue is off the nonneg-real axis."""
+    return bool(np.any(eigs.real < -tol) or np.any(np.abs(eigs.imag) > tol))
+
+
+# --------------------------------------------------------------------------- #
+# (1) Euclidean consistency: all-spacelike => signed volume == |volume|
+# --------------------------------------------------------------------------- #
+class TestLorentzianEuclideanConsistency(unittest.TestCase):
+    """On an all-spacelike complex the signed weights equal |volume|, so the
+    Lorentzian path reproduces #104: real spectrum equal to eigenvalues(k), the
+    same kernel dimension b_k, and no null harmonics."""
+
+    CASES = (("triangle k=1", _triangle_cycle, 1),
+             ("path k=1", _path, 1),
+             ("testbed k=1", _testbed, 1),
+             ("filled-square k=1", _filled_square, 1),  # both d_1 and d_2 terms
+             ("torus k=1", _torus, 1),                  # both d_1 and d_2 terms
+             ("torus k=2", _torus, 2))
+
+    def test_spectrum_matches_euclidean_and_is_real(self):
+        for name, build, k in self.CASES:
+            with self.subTest(case=name):
+                st = build()
+                hl = cob.HodgeLaplacian(st)
+                lor = np.sort(_lor_eigs(st, k).real)
+                euc = np.sort(np.array(hl.eigenvalues(k), dtype=float))
+                np.testing.assert_allclose(lor, euc, atol=1e-8)
+                # eigenvalues come back essentially real (indefinite-free here)
+                self.assertLess(np.max(np.abs(_lor_eigs(st, k).imag)), 1e-8)
+
+    def test_kernel_dimension_equals_betti(self):
+        for name, build, k in self.CASES:
+            with self.subTest(case=name):
+                st = build()
+                self.assertEqual(_near_kernel_count(st, k), _betti(st, k))
+
+    def test_no_null_harmonics_when_all_spacelike(self):
+        for name, build, k in self.CASES:
+            with self.subTest(case=name):
+                st = build()
+                norms = _null_norms(st, k)
+                self.assertEqual(len(norms), _betti(st, k))
+                # every harmonic has strictly positive (definite) W-norm
+                if norms.size:
+                    self.assertGreater(np.min(norms), 1e-6)
+
+    def test_signed_weights_equal_abs_weights_when_spacelike(self):
+        st = _torus()
+        hl = cob.HodgeLaplacian(st)
+        for k in (1, 2):
+            with self.subTest(k=k):
+                np.testing.assert_allclose(np.array(hl.weights(k, True)),
+                                           np.array(hl.weights(k, False)),
+                                           atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# (2) The Lorentzian d'Alembertian — closed-form triangle fixture
+# --------------------------------------------------------------------------- #
+class TestLorentzianDAlembertian(unittest.TestCase):
+    """The 3-cycle with one timelike edge: indefinite, non-symmetric, with the
+    closed-form spectrum {0, 3, 1 - 2/alpha} and harmonic null-norm (2-alpha)/3."""
+
+    def test_signed_weights_record_the_timelike_edge(self):
+        # W_1 = diag(+1, +1, -alpha) in sorted-edge order (0,1),(0,2),(1,2).
+        st = _triangle_one_timelike(2.0)
+        w = np.array(cob.HodgeLaplacian(st).weights(1, True))
+        np.testing.assert_allclose(np.sort(w), [-2.0, 1.0, 1.0], atol=1e-12)
+        # the Euclidean |volume| weighting stays all-positive
+        w_abs = np.array(cob.HodgeLaplacian(st).weights(1, False))
+        np.testing.assert_allclose(np.sort(w_abs), [1.0, 1.0, 2.0], atol=1e-12)
+
+    def test_operator_is_non_symmetric(self):
+        L = _lor_matrix(_triangle_one_timelike(1.0), 1)
+        self.assertGreater(np.linalg.norm(L - L.T), 1e-6)  # not self-adjoint
+        np.testing.assert_allclose(L.imag, 0.0, atol=1e-12)  # but real
+
+    def test_closed_form_spectrum(self):
+        for alpha in (0.5, 1.0, 1.5, 2.5, 3.0):
+            with self.subTest(alpha=alpha):
+                eigs = np.sort(_lor_eigs(_triangle_one_timelike(alpha), 1).real)
+                np.testing.assert_allclose(eigs, np.sort([0.0, 3.0, 1.0 - 2.0 / alpha]),
+                                           atol=1e-7)
+
+    def test_indefinite_below_alpha_two(self):
+        # alpha < 2: a strictly negative eigenvalue (1 - 2/alpha) => not PSD.
+        eigs = _lor_eigs(_triangle_one_timelike(1.0), 1)
+        self.assertTrue(_is_not_psd(eigs))
+        self.assertLess(np.min(eigs.real), -1e-6)
+        # Euclidean counterpart (all spacelike) IS PSD: {0, 3, 3}.
+        euc = _lor_eigs(_triangle_cycle(), 1)
+        self.assertFalse(_is_not_psd(euc))
+        np.testing.assert_allclose(np.sort(euc.real), [0.0, 3.0, 3.0], atol=1e-7)
+
+    def test_one_near_kernel_mode_for_alpha_away_from_two(self):
+        for alpha in (0.5, 1.0, 1.5, 2.5, 3.0):
+            with self.subTest(alpha=alpha):
+                self.assertEqual(_near_kernel_count(_triangle_one_timelike(alpha), 1), 1)
+
+    def test_harmonic_null_norm_is_two_minus_alpha_over_three(self):
+        for alpha in (0.5, 1.0, 1.5, 2.5, 3.0):
+            with self.subTest(alpha=alpha):
+                norms = _null_norms(_triangle_one_timelike(alpha), 1)
+                self.assertEqual(len(norms), 1)
+                self.assertAlmostEqual(norms[0], (2.0 - alpha) / 3.0, places=6)
+
+    def test_harmonic_is_the_cycle_with_unit_magnitude_support(self):
+        # The kernel mode is the 1-cycle: |h_i|^2 = 1/3 on every edge.
+        h = np.array(cob.HodgeLaplacian(_triangle_one_timelike(1.3))
+                     .lorentzianHarmonics(1, 1e-9), dtype=complex)
+        self.assertEqual(h.size, 3)  # one harmonic (H=1), three edges
+        np.testing.assert_allclose(np.abs(h) ** 2, np.full(3, 1.0 / 3.0), atol=1e-7)
+
+
+# --------------------------------------------------------------------------- #
+# (3) alpha sweep — how the spectrum / null-harmonic shifts vs. Euclidean
+# --------------------------------------------------------------------------- #
+class TestLorentzianAlphaSweep(unittest.TestCase):
+    """Vary the timelike/spacelike l^2 ratio (the CDT asymmetry alpha) and record
+    the spectrum and the harmonic's indefinite norm relative to the all-spacelike
+    (Euclidean) run. The harmonic null-norm crosses zero at alpha=2: positive
+    (spacelike-dominated) below, null at, negative (timelike-dominated) above."""
+
+    SWEEP = (0.25, 0.5, 1.0, 1.5, 2.5, 3.0, 4.0)
+
+    def test_record_sweep(self):
+        euclidean_null = (2.0 - 0.0) / 3.0  # alpha -> spacelike limit reference
+        records = []
+        for alpha in self.SWEEP:
+            eigs = np.sort(_lor_eigs(_triangle_one_timelike(alpha), 1).real)
+            null = _null_norms(_triangle_one_timelike(alpha), 1)[0]
+            records.append((alpha, eigs.tolist(), null))
+
+            # third eigenvalue tracks 1 - 2/alpha; null-norm tracks (2-alpha)/3.
+            np.testing.assert_allclose(eigs, np.sort([0.0, 3.0, 1.0 - 2.0 / alpha]),
+                                       atol=1e-7)
+            self.assertAlmostEqual(null, (2.0 - alpha) / 3.0, places=6)
+            # indefinite (negative eigenvalue) exactly when alpha < 2
+            self.assertEqual(np.min(eigs) < -1e-6, alpha < 2.0)
+
+        # monotone decrease of the harmonic norm, crossing zero at alpha=2.
+        nulls = [r[2] for r in records]
+        self.assertTrue(all(x > y for x, y in zip(nulls, nulls[1:])))  # strictly down
+        below = [n for a, _, n in records if a < 2.0]
+        above = [n for a, _, n in records if a > 2.0]
+        self.assertTrue(all(n > 0 for n in below))    # spacelike-dominated, positive
+        self.assertTrue(all(n < 0 for n in above))    # timelike-dominated, negative
+        self.assertLess(max(above), euclidean_null)   # all shifted below Euclidean
+
+    def test_shift_relative_to_euclidean_kernel(self):
+        # Euclidean (all-spacelike) reference: kernel dim = b_1 = 1, norm > 0.
+        st_euc = _triangle_cycle()
+        self.assertEqual(_near_kernel_count(st_euc, 1), _betti(st_euc, 1))
+        self.assertGreater(_null_norms(st_euc, 1)[0], 0.0)
+        # Under the sweep the kernel count is unchanged (1) but its norm migrates
+        # from positive through null to negative — the recorded sec-5.6 shift.
+        for alpha in self.SWEEP:
+            self.assertEqual(_near_kernel_count(_triangle_one_timelike(alpha), 1), 1)
+
+
+# --------------------------------------------------------------------------- #
+# (4) both-terms (d_1 AND d_2) genuine-Lorentzian fixtures — recording
+# --------------------------------------------------------------------------- #
+class TestLorentzianBothTerms(unittest.TestCase):
+    """Fixtures whose k=1 operator carries the d_{k+1} term too, so the two
+    indefinite pieces can cancel (the clean ker L_k ~= H_k degrades). Largely a
+    recording test: assert the operator is a genuine indefinite d'Alembertian and
+    that the near-kernel / null-norm machinery returns consistent shapes."""
+
+    def test_filled_square_is_indefinite_dalembertian(self):
+        st = _filled_square_timelike(1.5)
+        self.assertGreaterEqual(_nk(st, 2), 1)  # the 2-cell is present
+        L = _lor_matrix(st, 1)
+        self.assertGreater(np.linalg.norm(L - L.T), 1e-6)   # non-symmetric
+        eigs = _lor_eigs(st, 1)
+        self.assertTrue(_is_not_psd(eigs))                  # not PSD
+        # near-kernel modes are well-defined and their null-norms line up 1:1
+        h = np.array(cob.HodgeLaplacian(st).lorentzianHarmonics(1, TOL),
+                     dtype=complex)
+        norms = _null_norms(st, 1, tol=TOL)
+        n_edges = _nk(st, 1)
+        n_harm = 0 if n_edges == 0 else h.size // n_edges
+        self.assertEqual(n_harm, len(norms))
+
+    def test_filled_square_euclidean_limit_recovers_betti(self):
+        # alpha -> spacelike (all positive) recovers ker dim = b_1 with no nulls.
+        st = _filled_square()
+        b1 = _betti(st, 1)
+        self.assertEqual(_near_kernel_count(st, 1), b1)
+        norms = _null_norms(st, 1)
+        self.assertEqual(len(norms), b1)
+        if norms.size:
+            self.assertGreater(np.min(norms), 1e-6)
+
+    def test_cdt_torus_lorentzian_recording(self):
+        # A larger CDT-built complex (T^2, b_1 = 2) with genuine timelike edges
+        # (sec 5.6's "generate via CDT" + setSquaredLength). The geometry is not
+        # closed-form, so we RECORD the spectrum/near-kernel and assert only the
+        # robust qualitative facts.
+        st, n_time = _torus_lorentzian(2.0)
+        self.assertEqual(_betti(st, 1), 2)
+        self.assertGreater(n_time, 0)  # genuine timelike content present
+        L = _lor_matrix(st, 1)
+        self.assertGreater(np.linalg.norm(L - L.T), 1e-6)   # genuinely Lorentzian
+        eigs = _lor_eigs(st, 1)
+        self.assertTrue(_is_not_psd(eigs))                  # indefinite d'Alembertian
+        # near-kernel count and per-harmonic null flags are consistent in shape
+        near = _near_kernel_count(st, 1, tol=1e-6)
+        norms = _null_norms(st, 1, tol=1e-6)
+        self.assertEqual(len(norms), near)
+        n_null = int(np.sum(np.abs(norms) < 1e-6))
+        # recorded: with genuine timelike content the near-kernel may differ from
+        # b_1 and some harmonics may be null — both are valid sec-5.6 outcomes.
+        self.assertGreaterEqual(near, 0)
+        self.assertGreaterEqual(n_null, 0)
+
+
+# --------------------------------------------------------------------------- #
+# (5) degree-parameterization edges of the Lorentzian path
+# --------------------------------------------------------------------------- #
+class TestLorentzianDegreeParameterization(unittest.TestCase):
+
+    def test_negative_degree_raises(self):
+        hl = cob.HodgeLaplacian(_triangle_cycle())
+        for call in (lambda: hl.lorentzianEigenvalues(-1),
+                     lambda: hl.lorentzianEigenvectors(-1),
+                     lambda: hl.lorentzianHarmonics(-1),
+                     lambda: hl.lorentzianNullNorms(-1),
+                     lambda: hl.laplacian(-1, True, True)):
+            with self.subTest(call=call):
+                with self.assertRaises(RuntimeError):
+                    call()
+
+    def test_above_top_dimension_is_empty(self):
+        hl = cob.HodgeLaplacian(_triangle_cycle())  # S^1, top dim 1
+        for k in (2, 3):
+            with self.subTest(k=k):
+                self.assertEqual(hl.lorentzianEigenvalues(k), [])
+                self.assertEqual(hl.lorentzianEigenvectors(k), [])
+                self.assertEqual(hl.lorentzianHarmonics(k), [])
+                self.assertEqual(hl.lorentzianNullNorms(k), [])
+                self.assertEqual(hl.laplacian(k, True, True), [])
+
+    def test_metric_false_is_positive_combinatorial(self):
+        # With unit weights the signed path loses its Lorentzian content: the
+        # spectrum is the real, nonneg combinatorial one, kernel dim = b_1.
+        st = _triangle_one_timelike(1.0)
+        eigs = _lor_eigs(st, 1, metric=False)
+        self.assertLess(np.max(np.abs(eigs.imag)), 1e-9)
+        self.assertGreaterEqual(np.min(eigs.real), -1e-9)
+        self.assertEqual(_near_kernel_count(st, 1, metric=False), _betti(st, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the **Lorentzian** (signed-weight) variant of the metric Hodge Laplacian to `HodgeLaplacian`, alongside #104's Euclidean `k >= 1` path (which is untouched).

In CDT's Lorentzian signature, edge `squaredLength`s are signed (timelike `l^2 < 0`), so via the signed `Simplex::volume()` (#103) the k-simplex volumes — and the inner-product weights `W_k` — are signed. The metric goes **indefinite**: the symmetric `W^{1/2}` similarity breaks (the root of a negative weight is imaginary), so

```
L_k = W_k^-1 d_k^T W_{k-1} d_k  +  d_{k+1} W_{k+1}^-1 d_{k+1}^T W_k
```

is assembled **directly** (generally **non-self-adjoint** — a discrete d'Alembertian) and diagonalized with a general `Eigen::EigenSolver`, so eigenvalues may be negative or complex. The clean `ker L_k ≅ H_k` degrades to a pseudo-Hodge decomposition: "harmonic" becomes the small-`|λ|` near-kernel, and a representative `h` may be **null** in the indefinite metric (`⟨h,h⟩_W = Σ_i W_{k,i}|h_i|² ≈ 0`).

## API (Euclidean path unchanged)
- `laplacian(k, metric, lorentzian)` and `weights(k, lorentzian)` gain a `lorentzian` flag (signed volumes; degenerate cells still fall back to +1 to keep `W` invertible).
- `lorentzianEigenvalues(k, metric=True)` / `lorentzianEigenvectors(...)` — **complex**, sorted ascending by `(Re, Im)`.
- `lorentzianHarmonics(k, tol, metric=True)` — the near-kernel (`|λ| < tol`) representatives.
- `lorentzianNullNorms(k, tol, metric=True)` — the indefinite norms `⟨h,h⟩_W` of those representatives; `≈ 0` flags a **null** harmonic.

## What's recorded / tested
`tests/cobordism/test_hodge_laplacian_lorentzian_python.py` (19 tests):

- **Euclidean consistency** — on all-spacelike complexes (triangle, path, testbed, filled-square, torus `k=1,2`) the signed weights equal `|volume|`, so the Lorentzian path reproduces #104: real spectrum equal to `eigenvalues(k)`, kernel dim `= b_k`, and no null harmonics.
- **Closed-form d'Alembertian** — the 3-cycle `S^1` with one timelike edge (`l^2 = -α²`) gives `W_1 = diag(1, 1, -α)` and the exact spectrum **`{0, 3, 1 - 2/α}`**: non-symmetric, **not PSD** for `α < 2` (negative eigenvalue), with the single harmonic (the cycle) carrying indefinite norm **`(2 - α)/3`**.
- **α sweep** — records the spectrum and the harmonic null-norm vs. the Euclidean run: the null-norm decreases monotonically through the sweep, **crossing zero at `α = 2`** (positive/spacelike-dominated below, null at, negative/timelike-dominated above — the §5.6 "harmonic representative becomes null" point, which is also a defective spectral crossing where `1 - 2/α → 0`).
- **Both-terms recording** — a filled square and a CDT-built torus (both with genuine timelike edges, so the `k=1` operator carries the `d_{k+1}` term) confirm the assembled `L_1` is a genuine indefinite, non-symmetric d'Alembertian and exercise the near-kernel / null-norm machinery on larger complexes.

## Test results
`poetry run pytest tests/cobordism -q` → **178 passed, 369 subtests passed** (19 new Lorentzian tests, no regressions). Clean compile, no new warnings. Binding additions are localized to the `HodgeLaplacian` block (no overlap with #108).

Closes #105.