### PR TITLE
cobordism: EigenstateSynthesis residual + optimizer (§4b)

### DIFF
--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -1,0 +1,137 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_EIGENSTATESYNTHESIS_H
+#define TESSERA_COBORDISM_EIGENSTATESYNTHESIS_H
+
+#include <complex>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "cobordism/HodgeLaplacian.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::mesh { class Edge; }
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # EigenstateSynthesis
+///
+/// The §4b inverse eigenvector problem on a **fixed** complex: given a target
+/// state \f$ \psi \f$, score how close the complex's current Hermitian edge
+/// weights make \f$ \psi \f$ to being an eigenvector of the \f$ k=0 \f$ Hodge
+/// Laplacian \f$ L = D - A \f$ (the magnitude convention, via
+/// `HodgeLaplacian`), and read/write those weights so a search can perturb them.
+///
+/// The search itself (non-convex, multi-restart, e.g. `scipy.optimize.minimize`
+/// L-BFGS-B over the flat \f$ \{w_{ij}\}\cup\{\theta_{ij}\} \f$ vector) drives
+/// the cone-and-retry growth loop in a separate stage; this class is the
+/// **residual + parameter access** core it calls. Growing the complex
+/// (coning-in auxiliary vertices) is out of scope here.
+///
+/// ## Residual
+///
+/// For a unit target \f$ \psi \f$ the eigenvalue-agnostic residual is the
+/// squared norm of the component of \f$ L\psi \f$ orthogonal to \f$ \psi \f$,
+/// \f$ r(\psi) = \big\|\,(I-\psi\psi^\dagger)\,L\,\psi\,\big\|^2
+///            = \|L\psi - \lambda\psi\|^2,\quad \lambda = \psi^\dagger L\psi, \f$
+/// so \f$ r = 0 \iff L\psi \parallel \psi \iff \psi \f$ is an eigenvector, and
+/// the realized eigenvalue is the Rayleigh quotient \f$ \lambda \f$. A non-unit
+/// \f$ \psi \f$ is normalized internally (the eigenvector condition is
+/// scale-invariant). The Laplacian is reassembled from the **current** edge
+/// weights/phases on every call, so the residual tracks in-place perturbations
+/// of `setWeights` / `setPhases`.
+///
+/// ## Parameters
+///
+/// The tunable parameters are the per-edge squared-length magnitudes
+/// \f$ \{w_{ij}\} \f$ (`Edge::setSquaredLength`) and U(1) connection phases
+/// \f$ \{\theta_{ij}\} \f$ (`Edge::setPhase`), in a stable edge order fixed at
+/// construction (the `EdgeList` order, restricted to the edges that carry weight
+/// in \f$ L \f$: both endpoints present, no self-loops). `weights()` / `phases()`
+/// read them; `setWeights()` / `setPhases()` write them back in place — no mesh
+/// rebuild. `psi` components are indexed in the same sorted-vertex-id order as
+/// `HodgeLaplacian` (\f$ k=0 \f$), so they align with the operator.
+class EigenstateSynthesis {
+  public:
+    /// Construct over a fixed triangulation. The vertex order (sorted id) and the
+    /// tunable edge order are captured now; edge weights/phases are read live on
+    /// each residual query. The held `shared_ptr` keeps the spacetime alive.
+    explicit EigenstateSynthesis(std::shared_ptr<Spacetime> st);
+
+    /// Number of vertices \f$ N \f$ — the required length of any `psi`.
+    [[nodiscard]] std::size_t order() const noexcept { return order_; }
+
+    /// Number of tunable edges — the length of `weights()` / `phases()`.
+    [[nodiscard]] std::size_t numEdges() const noexcept { return edges_.size(); }
+
+    /// The eigenvalue-agnostic residual \f$ r(\psi) = \|(I-\psi\psi^\dagger)L\psi\|^2 \f$
+    /// against the current edge weights/phases. \f$ \psi \f$ is normalized
+    /// internally; \f$ r = 0 \iff L\psi \parallel \psi \f$.
+    /// @throws std::runtime_error if `psi.size() != order()`.
+    [[nodiscard]] double residual(const std::vector<std::complex<double>> &psi) const;
+
+    /// The Rayleigh quotient \f$ \lambda = \psi^\dagger L\psi / \psi^\dagger\psi \f$
+    /// (real; \f$ L \f$ Hermitian) — the realized eigenvalue when \f$ r = 0 \f$.
+    /// @throws std::runtime_error if `psi.size() != order()`.
+    [[nodiscard]] double rayleigh(const std::vector<std::complex<double>> &psi) const;
+
+    /// \f$ L\psi \f$ against the current edge weights/phases (no normalization),
+    /// for direct \f$ L\psi \parallel \psi \f$ cross-checks. Length `order()`.
+    /// @throws std::runtime_error if `psi.size() != order()`.
+    [[nodiscard]] std::vector<std::complex<double>> apply(
+        const std::vector<std::complex<double>> &psi) const;
+
+    /// The edge magnitudes \f$ \{w_{ij}\} \f$ (`Edge::getSquaredLength`) in the
+    /// stable edge order, length `numEdges()`.
+    [[nodiscard]] std::vector<double> weights() const;
+
+    /// The edge phases \f$ \{\theta_{ij}\} \f$ (`Edge::getPhase`) in the stable
+    /// edge order, length `numEdges()`.
+    [[nodiscard]] std::vector<double> phases() const;
+
+    /// Write the edge magnitudes in place (`Edge::setSquaredLength`).
+    /// @throws std::runtime_error if `w.size() != numEdges()`.
+    void setWeights(const std::vector<double> &w);
+
+    /// Write the edge phases in place (`Edge::setPhase`).
+    /// @throws std::runtime_error if `theta.size() != numEdges()`.
+    void setPhases(const std::vector<double> &theta);
+
+  private:
+    std::shared_ptr<Spacetime> st_;
+    // The k=0 Hermitian Laplacian operator over the same complex. laplacian(0)
+    // reassembles L = D - A from the live edges on each call, so perturbing the
+    // edges and re-querying is honest (the eigendecomposition cache is untouched
+    // by the matrix path).
+    HodgeLaplacian laplacian_;
+    std::size_t order_{0};  // N = |V|, the sorted-id vertex order
+    // The tunable edges, in EdgeList order, restricted to those carrying weight
+    // in L (both endpoints present, no self-loops). Raw pointers owned by the
+    // EdgeList; valid for the fixed complex's lifetime (kept alive via st_).
+    std::vector<::tessera::mesh::Edge *> edges_{};
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_EIGENSTATESYNTHESIS_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -33,6 +33,7 @@
 #include "cobordism/Cobordism.h"
 #include "cobordism/CombinatorialDimension.h"
 #include "cobordism/DijkgraafWitten.h"
+#include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
@@ -214,6 +215,55 @@ Euclidean spectrum/kernel.)doc")
            "representatives, one per column of lorentzianHarmonics (same order). "
            "A value ~0 flags a NULL (lightlike) harmonic; all positive on an "
            "all-spacelike complex.");
