### PR TITLE
spacetime: minimal RP³ fixture + DW T3 positive control

### DIFF
--- a/include/spacetime/topologies/RealProjectiveSpace.h
+++ b/include/spacetime/topologies/RealProjectiveSpace.h
@@ -1,0 +1,73 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_REALPROJECTIVESPACE_H
+#define TESSERA_REALPROJECTIVESPACE_H
+
+#include "Topology.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+class Spacetime;
+
+/// # Real projective 3-space \f$ \mathbb{RP}^3 = L(2,1) \f$ (minimal 11-vertex)
+///
+/// Walkup's vertex- and facet-minimal triangulation of \f$ \mathbb{RP}^3 \f$ —
+/// the unique simultaneously vertex- and facet-minimal triangulation, with
+/// f-vector \f$ (11, 51, 80, 40) \f$ (11 vertices, 40 tetrahedra) and Euler
+/// characteristic \f$ \chi = 0 \f$. A combinatorial triangulation of
+/// \f$ \mathbb{RP}^3 \f$ needs at least 11 vertices, so this is as small as it
+/// gets. The explicit facet list is the one tabulated by Lutz and shipped by
+/// SageMath's ``RealProjectiveSpace(3)``, with vertex labels shifted from the
+/// literature's \f$ 1\ldots 11 \f$ down to tessera's \f$ 0\ldots 10 \f$.
+///
+/// A closed, orientable 3-manifold with Betti numbers \f$ (1,0,0,1) \f$ over
+/// \f$ \mathbb{Q} \f$ and \f$ (1,1,1,1) \f$ over \f$ \mathbb{Z}/2 \f$; the gap
+/// is the 2-torsion \f$ H_1(\mathbb{RP}^3;\mathbb{Z}) = \mathbb{Z}/2 \f$, which
+/// distinguishes it from \f$ S^2 \times S^1 \f$ (same \f$ \mathbb{Z}/2 \f$ Betti,
+/// no torsion). Being closed and orientable (\f$ b_3 = 1 \f$) it carries a
+/// fundamental class.
+///
+/// ## Dijkgraaf–Witten positive control (P3)
+///
+/// \f$ \mathbb{RP}^3 \f$ is the canonical small manifold on which the
+/// \f$ \mathbb{Z}_2 \f$ sign cocycle \f$ \omega(a,b,c) = (-1)^{abc} \f$ *does*
+/// distinguish: its mod-2 cohomology ring is \f$ \mathbb{Z}_2[t]/t^4 \f$ with
+/// \f$ t^3 \neq 0 \f$, so the cup-cube pairing \f$ \langle g^3, [W] \rangle \f$
+/// is nonzero. Hence \f$ Z_\text{Sign}(\mathbb{RP}^3) = 0 \neq 1 =
+/// Z_\text{Trivial}(\mathbb{RP}^3) \f$ — unlike the negative controls
+/// \f$ T^3 \f$ and \f$ S^2 \times S^1 \f$, where every 1-class has \f$ g^3 = 0
+/// \f$ and the two state sums agree. With 11 vertices the flat space has
+/// \f$ \dim Z^1 = 11 \le 24 \f$, small enough for the brute-force state sum.
+///
+/// Exact, fixed, pre-geometric (coordinate-free); ``build()`` ignores
+/// ``numSimplices``.
+class RealProjectiveSpace : public Topology {
+  public:
+    RealProjectiveSpace() = default;
+
+    /// Build the 11-vertex \f$ \mathbb{RP}^3 \f$. ``numSimplices`` is ignored.
+    void build(Spacetime *spacetime, int numSimplices) override;
+};
+
+} // namespace tessera::spacetime
+
+#endif // TESSERA_REALPROJECTIVESPACE_H

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -33,6 +33,7 @@
 #include "spacetime/topologies/SimplexBoundarySphere.h"
 #include "spacetime/topologies/SolidSimplex.h"
 #include "spacetime/topologies/RealProjectivePlane.h"
+#include "spacetime/topologies/RealProjectiveSpace.h"
 #include "spacetime/topologies/ComplexProjectivePlane.h"
 #include "spacetime/topologies/SimplicialProduct.h"
 #include "spacetime/topologies/SphereCircleProduct.h"
