### PR TITLE
cobordism: DijkgraafWitten boundary map (T1)

### DIFF
--- a/include/cobordism/DijkgraafWitten.h
+++ b/include/cobordism/DijkgraafWitten.h
@@ -24,6 +24,7 @@
 
 #include <complex>
 #include <memory>
+#include <vector>
 
 // === tessera subsystem ns fwd-decls ===
 namespace tessera::spacetime { class Spacetime; }
@@ -81,6 +82,74 @@ class DijkgraafWitten {
     ///   to enumerate.
     [[nodiscard]] std::complex<double> partitionFunction() const;
 
+    /// # The Dijkgraaf–Witten state sum with boundary
+    ///
+    /// For a 3-manifold \f$ W \f$ **with boundary** \f$ \partial W \f$ the state
+    /// sum is no longer a scalar but a vector in the boundary Hilbert space
+    /// \f$ Z(\partial W) \f$. Holding the boundary connection \f$ g|_{\partial W} \f$
+    /// fixed and summing the same tetrahedron product
+    /// \f$ \prod_t \omega(g_{01},g_{12},g_{23})^{\varepsilon_t} \f$ over the
+    /// interior flat fields produces, for each boundary flat-connection class, a
+    /// complex amplitude — an element of \f$ Z(\partial W) \f$.
+    ///
+    /// Concretely the sum is taken over the **bulk cohomology classes**
+    /// \f$ [g] \in H^1(W;\mathbb{Z}_2) \f$ (the gauge-inequivalent flat
+    /// \f$ \mathbb{Z}_2 \f$ connections — the interior fields modulo gauge),
+    /// binned by the class of their restriction to each boundary component. A
+    /// boundary component \f$ \Sigma \f$ (a closed surface) carries the DW Hilbert
+    /// space \f$ Z(\Sigma) = \mathbb{C}[H^1(\Sigma;\mathbb{Z}_2)] \f$ of dimension
+    /// \f$ 2^{b_1(\Sigma)} \f$, indexed by the holonomy class of the connection.
+    /// Summing over cohomology classes (rather than the gauge-redundant cocycle
+    /// space) is exactly the gauge-fixed "sum over interior fields"; no gauge
+    /// volume divides it, and it is normalized so the trivial cobordism
+    /// \f$ \Sigma\times[0,T] \f$ is the identity on \f$ Z(\Sigma) \f$.
+    ///
+    /// For the real-valued \f$ \mathbb{Z}_2 \f$ cocycles (`Trivial` \f$ \equiv 1 \f$
+    /// and `Sign` \f$ = \pm 1 \f$) the orientation exponent is immaterial —
+    /// \f$ x^{\pm 1} = x \f$ for \f$ x \in \{+1,-1\} \f$, and \f$ \omega^{-1} =
+    /// \bar\omega = \omega \f$ — so no (relative) fundamental class is needed
+    /// (none exists for a manifold with boundary) and the product matches the
+    /// closed case.
+    ///
+    /// `boundaryVector()` returns the full element of \f$ Z(\partial W) \f$: the
+    /// amplitude for every joint
+    /// boundary flat-connection class, flattened row-major over the boundary
+    /// components (each component ordered deterministically by its sorted
+    /// top-face list). Length \f$ = \prod_i 2^{b_1(\Sigma_i)} \f$.
+    /// @throws std::runtime_error if \f$ W \f$ is null, not a 3-manifold, or
+    ///   closed (no boundary — use `partitionFunction()`).
+    [[nodiscard]] std::vector<std::complex<double>> boundaryVector() const;
+
+    /// The per-boundary-component Hilbert-space dimensions
+    /// \f$ 2^{b_1(\Sigma_i)} \f$, in the same deterministic component order used
+    /// by `boundaryVector()` / `map()`.
+    [[nodiscard]] std::vector<int> boundaryDimensions() const;
+
+    /// The boundary state sum read as a linear map \f$ Z(\Sigma_B) \to
+    /// Z(\Sigma_A) \f$ when \f$ \partial W \f$ has exactly two components: a dense
+    /// matrix returned as rows, `rows = 2^{b_1(\Sigma_A)}` (component 0),
+    /// `cols = 2^{b_1(\Sigma_B)}` (component 1), in the flat-connection-class
+    /// basis. For the trivial cobordism \f$ \Sigma\times[0,T] \f$ this is the
+    /// identity \f$ \mathrm{id}_{Z(\Sigma)} \f$.
+    /// @throws std::runtime_error if \f$ \partial W \f$ does not have exactly two
+    ///   connected components.
+    [[nodiscard]] std::vector<std::vector<std::complex<double>>> map() const;
+
+    /// The transition amplitude \f$ \langle \psi_A | Z(W) | \psi_B \rangle \f$
+    /// for boundary states \f$ \psi_A \in Z(\Sigma_A) \f$, \f$ \psi_B \in
+    /// Z(\Sigma_B) \f$ given in the flat-connection-class basis: the contraction
+    /// \f$ \sum_{a,b} \overline{\psi_A[a]}\, Z(W)_{ab}\, \psi_B[b] \f$ with the
+    /// two-component boundary map. For the trivial cobordism (\f$ Z(W) =
+    /// \mathrm{id} \f$) this reduces to the inner product
+    /// \f$ \langle \psi_A | \psi_B \rangle \f$. The boundary states are prepared
+    /// from the harmonic 1-forms \f$ \ker L_1(\Sigma) \f$ (the qubit of dimension
+    /// \f$ b_1 \f$, kept distinct from the \f$ 2^{b_1} \f$ flat-connection count).
+    /// @throws std::runtime_error if \f$ \partial W \f$ is not two components, or
+    ///   `std::invalid_argument` if the state lengths do not match the map dims.
+    [[nodiscard]] std::complex<double> amplitude(
+        const std::vector<std::complex<double>> &psiA,
+        const std::vector<std::complex<double>> &psiB) const;
+
     /// Whether the cocycle \f$ \omega \f$ for the given choice satisfies the
     /// normalized 3-cocycle (pentagon) identity over \f$ \mathbb{Z}_2 \f$:
     /// \f$ \omega(b,c,d)\,\omega(a, b{+}c, d)\,\omega(a,b,c) =
@@ -97,6 +166,16 @@ class DijkgraafWitten {
     /// Evaluate \f$ \omega(a,b,c) \f$ for a cocycle choice, \f$ a,b,c \in
     /// \{0,1\} \f$.
     [[nodiscard]] static std::complex<double> omega(Cocycle w, int a, int b, int c);
+
+    /// The computed boundary state sum: the per-component Hilbert dimensions and
+    /// the flat (row-major over components) amplitude vector \f$ \in
+    /// Z(\partial W) \f$. The shared kernel of `boundaryVector()`, `map()`,
+    /// `boundaryDimensions()`, and `amplitude()`.
+    struct Boundary {
+      std::vector<int> dims;                          // 2^{b_1(Σ_i)} per component
+      std::vector<std::complex<double>> amplitudes;   // flat, ∏ dims long
+    };
+    [[nodiscard]] Boundary computeBoundary() const;
 };
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -304,6 +304,30 @@ triangulations; a flat space too large to materialize is refused.)doc")
       .def("partitionFunction", &DijkgraafWitten::partitionFunction,
            "The partition function Z(W) as a complex number. Raises if W is not "
            "a closed oriented 3-manifold or the flat space is too large.")
