### PR TITLE
spacetime: lens-space L(p,q) fixtures

### DIFF
--- a/include/spacetime/topologies/LensSpace.h
+++ b/include/spacetime/topologies/LensSpace.h
@@ -1,0 +1,98 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_LENSSPACE_H
+#define TESSERA_LENSSPACE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "Topology.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+class Spacetime;
+
+/// # Lens space \f$ L(p,q) \f$ (vertex-minimal simplicial triangulation)
+///
+/// A closed orientable 3-manifold, the quotient of \f$ S^3 \f$ by the free
+/// \f$ \mathbb{Z}_p \f$ action \f$ (z_1, z_2) \mapsto (e^{2\pi i/p} z_1,
+/// e^{2\pi i q/p} z_2) \f$. Its only nontrivial reduced homology is
+/// \f$ H_1(L(p,q);\mathbb{Z}) = \mathbb{Z}_p \f$, so the rational Betti numbers
+/// are \f$ (1,0,0,1) \f$ and \f$ \mathrm{torsion}(H_1) = [p] \f$. Being closed
+/// and orientable (\f$ b_3 = 1 \f$) it carries a fundamental class, and like
+/// every closed odd-dimensional manifold it has \f$ \chi = 0 \f$.
+///
+/// The hardcoded facet lists are Lutz's vertex-minimal combinatorial
+/// triangulations (the spherical-space-form section of "The Manifold Page"),
+/// relabeled from the literature's \f$ 1\ldots n \f$ down to tessera's
+/// \f$ 0\ldots n-1 \f$. The homology is the proof the facet lists are right:
+///
+/// | \f$ (p,q) \f$ | f-vector            | \f$ \dim Z^1 \f$ |
+/// |---------------|---------------------|------------------|
+/// | \f$ (3,1) \f$ | \f$ (12,66,108,54)\f$ | 11             |
+/// | \f$ (4,1) \f$ | \f$ (14,84,140,70)\f$ | 14             |
+/// | \f$ (5,2) \f$ | \f$ (14,86,144,72)\f$ | 13             |
+///
+/// The minimal \f$ L(2,1) = \mathbb{RP}^3 \f$ is supplied separately as
+/// ``RealProjectiveSpace`` (Walkup's 11-vertex complex). Distinct
+/// \f$ L(p,q) \f$ that share a \f$ p \f$ (e.g. \f$ L(5,1) \f$ and \f$ L(5,2)
+/// \f$) have the same homology — they are told apart by the linking form /
+/// Reidemeister torsion, not the chain complex.
+///
+/// Every flat space here has \f$ \dim Z^1 \le 24 \f$, small enough for the
+/// brute-force Dijkgraaf–Witten state sum.
+///
+/// Exact, fixed, pre-geometric (coordinate-free); ``build()`` ignores
+/// ``numSimplices``.
+class LensSpace : public Topology {
+  public:
+    /// Construct \f$ L(p,q) \f$. Throws ``std::invalid_argument`` unless
+    /// \f$ (p,q) \f$ is one of the supplied triangulations: ``(3,1)``,
+    /// ``(4,1)``, ``(5,2)``.
+    LensSpace(int p, int q);
+
+    /// The order \f$ p \f$ — \f$ H_1(L(p,q)) = \mathbb{Z}_p \f$.
+    int p() const { return p_; }
+
+    /// The gluing parameter \f$ q \f$.
+    int q() const { return q_; }
+
+    /// Build the vertex-minimal \f$ L(p,q) \f$. ``numSimplices`` is ignored.
+    void build(Spacetime *spacetime, int numSimplices) override;
+
+  private:
+    int p_;
+    int q_;
+
+    /// The hardcoded triangulation of \f$ L(p,q) \f$: returns the top-simplex
+    /// (tetrahedron) vertex-id list and reports the vertex count through
+    /// ``numVertices``. Throws ``std::invalid_argument`` for an unsupported
+    /// \f$ (p,q) \f$. Single source of truth shared by the constructor's
+    /// validation and ``build()``.
+    static std::vector<std::vector<std::uint64_t>> triangulation(
+        int p, int q, std::size_t &numVertices);
+};
+
+} // namespace tessera::spacetime
+
+#endif // TESSERA_LENSSPACE_H

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -35,6 +35,7 @@
 #include "spacetime/topologies/RealProjectivePlane.h"
 #include "spacetime/topologies/RealProjectiveSpace.h"
 #include "spacetime/topologies/ComplexProjectivePlane.h"