@@ -166,6 +167,18 @@ Pachner moves (add, remove, flip, iflip, shift).)doc")
       .def("build", &SphereCircleProduct::build, py::arg("spacetime"),
            py::arg("numSimplices") = 0,
            "Build S^2 x S^1 (numSimplices ignored).");
+
+  py::class_<RealProjectiveSpace, Topology,
+             std::shared_ptr<RealProjectiveSpace> >(m, "RealProjectiveSpace",
+      "Minimal 11-vertex RP^3 = L(2,1) (Walkup): f=(11,51,80,40), chi=0, "
+      "Betti (1,0,0,1) over Q and (1,1,1,1) over Z/2 (H_1=Z/2), closed "
+      "orientable. The triple-cup positive control for T^3: the DW sign cocycle "
+      "distinguishes it (Z_Sign=0 != 1=Z_Trivial). Exact and pre-geometric; "
+      "build() ignores numSimplices.")
+      .def(py::init<>())
+      .def("build", &RealProjectiveSpace::build, py::arg("spacetime"),
+           py::arg("numSimplices") = 0,
+           "Build the 11-vertex RP^3 (numSimplices ignored).");
 
   py::class_<StellarSubdivision, Topology,
              std::shared_ptr<StellarSubdivision> >(m, "StellarSubdivision",

--- a/src/spacetime/topologies/RealProjectiveSpace.cpp
+++ b/src/spacetime/topologies/RealProjectiveSpace.cpp
@@ -1,0 +1,50 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "spacetime/topologies/RealProjectiveSpace.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace tessera::spacetime {
+
+void RealProjectiveSpace::build(Spacetime *spacetime, int /*numSimplices*/) {
+  // Walkup's minimal 11-vertex RP^3 (f-vector (11, 51, 80, 40)): the 40
+  // tetrahedra tabulated by Lutz and shipped by SageMath's
+  // RealProjectiveSpace(3), relabeled from the literature's 1..11 down to
+  // 0..10. Every triangle lies in exactly two tetrahedra (closed 3-manifold),
+  // and the complex is orientable with H_1 = Z/2 — the Dijkgraaf–Witten sign
+  // cocycle's positive control.
+  const std::vector<std::vector<std::uint64_t>> tops{
+      {0, 1, 2, 6}, {0, 1, 2, 10}, {0, 1, 5, 8}, {0, 1, 5, 10},
+      {0, 1, 6, 8}, {0, 2, 4, 9}, {0, 2, 4, 10}, {0, 2, 6, 9},
+      {0, 3, 6, 8}, {0, 3, 6, 9}, {0, 3, 7, 8}, {0, 3, 7, 9},
+      {0, 4, 5, 7}, {0, 4, 5, 10}, {0, 4, 7, 9}, {0, 5, 7, 8},
+      {1, 2, 3, 7}, {1, 2, 3, 10}, {1, 2, 6, 7}, {1, 3, 5, 9},
+      {1, 3, 5, 10}, {1, 3, 7, 9}, {1, 4, 6, 7}, {1, 4, 6, 8},
+      {1, 4, 7, 9}, {1, 4, 8, 9}, {1, 5, 8, 9}, {2, 3, 4, 8},
+      {2, 3, 4, 10}, {2, 3, 7, 8}, {2, 4, 8, 9}, {2, 5, 6, 7},
+      {2, 5, 6, 9}, {2, 5, 7, 8}, {2, 5, 8, 9}, {3, 4, 5, 6},
+      {3, 4, 5, 10}, {3, 4, 6, 8}, {3, 5, 6, 9}, {4, 5, 6, 7}};
+  buildExplicit(spacetime, 11, tops);
+}
+
+} // namespace tessera::spacetime