+      .def("boundaryVector", &DijkgraafWitten::boundaryVector,
+           "The element of Z(dW) for a 3-manifold W with boundary: the amplitude "
+           "for every joint boundary flat-connection class, flattened row-major "
+           "over the boundary components (each component a closed surface Sigma_i "
+           "with Hilbert dimension 2^{b1(Sigma_i)}). Holds g|dW fixed and sums "
+           "the same prod omega(g01,g12,g23) over the interior gauge classes "
+           "[g] in H^1(W;Z_2). Raises if W is null, not 3D, or closed.")
+      .def("boundaryDimensions", &DijkgraafWitten::boundaryDimensions,
+           "Per-boundary-component Hilbert-space dimensions 2^{b1(Sigma_i)}, in "
+           "the same deterministic component order as boundaryVector()/map().")
+      .def("map", &DijkgraafWitten::map,
+           "The boundary state sum as a linear map Z(Sigma_B) -> Z(Sigma_A) when "
+           "dW has exactly two components: a dense matrix (list of rows), "
+           "rows = 2^{b1(Sigma_A)} (component 0), cols = 2^{b1(Sigma_B)} "
+           "(component 1), in the flat-connection-class basis. For the trivial "
+           "cobordism Sigma x [0,T] this is the identity id_{Z(Sigma)}. Raises "
+           "unless dW has exactly two connected components.")
+      .def("amplitude", &DijkgraafWitten::amplitude, py::arg("psiA"),
+           py::arg("psiB"),
+           "The transition amplitude <psiA| Z(W) |psiB> = sum_ab conj(psiA[a]) "
+           "Z(W)_ab psiB[b] for boundary states in the flat-connection-class "
+           "basis (|psiA| = 2^{b1(Sigma_A)}, |psiB| = 2^{b1(Sigma_B)}); prepared "
+           "from the harmonic 1-forms ker L_1(Sigma). For the cylinder Z(W)=id, "
+           "so this is the inner product <psiA|psiB>.")
       .def_static("isCocycle", &DijkgraafWitten::isCocycle, py::arg("cocycle"),
                   "Whether omega satisfies the normalized 3-cocycle (pentagon) "
                   "identity over Z_2 (brute-forced over all 16 tuples of "

--- a/src/cobordism/DijkgraafWitten.cpp
+++ b/src/cobordism/DijkgraafWitten.cpp
@@ -21,14 +21,19 @@
 
 #include "cobordism/DijkgraafWitten.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <map>
+#include <numeric>
+#include <set>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "cobordism/ChainComplex.h"
+#include "cobordism/Cobordism.h"
 #include "cobordism/IntegerLinalg.h"
 #include "spacetime/Spacetime.h"
 
@@ -159,6 +164,280 @@ std::complex<double> DijkgraafWitten::partitionFunction() const {
   }
   total /= std::pow(2.0, static_cast<double>(numVertices));
   return total;
+}
+
+DijkgraafWitten::Boundary DijkgraafWitten::computeBoundary() const {
+  if (W_ == nullptr)
+    throw std::runtime_error(
+        "DijkgraafWitten boundary state sum: the spacetime is null");
+
+  const ChainComplex chain = ChainComplex::fromSpacetime(*W_);
+  if (chain.dimension() != 3)
+    throw std::runtime_error(
+        "DijkgraafWitten boundary state sum: a 3-manifold (dimension 3) is "
+        "required");
+
+  const int numEdges = static_cast<int>(chain.numSimplices(1));
+  const int numTriangles = static_cast<int>(chain.numSimplices(2));
+
+  // --- GF(2) helpers (echelon basis of a span + canonical coset residue) -----
+  // `echelon` returns a row-echelon basis (each row's leftmost 1 — its pivot —
+  // is unique and sits left of nothing else), sorted by pivot column. `residue`
+  // reduces a vector against such a basis to the canonical representative of its
+  // coset modulo the span (supported on the non-pivot columns); two vectors are
+  // equal modulo the span iff their residues match. Both are linear over GF(2).
+  auto echelon = [](std::vector<std::vector<int>> gens, int cols) {
+    std::vector<std::vector<int>> rows;
+    std::vector<int> pivots;
+    for (std::vector<int> g : gens) {
+      for (int &c : g) c &= 1;
+      for (std::size_t r = 0; r < rows.size(); ++r)
+        if (g[static_cast<std::size_t>(pivots[r])])
+          for (int c = pivots[r]; c < cols; ++c)
+            g[static_cast<std::size_t>(c)] ^= rows[r][static_cast<std::size_t>(c)];
+      int p = -1;
+      for (int c = 0; c < cols; ++c)
+        if (g[static_cast<std::size_t>(c)]) { p = c; break; }
+      if (p < 0) continue;  // dependent on the rows already collected
+      std::size_t pos = 0;
+      while (pos < pivots.size() && pivots[pos] < p) ++pos;
+      rows.insert(rows.begin() + static_cast<long>(pos), std::move(g));
+      pivots.insert(pivots.begin() + static_cast<long>(pos), p);
+    }
+    return rows;
+  };
+  auto residue = [](std::vector<int> v,
+                    const std::vector<std::vector<int>> &rows) {
+    for (const std::vector<int> &row : rows) {
+      int p = -1;
+      for (int c = 0; c < static_cast<int>(row.size()); ++c)
+        if (row[static_cast<std::size_t>(c)]) { p = c; break; }
+      if (p >= 0 && (v[static_cast<std::size_t>(p)] & 1))
+        for (int c = p; c < static_cast<int>(v.size()); ++c)
+          v[static_cast<std::size_t>(c)] ^= row[static_cast<std::size_t>(c)];
+    }
+    for (int &c : v) c &= 1;
+    return v;
+  };
+  auto isZero = [](const std::vector<int> &v) {
+    return std::all_of(v.begin(), v.end(), [](int x) { return x == 0; });
+  };
+  // Representatives of H^1 = Z^1 / B^1: from the cocycle basis keep exactly those
+  // independent modulo the coboundaries already accumulated (b_1 of them).
+  auto cohomologyReps = [&](const std::vector<std::vector<int>> &cocycles,
+                            std::vector<std::vector<int>> coboundaries,
+                            int cols) {
+    std::vector<std::vector<int>> spanRows = echelon(coboundaries, cols);
+    std::vector<std::vector<int>> reps;
+    for (const std::vector<int> &z : cocycles)
+      if (!isZero(residue(z, spanRows))) {
+        reps.push_back(z);
+        coboundaries.push_back(z);
+        spanRows = echelon(coboundaries, cols);
+      }
+    return reps;
+  };
+
+  // --- bulk: enumerate the gauge classes [g] ∈ H^1(W; ℤ₂) --------------------
+  // Flat connections Z^1(W) = ker(d_1 mod 2), d_1 = ∂_2^T (triangles × edges);
+  // coboundaries B^1(W) = im(d_0), each vertex's edge-incidence vector. The
+  // 2^{b_1(W)} classes (materialized via gf2Span) are the interior fields modulo
+  // gauge — small, so no gauge-redundant 2^{|V|+b_1} enumeration is needed.
+  const std::vector<long> &boundaryTwo = chain.boundaryMatrix(2);
+  std::vector<int> coboundaryOne(
+      static_cast<std::size_t>(numTriangles) * numEdges, 0);
+  for (int edge = 0; edge < numEdges; ++edge)
+    for (int triangle = 0; triangle < numTriangles; ++triangle)
+      coboundaryOne[static_cast<std::size_t>(triangle) * numEdges + edge] =
+          static_cast<int>(
+              boundaryTwo[static_cast<std::size_t>(edge) * numTriangles +
+                          triangle] &
+              1L);
+  const std::vector<std::vector<int>> cocycleBasis =
+      gf2Nullspace(coboundaryOne, numTriangles, numEdges);
+
+  const std::vector<std::vector<std::uint64_t>> edges = chain.kSimplexVertices(1);
+  std::map<std::pair<std::uint64_t, std::uint64_t>, int> edgeIndex;
+  for (int e = 0; e < numEdges; ++e) edgeIndex[{edges[e][0], edges[e][1]}] = e;
+
+  std::vector<std::vector<int>> coboundaryBasis;  // B^1(W) generators
+  for (const std::vector<std::uint64_t> &vertex : chain.kSimplexVertices(0)) {
+    const std::uint64_t id = vertex[0];
+    std::vector<int> incidence(numEdges, 0);
+    for (int e = 0; e < numEdges; ++e)
+      if (edges[e][0] == id || edges[e][1] == id) incidence[e] = 1;
+    coboundaryBasis.push_back(std::move(incidence));
+  }
+  const std::vector<std::vector<int>> bulkReps =
+      cohomologyReps(cocycleBasis, coboundaryBasis, numEdges);
+  const std::vector<std::vector<int>> bulkClasses = gf2Span(bulkReps, numEdges);
+
+  // --- boundary ∂W: components, each a closed surface Σ_i --------------------
+  const SimplexList boundaryTriangles = Cobordism::boundaryFaces(*W_);
+  if (boundaryTriangles.empty())
+    throw std::runtime_error(
+        "DijkgraafWitten boundary state sum: W is closed (∂W is empty); use "
+        "partitionFunction() for the scalar invariant");
+  std::vector<SimplexList> components =
+      Cobordism::connectedComponents(boundaryTriangles);
+  for (SimplexList &component : components)
+    std::sort(component.begin(), component.end());
+  std::sort(components.begin(), components.end());  // deterministic Σ_A, Σ_B, …
+
+  // Per component: the class-indexing data for its DW Hilbert space Z(Σ_i) =
+  // ℂ[H^1(Σ_i; ℤ₂)] (dimension 2^{b_1(Σ_i)}). A boundary connection's index is
+  // the position (in gf2Span order) of its H^1(Σ_i) class.
+  struct ComponentIndexer {
+    std::vector<int> localToGlobalEdge;            // local edge → bulk edge index
+    std::vector<std::vector<int>> coboundaryRows;  // echelon B^1(Σ_i)
+    std::map<std::vector<int>, int> classOfResidue;
+    int dimension{1};
+  };
+  std::vector<ComponentIndexer> indexers;
+  indexers.reserve(components.size());
+  for (const SimplexList &component : components) {
+    std::set<std::pair<std::uint64_t, std::uint64_t>> edgeSet;
+    std::set<std::uint64_t> vertexSet;
+    for (const std::vector<std::uint64_t> &triangle : component) {
+      vertexSet.insert(triangle[0]);
+      vertexSet.insert(triangle[1]);
+      vertexSet.insert(triangle[2]);
+      edgeSet.insert({triangle[0], triangle[1]});
+      edgeSet.insert({triangle[0], triangle[2]});
+      edgeSet.insert({triangle[1], triangle[2]});
+    }
+    const std::vector<std::pair<std::uint64_t, std::uint64_t>> localEdges(
+        edgeSet.begin(), edgeSet.end());
+    const int numLocalEdges = static_cast<int>(localEdges.size());
+    std::map<std::pair<std::uint64_t, std::uint64_t>, int> localEdgeIndex;
+    for (int i = 0; i < numLocalEdges; ++i) localEdgeIndex[localEdges[i]] = i;
+
+    // d_1 on Σ_i (triangles × local edges) — incidence; ℤ₂ flatness is its kernel.
+    std::vector<int> localCoboundary(
+        static_cast<std::size_t>(component.size()) * numLocalEdges, 0);
+    for (int t = 0; t < static_cast<int>(component.size()); ++t) {
+      const std::vector<std::uint64_t> &tri = component[static_cast<std::size_t>(t)];
+      const std::pair<std::uint64_t, std::uint64_t> triEdges[3] = {
+          {tri[0], tri[1]}, {tri[0], tri[2]}, {tri[1], tri[2]}};
+      for (const auto &pr : triEdges)
+        localCoboundary[static_cast<std::size_t>(t) * numLocalEdges +
+                        localEdgeIndex[pr]] = 1;
+    }
+    const std::vector<std::vector<int>> localCocycles = gf2Nullspace(
+        localCoboundary, static_cast<int>(component.size()), numLocalEdges);
+    std::vector<std::vector<int>> localCoboundaryBasis;
+    for (std::uint64_t v : vertexSet) {
+      std::vector<int> incidence(numLocalEdges, 0);
+      for (int i = 0; i < numLocalEdges; ++i)
+        if (localEdges[static_cast<std::size_t>(i)].first == v ||
+            localEdges[static_cast<std::size_t>(i)].second == v)
+          incidence[i] = 1;
+      localCoboundaryBasis.push_back(std::move(incidence));
+    }
+    const std::vector<std::vector<int>> localReps =
+        cohomologyReps(localCocycles, localCoboundaryBasis, numLocalEdges);
+    const std::vector<std::vector<int>> localClasses =
+        gf2Span(localReps, numLocalEdges);
+
+    ComponentIndexer indexer;
+    indexer.coboundaryRows = echelon(localCoboundaryBasis, numLocalEdges);
+    indexer.dimension = static_cast<int>(localClasses.size());
+    indexer.localToGlobalEdge.resize(static_cast<std::size_t>(numLocalEdges));
+    for (int i = 0; i < numLocalEdges; ++i)
+      indexer.localToGlobalEdge[static_cast<std::size_t>(i)] =
+          edgeIndex.at(localEdges[static_cast<std::size_t>(i)]);
+    for (int c = 0; c < static_cast<int>(localClasses.size()); ++c)
+      indexer.classOfResidue[residue(localClasses[static_cast<std::size_t>(c)],
+                                     indexer.coboundaryRows)] = c;
+    indexers.push_back(std::move(indexer));
+  }
+
+  // --- bin each bulk class by its boundary-restriction class, weight Π ω ------
+  // For the real ℤ₂ cocycles (Trivial ≡ 1, Sign = ±1) the orientation exponent
+  // ε_t is immaterial (x^{±1} = x, ω^{-1} = ω̄ = ω), so the product matches the
+  // closed case with no (relative) fundamental class. Summing over cohomology
+  // classes gives the gauge-fixed amplitude; the trivial cobordism comes out the
+  // identity with no normalization factor.
+  std::vector<int> dims;
+  long totalSize = 1;
+  for (const ComponentIndexer &indexer : indexers) {
+    dims.push_back(indexer.dimension);
+    totalSize *= indexer.dimension;
+  }
+  std::vector<std::complex<double>> amplitudes(
+      static_cast<std::size_t>(totalSize), {0.0, 0.0});
+  const std::vector<std::vector<std::uint64_t>> tetrahedra =
+      chain.orientedTopSimplices();
+  for (const std::vector<int> &g : bulkClasses) {
+    long jointIndex = 0;
+    for (const ComponentIndexer &indexer : indexers) {
+      std::vector<int> local(indexer.localToGlobalEdge.size());
+      for (std::size_t i = 0; i < local.size(); ++i)
+        local[i] = g[static_cast<std::size_t>(indexer.localToGlobalEdge[i])];
+      const int classIndex =
+          indexer.classOfResidue.at(residue(local, indexer.coboundaryRows));
+      jointIndex = jointIndex * indexer.dimension + classIndex;
+    }
+    std::complex<double> weight{1.0, 0.0};
+    for (const std::vector<std::uint64_t> &v : tetrahedra) {
+      const int g01 = g[static_cast<std::size_t>(edgeIndex.at({v[0], v[1]}))];
+      const int g12 = g[static_cast<std::size_t>(edgeIndex.at({v[1], v[2]}))];
+      const int g23 = g[static_cast<std::size_t>(edgeIndex.at({v[2], v[3]}))];
+      weight *= omega(cocycle_, g01, g12, g23);
+    }
+    amplitudes[static_cast<std::size_t>(jointIndex)] += weight;
+  }
+  return {std::move(dims), std::move(amplitudes)};
+}
+
+std::vector<std::complex<double>> DijkgraafWitten::boundaryVector() const {
+  return computeBoundary().amplitudes;
+}
+
+std::vector<int> DijkgraafWitten::boundaryDimensions() const {
+  return computeBoundary().dims;
+}
+
+std::vector<std::vector<std::complex<double>>> DijkgraafWitten::map() const {
+  const Boundary boundary = computeBoundary();
+  if (boundary.dims.size() != 2)
+    throw std::runtime_error(
+        "DijkgraafWitten::map: ∂W must have exactly two components for a map "
+        "Z(Σ_B) → Z(Σ_A); got " + std::to_string(boundary.dims.size()));
+  const int rows = boundary.dims[0];
+  const int cols = boundary.dims[1];
+  std::vector<std::vector<std::complex<double>>> matrix(
+      static_cast<std::size_t>(rows),
+      std::vector<std::complex<double>>(static_cast<std::size_t>(cols)));
+  for (int r = 0; r < rows; ++r)
+    for (int c = 0; c < cols; ++c)
+      matrix[static_cast<std::size_t>(r)][static_cast<std::size_t>(c)] =
+          boundary.amplitudes[static_cast<std::size_t>(r) * cols + c];
+  return matrix;
+}
+
+std::complex<double> DijkgraafWitten::amplitude(
+    const std::vector<std::complex<double>> &psiA,
+    const std::vector<std::complex<double>> &psiB) const {
+  const Boundary boundary = computeBoundary();
+  if (boundary.dims.size() != 2)
+    throw std::runtime_error(
+        "DijkgraafWitten::amplitude: ∂W must have exactly two components "
+        "(⟨ψ_A| Z(W) |ψ_B⟩ needs Σ_A and Σ_B)");
+  const int rows = boundary.dims[0];
+  const int cols = boundary.dims[1];
+  if (static_cast<int>(psiA.size()) != rows ||
+      static_cast<int>(psiB.size()) != cols)
+    throw std::invalid_argument(
+        "DijkgraafWitten::amplitude: state lengths must match the map "
+        "dimensions (|ψ_A| = 2^{b_1(Σ_A)}, |ψ_B| = 2^{b_1(Σ_B)})");
+  std::complex<double> accumulator{0.0, 0.0};
+  for (int r = 0; r < rows; ++r)
+    for (int c = 0; c < cols; ++c)
+      accumulator += std::conj(psiA[static_cast<std::size_t>(r)]) *
+                     boundary.amplitudes[static_cast<std::size_t>(r) * cols + c] *
+                     psiB[static_cast<std::size_t>(c)];
+  return accumulator;
 }
 
 }  // namespace tessera::cobordism