+#include "spacetime/topologies/LensSpace.h"
 #include "spacetime/topologies/SimplicialProduct.h"
 #include "spacetime/topologies/SphereCircleProduct.h"
 #include "spacetime/topologies/StellarSubdivision.h"
@@ -179,6 +180,20 @@ Pachner moves (add, remove, flip, iflip, shift).)doc")
       .def("build", &RealProjectiveSpace::build, py::arg("spacetime"),
            py::arg("numSimplices") = 0,
            "Build the 11-vertex RP^3 (numSimplices ignored).");
+
+  py::class_<LensSpace, Topology, std::shared_ptr<LensSpace> >(m, "LensSpace",
+      "Lens space L(p,q): a closed orientable 3-manifold with H_1 = Z_p, from "
+      "Lutz's vertex-minimal simplicial triangulations. Available (p,q): "
+      "(3,1), (4,1), (5,2) (L(2,1)=RP^3 is RealProjectiveSpace); other (p,q) "
+      "raise ValueError. Betti (1,0,0,1) over Q with torsion(1)=[p], chi=0, "
+      "closed orientable (b_3=1). Exact and pre-geometric; build() ignores "
+      "numSimplices.")
+      .def(py::init<int, int>(), py::arg("p"), py::arg("q"))
+      .def("p", &LensSpace::p, "The order p (H_1 = Z_p).")
+      .def("q", &LensSpace::q, "The gluing parameter q.")
+      .def("build", &LensSpace::build, py::arg("spacetime"),
+           py::arg("numSimplices") = 0,
+           "Build the vertex-minimal L(p,q) (numSimplices ignored).");
 
   py::class_<StellarSubdivision, Topology,
              std::shared_ptr<StellarSubdivision> >(m, "StellarSubdivision",

--- a/src/spacetime/topologies/LensSpace.cpp
+++ b/src/spacetime/topologies/LensSpace.cpp
@@ -1,0 +1,126 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "spacetime/topologies/LensSpace.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace tessera::spacetime {
+
+LensSpace::LensSpace(int p, int q) : p_(p), q_(q) {
+  // Validate eagerly: an unsupported (p,q) is an error at construction, not a
+  // deferred surprise at build() time.
+  std::size_t numVertices = 0;
+  (void)triangulation(p, q, numVertices);
+}
+
+void LensSpace::build(Spacetime *spacetime, int /*numSimplices*/) {
+  std::size_t numVertices = 0;
+  const std::vector<std::vector<std::uint64_t>> tops =
+      triangulation(p_, q_, numVertices);
+  buildExplicit(spacetime, numVertices, tops);
+}
+
+std::vector<std::vector<std::uint64_t>> LensSpace::triangulation(
+    int p, int q, std::size_t &numVertices) {
+  if (p == 3 && q == 1) {
+    // Lutz vertex-minimal L(3,1): f-vector (12, ...), 54 tetrahedra,
+    // H_1 = Z_3. Vertices 0..11; every triangle lies in exactly two
+    // tetrahedra (closed 3-manifold).
+    numVertices = 12;
+    return {
+        {0, 1, 2, 3}, {0, 1, 2, 4}, {0, 1, 3, 5}, {0, 1, 4, 5},
+        {0, 2, 3, 6}, {0, 2, 4, 6}, {0, 3, 5, 7}, {0, 3, 6, 8},
+        {0, 3, 7, 8}, {0, 4, 5, 9}, {0, 4, 6, 10}, {0, 4, 9, 10},
+        {0, 5, 7, 9}, {0, 6, 8, 10}, {0, 7, 8, 11}, {0, 7, 9, 11},
+        {0, 8, 10, 11}, {0, 9, 10, 11}, {1, 2, 3, 9}, {1, 2, 4, 8},
+        {1, 2, 7, 9}, {1, 2, 7, 10}, {1, 2, 8, 10}, {1, 3, 5, 11},
+        {1, 3, 9, 11}, {1, 4, 5, 8}, {1, 5, 6, 8}, {1, 5, 6, 11},
+        {1, 6, 7, 10}, {1, 6, 7, 11}, {1, 6, 8, 10}, {1, 7, 9, 11},
+        {2, 3, 6, 9}, {2, 4, 6, 11}, {2, 4, 8, 11}, {2, 5, 6, 9},
+        {2, 5, 6, 11}, {2, 5, 7, 9}, {2, 5, 7, 10}, {2, 5, 10, 11},
+        {2, 8, 10, 11}, {3, 4, 7, 8}, {3, 4, 7, 10}, {3, 4, 8, 9},
+        {3, 4, 9, 10}, {3, 5, 7, 10}, {3, 5, 10, 11}, {3, 6, 8, 9},
+        {3, 9, 10, 11}, {4, 5, 8, 9}, {4, 6, 7, 10}, {4, 6, 7, 11},
+        {4, 7, 8, 11}, {5, 6, 8, 9}};
+  }
+  if (p == 4 && q == 1) {
+    // Lutz vertex-minimal L(4,1): f-vector (14, ...), 70 tetrahedra,
+    // H_1 = Z_4. Vertices 0..13; every triangle lies in exactly two
+    // tetrahedra (closed 3-manifold).
+    numVertices = 14;
+    return {
+        {0, 1, 2, 3}, {0, 1, 2, 4}, {0, 1, 3, 5}, {0, 1, 4, 5},
+        {0, 2, 3, 6}, {0, 2, 4, 6}, {0, 3, 5, 7}, {0, 3, 6, 8},
+        {0, 3, 7, 8}, {0, 4, 5, 9}, {0, 4, 6, 10}, {0, 4, 9, 10},
+        {0, 5, 7, 9}, {0, 6, 8, 10}, {0, 7, 8, 11}, {0, 7, 9, 11},
+        {0, 8, 10, 11}, {0, 9, 10, 11}, {1, 2, 3, 9}, {1, 2, 4, 8},
+        {1, 2, 8, 9}, {1, 3, 5, 10}, {1, 3, 9, 10}, {1, 4, 5, 12},
+        {1, 4, 8, 13}, {1, 4, 12, 13}, {1, 5, 10, 11}, {1, 5, 11, 12},
+        {1, 8, 9, 13}, {1, 9, 10, 11}, {1, 9, 11, 13}, {1, 11, 12, 13},
+        {2, 3, 6, 13}, {2, 3, 9, 12}, {2, 3, 12, 13}, {2, 4, 6, 11},
+        {2, 4, 8, 11}, {2, 5, 6, 11}, {2, 5, 6, 13}, {2, 5, 7, 10},
+        {2, 5, 7, 13}, {2, 5, 10, 11}, {2, 7, 10, 12}, {2, 7, 12, 13},
+        {2, 8, 9, 12}, {2, 8, 10, 11}, {2, 8, 10, 12}, {3, 4, 7, 8},
+        {3, 4, 7, 10}, {3, 4, 8, 13}, {3, 4, 9, 10}, {3, 4, 9, 12},
+        {3, 4, 12, 13}, {3, 5, 7, 10}, {3, 6, 8, 13}, {4, 5, 9, 12},
+        {4, 6, 7, 10}, {4, 6, 7, 11}, {4, 7, 8, 11}, {5, 6, 9, 12},
+        {5, 6, 9, 13}, {5, 6, 11, 12}, {5, 7, 9, 13}, {6, 7, 10, 12},
+        {6, 7, 11, 12}, {6, 8, 9, 12}, {6, 8, 9, 13}, {6, 8, 10, 12},
+        {7, 9, 11, 13}, {7, 11, 12, 13}};
+  }
+  if (p == 5 && q == 2) {
+    // Lutz vertex-minimal L(5,2): f-vector (14, ...), 72 tetrahedra,
+    // H_1 = Z_5. Vertices 0..13; every triangle lies in exactly two
+    // tetrahedra (closed 3-manifold).
+    numVertices = 14;
+    return {
+        {0, 1, 2, 3}, {0, 1, 2, 4}, {0, 1, 3, 5}, {0, 1, 4, 5},
+        {0, 2, 3, 6}, {0, 2, 4, 6}, {0, 3, 5, 7}, {0, 3, 6, 8},
+        {0, 3, 7, 8}, {0, 4, 5, 9}, {0, 4, 6, 10}, {0, 4, 9, 11},
+        {0, 4, 10, 11}, {0, 5, 7, 9}, {0, 6, 8, 10}, {0, 7, 8, 11},
+        {0, 7, 9, 11}, {0, 8, 10, 11}, {1, 2, 3, 12}, {1, 2, 4, 7},
+        {1, 2, 7, 9}, {1, 2, 9, 10}, {1, 2, 10, 12}, {1, 3, 5, 13},
+        {1, 3, 12, 13}, {1, 4, 5, 8}, {1, 4, 7, 8}, {1, 5, 6, 11},
+        {1, 5, 6, 13}, {1, 5, 8, 11}, {1, 6, 9, 10}, {1, 6, 9, 11},
+        {1, 6, 10, 12}, {1, 6, 12, 13}, {1, 7, 8, 11}, {1, 7, 9, 11},
+        {2, 3, 6, 11}, {2, 3, 11, 12}, {2, 4, 6, 7}, {2, 5, 6, 11},
+        {2, 5, 6, 13}, {2, 5, 10, 12}, {2, 5, 10, 13}, {2, 5, 11, 12},
+        {2, 6, 7, 13}, {2, 7, 9, 13}, {2, 9, 10, 13}, {3, 4, 7, 8},
+        {3, 4, 7, 10}, {3, 4, 8, 9}, {3, 4, 9, 11}, {3, 4, 10, 11},
+        {3, 5, 7, 10}, {3, 5, 10, 13}, {3, 6, 8, 9}, {3, 6, 9, 11},
+        {3, 10, 11, 13}, {3, 11, 12, 13}, {4, 5, 8, 9}, {4, 6, 7, 10},
+        {5, 7, 9, 12}, {5, 7, 10, 12}, {5, 8, 9, 12}, {5, 8, 11, 12},
+        {6, 7, 10, 12}, {6, 7, 12, 13}, {6, 8, 9, 10}, {7, 9, 12, 13},
+        {8, 9, 10, 13}, {8, 9, 12, 13}, {8, 10, 11, 13}, {8, 11, 12, 13}};
+  }
+  throw std::invalid_argument(
+      "LensSpace: unsupported (p,q)=(" + std::to_string(p) + "," +
+      std::to_string(q) +
+      "); available: (3,1), (4,1), (5,2). Note L(2,1)=RP^3 is "
+      "RealProjectiveSpace.");
+}
+
+} // namespace tessera::spacetime