+
+  // ----- §4b eigenstate synthesis: residual + parameter access (#133) -----
+  py::class_<EigenstateSynthesis>(m, "EigenstateSynthesis",
+      R"doc(§4b inverse eigenvector problem on a fixed complex.
+
+Scores how close the complex's current Hermitian edge weights make a target
+state psi to being an eigenvector of the k=0 Hodge Laplacian L = D - A (the
+magnitude convention, via HodgeLaplacian), and reads/writes those weights so a
+search can perturb them. The non-convex, multi-restart search itself (e.g.
+scipy.optimize.minimize L-BFGS-B over the flat {w_ij} + {theta_ij} vector) lives
+in the driver and calls residual() here; the cone-and-retry growth loop is a
+separate stage (this class is fixed-complex only).
+
+Residual: for a unit target, r(psi) = ||(I - psi psi^dagger) L psi||^2 =
+||L psi - lambda psi||^2 with lambda = psi^dagger L psi, so r = 0 iff
+L psi || psi (psi is an eigenvector) and the realized eigenvalue is the Rayleigh
+quotient lambda. A non-unit psi is normalized internally. L is reassembled from
+the live edge weights/phases on every call, so residual() tracks setWeights /
+setPhases in place. psi is indexed in the same sorted-vertex-id order as
+HodgeLaplacian (k=0).
+
+Parameters: the per-edge squared-length magnitudes {w_ij} (Edge.setSquaredLength)
+and U(1) phases {theta_ij} (Edge.setPhase), in a stable edge order fixed at
+construction (the weight-carrying edges: both endpoints present, no self-loops).)doc")
+      .def(py::init<std::shared_ptr<Spacetime>>(), py::arg("spacetime"),
+           "Build the synthesizer over a fixed triangulation.")
+      .def("order", &EigenstateSynthesis::order,
+           "Number of vertices N — the required length of any psi.")
+      .def("numEdges", &EigenstateSynthesis::numEdges,
+           "Number of tunable edges — the length of weights() / phases().")
+      .def("residual", &EigenstateSynthesis::residual, py::arg("psi"),
+           "Eigenvalue-agnostic residual r(psi) = ||(I - psi psi^dagger) L psi||^2 "
+           "against the current edge weights/phases (psi normalized internally). "
+           "r = 0 iff L psi || psi. Raises if len(psi) != order().")
+      .def("rayleigh", &EigenstateSynthesis::rayleigh, py::arg("psi"),
+           "Rayleigh quotient lambda = psi^dagger L psi / psi^dagger psi (real; L "
+           "Hermitian) — the realized eigenvalue when r = 0. Raises if "
+           "len(psi) != order().")
+      .def("apply", &EigenstateSynthesis::apply, py::arg("psi"),
+           "L psi against the current edge weights/phases (no normalization), for "
+           "direct L psi || psi cross-checks. Raises if len(psi) != order().")
+      .def("weights", &EigenstateSynthesis::weights,
+           "Edge magnitudes {w_ij} (squaredLength) in the stable edge order.")
+      .def("phases", &EigenstateSynthesis::phases,
+           "Edge phases {theta_ij} (radians) in the stable edge order.")
+      .def("setWeights", &EigenstateSynthesis::setWeights, py::arg("w"),
+           "Write the edge magnitudes in place. Raises if len(w) != numEdges().")
+      .def("setPhases", &EigenstateSynthesis::setPhases, py::arg("theta"),
+           "Write the edge phases in place. Raises if len(theta) != numEdges().");
 
   // Exact integer / GF(2) / inertia primitives (also exposed for direct
   // testing). Matrices are passed flat row-major with explicit dims.

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1,0 +1,170 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/EigenstateSynthesis.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Vertex.h"
+#include "mesh/VertexList.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+using cd = std::complex<double>;
+
+EigenstateSynthesis::EigenstateSynthesis(std::shared_ptr<Spacetime> st)
+    : st_(st), laplacian_(std::move(st)) {
+  if (!st_) return;
+
+  // Stable vertex order (sorted id), matching HodgeLaplacian's k=0 indexing so a
+  // psi entry aligns with the operator's row/column for that vertex.
+  std::unordered_set<std::uint64_t> idset;
+  for (const auto v : st_->getVertexList()->toVector())
+    if (v != nullptr) idset.insert(v->getId());
+  order_ = idset.size();
+
+  // Stable edge order: the tunable edges in EdgeList order — those that actually
+  // carry weight in L = D - A (both endpoints present in the vertex set, not a
+  // self-loop). This is exactly HodgeLaplacian::assemble's edge filter, so the
+  // {w_ij, theta_ij} we expose are the parameters the Laplacian reads.
+  for (const auto e : st_->getEdgeList()->toVector()) {
+    if (e == nullptr) continue;
+    const auto s = e->getSource();
+    const auto t = e->getTarget();
+    if (s == nullptr || t == nullptr) continue;
+    if (s->getId() == t->getId()) continue;
+    if (idset.find(s->getId()) == idset.end() ||
+        idset.find(t->getId()) == idset.end())
+      continue;
+    edges_.push_back(e);
+  }
+}
+
+std::vector<cd> EigenstateSynthesis::apply(const std::vector<cd> &psi) const {
+  const std::size_t N = order_;
+  if (psi.size() != N)
+    throw std::runtime_error(
+        "EigenstateSynthesis::apply: psi has length " +
+        std::to_string(psi.size()) + ", expected " + std::to_string(N));
+  std::vector<cd> out(N, cd(0.0, 0.0));
+  if (N == 0) return out;
+  // L = D - A reassembled from the live edge weights/phases (the k=0 magnitude
+  // convention). The matrix path does not consult the eigendecomposition cache,
+  // so repeated perturb-then-query is honest.
+  const std::vector<cd> L = laplacian_.laplacian(0);
+  for (std::size_t i = 0; i < N; ++i) {
+    cd acc(0.0, 0.0);
+    for (std::size_t j = 0; j < N; ++j) acc += L[i * N + j] * psi[j];
+    out[i] = acc;
+  }
+  return out;
+}
+
+double EigenstateSynthesis::residual(const std::vector<cd> &psi) const {
+  const std::size_t N = order_;
+  if (psi.size() != N)
+    throw std::runtime_error(
+        "EigenstateSynthesis::residual: psi has length " +
+        std::to_string(psi.size()) + ", expected " + std::to_string(N));
+  if (N == 0) return 0.0;
+
+  // Normalize: r and the eigenvector condition are scale-invariant, and the spec
+  // writes r for a unit target.
+  double nrm2 = 0.0;
+  for (const cd &c : psi) nrm2 += std::norm(c);
+  if (nrm2 <= 0.0) return 0.0;
+  const double inv = 1.0 / std::sqrt(nrm2);
+  std::vector<cd> p(N);
+  for (std::size_t i = 0; i < N; ++i) p[i] = psi[i] * inv;
+
+  const std::vector<cd> Lp = apply(p);
+  // lambda = p^dagger L p (real for Hermitian L; take the real part).
+  cd lam(0.0, 0.0);
+  for (std::size_t i = 0; i < N; ++i) lam += std::conj(p[i]) * Lp[i];
+  const double lambda = lam.real();
+
+  // r = || L p - lambda p ||^2 = ||(I - p p^dagger) L p||^2 (p unit).
+  double r = 0.0;
+  for (std::size_t i = 0; i < N; ++i) r += std::norm(Lp[i] - lambda * p[i]);
+  return r;
+}
+
+double EigenstateSynthesis::rayleigh(const std::vector<cd> &psi) const {
+  const std::size_t N = order_;
+  if (psi.size() != N)
+    throw std::runtime_error(
+        "EigenstateSynthesis::rayleigh: psi has length " +
+        std::to_string(psi.size()) + ", expected " + std::to_string(N));
+  if (N == 0) return 0.0;
+
+  const std::vector<cd> Lp = apply(psi);
+  cd num(0.0, 0.0);
+  double den = 0.0;
+  for (std::size_t i = 0; i < N; ++i) {
+    num += std::conj(psi[i]) * Lp[i];
+    den += std::norm(psi[i]);
+  }
+  if (den <= 0.0) return 0.0;
+  return num.real() / den;
+}
+
+std::vector<double> EigenstateSynthesis::weights() const {
+  std::vector<double> w;
+  w.reserve(edges_.size());
+  for (const auto e : edges_) w.push_back(e->getSquaredLength());
+  return w;
+}
+
+std::vector<double> EigenstateSynthesis::phases() const {
+  std::vector<double> th;
+  th.reserve(edges_.size());
+  for (const auto e : edges_) th.push_back(e->getPhase());
+  return th;
+}
+
+void EigenstateSynthesis::setWeights(const std::vector<double> &w) {
+  if (w.size() != edges_.size())
+    throw std::runtime_error(
+        "EigenstateSynthesis::setWeights: got " + std::to_string(w.size()) +
+        " weights, expected " + std::to_string(edges_.size()));
+  for (std::size_t i = 0; i < edges_.size(); ++i)
+    edges_[i]->setSquaredLength(w[i]);
+}
+
+void EigenstateSynthesis::setPhases(const std::vector<double> &theta) {
+  if (theta.size() != edges_.size())
+    throw std::runtime_error(
+        "EigenstateSynthesis::setPhases: got " + std::to_string(theta.size()) +
+        " phases, expected " + std::to_string(edges_.size()));
+  for (std::size_t i = 0; i < edges_.size(); ++i)
+    edges_[i]->setPhase(theta[i]);
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_eigenstate_synthesis_python.py
+++ b/tests/cobordism/test_eigenstate_synthesis_python.py
@@ -1,0 +1,317 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""§4b boundary-state synthesis — residual + optimizer on a fixed complex (#133).
+
+EigenstateSynthesis scores how close the complex's current Hermitian edge weights
+make a target qubit psi to being an eigenvector of the k=0 Hodge Laplacian
+L = D - A (magnitude convention), via the eigenvalue-agnostic residual
+r(psi) = ||(I - psi psi^dagger) L psi||^2, and reads/writes the edge magnitudes
+{w_ij} and phases {theta_ij} so a search can perturb them. The non-convex,
+multi-restart search lives here in the Python driver (scipy L-BFGS-B over the flat
+[w; theta] vector), calling the C++ residual.
+
+Acceptance (numpy/scipy oracle), on the §4b two-vertex single-edge complex:
+  * a BALANCED qubit (e^{i*theta}, ±1)/√2 is recovered to r < 1e-10, and the
+    Rayleigh quotient is the realized eigenvalue;
+  * a GENERAL-amplitude qubit (|c0| != |c1|) cannot be a two-vertex eigenvector —
+    the search floor on r stays bounded away from 0 (the motivation for #134's
+    auxiliary vertices). The single edge has Laplacian
+    L = [[|w|, -w e^{i*theta}], [-w e^{-i*theta}, |w|]] whose eigenvectors are the
+    balanced (e^{i*theta}, ±1)/√2; over a box w in [w_min, w_max] the residual of
+    an unbalanced qubit floors at the closed form w_min^2 (|c0|^2 - |c1|^2)^2 > 0;
+  * residual == 0  <=>  L psi || psi, cross-checked against a direct numpy
+    eigendecomposition (and on a richer 4-vertex complex too).
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders (the hand-crafted-complex idiom shared with the Hodge tests)
+# --------------------------------------------------------------------------- #
+def _from_simplices(num_vertices, simplices):
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    verts = [st.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        st.createSimplex([verts[i] for i in simplex])
+    return st
+
+
+def _set_uniform(st, squared_length=1.0, phase=0.0):
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(squared_length)
+        e.setPhase(phase)
+
+
+def _two_vertex_edge():
+    """The §4b seed of the inverse problem: two vertices, one edge (K_2)."""
+    st = _from_simplices(2, [(0, 1)])
+    _set_uniform(st, 1.0, 0.0)
+    return st
+
+
+def _testbed():
+    """Square 00-01-11-10-00 plus the entangling diagonal 00-11 (|V|=4, |E|=5)."""
+    st = _from_simplices(4, [(0, 1), (1, 2), (2, 3), (3, 0), (0, 2)])
+    _set_uniform(st, 1.0, 0.0)
+    return st
+
+
+# --------------------------------------------------------------------------- #
+# numpy oracle + helpers
+# --------------------------------------------------------------------------- #
+def _cvec(v):
+    """A plain list of python complex (pybind's std::vector<complex> caster)."""
+    return [complex(z) for z in v]
+
+
+def _np_L(st):
+    """Independent D - A reference (magnitude convention), in the operator's
+    stable sorted-vertex-id order — the same oracle the Hodge tests use."""
+    ids = sorted(v.getId() for v in st.getVertexList().toVector())
+    idx = {vid: i for i, vid in enumerate(ids)}
+    n = len(ids)
+    A = np.zeros((n, n), dtype=complex)
+    D = np.zeros(n)
+    for e in st.getEdgeList().toVector():
+        s, t = e.getSource().getId(), e.getTarget().getId()
+        if s == t:
+            continue
+        i, j = idx[s], idx[t]
+        w = e.getSquaredLength()
+        z = w * np.exp(1j * e.getPhase())
+        A[i, j] += z
+        A[j, i] += np.conj(z)
+        D[i] += abs(w)
+        D[j] += abs(w)
+    return np.diag(D).astype(complex) - A
+
+
+def _np_residual(L, psi):
+    """The spec residual r = ||(I - psi psi^dagger) L psi||^2 for unit psi."""
+    psi = np.asarray(psi, dtype=complex)
+    psi = psi / np.linalg.norm(psi)
+    Lp = L @ psi
+    lam = np.vdot(psi, Lp).real
+    r = Lp - lam * psi
+    return float(np.vdot(r, r).real)
+
+
+def _synthesize(es, psi, n_restarts=40, seed=0, w_bounds=(0.1, 10.0)):
+    """Non-convex multi-restart search (scipy L-BFGS-B) over the flat [w; theta]
+    vector minimizing the C++ residual r(psi). Leaves the complex at the best
+    parameters found and returns (best_r, best_x)."""
+    from scipy.optimize import minimize
+
+    m = es.numEdges()
+    psi = _cvec(psi)
+    rng = np.random.default_rng(seed)
+    th_bounds = (-2.0 * math.pi, 2.0 * math.pi)
+    bounds = [w_bounds] * m + [th_bounds] * m
+
+    def objective(x):
+        es.setWeights(x[:m].tolist())
+        es.setPhases(x[m:].tolist())
+        return es.residual(psi)
+
+    best_r, best_x = np.inf, None
+    for _ in range(n_restarts):
+        w0 = rng.uniform(w_bounds[0], w_bounds[1], size=m)
+        th0 = rng.uniform(-math.pi, math.pi, size=m)
+        res = minimize(objective, np.concatenate([w0, th0]),
+                       method="L-BFGS-B", bounds=bounds)
+        if res.fun < best_r:
+            best_r, best_x = float(res.fun), np.asarray(res.x, dtype=float)
+    objective(best_x)  # leave the complex realized at the optimum
+    return best_r, best_x
+
+
+# --------------------------------------------------------------------------- #
+class EigenstateSynthesisStructureTest(unittest.TestCase):
+    """Shape / parameter-access surface."""
+
+    def test_order_and_edge_count(self):
+        es = cob.EigenstateSynthesis(_two_vertex_edge())
+        self.assertEqual(es.order(), 2)
+        self.assertEqual(es.numEdges(), 1)
+
+        es5 = cob.EigenstateSynthesis(_testbed())
+        self.assertEqual(es5.order(), 4)
+        self.assertEqual(es5.numEdges(), 5)
+
+    def test_weights_phases_roundtrip(self):
+        st = _testbed()
+        es = cob.EigenstateSynthesis(st)
+        w = [0.5, 1.5, 2.0, 0.25, 3.0]
+        th = [0.1, -0.2, 0.3, -0.4, 0.5]
+        es.setWeights(w)
+        es.setPhases(th)
+        self.assertTrue(np.allclose(es.weights(), w))
+        self.assertTrue(np.allclose(es.phases(), th))
+        # And the writes reach the underlying edges (the Laplacian sees them).
+        self.assertTrue(np.allclose(np.array(es.weights()),
+                                    [e.getSquaredLength()
+                                     for e in st.getEdgeList().toVector()]))
+
+    def test_size_mismatch_raises(self):
+        es = cob.EigenstateSynthesis(_two_vertex_edge())
+        with self.assertRaises(Exception):
+            es.residual([1.0 + 0j])            # needs length order() == 2
+        with self.assertRaises(Exception):
+            es.setWeights([1.0, 2.0])          # needs length numEdges() == 1
+
+
+class ResidualParallelTest(unittest.TestCase):
+    """residual == 0  <=>  L psi || psi, cross-checked vs numpy eigh."""
+
+    def _check(self, st):
+        es = cob.EigenstateSynthesis(st)
+        L = _np_L(st)
+        evals, evecs = np.linalg.eigh(L)
+        n = L.shape[0]
+        for k in range(n):
+            v = evecs[:, k]
+            # eigenvector => residual 0 (C++ matches the numpy oracle)
+            self.assertLess(es.residual(_cvec(v)), 1e-18)
+            self.assertAlmostEqual(es.residual(_cvec(v)), _np_residual(L, v),
+                                   places=14)
+            # ... and L v is genuinely parallel to v: |<v, Lv>| == ||Lv||
+            Lv = np.asarray(es.apply(_cvec(v)))
+            self.assertAlmostEqual(abs(np.vdot(v, Lv)), np.linalg.norm(Lv),
+                                   places=10)
+            self.assertTrue(np.allclose(Lv, evals[k] * v, atol=1e-10))
+            # realized eigenvalue == Rayleigh quotient == numpy eigenvalue
+            self.assertAlmostEqual(es.rayleigh(_cvec(v)), evals[k], places=10)
+
+    def test_two_vertex(self):
+        st = _two_vertex_edge()
+        _set_uniform(st, 1.3, 0.5)  # arbitrary nonzero Hermitian weight
+        self._check(st)
+        # a generic NON-eigenvector => residual > 0 and L u not parallel to u
+        es = cob.EigenstateSynthesis(st)
+        u = np.array([0.6, 0.8j], dtype=complex)
+        u /= np.linalg.norm(u)
+        r = es.residual(_cvec(u))
+        self.assertGreater(r, 1e-3)
+        self.assertAlmostEqual(r, _np_residual(_np_L(st), u), places=12)
+
+    def test_richer_complex(self):
+        st = _testbed()
+        # generic Hermitian weights so the spectrum is non-degenerate
+        for i, e in enumerate(st.getEdgeList().toVector()):
+            e.setSquaredLength(0.7 + 0.3 * i)
+            e.setPhase(0.2 * (i + 1))
+        self._check(st)
+
+
+class BalancedRecoveryTest(unittest.TestCase):
+    """A balanced qubit is recoverable to r < 1e-10 on the single edge; the
+    realized eigenvalue is the Rayleigh quotient."""
+
+    def test_balanced_recovered(self):
+        for sign in (+1.0, -1.0):
+            for alpha in (0.0, 0.7, -1.3):
+                with self.subTest(sign=sign, alpha=alpha):
+                    st = _two_vertex_edge()
+                    es = cob.EigenstateSynthesis(st)
+                    psi = np.array([np.exp(1j * alpha), sign]) / math.sqrt(2.0)
+                    best_r, _ = _synthesize(es, psi, seed=abs(int(10 * alpha)) + 1)
+                    self.assertLess(best_r, 1e-10)
+
+                    # The Rayleigh quotient is the realized eigenvalue: cross-check
+                    # against numpy eigh of the synthesized Laplacian.
+                    lam = es.rayleigh(_cvec(psi))
+                    L = _np_L(st)
+                    evals, evecs = np.linalg.eigh(L)
+                    overlaps = [abs(np.vdot(evecs[:, k], psi)) for k in range(2)]
+                    k = int(np.argmax(overlaps))
+                    self.assertAlmostEqual(overlaps[k], 1.0, places=5)
+                    self.assertAlmostEqual(lam, evals[k], places=6)
+                    # A balanced state can be realized as either branch of the
+                    # single edge — the kernel mode (lambda = 0, theta = alpha) or
+                    # the lambda = 2w mode (theta = alpha + pi), since
+                    # (e^{i(alpha+pi)}, -1)/sqrt2 = -(e^{i*alpha}, +1)/sqrt2 is the
+                    # same ray. The realized eigenvalue is whichever the search
+                    # lands on; it must equal the Rayleigh quotient (checked above)
+                    # and be one of the two analytic eigenvalues {0, 2w}.
+                    w = es.weights()[0]
+                    self.assertTrue(min(abs(lam - 0.0), abs(lam - 2.0 * w)) < 1e-6)
+
+
+class GeneralAmplitudeFloorTest(unittest.TestCase):
+    """An unbalanced qubit cannot be a two-vertex eigenvector: the residual floors
+    bounded away from 0 — the motivation for auxiliary vertices (#134)."""
+
+    def test_floor_bounded_away_from_zero(self):
+        w_min = 0.1
+
+        # Balanced sibling: reaches ~0 on the same single edge.
+        es_bal = cob.EigenstateSynthesis(_two_vertex_edge())
+        bal = np.array([1.0, 1.0]) / math.sqrt(2.0)
+        r_bal, _ = _synthesize(es_bal, bal, seed=7, w_bounds=(w_min, 10.0))
+        self.assertLess(r_bal, 1e-10)
+
+        # Unbalanced qubit: |c0|^2 = 0.8, |c1|^2 = 0.2.
+        a, b = math.sqrt(0.8), math.sqrt(0.2)
+        es_gen = cob.EigenstateSynthesis(_two_vertex_edge())
+        gen = np.array([a, b], dtype=complex)
+        r_gen, _ = _synthesize(es_gen, gen, seed=8, w_bounds=(w_min, 10.0))
+
+        # Closed-form floor over the box: min_{w,theta} w^2 (d^2 cos^2 + sin^2)
+        #   = w_min^2 * d^2,  d = |c0|^2 - |c1|^2.
+        d = a * a - b * b
+        oracle_floor = w_min ** 2 * d ** 2
+        self.assertAlmostEqual(r_gen, oracle_floor, delta=1e-4)
+        self.assertGreater(r_gen, 1e-3)          # bounded away from 0
+        # The contrast is the whole point: the balanced sibling reaches ~0 while
+        # the unbalanced qubit cannot — it needs auxiliary scaffolding (#134).
+        self.assertLess(r_bal, 1e-6 * r_gen)
+
+    def test_floor_scales_with_imbalance(self):
+        # The floor grows with the amplitude imbalance d = |c0|^2 - |c1|^2.
+        w_min = 0.1
+        prev = -1.0
+        for p0 in (0.55, 0.7, 0.9):
+            es = cob.EigenstateSynthesis(_two_vertex_edge())
+            psi = np.array([math.sqrt(p0), math.sqrt(1.0 - p0)], dtype=complex)
+            r, _ = _synthesize(es, psi, seed=int(100 * p0), w_bounds=(w_min, 10.0))
+            d = 2.0 * p0 - 1.0
+            floor = w_min ** 2 * d ** 2
+            # The box minimum is the closed form; the search reaches it (it cannot
+            # go below — that is the global min over w in [w_min, w_max], theta).
+            self.assertLessEqual(abs(r - floor), 0.1 * floor + 2e-5)
+            self.assertGreater(r, prev)  # grows with the amplitude imbalance
+            prev = r
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The §4b inverse eigenvector problem on a **fixed** complex: find Hermitian edge weights making a target qubit ψ an eigenvector of the k=0 Hodge Laplacian. This is the residual + optimizer core; the cone-and-retry growth loop is #134 (not built here).

## What's added
- **C++ `cobordism::EigenstateSynthesis`** (constructed from a `Spacetime`), reusing `HodgeLaplacian` (k=0, magnitude convention) for `L = D − A` and `Edge::setSquaredLength`/`setPhase` for the parameters:
  - `residual(psi) = ‖(I−ψψ†)Lψ‖² = ‖Lψ − λψ‖²` (ψ normalized internally; `L` reassembled from the live edges each call, so it tracks in-place perturbations)
  - `rayleigh(psi) = ψ†Lψ / ψ†ψ` — the realized eigenvalue when `r = 0`
  - `apply(psi) = Lψ` (for `Lψ ∥ ψ` cross-checks)
  - `weights()` / `phases()` / `setWeights()` / `setPhases()` over the stable edge order; `order()`, `numEdges()`
- Bound in `src/cobordism/Bindings.cpp`.
- The non-convex, multi-restart **search** lives in the Python test driver (`scipy.optimize.minimize`, L-BFGS-B over the flat `[w; θ]` vector), calling the C++ residual.

## Acceptance (numpy/scipy oracle, `tests/cobordism/test_eigenstate_synthesis_python.py`)
- On the §4b two-vertex single-edge complex, the search recovers a **balanced** qubit `(e^{iθ},±1)/√2` to `r < 1e-10`, and the Rayleigh quotient equals the realized eigenvalue (cross-checked vs `numpy.linalg.eigh`).
- A **general-amplitude** qubit (`|c₀|≠|c₁|`) cannot be a two-vertex eigenvector: over the box `w ∈ [w_min, w_max]` the residual floors at the closed form `w_min²(|c₀|²−|c₁|²)² > 0` (the search reaches it, bounded away from 0) — the motivation for auxiliaries / #134.
- `residual == 0 ⟺ Lψ ∥ ψ`, cross-checked against a direct numpy eigendecomposition (on the single edge and a richer 4-vertex complex).

Full `tests/cobordism` suite: 238 passed, 1 skipped, 395 subtests passed.

Closes #133.