### PR TITLE
spacetime: pre-geometric boundary-fixed Pachner moves (T2)

### DIFF
--- a/include/spacetime/PachnerMove.h
+++ b/include/spacetime/PachnerMove.h
@@ -4,6 +4,7 @@
 #ifndef TESSERA_PACHNERMOVE_H
 #define TESSERA_PACHNERMOVE_H
 
+#include <algorithm>
 #include <cstdint>
 #include <random>
 #include <string>
@@ -103,7 +104,131 @@ inline VertexPtrs unionVerticesAcross(SimplexRange const &simplices) {
   return out;
 }
 
+// ===================================================================
+// Pre-geometric / boundary-fixed helpers.
+//
+// These read the incidence structure straight off the vertices'
+// simplex lists, so they work on a *pre-geometric* complex (one built
+// combinatorially via ``Topology::buildExplicit``, where facet/coface
+// caches are not pre-materialised and the metric dimension may differ
+// from the manifold dimension).  They are also coface-cache-independent
+// in the CDT case, but the CDT move paths deliberately keep using the
+// cached ``getCofaces`` walk so their behaviour is byte-identical.
+// ===================================================================
+
+/// Every top-dimensional simplex (``topVerts`` vertices) that contains
+/// all of ``verts``.  Found by scanning the simplex list of ``verts``'
+/// first vertex — no facet/coface materialisation required.
+inline std::vector<SimplexPtr> topCofacesOf(const VertexPtrs &verts,
+                                            int topVerts) {
+  std::vector<SimplexPtr> out;
+  if (verts.empty()) return out;
+  for (const auto &s : verts.front()->getSimplices()) {
+    if (static_cast<int>(s->size()) != topVerts) continue;
+    bool all = true;
+    for (std::size_t i = 1; i < verts.size(); ++i) {
+      if (!s->hasVertex(verts[i])) { all = false; break; }
+    }
+    if (all) out.push_back(s);
+  }
+  return out;
+}
+
+/// Number of top simplices sharing the (codim-1) face ``facetVerts``.
+inline int topCofaceCount(const VertexPtrs &facetVerts, int topVerts) {
+  return static_cast<int>(topCofacesOf(facetVerts, topVerts).size());
+}
+
+/// A codimension-1 face is on the boundary ``∂W`` iff exactly one top
+/// cell contains it; an interior face is shared by exactly two.
+inline bool isBoundaryFacet(const VertexPtrs &facetVerts, int topVerts) {
+  return topCofaceCount(facetVerts, topVerts) == 1;
+}
+
+/// Order a cell's vertices by ascending id.  ``cobordism::ChainComplex``
+/// (and every coordinate-free fixture) takes the increasing-vertex-id
+/// ordering as each simplex's reference orientation, so the simplicial
+/// boundary signs (facet ``i`` ↦ ``(-1)^i``) glue consistently and
+/// ``∂² = 0`` holds globally.  Pre-geometric moves build new cells from
+/// mixed (shared/unique) vertex lists, so they must re-sort before
+/// committing or the homology of the mutated complex is corrupted.
+inline void sortByVertexId(VertexPtrs &verts) {
+  std::sort(verts.begin(), verts.end(),
+            [](const VertexPtr &a, const VertexPtr &b) {
+              return a->getId() < b->getId();
+            });
+}
+
+/// True iff vertices ``a`` and ``b`` already co-occur in some simplex
+/// (i.e. the edge ``a–b`` already exists).  Used to reject a 2→(d+1)
+/// flip whose new apex edge would collide with existing structure.
+inline bool verticesAdjacent(const VertexPtr &a, const VertexPtr &b) {
+  for (const auto &s : a->getSimplices()) {
+    if (s->hasVertex(b)) return true;
+  }
+  return false;
+}
+
+/// True iff the edge ``a–b`` is interior: no boundary facet contains
+/// both endpoints.  An interior-only (boundary-fixed) ``d→2`` flip
+/// must not collapse an edge that lies on ``∂W``.
+inline bool isInteriorEdge(const VertexPtr &a, const VertexPtr &b,
+                           int topVerts) {
+  for (const auto &s : a->getSimplices()) {
+    if (static_cast<int>(s->size()) != topVerts) continue;
+    if (!s->hasVertex(b)) continue;
+    const auto &sv = s->getVertices();
+    for (std::size_t skip = 0; skip < sv.size(); ++skip) {
+      VertexPtrs facetVerts;
+      facetVerts.reserve(sv.size() - 1);
+      bool hasA = false, hasB = false;
+      for (std::size_t i = 0; i < sv.size(); ++i) {
+        if (i == skip) continue;
+        facetVerts.push_back(sv[i]);
+        if (sv[i]->getId() == a->getId()) hasA = true;
+        if (sv[i]->getId() == b->getId()) hasB = true;
+      }
+      if (hasA && hasB && isBoundaryFacet(facetVerts, topVerts)) return false;
+    }
+  }
+  return true;
+}
+
+/// True iff vertex ``v`` is interior: none of the codim-1 faces
+/// incident to it lies on ``∂W``.  An interior-only (boundary-fixed)
+/// ``(d+1)→1`` move must only delete interior vertices.
+inline bool isInteriorVertex(const VertexPtr &v, int topVerts) {
+  for (const auto &s : v->getSimplices()) {
+    if (static_cast<int>(s->size()) != topVerts) continue;
+    const auto &sv = s->getVertices();
+    for (std::size_t skip = 0; skip < sv.size(); ++skip) {
+      if (sv[skip]->getId() == v->getId()) continue;  // facet would drop v
+      VertexPtrs facetVerts;
+      facetVerts.reserve(sv.size() - 1);
+      for (std::size_t i = 0; i < sv.size(); ++i) {
+        if (i != skip) facetVerts.push_back(sv[i]);
+      }
+      if (isBoundaryFacet(facetVerts, topVerts)) return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace pachner_detail
+
+/// Validity regime a :class:`PachnerMove` runs under.
+///
+/// * ``CDT`` — the original causal-dynamical-triangulations path: every
+///   proposed cell must satisfy the time-sliced CDT orientation
+///   constraint (``pachner_detail::isValidCDTOrientation``) and the
+///   move dimension comes from the metric signature.  This path is left
+///   byte-identical to the pre-#112 behaviour.
+/// * ``PreGeometric`` — the CDT orientation/time-slice guards are
+///   dropped so the bistellar moves run on a coordinate-free simplicial
+///   complex (e.g. a ``SimplicialProduct`` fixture).  The move dimension
+///   is read off the actual top cell rather than the metric, and a
+///   manifold-preservation check stands in for the orientation guard.
+enum class PachnerMode : std::uint8_t { CDT = 0, PreGeometric = 1 };
 
 
 /// Transactional Pachner move: a propose-apply-rollback wrapper around
@@ -149,6 +274,16 @@ class PachnerMove {
 public:
   virtual ~PachnerMove() = default;
 
+  /// The validity regime this move runs under (CDT vs. pre-geometric).
+  /// Defaults to :enumerator:`PachnerMode::CDT` so existing callers and
+  /// the CDT Markov chain are unaffected.
+  PachnerMode mode() const { return mode_; }
+
+  /// True iff the move is restricted to the interior of the complex:
+  /// it only fires when it leaves the boundary face-set ``∂W``
+  /// (codim-1 faces in exactly one top cell) unchanged.
+  bool boundaryFixed() const { return boundaryFixed_; }
+
   /// Pick a target and validate it.  No spacetime mutation.
   /// Returns ``true`` on success, ``false`` if no eligible target.
   virtual bool propose() = 0;
@@ -190,6 +325,16 @@ public:
   /// One of: ``"add"``, ``"remove"``, ``"flip"``, ``"iflip"``,
   /// ``"shift"``.
   virtual std::string moveType() const = 0;
+
+protected:
+  /// CDT-mode move (the default; preserves the pre-#112 behaviour).
+  PachnerMove() = default;
+  /// Move configured with an explicit validity regime / boundary policy.
+  PachnerMove(PachnerMode mode, bool boundaryFixed)
+      : mode_(mode), boundaryFixed_(boundaryFixed) {}
+
+  PachnerMode mode_ = PachnerMode::CDT;
+  bool boundaryFixed_ = false;
 };
 
 }  // namespace tessera

--- a/include/spacetime/pachner/AddMove.h
+++ b/include/spacetime/pachner/AddMove.h
@@ -40,8 +40,10 @@ using namespace ::tessera::quantum;
 /// removing the new vertex.
 class AddMove : public PachnerMove {
 public:
-  AddMove(Spacetime *st, std::mt19937 *rng, bool relabelEnabled = true);
-  AddMove(Spacetime *st, std::uint64_t seed, bool relabelEnabled = true);
+  AddMove(Spacetime *st, std::mt19937 *rng, bool relabelEnabled = true,
+          PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
+  AddMove(Spacetime *st, std::uint64_t seed, bool relabelEnabled = true,
+          PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
 
   bool propose() override;
   int dN0() const override { return 1; }
@@ -55,6 +57,14 @@ public:
   std::string moveType() const override { return "add"; }
 
 private:
+  // Pre-geometric 1→(d+1) stellar move: insert a fresh interior vertex
+  // into a single top cell and cone it over the cell's facets, replacing
+  // 1 cell with d+1.  Always interior (it never touches ∂W), so it is
+  // unconditionally boundary-fixed-safe.
+  bool proposePreGeometric();
+  bool applyPreGeometric();
+  void rollbackPreGeometric();
+
   Spacetime *st_;
   std::unique_ptr<std::mt19937> ownedRng_;
   std::mt19937 *rng_;

--- a/include/spacetime/pachner/FlipMove.h
+++ b/include/spacetime/pachner/FlipMove.h
@@ -36,8 +36,10 @@ using namespace ::tessera::quantum;
 /// See ``CDT::flip`` for the original (non-transactional) implementation.
 class FlipMove : public PachnerMove {
 public:
-  FlipMove(Spacetime *st, std::mt19937 *rng);
-  FlipMove(Spacetime *st, std::uint64_t seed);
+  FlipMove(Spacetime *st, std::mt19937 *rng,
+           PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
+  FlipMove(Spacetime *st, std::uint64_t seed,
+           PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
 
   bool propose() override;
   int dN0() const override { return 0; }
@@ -54,6 +56,13 @@ private:
   Spacetime *st_;
   std::unique_ptr<std::mt19937> ownedRng_;
   std::mt19937 *rng_;
+
+  /// Pre-geometric 2→(d+1) flip: the same combinatorial replacement as
+  /// the CDT path but without the time-slice / CDT-orientation guard,
+  /// with the move dimension read off the chosen top cell and a
+  /// manifold-preservation check (apex edge must not pre-exist).  In
+  /// boundary-fixed mode the operative facet must be interior.
+  bool proposePreGeometric();
 
   bool proposed_ = false;
   std::vector<VertexPtrs> oldSimplexVerts_;

--- a/include/spacetime/pachner/IFlipMove.h
+++ b/include/spacetime/pachner/IFlipMove.h
@@ -39,8 +39,10 @@ using namespace ::tessera::quantum;
 /// advertised changes.
 class IFlipMove : public PachnerMove {
 public:
-  IFlipMove(Spacetime *st, std::mt19937 *rng);
-  IFlipMove(Spacetime *st, std::uint64_t seed);
+  IFlipMove(Spacetime *st, std::mt19937 *rng,
+            PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
+  IFlipMove(Spacetime *st, std::uint64_t seed,
+            PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
 
   bool propose() override;
   int dN0() const override { return 0; }

--- a/include/spacetime/pachner/RemoveMove.h
+++ b/include/spacetime/pachner/RemoveMove.h
@@ -39,8 +39,10 @@ using namespace ::tessera::quantum;
 /// by ``apply()`` before the geometry is mutated.
 class RemoveMove : public PachnerMove {
 public:
-  RemoveMove(Spacetime *st, std::mt19937 *rng);
-  RemoveMove(Spacetime *st, std::uint64_t seed);
+  RemoveMove(Spacetime *st, std::mt19937 *rng,
+             PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
+  RemoveMove(Spacetime *st, std::uint64_t seed,
+             PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
 
   bool propose() override;
   int dN0() const override { return -1; }
@@ -54,6 +56,16 @@ public:
   std::string moveType() const override { return "remove"; }
 
 private:
+  // Pre-geometric (d+1)→1 stellar weld: the inverse of the 1→(d+1)
+  // add.  Picks a vertex whose star is exactly the cone over the
+  // boundary of one d-simplex (degree d+1, link = a (d-1)-sphere),
+  // deletes it and its d+1 cells, and welds in the single cell on the
+  // link vertices.  The structural check guarantees the vertex is
+  // interior, so the move never touches ∂W.  rollback() is shared with
+  // the CDT path (it is generic over the removed-cell count).
+  bool proposePreGeometric();
+  bool applyPreGeometric();
+
   Spacetime *st_;
   std::unique_ptr<std::mt19937> ownedRng_;
   std::mt19937 *rng_;

--- a/include/spacetime/pachner/ShiftMove.h
+++ b/include/spacetime/pachner/ShiftMove.h
@@ -41,11 +41,13 @@ class ShiftMove : public PachnerMove {
 public:
   /// Construct with a caller-owned RNG (used by CDT internally so all
   /// moves share the same Markov chain).
-  ShiftMove(Spacetime *st, std::mt19937 *rng);
+  ShiftMove(Spacetime *st, std::mt19937 *rng,
+            PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
 
   /// Construct with an internally-owned RNG seeded from ``seed``
   /// (convenient for one-shot use from Python tests).
-  ShiftMove(Spacetime *st, std::uint64_t seed);
+  ShiftMove(Spacetime *st, std::uint64_t seed,
+            PachnerMode mode = PachnerMode::CDT, bool boundaryFixed = false);
 
   bool propose() override;
   int dN0() const override { return 0; }

--- a/src/cobordism/ChainComplex.cpp
+++ b/src/cobordism/ChainComplex.cpp
@@ -66,7 +66,24 @@ ChainComplex ChainComplex::fromSpacetime(const Spacetime &K) {
   // sign below, which mesh facets don't carry.
   std::map<int, std::vector<SimplexPtr>> byDim;
   std::unordered_set<std::uint64_t> seen;
-  std::vector<SimplexPtr> stack(K.getSimplices().begin(), K.getSimplices().end());
+  // Seed the downward BFS from the top-dimensional cells only.  Genuine
+  // lower-dimensional faces are reached through getFacets below; starting
+  // from *every* registered simplex would also pull in orphaned
+  // sub-simplices that the mesh creates lazily (Simplex::getFacets) and
+  // never garbage-collects once their cofaces are removed — e.g. the
+  // shared facet a 2->3 Pachner flip deletes, or any facet materialised
+  // by a previous fromSpacetime() call whose top cell a later move
+  // removed.  Such orphans are faces of no current top cell and would
+  // corrupt the chain groups (spurious cycles, even negative Betti
+  // numbers).  For a pure complex — every manifold/fixture here — the top
+  // cells' face-closure is exactly the chain complex, so on a freshly
+  // built complex this seeds the identical simplex set as before.
+  std::size_t topSize = 0;
+  for (const auto &s : K.getSimplices())
+    if (s != nullptr) topSize = std::max(topSize, static_cast<std::size_t>(s->size()));
+  std::vector<SimplexPtr> stack;
+  for (const auto &s : K.getSimplices())
+    if (s != nullptr && s->size() == topSize) stack.push_back(s);
   while (!stack.empty()) {
     SimplexPtr s = stack.back();
     stack.pop_back();

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -521,6 +521,26 @@ Args:
   // ========================================
   // PachnerMove (transactional Pachner moves)
   // ========================================
+  py::enum_<PachnerMode>(m, "PachnerMode",
+      R"doc(Validity regime a Pachner move runs under.
+
+  - CDT:          the causal-dynamical-triangulations path. Every
+                  proposed cell must satisfy the time-sliced CDT
+                  orientation constraint and the move dimension comes
+                  from the metric signature. This path is byte-identical
+                  to the pre-generalization behaviour.
+  - PreGeometric: the CDT orientation/time-slice guards are dropped so
+                  the bistellar moves run on a coordinate-free
+                  (non-time-sliced) simplicial complex. The move
+                  dimension is read off the actual top cell and a
+                  manifold-preservation check stands in for the
+                  orientation guard.)doc")
+      .value("CDT", PachnerMode::CDT)
+      .value("PreGeometric", PachnerMode::PreGeometric);
+      // NB: no export_values() — that would inject a module-level ``CDT``
+      // that shadows ``SpacetimeType.CDT`` (``tessera.CDT``).  Access the
+      // members as ``tessera.PachnerMode.CDT`` / ``.PreGeometric``.
+
   py::class_<PachnerMove>(m, "PachnerMove",
       R"doc(Abstract base class for transactional Pachner moves.
 
@@ -561,7 +581,11 @@ See ``docs/source/modularity-plan.md`` for the design rationale.)doc")
            "Used for informed (community-aware) proposals.")
       .def("moveType", &PachnerMove::moveType,
            "Move-type tag: one of 'add', 'remove', 'flip', 'iflip', "
-           "'shift'.");
+           "'shift'.")
+      .def("mode", &PachnerMove::mode,
+           "Validity regime: PachnerMode.CDT or PachnerMode.PreGeometric.")
+      .def("boundaryFixed", &PachnerMove::boundaryFixed,
+           "True iff the move is restricted to the interior (∂W fixed).");
 
   py::class_<AddMove, PachnerMove>(m, "AddMove",
       R"doc(Transactional (2,2d) add (vertex insertion) move.
@@ -574,14 +598,19 @@ spatial time slice.  ``dN0 = +1``; ``dN41 = +(2d-2) = +6`` in 4D;
 Vertex relabeling (per [BGL] Sec. 2.2.1) is enabled by default.
 Pass ``relabel=False`` to disable for tests that need stable
 fingerprints across moves.)doc")
-      .def(py::init<Spacetime *, std::uint64_t, bool>(),
+      .def(py::init<Spacetime *, std::uint64_t, bool, PachnerMode, bool>(),
            py::arg("spacetime"), py::arg("seed"),
            py::arg("relabel") = true,
+           py::arg("mode") = PachnerMode::CDT,
+           py::arg("boundaryFixed") = false,
            py::keep_alive<1, 2>(),
            "Construct an add move bound to ``spacetime`` with a fresh "
            "RNG seeded from ``seed``.  ``relabel`` controls whether the "
            "new vertex's ID is swap-relabeled with a random existing "
-           "vertex on apply().");
+           "vertex on apply().  ``mode=PachnerMode.PreGeometric`` runs "
+           "the 1->(d+1) stellar subdivision on a coordinate-free "
+           "complex; ``boundaryFixed`` restricts the move to the "
+           "interior (a no-op for add, which never touches ∂W).");
 
   py::class_<FlipMove, PachnerMove>(m, "FlipMove",
       R"doc(Transactional (2,d) flip move.
@@ -589,11 +618,17 @@ fingerprints across moves.)doc")
 Removes 2 d-simplices sharing a (d-1)-face and creates d new
 d-simplices sharing an edge.  ``dN0 = 0``; ``ΔN4 = d - 2 = +2`` in 4D.
 Inverse: :class:`IFlipMove`.)doc")
-      .def(py::init<Spacetime *, std::uint64_t>(),
+      .def(py::init<Spacetime *, std::uint64_t, PachnerMode, bool>(),
            py::arg("spacetime"), py::arg("seed"),
+           py::arg("mode") = PachnerMode::CDT,
+           py::arg("boundaryFixed") = false,
            py::keep_alive<1, 2>(),
            "Construct a (2,d) flip move bound to ``spacetime`` with a "
-           "fresh ``std::mt19937`` seeded with ``seed``.");
+           "fresh ``std::mt19937`` seeded with ``seed``.  "
+           "``mode=PachnerMode.PreGeometric`` runs the 2->(d+1) bistellar "
+           "flip on a coordinate-free complex (drops the CDT orientation "
+           "guard, adds a manifold check); ``boundaryFixed`` keeps it "
+           "interior (∂W fixed).");
 
   py::class_<RemoveMove, PachnerMove>(m, "RemoveMove",
       R"doc(Transactional (2d, 2) remove (vertex deletion) move.
@@ -606,11 +641,16 @@ simplices.  ``dN0 = -1``; ``dN41 = -(2d-2) = -6`` in 4D;
 Rollback recreates the deleted vertex (with original ID and
 coordinates), reinserts its incident edges (with original squared
 lengths), and recreates the 2d removed simplices.)doc")
-      .def(py::init<Spacetime *, std::uint64_t>(),
+      .def(py::init<Spacetime *, std::uint64_t, PachnerMode, bool>(),
            py::arg("spacetime"), py::arg("seed"),
+           py::arg("mode") = PachnerMode::CDT,
+           py::arg("boundaryFixed") = false,
            py::keep_alive<1, 2>(),
            "Construct a remove move bound to ``spacetime`` with a fresh "
-           "RNG seeded from ``seed``.");
+           "RNG seeded from ``seed``.  ``mode=PachnerMode.PreGeometric`` "
+           "runs the (d+1)->1 stellar weld (inverse of the pre-geometric "
+           "add) on a coordinate-free complex; the move is interior by "
+           "construction, so ``boundaryFixed`` adds no restriction.");
 
   py::class_<IFlipMove, PachnerMove>(m, "IFlipMove",
       R"doc(Transactional inverse (d, 2) flip move.
@@ -621,11 +661,16 @@ Inverse: :class:`FlipMove`.
 
 Includes a manifold-preservation check in propose() — rejects if
 either new simplex would already exist in the lattice.)doc")
-      .def(py::init<Spacetime *, std::uint64_t>(),
+      .def(py::init<Spacetime *, std::uint64_t, PachnerMode, bool>(),
            py::arg("spacetime"), py::arg("seed"),
+           py::arg("mode") = PachnerMode::CDT,
+           py::arg("boundaryFixed") = false,
            py::keep_alive<1, 2>(),
            "Construct an inverse flip bound to ``spacetime`` with a "
-           "fresh ``std::mt19937`` seeded with ``seed``.");
+           "fresh ``std::mt19937`` seeded with ``seed``.  "
+           "``mode=PachnerMode.PreGeometric`` runs the (d+1)->2 bistellar "
+           "flip on a coordinate-free complex; ``boundaryFixed`` rejects "
+           "flips that would collapse an edge on ∂W.");
 
   py::class_<ShiftMove, PachnerMove>(m, "ShiftMove",
       R"doc(Transactional (3,3) shift move.
@@ -634,11 +679,16 @@ Picks a random top simplex and a random (d-2)-face.  If exactly d-1
 top simplices share that face, replaces them with d-1 new simplices
 sharing the complementary (d-2)-face.  Self-inverse — dN0 = 0 and
 dN41 + dN32 = 0.)doc")
-      .def(py::init<Spacetime *, std::uint64_t>(),
+      .def(py::init<Spacetime *, std::uint64_t, PachnerMode, bool>(),
            py::arg("spacetime"), py::arg("seed"),
+           py::arg("mode") = PachnerMode::CDT,
+           py::arg("boundaryFixed") = false,
            py::keep_alive<1, 2>(),
            R"doc(Construct a shift move bound to ``spacetime``, using a
 fresh ``std::mt19937`` seeded with ``seed`` for the proposal.
+
+``mode=PachnerMode.PreGeometric`` drops the CDT orientation guard;
+``boundaryFixed`` only fires shifts whose whole region is interior.
 
 For sweeps that share a single Markov chain across many moves, drive
 moves via ``CDT.proposeShift()`` instead.)doc");

--- a/src/spacetime/pachner/AddMove.cpp
+++ b/src/spacetime/pachner/AddMove.cpp
@@ -23,18 +23,23 @@ using namespace ::tessera::observables;
 using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
 
-AddMove::AddMove(Spacetime *st, std::mt19937 *rng, bool relabelEnabled)
-    : st_(st), ownedRng_(nullptr), rng_(rng),
+AddMove::AddMove(Spacetime *st, std::mt19937 *rng, bool relabelEnabled,
+                 PachnerMode mode, bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st), ownedRng_(nullptr), rng_(rng),
       relabelEnabled_(relabelEnabled) {}
 
-AddMove::AddMove(Spacetime *st, std::uint64_t seed, bool relabelEnabled)
-    : st_(st),
+AddMove::AddMove(Spacetime *st, std::uint64_t seed, bool relabelEnabled,
+                 PachnerMode mode, bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st),
       ownedRng_(std::make_unique<std::mt19937>(seed)),
       rng_(ownedRng_.get()),
       relabelEnabled_(relabelEnabled) {}
 
 bool AddMove::propose() {
   if (proposed_) return false;
+  if (mode_ == PachnerMode::PreGeometric) return proposePreGeometric();
   using namespace pachner_detail;
   const int d = spacetimeDim(*st_);
   const int dPlus1 = d + 1;
@@ -129,8 +134,84 @@ bool AddMove::propose() {
   return true;
 }
 
+bool AddMove::proposePreGeometric() {
+  SimplexPtr sigma = st_->getRandomTopSimplex();
+  if (!sigma) return false;
+  const int dPlus1 = static_cast<int>(sigma->size());
+  if (dPlus1 < 3) return false;  // need at least a triangle to subdivide
+
+  // A 1→(d+1) stellar subdivision lives entirely inside one cell, so it
+  // is always interior — nothing to check for boundary-fixed mode.
+  sigma_ = sigma;
+  {
+    const auto &sv = sigma_->getVertices();
+    sigmaVerts_.assign(sv.begin(), sv.end());
+  }
+  // Causal bookkeeping is meaningless without a foliation.
+  dN41_ = 0;
+  logPrefactor_ = 0.0;
+
+  touchedIds_.reserve(sigmaVerts_.size());
+  for (const auto &v : sigmaVerts_) touchedIds_.push_back(v->getId());
+
+  proposed_ = true;
+  return true;
+}
+
+bool AddMove::applyPreGeometric() {
+  // 1. Fresh coordinate-free interior vertex.
+  newVert_ = st_->createVertex();
+
+  // 2. Remove the cell being subdivided.
+  st_->removeSimplex(sigma_);
+
+  // 3. Cone the new vertex over each facet of the old cell: drop one
+  //    original vertex, append the new vertex.  d+1 new cells in total.
+  const std::size_t n = sigmaVerts_.size();
+  for (std::size_t skip = 0; skip < n; ++skip) {
+    VertexPtrs verts;
+    verts.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+      if (i != skip) verts.push_back(sigmaVerts_[i]);
+    }
+    verts.push_back(newVert_);
+    // Increasing-id orientation (the new vertex has the largest id, so
+    // this is already sorted, but keep it explicit and robust).
+    pachner_detail::sortByVertexId(verts);
+    auto r = st_->createSimplexTracked(verts);
+    if (r.created) createdSimplexVerts_.push_back(verts);
+    for (const auto &e : r.newEdges) createdEdges_.push_back(e);
+  }
+
+  applied_ = true;
+  return true;
+}
+
+void AddMove::rollbackPreGeometric() {
+  // Remove the d+1 created cells (resolve by verts; see ShiftMove).
+  for (const auto &verts : createdSimplexVerts_) {
+    if (auto s = st_->findSimplexByVerts(verts)) st_->removeSimplex(s);
+  }
+  createdSimplexVerts_.clear();
+
+  // Remove the freshly-inserted edges (those from the new vertex).
+  pachner_detail::removeAndClearEdges(createdEdges_, st_);
+
+  // Remove the now-isolated new vertex.
+  if (newVert_ != nullptr) {
+    (void)st_->removeIfIsolated(newVert_);
+    newVert_ = nullptr;
+  }
+
+  // Recreate the single original cell.
+  st_->createSimplexTracked(sigmaVerts_);
+
+  applied_ = false;
+}
+
 bool AddMove::apply() {
   if (!proposed_ || applied_) return false;
+  if (mode_ == PachnerMode::PreGeometric) return applyPreGeometric();
   const int d = pachner_detail::spacetimeDim(*st_);
 
   // 1. Create the new vertex at the shared spatial time slice.
@@ -183,6 +264,7 @@ bool AddMove::apply() {
 
 void AddMove::rollback() {
   if (!applied_) return;
+  if (mode_ == PachnerMode::PreGeometric) { rollbackPreGeometric(); return; }
 
   // 1. Reverse the label swap (if any).  ``swapVertexLabels`` is its
   // own inverse — calling it again restores both vertices to their

--- a/src/spacetime/pachner/FlipMove.cpp
+++ b/src/spacetime/pachner/FlipMove.cpp
@@ -23,16 +23,21 @@ using namespace ::tessera::observables;
 using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
 
-FlipMove::FlipMove(Spacetime *st, std::mt19937 *rng)
-    : st_(st), ownedRng_(nullptr), rng_(rng) {}
+FlipMove::FlipMove(Spacetime *st, std::mt19937 *rng, PachnerMode mode,
+                   bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st), ownedRng_(nullptr), rng_(rng) {}
 
-FlipMove::FlipMove(Spacetime *st, std::uint64_t seed)
-    : st_(st),
+FlipMove::FlipMove(Spacetime *st, std::uint64_t seed, PachnerMode mode,
+                   bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st),
       ownedRng_(std::make_unique<std::mt19937>(seed)),
       rng_(ownedRng_.get()) {}
 
 bool FlipMove::propose() {
   if (proposed_) return false;
+  if (mode_ == PachnerMode::PreGeometric) return proposePreGeometric();
   using namespace pachner_detail;
   const int d = spacetimeDim(*st_);
   const int dPlus1 = d + 1;
@@ -115,6 +120,95 @@ bool FlipMove::propose() {
   // Combinatorial prefactor (matches CDT::flip): log(N4 / (N4 + d - 2)).
   double N4 = static_cast<double>(st_->getSimplexCount());
   logPrefactor_ = std::log(N4) - std::log(N4 + d - 2);
+
+  touchedIds_.reserve(d + 2);
+  for (const auto &v : shared) touchedIds_.push_back(v->getId());
+  for (const auto &v : unique) touchedIds_.push_back(v->getId());
+
+  proposed_ = true;
+  return true;
+}
+
+bool FlipMove::proposePreGeometric() {
+  using namespace pachner_detail;
+
+  SimplexPtr sigma = st_->getRandomTopSimplex();
+  if (!sigma) return false;
+  const int dPlus1 = static_cast<int>(sigma->size());
+  const int d = dPlus1 - 1;
+  if (d < 2) return false;
+
+  // Pick a random facet of sigma combinatorially (drop one vertex).  We
+  // deliberately avoid Simplex::getFacets here: it materialises facet
+  // simplices that the mesh never garbage-collects, which would litter
+  // the complex with orphans after the flip removes sigma.
+  const auto &svRef = sigma->getVertices();
+  VertexPtrs sigmaV(svRef.begin(), svRef.end());
+  std::uniform_int_distribution<std::size_t> dropDist(0, sigmaV.size() - 1);
+  const std::size_t drop = dropDist(*rng_);
+  VertexPtrs facetVerts;
+  facetVerts.reserve(static_cast<std::size_t>(d));
+  for (std::size_t i = 0; i < sigmaV.size(); ++i) {
+    if (i != drop) facetVerts.push_back(sigmaV[i]);
+  }
+
+  // The two top cells sharing this facet, found by a local scan so we
+  // don't depend on a pre-materialised coface cache (buildExplicit
+  // fixtures don't have one).
+  auto topCofaces = topCofacesOf(facetVerts, dPlus1);
+  if (topCofaces.size() != 2) return false;  // boundary facet (∂W) or non-manifold
+
+  SimplexPtr s1 = topCofaces[0];
+  SimplexPtr s2 = topCofaces[1];
+
+  auto allVerts = unionVerticesAcross(Simplices{s1, s2});
+  if (static_cast<int>(allVerts.size()) != d + 2) return false;
+
+  VertexPtrs shared, unique;
+  for (const auto &v : allVerts) {
+    if (s1->hasVertex(v) && s2->hasVertex(v)) shared.push_back(v);
+    else unique.push_back(v);
+  }
+  if (static_cast<int>(shared.size()) != d ||
+      static_cast<int>(unique.size()) != 2) return false;
+
+  // Manifold check: the 2→(d+1) flip introduces the apex edge between
+  // the two unique vertices.  If that edge already exists the flip would
+  // create a degenerate (non-embedded) cell, so reject.
+  if (verticesAdjacent(unique[0], unique[1])) return false;
+
+  // Boundary-fixed: the operative facet is interior by construction (it
+  // has exactly two top cofaces), so this flip never touches ∂W.  No
+  // further restriction is needed — see ticket #112.
+
+  std::vector<VertexPtrs> proposedNew;
+  proposedNew.reserve(d);
+  for (int skip = 0; skip < d; ++skip) {
+    VertexPtrs nv;
+    nv.reserve(dPlus1);
+    for (int i = 0; i < d; ++i) {
+      if (i != skip) nv.push_back(shared[i]);
+    }
+    nv.push_back(unique[0]);
+    nv.push_back(unique[1]);
+    if (static_cast<int>(nv.size()) != dPlus1) return false;
+    sortByVertexId(nv);  // increasing-id orientation (see helper)
+    proposedNew.push_back(std::move(nv));
+  }
+
+  oldSimplices_ = {s1, s2};
+  oldSimplexVerts_.reserve(2);
+  for (const auto &s : oldSimplices_) {
+    const auto &verts = s->getVertices();
+    oldSimplexVerts_.emplace_back(verts.begin(), verts.end());
+  }
+  newSimplexVerts_ = std::move(proposedNew);
+  // Causal (N41/N32) bookkeeping is meaningless without a foliation; the
+  // pre-geometric path reports zero and the move is scored by simplex
+  // count only.
+  dN41_ = 0;
+  dN32_ = 0;
+  logPrefactor_ = 0.0;
 
   touchedIds_.reserve(d + 2);
   for (const auto &v : shared) touchedIds_.push_back(v->getId());

--- a/src/spacetime/pachner/IFlipMove.cpp
+++ b/src/spacetime/pachner/IFlipMove.cpp
@@ -24,22 +24,33 @@ using namespace ::tessera::observables;
 using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
 
-IFlipMove::IFlipMove(Spacetime *st, std::mt19937 *rng)
-    : st_(st), ownedRng_(nullptr), rng_(rng) {}
+IFlipMove::IFlipMove(Spacetime *st, std::mt19937 *rng, PachnerMode mode,
+                     bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st), ownedRng_(nullptr), rng_(rng) {}
 
-IFlipMove::IFlipMove(Spacetime *st, std::uint64_t seed)
-    : st_(st),
+IFlipMove::IFlipMove(Spacetime *st, std::uint64_t seed, PachnerMode mode,
+                     bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st),
       ownedRng_(std::make_unique<std::mt19937>(seed)),
       rng_(ownedRng_.get()) {}
 
 bool IFlipMove::propose() {
   if (proposed_) return false;
   using namespace pachner_detail;
-  const int d = spacetimeDim(*st_);
-  const int dPlus1 = d + 1;
 
   SimplexPtr sigma = st_->getRandomTopSimplex();
   if (!sigma) return false;
+
+  // Pre-geometric complexes can carry a metric whose dimension differs
+  // from the manifold's, so read the move dimension off the actual top
+  // cell in that mode; CDT keeps using the (foliated) metric dimension.
+  const int d = (mode_ == PachnerMode::PreGeometric)
+                    ? static_cast<int>(sigma->size()) - 1
+                    : spacetimeDim(*st_);
+  const int dPlus1 = d + 1;
+  if (d < 2) return false;
 
   const auto &edges = sigma->getEdges();
   if (edges.empty()) return false;
@@ -71,6 +82,20 @@ bool IFlipMove::propose() {
       unique.push_back(v);
   }
   if (shared.size() != 2 || static_cast<int>(unique.size()) != d) return false;
+
+  // Boundary-fixed: a d→2 flip collapses the shared edge (v1,v2).  If
+  // that edge lies on ∂W the move would change the boundary, so reject.
+  if (boundaryFixed_ &&
+      !pachner_detail::isInteriorEdge(v1, v2, dPlus1)) return false;
+
+  // Pre-geometric manifold check: the welded (d-1)-facet is the simplex
+  // on the link (unique) vertices.  If any current top cell already
+  // contains all of them that facet is already present, so the weld
+  // would over-share it (>2 cofaces) and tear the pseudomanifold.  This
+  // subsumes the CDT "new cells already exist" check below (a pre-
+  // existing cell on those verts would be counted here).
+  if (mode_ == PachnerMode::PreGeometric &&
+      pachner_detail::topCofaceCount(unique, dPlus1) != 0) return false;
 
   // Manifold check: would either proposed new simplex already exist?
   // We look for a top simplex incident to unique[0] that contains all
@@ -106,11 +131,19 @@ bool IFlipMove::propose() {
     VertexPtrs nv(unique.begin(), unique.end());
     nv.push_back(shared[i]);
     if (static_cast<int>(nv.size()) != dPlus1) return false;
+    // Increasing-id orientation so the mutated complex's homology is
+    // well-defined (see pachner_detail::sortByVertexId).  CDT cell order
+    // is orientation-bearing, so only re-sort on the pre-geometric path.
+    if (mode_ == PachnerMode::PreGeometric) sortByVertexId(nv);
     proposedNew.push_back(std::move(nv));
   }
 
-  for (const auto &nv : proposedNew) {
-    if (!isValidCDTOrientation(nv, d)) return false;
+  // The CDT orientation/time-slice guard is dropped in pre-geometric
+  // mode; the manifold check above stands in for it.
+  if (mode_ == PachnerMode::CDT) {
+    for (const auto &nv : proposedNew) {
+      if (!isValidCDTOrientation(nv, d)) return false;
+    }
   }
 
   int newN41 = 0, newN32 = 0;
@@ -130,8 +163,14 @@ bool IFlipMove::propose() {
   dN32_ = newN32 - oldN32;
 
   // Combinatorial prefactor (matches CDT::iflip): log(N4 / (N4 - d + 2)).
-  double N4 = static_cast<double>(st_->getSimplexCount());
-  logPrefactor_ = std::log(N4) - std::log(N4 - d + 2);
+  // The Metropolis prefactor is a CDT-sampling quantity; the
+  // pre-geometric path is not Metropolis-driven, so it reports 0.
+  if (mode_ == PachnerMode::PreGeometric) {
+    logPrefactor_ = 0.0;
+  } else {
+    double N4 = static_cast<double>(st_->getSimplexCount());
+    logPrefactor_ = std::log(N4) - std::log(N4 - d + 2);
+  }
 
   touchedIds_.reserve(d + 2);
   for (const auto &v : shared) touchedIds_.push_back(v->getId());

--- a/src/spacetime/pachner/RemoveMove.cpp
+++ b/src/spacetime/pachner/RemoveMove.cpp
@@ -3,6 +3,7 @@
 
 #include "spacetime/pachner/RemoveMove.h"
 
+#include <algorithm>
 #include <cmath>
 #include <map>
 
@@ -24,16 +25,21 @@ using namespace ::tessera::observables;
 using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
 
-RemoveMove::RemoveMove(Spacetime *st, std::mt19937 *rng)
-    : st_(st), ownedRng_(nullptr), rng_(rng) {}
+RemoveMove::RemoveMove(Spacetime *st, std::mt19937 *rng, PachnerMode mode,
+                       bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st), ownedRng_(nullptr), rng_(rng) {}
 
-RemoveMove::RemoveMove(Spacetime *st, std::uint64_t seed)
-    : st_(st),
+RemoveMove::RemoveMove(Spacetime *st, std::uint64_t seed, PachnerMode mode,
+                       bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st),
       ownedRng_(std::make_unique<std::mt19937>(seed)),
       rng_(ownedRng_.get()) {}
 
 bool RemoveMove::propose() {
   if (proposed_) return false;
+  if (mode_ == PachnerMode::PreGeometric) return proposePreGeometric();
   using namespace pachner_detail;
   const int d = spacetimeDim(*st_);
   const int dPlus1 = d + 1;
@@ -122,8 +128,118 @@ bool RemoveMove::propose() {
   return true;
 }
 
+bool RemoveMove::proposePreGeometric() {
+  VertexPtr v = st_->getRandomVertex();
+  if (!v) return false;
+
+  // Read the top-cell vertex count off v's incident cells.
+  int dPlus1 = 0;
+  for (const auto &s : v->getSimplices())
+    dPlus1 = std::max(dPlus1, static_cast<int>(s->size()));
+  if (dPlus1 < 3) return false;
+  const int d = dPlus1 - 1;
+
+  // (d+1)→1 requires v to be incident to exactly d+1 top cells.
+  std::vector<SimplexPtr> incident;
+  for (const auto &s : v->getSimplices())
+    if (static_cast<int>(s->size()) == dPlus1) incident.push_back(s);
+  if (static_cast<int>(incident.size()) != dPlus1) return false;
+
+  // The d+1 link vertices, with how many cells each appears in.
+  std::map<std::uint64_t, VertexPtr> otherVerts;
+  std::map<std::uint64_t, int> counts;
+  for (const auto &s : incident)
+    for (const auto &vert : s->getVertices()) {
+      if (vert->getId() == v->getId()) continue;
+      otherVerts[vert->getId()] = vert;
+      counts[vert->getId()]++;
+    }
+  if (static_cast<int>(otherVerts.size()) != dPlus1) return false;
+  // Each link vertex must be omitted from exactly one cell (present in
+  // exactly d): the signature of a stellar star whose link is ∂(newTop).
+  for (const auto &[vid, c] : counts) {
+    (void)vid;
+    if (c != d) return false;
+  }
+
+  // The single replacement cell is the simplex on the link vertices.
+  VertexPtrs newTop;
+  newTop.reserve(static_cast<std::size_t>(dPlus1));
+  for (const auto &[vid, vp] : otherVerts) {
+    (void)vid;
+    newTop.push_back(vp);
+  }
+  pachner_detail::sortByVertexId(newTop);  // increasing-id orientation
+  if (st_->findSimplexByVerts(newTop)) return false;  // would duplicate a cell
+
+  // The structural check forces v's link to be the (d-1)-sphere
+  // ∂(newTop), so v is interior; the weld never touches ∂W and there is
+  // nothing extra to verify for boundary-fixed mode.
+
+  v_ = v;
+  incident_ = std::move(incident);
+  spatialVerts_ = std::move(newTop);  // the replacement cell's vertices
+  dN41_ = 0;
+  logPrefactor_ = 0.0;
+
+  incidentVerts_.reserve(incident_.size());
+  for (const auto &s : incident_) {
+    const auto &verts = s->getVertices();
+    incidentVerts_.emplace_back(verts.begin(), verts.end());
+  }
+
+  touchedIds_.reserve(static_cast<std::size_t>(dPlus1) + 1);
+  touchedIds_.push_back(v_->getId());
+  for (const auto &vp : spatialVerts_) touchedIds_.push_back(vp->getId());
+
+  proposed_ = true;
+  return true;
+}
+
+bool RemoveMove::applyPreGeometric() {
+  // Capture the vertex and its incident edges for rollback.  Pre-geometric
+  // vertices are coordinate-free, so getCoordinates() would throw; an empty
+  // coordinate vector recreates an identical coordinate-independent vertex
+  // (rollback's createVertex(id, {}) is the same call buildExplicit makes).
+  vertexId_ = v_->getId();
+  vertexCoords_.clear();
+  for (const auto &e : v_->getInEdges())
+    deletedEdges_.push_back({e->getSource(), e->getTarget(),
+                             e->getSquaredLength()});
+  for (const auto &e : v_->getOutEdges())
+    deletedEdges_.push_back({e->getSource(), e->getTarget(),
+                             e->getSquaredLength()});
+
+  // Remove the d+1 incident cells.
+  for (const auto &s : incident_) st_->removeSimplex(s);
+
+  // Remove edges incident to v from both endpoints + the global list.
+  Edges inCopy(v_->getInEdges().begin(), v_->getInEdges().end());
+  for (const auto &e : inCopy) {
+    e->getSource()->removeOutEdge(e);
+    v_->removeInEdge(e);
+    st_->getEdgeList()->remove(e);
+  }
+  Edges outCopy(v_->getOutEdges().begin(), v_->getOutEdges().end());
+  for (const auto &e : outCopy) {
+    e->getTarget()->removeInEdge(e);
+    v_->removeOutEdge(e);
+    st_->getEdgeList()->remove(e);
+  }
+  (void)st_->removeIfIsolated(v_);
+
+  // Weld in the single replacement cell on the link vertices.
+  auto r = st_->createSimplexTracked(spatialVerts_);
+  if (r.created) createdSimplexVerts_.push_back(spatialVerts_);
+  for (const auto &e : r.newEdges) createdEdges_.push_back(e);
+
+  applied_ = true;
+  return true;
+}
+
 bool RemoveMove::apply() {
   if (!proposed_ || applied_) return false;
+  if (mode_ == PachnerMode::PreGeometric) return applyPreGeometric();
 
   // 1. Capture edge data BEFORE deletion (for rollback).
   // Mirrors CDT::remove's edge-cleanup loop.

--- a/src/spacetime/pachner/ShiftMove.cpp
+++ b/src/spacetime/pachner/ShiftMove.cpp
@@ -22,23 +22,34 @@ using namespace ::tessera::observables;
 using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
 
-ShiftMove::ShiftMove(Spacetime *st, std::mt19937 *rng)
-    : st_(st), ownedRng_(nullptr), rng_(rng) {}
+ShiftMove::ShiftMove(Spacetime *st, std::mt19937 *rng, PachnerMode mode,
+                     bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st), ownedRng_(nullptr), rng_(rng) {}
 
-ShiftMove::ShiftMove(Spacetime *st, std::uint64_t seed)
-    : st_(st),
+ShiftMove::ShiftMove(Spacetime *st, std::uint64_t seed, PachnerMode mode,
+                     bool boundaryFixed)
+    : PachnerMove(mode, boundaryFixed),
+      st_(st),
       ownedRng_(std::make_unique<std::mt19937>(seed)),
       rng_(ownedRng_.get()) {}
 
 bool ShiftMove::propose() {
   if (proposed_) return false;
   using namespace pachner_detail;
-  const int d = spacetimeDim(*st_);
-  const int dPlus1 = d + 1;
-  const int hingeSize = d - 1;
 
   SimplexPtr sigma = st_->getRandomTopSimplex();
   if (!sigma) return false;
+
+  // Pre-geometric complexes can carry a metric whose dimension differs
+  // from the manifold's, so read the move dimension off the actual top
+  // cell in that mode; CDT keeps using the (foliated) metric dimension.
+  const int d = (mode_ == PachnerMode::PreGeometric)
+                    ? static_cast<int>(sigma->size()) - 1
+                    : spacetimeDim(*st_);
+  const int dPlus1 = d + 1;
+  const int hingeSize = d - 1;
+  if (hingeSize < 1) return false;
 
   const auto &sigmaVertsRef = sigma->getVertices();
   if (static_cast<int>(sigmaVertsRef.size()) < hingeSize) return false;
@@ -75,6 +86,23 @@ bool ShiftMove::propose() {
   if (static_cast<int>(sharedVerts.size()) != hingeSize ||
       static_cast<int>(uniqueVerts.size()) != hingeSize) return false;
 
+  // Boundary-fixed: only fire when the whole affected region is interior
+  // (no involved cell carries a face on ∂W), so the shift cannot move
+  // the boundary.  Conservative but always correct.
+  if (boundaryFixed_) {
+    for (const auto &s : sharing) {
+      const auto &sv = s->getVertices();
+      for (std::size_t skip = 0; skip < sv.size(); ++skip) {
+        VertexPtrs fv;
+        fv.reserve(sv.size() - 1);
+        for (std::size_t i = 0; i < sv.size(); ++i) {
+          if (i != skip) fv.push_back(sv[i]);
+        }
+        if (isBoundaryFacet(fv, dPlus1)) return false;
+      }
+    }
+  }
+
   // Old orientation counts.
   int oldN41 = 0, oldN32 = 0;
   for (const auto &s : sharing) {
@@ -93,12 +121,19 @@ bool ShiftMove::propose() {
     }
     for (const auto &u : uniqueVerts) nv.push_back(u);
     if (static_cast<int>(nv.size()) != dPlus1) return false;
+    // Increasing-id orientation on the pre-geometric path (see
+    // pachner_detail::sortByVertexId); CDT cell order is orientation-
+    // bearing and left untouched.
+    if (mode_ == PachnerMode::PreGeometric) sortByVertexId(nv);
     proposedNew.push_back(std::move(nv));
   }
 
-  // Reject if any new simplex would have a non-CDT orientation.
-  for (const auto &nv : proposedNew) {
-    if (!isValidCDTOrientation(nv, d)) return false;
+  // Reject if any new simplex would have a non-CDT orientation.  Dropped
+  // in pre-geometric mode (no foliation to respect).
+  if (mode_ == PachnerMode::CDT) {
+    for (const auto &nv : proposedNew) {
+      if (!isValidCDTOrientation(nv, d)) return false;
+    }
   }
 
   // New orientation counts.

--- a/src/spacetime/topologies/Topology.cpp
+++ b/src/spacetime/topologies/Topology.cpp
@@ -50,9 +50,14 @@ void Topology::buildExplicit(
     const std::vector<std::vector<std::uint64_t>> &topSimplices) {
   std::vector<VertexPtr> verts;
   verts.reserve(numVertices);
-  // Coordinate-free vertices: the triangulation is purely combinatorial here.
+  // Coordinate-free vertices: the triangulation is purely combinatorial
+  // here.  Allocate through the id-counter path (not the explicit-id
+  // overload) so the counter advances past these ids — on a fresh
+  // spacetime this still assigns 0..numVertices-1, but it leaves the
+  // counter able to hand out collision-free ids to anything that later
+  // grows the complex (e.g. a pre-geometric Pachner add move).
   for (std::size_t i = 0; i < numVertices; ++i) {
-    verts.push_back(spacetime->createVertex(static_cast<std::uint64_t>(i)));
+    verts.push_back(spacetime->createVertex());
   }
   for (const auto &simplex : topSimplices) {
     VertexPtrs sv;

--- a/tests/test_pachner_pregeometric.py
+++ b/tests/test_pachner_pregeometric.py
@@ -1,0 +1,466 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+"""
+Pre-geometric, boundary-fixed Pachner moves (#112).
+
+The CDT Pachner hierarchy (Add / Remove / Flip / IFlip / Shift) is
+generalized so the 3D bistellar moves run on a *pre-geometric*
+(non-time-sliced, coordinate-free) simplicial complex via
+``mode=PachnerMode.PreGeometric``:
+
+  * Flip   — the 2 -> (d+1) bistellar flip (2->3 in 3D),
+  * IFlip  — the (d+1) -> 2 inverse flip (3->2 in 3D),
+  * Add    — the 1 -> (d+1) stellar subdivision (1->4 in 3D),
+  * Remove — the (d+1) -> 1 stellar weld (4->1 in 3D).
+
+The CDT-orientation / time-slice guard is dropped (a manifold-
+preservation check stands in for it) and the move dimension is read off
+the actual top cell rather than the metric signature.  A ``boundaryFixed``
+flag additionally restricts a move to the interior so the boundary
+face-set ``∂W`` (codim-1 faces in exactly one top cell) stays fixed.
+
+What is verified here:
+
+  * **Pre-geometric validity** — on a closed ``T^3`` a random sequence of
+    interior moves keeps it a valid closed pseudomanifold and preserves
+    homology (Betti numbers ``[1, 3, 3, 1]``).
+  * **Boundary-fixed** — on a bounded complex (a solid tetrahedron, and a
+    triangular bipyramid) interior moves leave ``∂W`` exactly unchanged
+    while changing the interior.
+
+  * **Dijkgraaf-Witten Z-invariance** (the headline T2 check) — the ℤ₂
+    state sum ``Z(W)`` is invariant to machine precision across an interior
+    Pachner sweep on the small closed 3-manifold ``S^2 x S^1``, for both the
+    Trivial and Sign cocycles.
+
+The CDT (foliated) path is unaffected — see the ``test_pachner_*`` /
+``test_*cdt*`` suites for the non-regression coverage; a couple of
+defaults are re-checked here.
+"""
+
+import itertools
+import unittest
+
+import tessera
+
+cobordism = tessera.cobordism
+PRE = tessera.PachnerMode.PreGeometric
+
+
+# =====================================================================
+# Helpers
+# =====================================================================
+
+def _spacetime(dim, topology=None):
+    """A ``dim``-dimensional spacetime.  The signature dimension is what
+    makes the (dim)-cells register as *top* simplices, so it must match
+    the manifold dimension for ``getRandomTopSimplex`` to see them."""
+    sig = tessera.Signature(dim, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    topo = topology if topology is not None else tessera.SolidSimplex(dim)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, topo)
+
+
+def _built(topology, dim=3):
+    st = _spacetime(dim, topology)
+    st.build()
+    return st
+
+
+def _circle():
+    return tessera.SimplexBoundarySphere(1)  # S^1
+
+
+def _t3():
+    """T^3 = S^1 x S^1 x S^1 — a closed, coordinate-free 3-manifold."""
+    return tessera.SimplicialProduct(
+        tessera.SimplicialProduct(_circle(), _circle()), _circle())
+
+
+def _tops(st):
+    """Top-dimensional cells as sorted vertex-id tuples (plain ints)."""
+    sizes = [len(s.getVertices()) for s in st.getSimplices()]
+    if not sizes:
+        return []
+    top = max(sizes)
+    return [tuple(sorted(v.getId() for v in s.getVertices()))
+            for s in st.getSimplices() if len(s.getVertices()) == top]
+
+
+def _facet_counts(tops):
+    counts = {}
+    for t in tops:
+        for f in itertools.combinations(t, len(t) - 1):
+            counts[f] = counts.get(f, 0) + 1
+    return counts
+
+
+def _boundary(tops):
+    """``∂W``: the codim-1 faces contained in exactly one top cell."""
+    return frozenset(f for f, c in _facet_counts(tops).items() if c == 1)
+
+
+def _is_closed_pseudomanifold(tops):
+    """Every codim-1 face is shared by exactly two top cells."""
+    counts = _facet_counts(tops)
+    return bool(counts) and all(c == 2 for c in counts.values())
+
+
+def _betti(st):
+    return cobordism.ChainComplex.fromSpacetime(st).bettiNumbers()
+
+
+def _make(cls, st, seed, boundary_fixed=False):
+    """A pre-geometric move of type ``cls`` (AddMove has the extra
+    ``relabel`` positional argument)."""
+    if cls is tessera.AddMove:
+        return cls(st, seed, False, PRE, boundary_fixed)
+    return cls(st, seed, PRE, boundary_fixed)
+
+
+_BISTELLAR = (tessera.FlipMove, tessera.IFlipMove, tessera.AddMove)
+
+
+def _run_sequence(st, n_moves, classes=_BISTELLAR, boundary_fixed=False,
+                  max_attempts=4000, after=None):
+    """Apply up to ``n_moves`` successful pre-geometric moves, cycling
+    through ``classes``.  Calls ``after(st)`` after each success (e.g. to
+    assert an invariant).  Returns the per-type success counts."""
+    counts = {c.__name__: 0 for c in classes}
+    seed = 0
+    while sum(counts.values()) < n_moves and seed < max_attempts:
+        progressed = False
+        for cls in classes:
+            m = _make(cls, st, seed, boundary_fixed)
+            if m.propose() and m.apply():
+                counts[cls.__name__] += 1
+                progressed = True
+                if after is not None:
+                    after(st)
+                break
+        seed += 1
+        if not progressed:
+            continue
+    return counts
+
+
+# =====================================================================
+# Pre-geometric validity on the closed 3-torus
+# =====================================================================
+
+class TestPreGeometricClosedT3(unittest.TestCase):
+    """A random sequence of interior bistellar moves on a closed T^3
+    keeps it a valid closed pseudomanifold and preserves homology."""
+
+    def test_fixture_starts_as_t3(self):
+        st = _built(_t3())
+        self.assertEqual(_betti(st), [1, 3, 3, 1])
+        self.assertTrue(_is_closed_pseudomanifold(_tops(st)))
+        # 3-manifold: top cells are tetrahedra.
+        self.assertTrue(all(len(t) == 4 for t in _tops(st)))
+
+    def test_random_interior_moves_preserve_homology(self):
+        st = _built(_t3())
+        st.setSeed(20240601)
+        before_tops = set(_tops(st))
+
+        counts = _run_sequence(st, n_moves=40)
+        self.assertGreaterEqual(sum(counts.values()), 40,
+                                f"too few moves fired: {counts}")
+        # The bistellar moves actually fire (not just the always-on add).
+        self.assertGreater(counts["FlipMove"] + counts["IFlipMove"], 0,
+                           f"no 2<->3 flips fired: {counts}")
+
+        # Still a closed 3-manifold with the homology of T^3.
+        self.assertTrue(_is_closed_pseudomanifold(_tops(st)))
+        self.assertEqual(_betti(st), [1, 3, 3, 1])
+        # ... and genuinely retriangulated, not a no-op.
+        self.assertNotEqual(set(_tops(st)), before_tops)
+
+    def test_homology_preserved_after_each_move(self):
+        st = _built(_t3())
+        st.setSeed(7)
+
+        def check(s):
+            self.assertEqual(_betti(s), [1, 3, 3, 1])
+            self.assertTrue(_is_closed_pseudomanifold(_tops(s)))
+
+        counts = _run_sequence(st, n_moves=15, after=check)
+        self.assertGreaterEqual(sum(counts.values()), 15)
+
+
+# =====================================================================
+# Boundary-fixed: triangular bipyramid (a flippable interior facet)
+# =====================================================================
+
+class TestBoundaryFixedBipyramid(unittest.TestCase):
+    """Two tetrahedra glued on triangle 012 (apexes 3, 4).  The shared
+    triangle is the only interior facet; the six outer triangles are
+    ``∂W``.  A boundary-fixed 2->3 flip retriangulates the interior while
+    leaving ``∂W`` exactly fixed."""
+
+    @staticmethod
+    def _bipyramid():
+        st = _spacetime(3)
+        v = [st.createVertex(i) for i in range(5)]
+        st.createSimplex([v[0], v[1], v[2], v[3]])  # tet 0123
+        st.createSimplex([v[0], v[1], v[2], v[4]])  # tet 0124
+        return st
+
+    def test_setup_has_one_interior_facet(self):
+        st = self._bipyramid()
+        tops = _tops(st)
+        self.assertEqual(len(tops), 2)
+        # 6 outer triangles on the boundary, 012 interior.
+        self.assertEqual(len(_boundary(tops)), 6)
+        self.assertNotIn((0, 1, 2), _boundary(tops))
+
+    def test_boundary_fixed_flip_keeps_boundary_changes_interior(self):
+        st = self._bipyramid()
+        boundary_before = _boundary(_tops(st))
+
+        flipped = None
+        for seed in range(200):
+            m = _make(tessera.FlipMove, st, seed, boundary_fixed=True)
+            if m.propose():
+                self.assertEqual(m.mode(), PRE)
+                self.assertTrue(m.boundaryFixed())
+                self.assertTrue(m.apply())
+                flipped = m
+                break
+        self.assertIsNotNone(flipped, "boundary-fixed flip never fired")
+
+        tops_after = _tops(st)
+        # ∂W is byte-identical; the interior changed (2 -> 3 tetrahedra).
+        self.assertEqual(_boundary(tops_after), boundary_before)
+        self.assertEqual(len(tops_after), 3)
+        # The apex edge 3-4 now exists (it did not before the flip).
+        self.assertTrue(any(3 in t and 4 in t for t in tops_after))
+
+    def test_flip_then_iflip_round_trips_with_fixed_boundary(self):
+        st = self._bipyramid()
+        boundary = _boundary(_tops(st))
+
+        for seed in range(200):
+            m = _make(tessera.FlipMove, st, seed, boundary_fixed=True)
+            if m.propose() and m.apply():
+                break
+        self.assertEqual(len(_tops(st)), 3)
+        self.assertEqual(_boundary(_tops(st)), boundary)
+
+        for seed in range(200):
+            m = _make(tessera.IFlipMove, st, seed, boundary_fixed=True)
+            if m.propose() and m.apply():
+                break
+        # Back to two tetrahedra, boundary still fixed throughout.
+        self.assertEqual(len(_tops(st)), 2)
+        self.assertEqual(_boundary(_tops(st)), boundary)
+
+
+# =====================================================================
+# Boundary-fixed: solid tetrahedron (∂ = S^2) under interior moves
+# =====================================================================
+
+class TestBoundaryFixedSolidSimplex(unittest.TestCase):
+    """``SolidSimplex(3)`` is a single tetrahedron whose boundary is the
+    4-triangle 2-sphere.  Interior moves grow the interior while ``∂W``
+    stays exactly the original four faces."""
+
+    S2 = frozenset([(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)])
+
+    def test_solid_simplex_boundary_is_s2(self):
+        st = _built(tessera.SolidSimplex(3))
+        self.assertEqual(len(_tops(st)), 1)
+        self.assertEqual(_boundary(_tops(st)), self.S2)
+
+    def test_interior_moves_fix_boundary_and_grow_interior(self):
+        st = _built(tessera.SolidSimplex(3))
+        st.setSeed(101)
+        n0_before = st.getVertexCount()
+        ntops_before = len(_tops(st))
+
+        # After every successful boundary-fixed move ∂W is unchanged.
+        self.assertEqual(_boundary(_tops(st)), self.S2)
+
+        def check(s):
+            self.assertEqual(_boundary(_tops(s)), self.S2)
+
+        counts = _run_sequence(st, n_moves=12, boundary_fixed=True, after=check)
+        self.assertGreaterEqual(sum(counts.values()), 12)
+        self.assertGreater(counts["AddMove"], 0)
+
+        # ∂W fixed, interior genuinely larger.
+        self.assertEqual(_boundary(_tops(st)), self.S2)
+        self.assertGreater(st.getVertexCount(), n0_before)
+        self.assertGreater(len(_tops(st)), ntops_before)
+
+
+# =====================================================================
+# Pre-geometric add / remove are a 1<->(d+1) inverse pair
+# =====================================================================
+
+class TestPreGeometricAddRemoveRoundTrip(unittest.TestCase):
+    """The 1->(d+1) add and the (d+1)->1 remove invert each other, and
+    the add's rollback restores the complex byte-for-byte."""
+
+    S2 = frozenset([(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)])
+
+    def _apply_add(self, st):
+        for seed in range(50):
+            m = _make(tessera.AddMove, st, seed)
+            if m.propose() and m.apply():
+                return m
+        self.fail("pre-geometric add never fired")
+
+    def test_add_creates_d_plus_1_cells_one_vertex(self):
+        st = _built(tessera.SolidSimplex(3))
+        n0, ntop = st.getVertexCount(), len(_tops(st))
+        self._apply_add(st)
+        self.assertEqual(st.getVertexCount(), n0 + 1)
+        self.assertEqual(len(_tops(st)), ntop + 3)  # 1 -> d+1 = 4 in 3D
+        # A 1->4 subdivision is interior: ∂W (the S^2) is untouched.
+        self.assertEqual(_boundary(_tops(st)), self.S2)
+
+    def test_add_rollback_restores_state(self):
+        st = _built(tessera.SolidSimplex(3))
+        before = sorted(_tops(st))
+        n0 = st.getVertexCount()
+        m = self._apply_add(st)
+        self.assertTrue(m.isApplied())
+        m.rollback()
+        self.assertFalse(m.isApplied())
+        self.assertEqual(sorted(_tops(st)), before)
+        self.assertEqual(st.getVertexCount(), n0)
+
+    def test_add_then_remove_returns_to_start(self):
+        st = _built(tessera.SolidSimplex(3))
+        before = sorted(_tops(st))
+        n0 = st.getVertexCount()
+
+        self._apply_add(st)
+        self.assertEqual(len(_tops(st)), len(before) + 3)
+
+        # The (d+1)->1 weld targets the freshly inserted interior vertex
+        # (the only vertex whose link is the boundary of a tetrahedron).
+        for seed in range(200):
+            m = _make(tessera.RemoveMove, st, seed)
+            if m.propose() and m.apply():
+                break
+        else:
+            self.fail("pre-geometric remove never fired")
+
+        self.assertEqual(sorted(_tops(st)), before)
+        self.assertEqual(st.getVertexCount(), n0)
+
+
+# =====================================================================
+# CDT default path is undisturbed
+# =====================================================================
+
+class TestCDTDefaultsUnchanged(unittest.TestCase):
+    """Moves default to the CDT regime; the new knobs are opt-in."""
+
+    @staticmethod
+    def _cdt():
+        sig = tessera.Signature(4, tessera.Lorentzian)
+        metric = tessera.Metric(True, sig)
+        st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                               tessera.PREFERRED, tessera.Toroid())
+        st.build(60)
+        return st
+
+    def test_default_mode_is_cdt(self):
+        st = self._cdt()
+        for cls in (tessera.FlipMove, tessera.IFlipMove, tessera.ShiftMove,
+                    tessera.RemoveMove):
+            m = cls(st, 0)
+            self.assertEqual(m.mode(), tessera.PachnerMode.CDT)
+            self.assertFalse(m.boundaryFixed())
+        add = tessera.AddMove(st, 0)
+        self.assertEqual(add.mode(), tessera.PachnerMode.CDT)
+        self.assertFalse(add.boundaryFixed())
+
+    def test_spacetimetype_cdt_not_shadowed(self):
+        # Regression guard: tessera.CDT must remain SpacetimeType.CDT,
+        # not PachnerMode.CDT (the enums share the member name "CDT").
+        self.assertIs(tessera.CDT, tessera.SpacetimeType.CDT)
+
+    def test_cdt_flip_still_proposes(self):
+        st = self._cdt()
+        ok = any(tessera.FlipMove(st, s).propose() for s in range(200))
+        self.assertTrue(ok)
+
+
+# =====================================================================
+# Dijkgraaf-Witten Z-invariance — the headline T2 check (#108)
+# =====================================================================
+
+class TestDijkgraafWittenZInvariance(unittest.TestCase):
+    """The make-or-break T2 check: the Dijkgraaf-Witten ℤ₂ state sum
+    ``Z(W)`` is invariant to machine precision across a sequence of
+    interior Pachner moves.
+
+    Run on the closed oriented 3-manifold ``S^2 x S^1`` (the vertex-minimal
+    ``SphereCircleProduct``): the state sum brute-forces the whole flat
+    space ``2^{|V|-1+b_1}``, so it needs a small triangulation — flips and
+    iflips leave ``|V|`` fixed, and the few subdivisions are capped so the
+    flat space stays enumerable.  Both normalized cocycles are checked: the
+    untwisted ``Trivial`` and the ``Sign`` twist (which agrees on
+    ``S^2 x S^1`` because its mod-2 cup cube vanishes)."""
+
+    def _Z(self, st):
+        zt = cobordism.DijkgraafWitten(
+            st, cobordism.Cocycle.Trivial).partitionFunction()
+        zs = cobordism.DijkgraafWitten(
+            st, cobordism.Cocycle.Sign).partitionFunction()
+        return zt, zs
+
+    @unittest.skipUnless(hasattr(cobordism, "DijkgraafWitten"),
+                         "cobordism.DijkgraafWitten unavailable (#108)")
+    def test_z_invariant_under_interior_pachner_sweep(self):
+        st = _built(tessera.SphereCircleProduct())
+        st.setSeed(11)
+
+        # Convention anchor: Z_Trivial(S^2 x S^1) = 2^{b_1 - 1} = 1, and the
+        # Sign cocycle agrees here (the cup cube vanishes on S^2 x S^1).
+        zt0, zs0 = self._Z(st)
+        self.assertAlmostEqual(zt0.real, 1.0, places=9)
+        self.assertAlmostEqual(zt0.imag, 0.0, places=9)
+        self.assertAlmostEqual(abs(zs0 - zt0), 0.0, places=9)
+
+        depth, seed = 0, 0
+        counts = {"FlipMove": 0, "IFlipMove": 0, "AddMove": 0}
+        classes = (tessera.FlipMove, tessera.IFlipMove, tessera.AddMove)
+        while depth < 18 and seed < 6000:
+            for cls in classes:
+                # Cap |V| so the flat space (2^{|V|-1+b_1}) stays enumerable.
+                if cls is tessera.AddMove and st.getVertexCount() >= 16:
+                    continue
+                m = _make(cls, st, seed)
+                if m.propose() and m.apply():
+                    depth += 1
+                    counts[cls.__name__] += 1
+                    # Still a closed pseudomanifold ...
+                    self.assertTrue(_is_closed_pseudomanifold(_tops(st)),
+                                    f"not closed at depth {depth}")
+                    # ... and Z(W) is invariant to machine precision, for
+                    # both cocycles, at every depth of the sweep.
+                    zt, zs = self._Z(st)
+                    self.assertAlmostEqual(abs(zt - zt0), 0.0, places=9,
+                                           msg=f"Z_Trivial drifted at depth {depth}")
+                    self.assertAlmostEqual(abs(zs - zs0), 0.0, places=9,
+                                           msg=f"Z_Sign drifted at depth {depth}")
+                    break
+            seed += 1
+
+        self.assertGreaterEqual(depth, 15, f"too few moves fired: {counts}")
+        self.assertGreater(counts["FlipMove"] + counts["IFlipMove"], 0,
+                           f"no 2<->3 flips fired: {counts}")
+        # A 1->4 subdivision changes |V|, hence the 1/2^|V| prefactor and the
+        # flat space itself — Z staying put through it is the strong check.
+        self.assertGreater(counts["AddMove"], 0, f"no subdivisions fired: {counts}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Generalizes the existing Pachner hierarchy (`AddMove`/`RemoveMove`/`FlipMove`/`IFlipMove`/`ShiftMove`) so the 3D bistellar moves run on a **pre-geometric** (non-time-sliced, coordinate-free) simplicial complex, plus a **boundary-fixed** interior-only mode — without duplicating the move logic. Part of #112.

## Approach
- `PachnerMove` gains a `mode` (`PachnerMode.CDT` | `PachnerMode.PreGeometric`) and a `boundaryFixed` flag, both **defaulted**, so the CDT Markov chain is byte-identical and every existing call site is unchanged.
- `PreGeometric` mode drops the CDT orientation/time-slice guard (a manifold-preservation check stands in for it), reads the move dimension off the **actual top cell** rather than the metric signature (fixtures can carry a 4D signature on a 3-manifold), and emits new cells in **increasing-vertex-id orientation** so the mutated complex's homology stays well-defined (`∂²=0`).
  - `Flip` (2↔3) / `IFlip` (3↔2): relax the orientation guard; the pre-geometric `IFlip` additionally rejects welds whose new shared facet already exists (which would over-share it and tear the pseudomanifold).
  - `Add` (1↔4) / `Remove` (4↔1): new pre-geometric stellar **subdivision** / **weld** paths that reuse the existing transactional apply/rollback machinery.
- `boundaryFixed` only fires a move that leaves the boundary face-set `∂W` (codim-1 faces in exactly one top cell) unchanged.
- `src/spacetime/Bindings.cpp` exposes `PachnerMode` and the new `mode`/`boundaryFixed` keyword args.

## Two supporting fixes (needed for homology/DW on a mutated complex)
- `ChainComplex::fromSpacetime` seeds its downward BFS from the **top cells only**. The mesh creates facet simplices lazily (`Simplex::getFacets`) and never garbage-collects them when a move removes their cofaces; those orphans were polluting the chain groups (spurious cycles, even negative Betti). For a pure complex the top cells' face-closure *is* the chain complex, so freshly-built fixtures are unaffected (cobordism suite green).
- `Topology::buildExplicit` allocates vertices through the id counter so it advances past the fixture ids, giving the pre-geometric add a collision-free fresh vertex id.

## Verified now
- **CDT non-regression (critical):** the full `pachner`/`move`/`cdt` and `cobordism` suites are green; the CDT geometry and move behavior are unchanged.
- **Pre-geometric validity:** on a closed `T³`, a random sequence of interior moves keeps it a valid closed pseudomanifold and preserves homology (Betti `[1,3,3,1]`), checked after every move.
- **Boundary-fixed:** on a solid tetrahedron (`∂ = S²`) and a triangular bipyramid, interior moves leave `∂W` **exactly** unchanged while changing the interior.
- **Dijkgraaf–Witten Z-invariance (the headline T2 check):** `#108` (`cobordism.DijkgraafWitten`) merged to `main`, so this branch was rebased onto it and the full check is **included**: `Z(W)` is invariant to machine precision across an interior Pachner sweep on `S²×S¹`, for **both** the `Trivial` and `Sign` cocycles, at every depth of the sweep (including `1→4` subdivisions that change `|V|`, hence the `1/2^|V|` prefactor and the flat space itself).

Tests live in `tests/test_pachner_pregeometric.py` (15 tests). The known `test_regge_solver` gradient-norm CUDA-OOM flaky is unrelated (no CUDA/Regge code touched).

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)