--- a/tests/cobordism/test_dijkgraaf_witten_boundary_python.py
+++ b/tests/cobordism/test_dijkgraaf_witten_boundary_python.py
@@ -1,0 +1,420 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Dijkgraaf–Witten ℤ₂ state sum with boundary (#109) — Z(Σ_B) → Z(Σ_A), T1.
+
+For a 3-manifold W with boundary the state sum is a vector in Z(∂W): holding the
+boundary connection g|∂W fixed and summing the closed-case tetrahedron product
+∏_t ω(g_01,g_12,g_23) over the interior gauge classes [g] ∈ H¹(W;ℤ₂) gives, for
+each boundary flat-connection class, a complex amplitude. With ∂W = Σ_A ⊔ Σ_B
+this reads as a map Z(Σ_B) → Z(Σ_A); each closed surface Σ carries the DW
+Hilbert space Z(Σ) = ℂ[H¹(Σ;ℤ₂)] of dimension 2^{b₁(Σ)}.
+
+Acceptance (spec §5.4, plan ticket 7):
+
+* **T1 — cylinder is the identity.** For W = Σ×[0,T] (built as the simplicial
+  product Σ × interval), Z(W) = id on Z(Σ); hence ⟨ψ_A|Z(W)|ψ_B⟩ = ⟨ψ_A|ψ_B⟩.
+  The boundary states ψ are prepared from the harmonic 1-forms ker L₁(Σ) — the
+  qubit of dimension b₁ = 2 for the torus, kept distinct from the 2^{b₁} = 4
+  flat-connection count that indexes the state sum (spec §5.2).
+
+* **numpy oracle.** On a small bounded fixture (the solid torus S¹×D², whose
+  boundary is a single T²) an independent numpy reimplementation of the boundary
+  sum reproduces the C++ amplitude vector.
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+
+import tessera
+
+cobordism = tessera.cobordism
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures.
+# --------------------------------------------------------------------------- #
+def _build(topology):
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()
+    return spacetime
+
+
+def _circle():
+    # S¹ = ∂Δ², the minimal triangle-boundary circle (3 vertices).
+    return tessera.SimplexBoundarySphere(1)
+
+
+def _torus_topology():
+    # T² = S¹ × S¹ via the simplicial (Eilenberg–Zilber) product.
+    return tessera.SimplicialProduct(_circle(), _circle())
+
+
+def _interval():
+    return tessera.SolidSimplex(1)  # a single edge = [0, 1]
+
+
+def _torus_cylinder():
+    # W = T² × [0,T], the trivial cobordism T² → T² (∂W = T² ⊔ T²).
+    return _build(tessera.SimplicialProduct(_torus_topology(), _interval()))
+
+
+def _sphere_cylinder():
+    # W = S² × [0,T], trivial cobordism S² → S² (Z(S²) is one-dimensional).
+    return _build(tessera.SimplicialProduct(tessera.SimplexBoundarySphere(2),
+                                            _interval()))
+
+
+def _solid_torus():
+    # W = S¹ × D² (solid torus); ∂W = S¹ × S¹ = T² (one boundary component).
+    return _build(tessera.SimplicialProduct(_circle(), tessera.SolidSimplex(2)))
+
+
+def _three_sphere():
+    return _build(tessera.SimplexBoundarySphere(3))  # closed: no boundary
+
+
+# --------------------------------------------------------------------------- #
+# Pure-numpy GF(2) linear algebra (independent of the C++ routines).
+# --------------------------------------------------------------------------- #
+def _gf2_nullspace(matrix, cols):
+    """Basis of {x : matrix·x ≡ 0 (mod 2)} as length-`cols` rows, via RREF."""
+    if matrix.size == 0:
+        return [np.eye(cols, dtype=np.int64)[i] for i in range(cols)]
+    a = (np.asarray(matrix, dtype=np.int64) & 1).copy()
+    rows, _ = a.shape
+    pivots, r = [], 0
+    for col in range(cols):
+        if r >= rows:
+            break
+        piv = next((i for i in range(r, rows) if a[i, col] & 1), None)
+        if piv is None:
+            continue
+        a[[r, piv]] = a[[piv, r]]
+        for i in range(rows):
+            if i != r and (a[i, col] & 1):
+                a[i] ^= a[r]
+        pivots.append(col)
+        r += 1
+    is_pivot = [c in pivots for c in range(cols)]
+    basis = []
+    for free in range(cols):
+        if is_pivot[free]:
+            continue
+        x = np.zeros(cols, dtype=np.int64)
+        x[free] = 1
+        for t, pc in enumerate(pivots):
+            x[pc] = a[t, free] & 1
+        basis.append(x)
+    return basis
+
+
+def _gf2_span(basis, cols):
+    """All 2^k combinations of `basis` (each a length-`cols` 0/1 vector)."""
+    k = len(basis)
+    out = []
+    for mask in range(1 << k):
+        x = np.zeros(cols, dtype=np.int64)
+        for b in range(k):
+            if (mask >> b) & 1:
+                x ^= basis[b]
+        out.append(x)
+    return out
+
+
+def _gf2_independent_mod(vector, span_rows):
+    """Reduce `vector` by the echelon `span_rows`; return the residue (0/1)."""
+    v = (np.asarray(vector, dtype=np.int64) & 1).copy()
+    for row in span_rows:
+        piv = int(np.argmax(row)) if row.any() else -1
+        if piv >= 0 and (v[piv] & 1):
+            v ^= row
+    return v & 1
+
+
+def _gf2_echelon(generators, cols):
+    """Row-echelon basis (sorted by pivot) of the span of `generators`."""
+    rows = []
+    for gen in generators:
+        v = (np.asarray(gen, dtype=np.int64) & 1).copy()
+        v = _gf2_independent_mod(v, rows)
+        if v.any():
+            rows.append(v)
+            rows.sort(key=lambda row: int(np.argmax(row)))
+    return rows
+
+
+def _cohomology_reps(cocycles, coboundaries, cols):
+    """Representatives of H¹ = Z¹/B¹: cocycles independent modulo B¹."""
+    span_rows = _gf2_echelon(coboundaries, cols)
+    reps = []
+    for z in cocycles:
+        if _gf2_independent_mod(z, span_rows).any():
+            reps.append(np.asarray(z, dtype=np.int64) & 1)
+            span_rows = _gf2_echelon(
+                [r for r in span_rows] + [np.asarray(z, dtype=np.int64) & 1], cols)
+    return reps
+
+
+def _omega(kind, a, b, c):
+    if kind == "trivial":
+        return 1
+    if kind == "sign":
+        return -1 if (a & b & c) else 1
+    raise ValueError(kind)
+
+
+def _boundary_oracle(spacetime, kind):
+    """Independent numpy recomputation of the boundary amplitude multiset.
+
+    Returns the sorted list of amplitudes over the joint boundary classes — the
+    indexing-convention-free fingerprint of the Z(∂W) vector, recomputed through
+    a separate path (numpy GF(2) cohomology, holonomy binning, ω product).
+    """
+    chain = cobordism.ChainComplex.fromSpacetime(spacetime)
+    num_edges = chain.numSimplices(1)
+    num_triangles = chain.numSimplices(2)
+
+    boundary2 = (np.asarray(chain.boundaryMatrix(2), dtype=np.int64)
+                 .reshape(num_edges, num_triangles)) & 1     # edges × triangles
+    coboundary1 = boundary2.T                                # triangles × edges
+    z1 = _gf2_nullspace(coboundary1, num_edges)
+
+    edges = [tuple(e) for e in chain.kSimplexVertices(1)]
+    edge_index = {e: i for i, e in enumerate(edges)}
+    vertex_ids = [int(v[0]) for v in chain.kSimplexVertices(0)]
+    coboundary_basis = [
+        np.array([1 if vid in edge else 0 for edge in edges], dtype=np.int64)
+        for vid in vertex_ids]
+    bulk_reps = _cohomology_reps(z1, coboundary_basis, num_edges)
+    bulk_classes = _gf2_span(bulk_reps, num_edges)
+
+    btris = [tuple(t) for t in cobordism.Cobordism.boundaryFaces(spacetime)]
+    raw_components = cobordism.Cobordism.connectedComponents(
+        [list(t) for t in btris])
+    components = sorted(
+        [sorted(tuple(t) for t in comp) for comp in raw_components])
+
+    # Per component, an independent class index via holonomy around an H₁ basis.
+    component_indexers = []
+    for comp in components:
+        comp_edges = sorted({pair for tri in comp
+                             for pair in ((tri[0], tri[1]), (tri[0], tri[2]),
+                                          (tri[1], tri[2]))})
+        local_index = {e: i for i, e in enumerate(comp_edges)}
+        n_local = len(comp_edges)
+        # 1-boundary ∂₁ (vertices × local edges) for cycles, ∂₂ for filling.
+        comp_verts = sorted({v for tri in comp for v in tri})
+        vert_index = {v: i for i, v in enumerate(comp_verts)}
+        d1 = np.zeros((len(comp_verts), n_local), dtype=np.int64)
+        for (u, w) in comp_edges:
+            e = local_index[(u, w)]
+            d1[vert_index[u], e] ^= 1
+            d1[vert_index[w], e] ^= 1
+        cycles = _gf2_nullspace(d1, n_local)            # Z₁(Σ) = ker ∂₁
+        d2 = np.zeros((n_local, len(comp)), dtype=np.int64)
+        for j, tri in enumerate(comp):
+            for pair in ((tri[0], tri[1]), (tri[0], tri[2]), (tri[1], tri[2])):
+                d2[local_index[pair], j] ^= 1
+        boundaries = [d2[:, j] for j in range(len(comp))]  # B₁(Σ) = im ∂₂
+        h1_cycles = _cohomology_reps(cycles, boundaries, n_local)  # H₁ basis
+        component_indexers.append((comp_edges, h1_cycles))
+
+    # Bin every bulk class by its boundary holonomy signature; sum ω product.
+    amplitudes = {}
+    tets = [tuple(t) for t in chain.orientedTopSimplices()]
+    for g in bulk_classes:
+        signature = []
+        for comp_edges, h1_cycles in component_indexers:
+            local = np.array([g[edge_index[e]] for e in comp_edges],
+                             dtype=np.int64)
+            signature.extend(int(np.dot(local, cyc) & 1) for cyc in h1_cycles)
+        weight = 1
+        for tet in tets:
+            g01 = int(g[edge_index[(tet[0], tet[1])]])
+            g12 = int(g[edge_index[(tet[1], tet[2])]])
+            g23 = int(g[edge_index[(tet[2], tet[3])]])
+            weight *= _omega(kind, g01, g12, g23)
+        key = tuple(signature)
+        amplitudes[key] = amplitudes.get(key, 0) + weight
+
+    total_classes = 1
+    for _, h1_cycles in component_indexers:
+        total_classes *= (1 << len(h1_cycles))
+    values = list(amplitudes.values()) + [0] * (total_classes - len(amplitudes))
+    return sorted(float(v) for v in values)
+
+
+# --------------------------------------------------------------------------- #
+# T1 — the cylinder is the identity.
+# --------------------------------------------------------------------------- #
+class TestCylinderIsIdentity(unittest.TestCase):
+
+    def test_torus_cylinder_map_is_identity(self):
+        matrix = np.asarray(DijkgraafWitten(_torus_cylinder(),
+                                            Cocycle.Trivial).map())
+        # Z(T²) has dimension 2^{b₁(T²)} = 4.
+        self.assertEqual(matrix.shape, (4, 4))
+        np.testing.assert_allclose(matrix, np.eye(4), atol=1e-9)
+
+    def test_sphere_cylinder_map_is_identity(self):
+        # Z(S²) is one-dimensional, so Z(S²×I) is the 1×1 identity [[1]].
+        matrix = np.asarray(DijkgraafWitten(_sphere_cylinder(),
+                                            Cocycle.Trivial).map())
+        self.assertEqual(matrix.shape, (1, 1))
+        np.testing.assert_allclose(matrix, np.eye(1), atol=1e-9)
+
+    def test_sign_cocycle_cylinder_is_also_identity(self):
+        # The cup cube vanishes on the cylinder, so the Sign twist agrees.
+        matrix = np.asarray(DijkgraafWitten(_torus_cylinder(),
+                                            Cocycle.Sign).map())
+        np.testing.assert_allclose(matrix, np.eye(4), atol=1e-9)
+
+    def test_boundary_dimensions_are_two_qubits_worth(self):
+        dims = DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial).boundaryDimensions()
+        self.assertEqual(list(dims), [4, 4])  # 2^{b₁(T²)} per boundary T²
+
+
+# --------------------------------------------------------------------------- #
+# T1 — ⟨ψ_A|Z(W)|ψ_B⟩ = ⟨ψ_A|ψ_B⟩, with states from the harmonic 1-forms.
+# --------------------------------------------------------------------------- #
+class TestCylinderReproducesInnerProduct(unittest.TestCase):
+
+    def test_harmonic_one_forms_are_a_qubit(self):
+        # ker L₁(T²) has dimension b₁ = 2 — the qubit. This is the continuous
+        # harmonic count, deliberately distinct from the 2^{b₁} = 4 flat ℤ₂
+        # connections that index Z(T²) (spec §5.2).
+        torus = _build(_torus_topology())
+        harmonics = np.asarray(
+            cobordism.HodgeLaplacian(torus).harmonics(1)).reshape(-1)
+        num_edges = cobordism.ChainComplex.fromSpacetime(torus).numSimplices(1)
+        self.assertEqual(harmonics.size % num_edges, 0)
+        self.assertEqual(harmonics.size // num_edges, 2)
+
+    def _boundary_states_from_harmonics(self):
+        """Two Z(T²) states (length 2^{b₁}=4) seeded by the ker L₁ harmonics."""
+        torus = _build(_torus_topology())
+        harmonics = np.asarray(
+            cobordism.HodgeLaplacian(torus).harmonics(1, 1e-9, True))
+        num_edges = cobordism.ChainComplex.fromSpacetime(torus).numSimplices(1)
+        cols = harmonics.reshape(num_edges, -1) if harmonics.size else harmonics
+        # Map the two real harmonic 1-forms to two distinct unit vectors in the
+        # 4-dim flat-connection Hilbert space Z(T²) (the precise embedding is
+        # immaterial for T1: Z(W)=id makes the amplitude the inner product).
+        psi_a = np.zeros(4, dtype=complex)
+        psi_b = np.zeros(4, dtype=complex)
+        seed_a = cols[:, 0]
+        seed_b = cols[:, 1] if cols.shape[1] > 1 else cols[:, 0]
+        for i in range(4):
+            psi_a[i] = complex(seed_a[i % seed_a.size], seed_b[(i + 1) % seed_b.size])
+            psi_b[i] = complex(seed_b[i % seed_b.size], -seed_a[(i + 2) % seed_a.size])
+        psi_a /= np.linalg.norm(psi_a)
+        psi_b /= np.linalg.norm(psi_b)
+        return psi_a, psi_b
+
+    def test_amplitude_equals_inner_product(self):
+        dw = DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial)
+        psi_a, psi_b = self._boundary_states_from_harmonics()
+        amplitude = dw.amplitude(list(psi_a), list(psi_b))
+        self.assertAlmostEqual(amplitude, np.vdot(psi_a, psi_b), places=9)
+
+    def test_amplitude_equals_inner_product_random_states(self):
+        dw = DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial)
+        rng = np.random.default_rng(109)
+        for _ in range(5):
+            psi_a = rng.standard_normal(4) + 1j * rng.standard_normal(4)
+            psi_b = rng.standard_normal(4) + 1j * rng.standard_normal(4)
+            amplitude = dw.amplitude(list(psi_a), list(psi_b))
+            self.assertAlmostEqual(amplitude, np.vdot(psi_a, psi_b), places=9)
+
+    def test_diagonal_amplitudes_are_norms(self):
+        # ⟨ψ|Z(W)|ψ⟩ = ‖ψ‖² for the identity cobordism.
+        dw = DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial)
+        for basis in range(4):
+            psi = [1.0 if i == basis else 0.0 for i in range(4)]
+            self.assertAlmostEqual(dw.amplitude(psi, psi), 1.0, places=9)
+
+
+# --------------------------------------------------------------------------- #
+# numpy oracle for the boundary sum on a small bounded fixture.
+# --------------------------------------------------------------------------- #
+class TestBoundaryAgainstOracle(unittest.TestCase):
+
+    def _check(self, spacetime):
+        for cocycle, kind in ((Cocycle.Trivial, "trivial"), (Cocycle.Sign, "sign")):
+            with self.subTest(cocycle=kind):
+                vector = np.asarray(
+                    DijkgraafWitten(spacetime, cocycle).boundaryVector())
+                np.testing.assert_allclose(vector.imag, 0.0, atol=1e-9)
+                got = sorted(float(x) for x in vector.real)
+                self.assertEqual([round(x, 9) for x in got],
+                                 [round(x, 9) for x in _boundary_oracle(spacetime, kind)])
+
+    def test_solid_torus(self):
+        self._check(_solid_torus())
+
+    def test_solid_torus_pinned_values(self):
+        # S¹×D² has H¹=ℤ₂ (2 bulk classes); the restriction to ∂=T² is injective,
+        # so 2 of the 4 boundary classes get amplitude 1 and the rest 0.
+        vector = np.asarray(
+            DijkgraafWitten(_solid_torus(), Cocycle.Trivial).boundaryVector())
+        self.assertEqual(vector.size, 4)
+        self.assertAlmostEqual(vector.real.sum(), 2.0, places=9)
+        self.assertEqual(int(np.count_nonzero(np.round(vector.real, 6))), 2)
+        self.assertEqual(sorted(np.round(vector.real, 6)), [0.0, 0.0, 1.0, 1.0])
+
+    def test_sphere_cylinder_oracle(self):
+        # A two-component boundary fixture for the oracle as well (S² ⊔ S²).
+        self._check(_sphere_cylinder())
+
+
+# --------------------------------------------------------------------------- #
+# Guards.
+# --------------------------------------------------------------------------- #
+class TestBoundaryGuards(unittest.TestCase):
+
+    def test_closed_manifold_has_no_boundary_vector(self):
+        with self.assertRaises(RuntimeError):
+            DijkgraafWitten(_three_sphere(), Cocycle.Trivial).boundaryVector()
+
+    def test_map_requires_two_components(self):
+        # The solid torus has a single boundary component, so map() (which needs
+        # Σ_A and Σ_B) must refuse it; boundaryVector() still works.
+        dw = DijkgraafWitten(_solid_torus(), Cocycle.Trivial)
+        self.assertEqual(len(dw.boundaryVector()), 4)
+        with self.assertRaises(RuntimeError):
+            dw.map()
+
+    def test_amplitude_rejects_wrong_length(self):
+        dw = DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial)
+        with self.assertRaises((ValueError, RuntimeError)):
+            dw.amplitude([1.0, 0.0], [1.0, 0.0, 0.0, 0.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extends `cobordism::DijkgraafWitten` (the closed-W ℤ₂ state sum, #108) to **W-with-boundary**, giving the Dijkgraaf–Witten state sum as a vector in the boundary Hilbert space `Z(∂W)` — read as a map `Z(Σ_B) → Z(Σ_A)`.

## What

New methods on `DijkgraafWitten` (bindings localized to its block in `src/cobordism/Bindings.cpp`):

- **`boundaryVector()`** — the element of `Z(∂W)`: the amplitude for every joint boundary flat-connection class, flattened over the boundary components (each closed surface `Σ_i` carries `Z(Σ_i) = ℂ[H¹(Σ_i;ℤ₂)]`, dimension `2^{b₁(Σ_i)}`).
- **`map()`** — the boundary state sum as a dense matrix `Z(Σ_B) → Z(Σ_A)` when `∂W` has exactly two components (rows `2^{b₁(Σ_A)}`, cols `2^{b₁(Σ_B)}`).
- **`amplitude(ψ_A, ψ_B)`** — `⟨ψ_A | Z(W) | ψ_B⟩` in the flat-connection-class basis.
- **`boundaryDimensions()`** — the per-component Hilbert dims.

## Method

`∂W` is identified via `Cobordism::boundaryFaces` (codim-1 faces in exactly one top cell) and split into components. The sum holds `g|∂W` fixed and runs over the **interior fields modulo gauge** — the bulk cohomology classes `[g] ∈ H¹(W;ℤ₂)` — binned by the `H¹(Σ_i;ℤ₂)` class of each boundary restriction, weighting each by the same `∏_t ω(g₀₁,g₁₂,g₂₃)` product as the closed case. Working with cohomology classes (not the gauge-redundant cocycle space) keeps it small (`2^{b₁(W)}` terms, no `2^{|V|+b₁}` blow-up) and is normalized so the trivial cobordism is the identity — no gauge-volume divides it. For the real ℤ₂ cocycles (`Trivial`, `Sign`) the orientation exponent `ε_t` is immaterial (`x^{±1}=x`, `ω̄=ω`), so no relative fundamental class is needed (none exists for a bounded manifold) and the product matches the closed case.

Boundary states `ψ ∈ ker L₁(Σ)` come from the merged `HodgeLaplacian` (k=1, #104).

## Acceptance (T1)

Tests in `tests/cobordism/test_dijkgraaf_witten_boundary_python.py` (14 tests + subtests, all green; full `tests/cobordism` suite: 183 passed, 1 pre-existing skip):

- **Cylinder = identity.** For `W = Cylinder(T²) = T²×[0,T]`, `Z(W)` is exactly the 4×4 identity on `Z(T²)` (and `[[1]]` for `S²×[0,T]`); the `Sign` cocycle agrees (vanishing cup cube).
- **`⟨ψ_A|Z(W)|ψ_B⟩ = ⟨ψ_A|ψ_B⟩`** for boundary states, with `ker L₁(T²)` confirmed 2-dimensional — the harmonic qubit (`b₁=2`), kept distinct from the `2^{b₁}=4` flat-connection count per spec §5.2.
- **numpy oracle.** An independent numpy reimplementation of the boundary sum (separate GF(2) cohomology + holonomy binning) reproduces the C++ amplitude vector on a small bounded fixture (solid torus `S¹×D²`, boundary `T²`), for both cocycles.

Normalization cross-check: by gluing, `Tr Z(T²×I) = dim Z(T²) = 4 = Z_closed(T³) = 2^{b₁(T³)−1}`. ✓

Closes #109.