--- a/tests/cobordism/test_lens_spaces_python.py
+++ b/tests/cobordism/test_lens_spaces_python.py
@@ -1,0 +1,198 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Lens-space L(p,q) fixtures (#140).
+
+Closed-3-manifold fixtures beyond RP³ = L(2,1). ``LensSpace(p, q)`` builds
+Lutz's vertex-minimal simplicial triangulation of the lens space L(p,q) — the
+quotient of S³ by a free ℤ_p action, a closed orientable 3-manifold whose only
+nontrivial reduced homology is H₁ = ℤ_p.
+
+The homology is the proof the hardcoded facet lists are right: for every case
+the rational Betti numbers are [1,0,0,1] and torsion(1) = [p] (H₁ = ℤ_p),
+cross-checked against an independent Smith-normal-form computation of the same
+triangulations. Each is a closed oriented pseudomanifold (every triangle in
+exactly two tetrahedra, a ±1 fundamental class on all tops, b₃ = 1) with χ = 0.
+
+The three shipped cases keep dim Z¹ ≤ 24, so the brute-force Dijkgraaf–Witten
+ℤ₂ state sum is feasible. None is distinguished by the DW sign cocycle (unlike
+the RP³ positive control): L(3,1) and L(5,2) have odd torsion invisible to a
+ℤ₂ theory, and L(4,1) has p ≡ 0 (mod 4) so the mod-2 cup cube t³ vanishes.
+Z_Trivial = 2^{b₁(ℤ₂) − 1} is 1 for L(4,1) and ½ for the odd-p cases.
+"""
+
+import itertools
+import unittest
+
+import tessera
+
+cobordism = tessera.cobordism
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+
+
+# (p, q) -> expected invariants of Lutz's vertex-minimal L(p,q).
+CASES = {
+    (3, 1): dict(f_vector=[12, 66, 108, 54], betti_gf2=[1, 0, 0, 1],
+                 dim_z1=11, z_trivial=0.5),
+    (4, 1): dict(f_vector=[14, 84, 140, 70], betti_gf2=[1, 1, 1, 1],
+                 dim_z1=14, z_trivial=1.0),
+    (5, 2): dict(f_vector=[14, 86, 144, 72], betti_gf2=[1, 0, 0, 1],
+                 dim_z1=13, z_trivial=0.5),
+}
+
+
+def _build(topology):
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()  # delegates to topology.build(); numSimplices ignored
+    return spacetime
+
+
+def _chain(topology):
+    return cobordism.ChainComplex.fromSpacetime(_build(topology))
+
+
+class TestLensSpaceHomology(unittest.TestCase):
+    """The homology assertions that validate each hardcoded facet list:
+    H₁ = ℤ_p is the proof it really is L(p,q)."""
+
+    def test_accessors(self):
+        for (p, q) in CASES:
+            ls = tessera.LensSpace(p, q)
+            self.assertEqual((ls.p(), ls.q()), (p, q))
+
+    def test_f_vector(self):
+        for (p, q), want in CASES.items():
+            with self.subTest(p=p, q=q):
+                chain = _chain(tessera.LensSpace(p, q))
+                self.assertEqual([chain.numSimplices(k) for k in range(4)],
+                                 want["f_vector"])
+
+    def test_betti_numbers_rational(self):
+        # b = (1,0,0,1): a closed orientable 3-manifold with no rational H₁/H₂.
+        for (p, q) in CASES:
+            with self.subTest(p=p, q=q):
+                self.assertEqual(_chain(tessera.LensSpace(p, q)).bettiNumbers(),
+                                 [1, 0, 0, 1])
+
+    def test_h1_is_p_torsion(self):
+        # The defining invariant: H₁(L(p,q)) = ℤ_p, i.e. torsion(1) = [p]. No
+        # torsion in H₂ (torsion(2) = []), so the manifold is orientable.
+        for (p, q) in CASES:
+            with self.subTest(p=p, q=q):
+                chain = _chain(tessera.LensSpace(p, q))
+                self.assertEqual(chain.torsion(1), [p])
+                self.assertEqual(chain.torsion(2), [])
+
+    def test_betti_numbers_gf2(self):
+        # Universal coefficients over ℤ₂: the even-p case L(4,1) (2-torsion in
+        # H₁) reads (1,1,1,1), while the odd-p cases match the rational (1,0,0,1).
+        for (p, q), want in CASES.items():
+            with self.subTest(p=p, q=q):
+                self.assertEqual(_chain(tessera.LensSpace(p, q)).bettiNumbersGF2(),
+                                 want["betti_gf2"])
+
+    def test_euler_characteristic_zero(self):
+        # Closed odd-dimensional manifold ⇒ χ = 0, cross-checked against the
+        # alternating Betti sum (Euler–Poincaré).
+        for (p, q) in CASES:
+            with self.subTest(p=p, q=q):
+                chain = _chain(tessera.LensSpace(p, q))
+                self.assertEqual(chain.eulerCharacteristic(), 0)
+                self.assertEqual(sum((-1) ** k * b
+                                     for k, b in enumerate(chain.bettiNumbers())),
+                                 0)
+
+    def test_closed_oriented_pseudomanifold(self):
+        # Tetrahedra only, every triangle in exactly two of them (closed
+        # 3-pseudomanifold), and a ±1 fundamental class on all tops (b₃ = 1 ⇒
+        # closed, connected, oriented).
+        for (p, q) in CASES:
+            with self.subTest(p=p, q=q):
+                chain = _chain(tessera.LensSpace(p, q))
+                tops = [tuple(t) for t in chain.orientedTopSimplices()]
+                self.assertTrue(all(len(t) == 4 for t in tops))
+                facet_counts = {}
+                for top in tops:
+                    for facet in itertools.combinations(top, 3):
+                        facet_counts[facet] = facet_counts.get(facet, 0) + 1
+                self.assertTrue(all(c == 2 for c in facet_counts.values()))
+                fundamental = chain.fundamentalClass()
+                self.assertEqual(chain.bettiNumbers()[3], 1)
+                self.assertEqual(len(fundamental), len(tops))
+                self.assertTrue(all(abs(coeff) == 1 for coeff in fundamental))
+
+    def test_flat_space_small_enough_for_state_sum(self):
+        # dim Z¹ = b₁(ℤ₂) + (|V| − b₀(ℤ₂)) ≤ 24, so the brute-force DW sum can
+        # materialize the whole flat space.
+        for (p, q), want in CASES.items():
+            with self.subTest(p=p, q=q):
+                chain = _chain(tessera.LensSpace(p, q))
+                betti_gf2 = chain.bettiNumbersGF2()
+                dim_z1 = betti_gf2[1] + chain.numSimplices(0) - betti_gf2[0]
+                self.assertEqual(dim_z1, want["dim_z1"])
+                self.assertLessEqual(dim_z1, 24)
+
+
+class TestLensSpaceDijkgraafWitten(unittest.TestCase):
+    """A feasible DW state-sum sanity value per fixture. These lens spaces are
+    ℤ₂ negative controls: the sign cocycle does not distinguish any of them, so
+    Z_Sign = Z_Trivial (contrast the RP³ positive control, Z_Sign = 0 ≠ 1)."""
+
+    @staticmethod
+    def _z(spacetime, cocycle):
+        return DijkgraafWitten(spacetime, cocycle).partitionFunction()
+
+    def test_trivial_partition_function(self):
+        # Z_Trivial = 2^{b₁(ℤ₂) − 1}: 1 for L(4,1), ½ for the odd-p cases.
+        for (p, q), want in CASES.items():
+            with self.subTest(p=p, q=q):
+                z = self._z(_build(tessera.LensSpace(p, q)), Cocycle.Trivial)
+                self.assertAlmostEqual(z.imag, 0.0, places=9)
+                self.assertAlmostEqual(z.real, want["z_trivial"], places=9)
+
+    def test_sign_cocycle_does_not_distinguish(self):
+        # Odd p: H¹(;ℤ₂) = 0. p = 4 ≡ 0 (mod 4): mod-2 cup cube t³ = 0. Either
+        # way the sign twist is trivial, so Z_Sign = Z_Trivial.
+        for (p, q) in CASES:
+            with self.subTest(p=p, q=q):
+                spacetime = _build(tessera.LensSpace(p, q))
+                z_trivial = self._z(spacetime, Cocycle.Trivial)
+                z_sign = self._z(spacetime, Cocycle.Sign)
+                self.assertAlmostEqual(abs(z_trivial - z_sign), 0.0, places=9)
+
+
+class TestLensSpaceUnsupported(unittest.TestCase):
+    """Unsupported (p,q) fail fast at construction."""
+
+    def test_unsupported_raises(self):
+        # (2,1) = RP³ is RealProjectiveSpace; (6,1) is simply not shipped.
+        for (p, q) in [(2, 1), (6, 1), (3, 2)]:
+            with self.subTest(p=p, q=q):
+                with self.assertRaises(ValueError):
+                    tessera.LensSpace(p, q)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Richer closed-3-manifold fixtures for realizability/distinguishing tests beyond RP³ = L(2,1).

## What

A single parameterized `LensSpace(p, q)` `Topology` (mirroring `SimplexBoundarySphere(n)`/`RealProjectiveSpace`), with hardcoded vertex-minimal simplicial triangulations from Frank Lutz's catalog (the spherical-space-form section of "The Manifold Page"), relabeled to tessera's `0..n-1`:

| L(p,q) | f-vector | tets | dim Z¹ |
|--------|----------|------|--------|
| L(3,1) | (12, 66, 108, 54) | 54 | 11 |
| L(4,1) | (14, 84, 140, 70) | 70 | 14 |
| L(5,2) | (14, 86, 144, 72) | 72 | 13 |

The minimal L(2,1) = RP³ stays as `RealProjectiveSpace`; unsupported `(p,q)` raise `ValueError`. Bound in `src/spacetime/Bindings.cpp` like the other topologies.

## Homology proof (the facet lists are right)

For every case the `ChainComplex` homology matches L(p,q):

- `bettiNumbers` (ℚ) = `[1, 0, 0, 1]`
- `torsion(1) = [p]`, i.e. **H₁ = ℤ_p** (the defining invariant); `torsion(2) = []`
- `bettiNumbersGF2` = `[1,0,0,1]` for odd p, `[1,1,1,1]` for L(4,1) (the 2-torsion shows over ℤ₂)
- closed oriented pseudomanifold: every triangle in exactly two tetrahedra, a ±1 fundamental class on all tops (`b₃ = 1`), `χ = 0`

These were cross-checked against an independent Smith-normal-form homology computation of the same triangulations (which also reproduces S³ = trivial and RP³ = ℤ/2 as anchors).

## DW sanity value (dim Z¹ ≤ 24)

All three keep `dim Z¹ ≤ 24`, so the brute-force Dijkgraaf–Witten ℤ₂ state sum runs. They are ℤ₂ negative controls (unlike the RP³ positive control): `Z_Sign = Z_Trivial` for each — odd torsion is invisible to a ℤ₂ theory, and L(4,1) has p ≡ 0 (mod 4) so the mod-2 cup cube t³ vanishes. `Z_Trivial = 2^{b₁(ℤ₂) − 1}` = 1 for L(4,1), ½ for the odd-p cases.

Tests in `tests/cobordism/test_lens_spaces_python.py` (11 tests / 30 subtests). Full `tests/cobordism` suite green (241 passed). `tests/spacetime/` does not exist in this repo, so the fixture tests live under `tests/cobordism/` alongside the RP³ fixture test.

Closes #140.