--- a/tests/cobordism/test_rp3_fixture_python.py
+++ b/tests/cobordism/test_rp3_fixture_python.py
@@ -1,0 +1,170 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""RP³ fixture + Dijkgraaf–Witten T3/P3 positive control (#124).
+
+The ℤ₂ Dijkgraaf–Witten sign cocycle ω(a,b,c) = (-1)^{abc} twists the untwisted
+state sum by the mod-2 cup cube (-1)^{⟨g³,[W]⟩}. That pairing vanishes on T³ and
+S²×S¹ (every 1-class has g³ = 0 — the negative controls), so the sign cocycle
+cannot distinguish there. It is nonzero exactly where some 1-class has g³ ≠ 0 —
+canonically RP³ = L(2,1), whose mod-2 cohomology ring is ℤ₂[t]/t⁴ with t³ ≠ 0.
+
+Two deliverables:
+
+  1. **It really is RP³.** ``RealProjectiveSpace`` is the Walkup vertex-minimal
+     11-vertex triangulation; the chain-complex homology is the proof —
+     bettiNumbers (ℚ) = [1,0,0,1], bettiNumbersGF2 = [1,1,1,1], and the gap is
+     the 2-torsion H₁ = ℤ₂ (torsion(1) = [2]) that separates RP³ from S²×S¹.
+     Closed oriented pseudomanifold, so a fundamental class (b₃ = 1) exists.
+
+  2. **T3 / P3 — the positive control.** Z_Sign(RP³) = 0 ≠ 1 = Z_Trivial(RP³),
+     so the sign cocycle distinguishes *some* W (it does not on the S²×S¹
+     negative control). Z_Trivial = 2^{b₁(ℤ₂) - 1} = 2^0 = 1.
+"""
+
+import itertools
+import unittest
+
+import tessera
+
+cobordism = tessera.cobordism
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+
+
+def _build(topology):
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()  # delegates to topology.build(); numSimplices ignored
+    return spacetime
+
+
+def _chain(topology):
+    return cobordism.ChainComplex.fromSpacetime(_build(topology))
+
+
+def _rp3():
+    return tessera.RealProjectiveSpace()
+
+
+def _s2_cross_s1():
+    # Negative control: S²×S¹ via the simplicial product, betti (1,1,1,1) but no
+    # torsion. dim Z¹ = 12 ≤ 24, so the brute-force state sum admits it.
+    return tessera.SimplicialProduct(tessera.SimplexBoundarySphere(2),
+                                     tessera.SimplexBoundarySphere(1))
+
+
+class TestRealProjectiveSpaceIsRP3(unittest.TestCase):
+    """The homology assertions that validate the hardcoded facet list."""
+
+    def test_f_vector(self):
+        # Walkup's vertex- and facet-minimal RP³: f = (11, 51, 80, 40).
+        chain = _chain(_rp3())
+        self.assertEqual([chain.numSimplices(k) for k in range(4)],
+                         [11, 51, 80, 40])
+
+    def test_betti_numbers_rational(self):
+        self.assertEqual(_chain(_rp3()).bettiNumbers(), [1, 0, 0, 1])
+
+    def test_betti_numbers_gf2(self):
+        self.assertEqual(_chain(_rp3()).bettiNumbersGF2(), [1, 1, 1, 1])
+
+    def test_h1_is_two_torsion(self):
+        # The ℤ₂ in H₁ — the invariant that distinguishes RP³ from S²×S¹, which
+        # has the same ℤ/2 Betti numbers but no torsion.
+        self.assertEqual(_chain(_rp3()).torsion(1), [2])
+        self.assertEqual(_chain(_s2_cross_s1()).torsion(1), [])
+
+    def test_euler_characteristic_zero(self):
+        # Closed odd-dimensional manifold ⇒ χ = 0; cross-checked against the
+        # alternating Betti sum (Euler–Poincaré).
+        chain = _chain(_rp3())
+        self.assertEqual(chain.eulerCharacteristic(), 0)
+        self.assertEqual(sum((-1) ** k * b
+                             for k, b in enumerate(chain.bettiNumbers())), 0)
+
+    def test_closed_oriented_pseudomanifold(self):
+        # Every tetrahedron is a 4-vertex cell, every triangle bounds exactly two
+        # of them (closed 3-pseudomanifold), and a ±1 fundamental class on all 40
+        # tetrahedra exists (b₃ = 1 ⇒ orientable).
+        chain = _chain(_rp3())
+        tops = [tuple(t) for t in chain.orientedTopSimplices()]
+        self.assertTrue(all(len(t) == 4 for t in tops))
+        facet_counts = {}
+        for top in tops:
+            for facet in itertools.combinations(top, 3):
+                facet_counts[facet] = facet_counts.get(facet, 0) + 1
+        self.assertTrue(all(count == 2 for count in facet_counts.values()))
+        fundamental = chain.fundamentalClass()
+        self.assertEqual(chain.bettiNumbers()[3], 1)
+        self.assertEqual(len(fundamental), len(tops))
+        self.assertTrue(all(abs(coeff) == 1 for coeff in fundamental))
+
+    def test_flat_space_small_enough_for_state_sum(self):
+        # dim Z¹ = b₁(ℤ₂) + (|V| − b₀(ℤ₂)) = 1 + (11 − 1) = 11 ≤ 24, so gf2Span
+        # can materialize the whole flat space for the brute-force sum.
+        chain = _chain(_rp3())
+        betti_gf2 = chain.bettiNumbersGF2()
+        dim_z1 = betti_gf2[1] + chain.numSimplices(0) - betti_gf2[0]
+        self.assertEqual(dim_z1, 11)
+        self.assertLessEqual(dim_z1, 24)
+
+
+class TestDijkgraafWittenPositiveControl(unittest.TestCase):
+    """T3 / P3: the sign cocycle distinguishes RP³ (and not the negative
+    control S²×S¹)."""
+
+    @staticmethod
+    def _z(spacetime, cocycle):
+        return DijkgraafWitten(spacetime, cocycle).partitionFunction()
+
+    def test_trivial_partition_function_is_one(self):
+        # Z_Trivial = 2^{b₁(ℤ₂) − 1} = 2^0 = 1 for the connected closed oriented
+        # RP³ (b₁(ℤ₂) = 1).
+        z = self._z(_build(_rp3()), Cocycle.Trivial)
+        self.assertAlmostEqual(z.imag, 0.0, places=9)
+        self.assertAlmostEqual(z.real, 1.0, places=9)
+
+    def test_sign_partition_function_vanishes(self):
+        # The cup cube t³ ≠ 0 on RP³ ⇒ the sign twist kills the state sum.
+        z = self._z(_build(_rp3()), Cocycle.Sign)
+        self.assertAlmostEqual(z.imag, 0.0, places=9)
+        self.assertAlmostEqual(z.real, 0.0, places=9)
+
+    def test_sign_distinguishes_rp3(self):
+        # The positive control: Z_Sign ≠ Z_Trivial on RP³.
+        spacetime = _build(_rp3())
+        z_trivial = self._z(spacetime, Cocycle.Trivial)
+        z_sign = self._z(spacetime, Cocycle.Sign)
+        self.assertGreater(abs(z_trivial - z_sign), 0.5)
+
+    def test_sign_does_not_distinguish_negative_control(self):
+        # Contrast: on S²×S¹ the cup cube vanishes, so Z_Sign == Z_Trivial.
+        spacetime = _build(_s2_cross_s1())
+        z_trivial = self._z(spacetime, Cocycle.Trivial)
+        z_sign = self._z(spacetime, Cocycle.Sign)
+        self.assertAlmostEqual(abs(z_trivial - z_sign), 0.0, places=9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #124 — the **T3 positive control (P3)** for the ℤ₂ Dijkgraaf–Witten experiment.

The sign cocycle `(-1)^{abc}` twists by the mod-2 cup-cube `(-1)^{⟨g³,[W]⟩}`, which vanishes on T³ and S²×S¹ (negative controls) and is nonzero only where some 1-class has `g³≠0` — canonically **RP³ = L(2,1)** (`H*(RP³;ℤ₂)=ℤ₂[t]/t⁴`, `t³≠0`).

- **`RealProjectiveSpace`** — Walkup's vertex-minimal **11-vertex** RP³ (f-vector (11,51,80,40)), from SageMath's `RealProjectiveSpace(3)` / Lutz, relabeled 0..10; mirrors the `ComplexProjectivePlane` explicit-facet pattern.
- **Verified it is RP³** (homology proves the facet list): `bettiNumbers`(ℚ)=`[1,0,0,1]`, `bettiNumbersGF2`=`[1,1,1,1]`, `torsion(1)=[2]` (the ℤ₂ in H₁ that separates RP³ from S²×S¹), χ=0, closed oriented pseudomanifold with a ±1 fundamental class.
- **T3 / P3:** `Z_Sign(RP³)=0 ≠ 1=Z_Trivial(RP³)` — the sign cocycle distinguishes RP³, while `Z_Sign==Z_Trivial` on the S²×S¹ negative control. `dim Z¹=11≤24` keeps the brute-force state-sum feasible.

**11 tests pass.** With this, P1–P3 are all demonstrated.

Closes #124.