### PR TITLE
cobordism: cohomology-class DW state-sum (T2 robustness)

### DIFF
--- a/include/cobordism/DijkgraafWitten.h
+++ b/include/cobordism/DijkgraafWitten.h
@@ -82,6 +82,52 @@ class DijkgraafWitten {
     ///   to enumerate.
     [[nodiscard]] std::complex<double> partitionFunction() const;
 
+    /// # The cohomology-class (closed-form) Dijkgraaf–Witten state sum
+    ///
+    /// The same invariant as `partitionFunction()`, summed over the **cohomology
+    /// classes** \f$ [g] \in H^1(W;\mathbb{Z}_2) \f$ instead of the
+    /// gauge-redundant cocycle space \f$ Z^1 \f$. The DW weight
+    /// \f$ \prod_t \omega(g_{01},g_{12},g_{23})^{\varepsilon_t} \f$ depends only
+    /// on the class \f$ [g] \f$ (the cup-cube \f$ \langle g^3,[W]\rangle \f$ is a
+    /// cohomology pairing; the trivial class has weight 1), so the sum collapses:
+    /// \f[
+    ///   Z(W) = \frac{1}{2^{b_0}} \sum_{[g] \in H^1(W;\mathbb{Z}_2)}
+    ///          \mathrm{weight}([g]),
+    /// \f]
+    /// i.e. \f$ 2^{b_1} \f$ terms in place of \f$ 2^{\dim Z^1} \f$ — identical in
+    /// value to `partitionFunction()`, but feasible where the brute force is not
+    /// (e.g. \f$ T^3 \f$, \f$ \dim Z^1 = 29 \f$). \f$ H^1 = Z^1/B^1 \f$ is
+    /// enumerated with `gf2Nullspace` (\f$ Z^1 = \ker \partial_2^\top \f$),
+    /// `gf2CohomologyBasis` (quotient by the coboundaries \f$ B^1 = \mathrm{im}\,
+    /// \partial_1^\top \f$), and `gf2Span` (the \f$ 2^{b_1} \f$ classes); a
+    /// runtime guard confirms the weight agrees across representatives of each
+    /// class (gauge-shifts by every elementary coboundary). The \f$ 2^{-b_0} \f$
+    /// factor (\f$ b_0 = \f$ #components \f$ = \dim H^0 \f$) is the residual gauge
+    /// volume that makes this equal the \f$ 2^{-|V|} \sum_{\text{flat }g} \f$
+    /// brute-force sum.
+    /// @throws std::runtime_error if \f$ W \f$ is null or not a closed oriented
+    ///   3-manifold (dimension \f$ \neq 3 \f$, or no fundamental class).
+    [[nodiscard]] std::complex<double> partitionFunctionByCohomology() const;
+
+    /// The enumeration size of each state-sum path, for reporting the cohomology
+    /// collapse's speedup. `partitionFunction()` brute-forces all
+    /// \f$ 2^{\dim Z^1} \f$ flat cocycles; `partitionFunctionByCohomology()` sums
+    /// the \f$ 2^{b_1(W;\mathbb{Z}_2)} \f$ cohomology classes. The classes are
+    /// \f$ 2^{\dim B^1} = 2^{|V|-b_0} \f$-fold fewer, so the speedup is
+    /// \f$ 2^{\dim Z^1 - b_1} \f$.
+    struct StateSumTerms {
+      int firstBetti{0};            ///< \f$ b_1(W;\mathbb{Z}_2) \f$: cohomology-path exponent.
+      int cocycleDimension{0};      ///< \f$ \dim Z^1 \f$: brute-force-path exponent.
+      double cohomologyTerms{1.0};  ///< \f$ 2^{\text{firstBetti}} \f$.
+      double bruteForceTerms{1.0};  ///< \f$ 2^{\text{cocycleDimension}} \f$.
+      double speedup{1.0};          ///< bruteForceTerms / cohomologyTerms.
+    };
+
+    /// Report the two state-sum enumeration sizes (see `StateSumTerms`).
+    /// @throws std::runtime_error if \f$ W \f$ is null or not a 3-manifold
+    ///   (dimension \f$ \neq 3 \f$).
+    [[nodiscard]] StateSumTerms stateSumTerms() const;
+
     /// # The Dijkgraaf–Witten state sum with boundary
     ///
     /// For a 3-manifold \f$ W \f$ **with boundary** \f$ \partial W \f$ the state

--- a/include/cobordism/IntegerLinalg.h
+++ b/include/cobordism/IntegerLinalg.h
@@ -76,6 +76,21 @@ struct SmithNormalForm {
 [[nodiscard]] std::vector<std::vector<int>> gf2Span(
     const std::vector<std::vector<int>> &basis, int cols);
 
+/// A basis of representatives for the GF(2) cohomology quotient H = Z / B. Given
+/// a generating set `cocycles` of the cocycle space Z (e.g. the Z¹ basis from
+/// gf2Nullspace) and a generating set `coboundaries` of the subspace B ⊆ Z (e.g.
+/// the vertex edge-incidence vectors B¹ = im(∂₁ᵀ)), all length-`cols` 0/1 vectors
+/// (entries read mod 2), return the members of `cocycles` that stay independent
+/// modulo B and modulo the representatives already chosen. There are exactly
+/// dim Z − dim B = b₁ of them; together with B they span Z, and — being a
+/// complement of B in Z — their GF(2) span (gf2Span) is a transversal that hits
+/// each coset of B exactly once. This is H¹(W; ℤ₂) for the Dijkgraaf–Witten state
+/// sum: the gauge-inequivalent flat ℤ₂ connections, 2^{dim B} = 2^{|V|−b₀}-fold
+/// fewer than the full cocycle space, so the state sum collapses to 2^{b₁} terms.
+[[nodiscard]] std::vector<std::vector<int>> gf2CohomologyBasis(
+    const std::vector<std::vector<int>> &cocycles,
+    const std::vector<std::vector<int>> &coboundaries, int cols);
+
 /// Inertia of a symmetric integer matrix Q (n x n): the counts of positive,
 /// negative, and zero eigenvalues by Sylvester's law of inertia. The signature
 /// is nPos - nNeg.

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -234,6 +234,13 @@ Euclidean spectrum/kernel.)doc")
   m.def("gf2_span", &gf2Span, py::arg("basis"), py::arg("cols"),
         "All 2^k GF(2) combinations of a basis of k length-cols vectors (first "
         "is the zero vector). For a gf2_nullspace basis, the flat Z2 connections.");
+  m.def("gf2_cohomology_basis", &gf2CohomologyBasis, py::arg("cocycles"),
+        py::arg("coboundaries"), py::arg("cols"),
+        "A basis of representatives for the GF(2) quotient H = Z/B: the members "
+        "of `cocycles` (a generating set of Z) independent modulo `coboundaries` "
+        "(a generating set of B subset Z). Returns dim Z - dim B vectors whose "
+        "gf2_span is a transversal hitting each coset of B once. This is "
+        "H^1(W;Z2) = Z^1/B^1 for the Dijkgraaf-Witten state sum.");
 
   py::class_<Inertia>(m, "Inertia")
       .def_readonly("n_pos", &Inertia::nPos)
@@ -338,6 +345,25 @@ Euclidean spectrum/kernel.)doc")
       .value("Trivial", Cocycle::Trivial)
       .value("Sign", Cocycle::Sign);
 
+  py::class_<DijkgraafWitten::StateSumTerms>(m, "StateSumTerms",
+      "Enumeration sizes of the two Dijkgraaf-Witten state-sum paths, for "
+      "reporting the cohomology collapse's speedup: the brute force visits "
+      "2^{cocycle_dimension} = 2^{dim Z^1} flat cocycles, the cohomology path "
+      "only 2^{first_betti} = 2^{b_1(W;Z_2)} classes; speedup = 2^{dim Z^1 - b_1}.")
+      .def_readonly("first_betti", &DijkgraafWitten::StateSumTerms::firstBetti,
+                    "b_1(W;Z_2): the cohomology-path exponent.")
+      .def_readonly("cocycle_dimension",
+                    &DijkgraafWitten::StateSumTerms::cocycleDimension,
+                    "dim Z^1: the brute-force-path exponent.")
+      .def_readonly("cohomology_terms",
+                    &DijkgraafWitten::StateSumTerms::cohomologyTerms,
+                    "2^{first_betti}, the terms the cohomology sum visits.")
+      .def_readonly("brute_force_terms",
+                    &DijkgraafWitten::StateSumTerms::bruteForceTerms,
+                    "2^{cocycle_dimension}, the terms the brute force visits.")
+      .def_readonly("speedup", &DijkgraafWitten::StateSumTerms::speedup,
+                    "brute_force_terms / cohomology_terms = 2^{dim Z^1 - b_1}.");
+
   py::class_<DijkgraafWitten>(m, "DijkgraafWitten",
       R"doc(Dijkgraaf-Witten Z_2 state sum of a closed oriented 3-manifold.
 
@@ -348,8 +374,12 @@ the fundamental class. For connected W the untwisted value is Z_Trivial(W) =
 2^{b_1(W;Z_2) - 1}; the Sign cocycle twists it by (-1)^{<g cup g cup g, [W]>},
 which differs from the trivial value exactly when the mod-2 cup cube is nonzero
 on W (e.g. RP^3), and agrees with it when the cube vanishes (e.g. T^3, S^2xS^1).
-Enumerates the whole flat space (gauge-redundant), so it is intended for small
-triangulations; a flat space too large to materialize is refused.)doc")
+partitionFunction() enumerates the whole flat space (gauge-redundant), so it is
+intended for small triangulations; a flat space too large to materialize is
+refused. partitionFunctionByCohomology() computes the same Z(W) over the
+2^{b_1(W;Z_2)} cohomology classes [g] in H^1(W;Z_2) (with 2^{-b_0} normalization)
+instead of all 2^{dim Z^1} cocycles, so it stays feasible where the brute force is
+not (e.g. T^3, dim Z^1 = 29); stateSumTerms() reports the speedup.)doc")
       .def(py::init<std::shared_ptr<Spacetime>, Cocycle>(), py::arg("W"),
            py::arg("cocycle"),
            "Build the state sum over a closed oriented 3-manifold W with the "
@@ -357,6 +387,18 @@ triangulations; a flat space too large to materialize is refused.)doc")
       .def("partitionFunction", &DijkgraafWitten::partitionFunction,
            "The partition function Z(W) as a complex number. Raises if W is not "
            "a closed oriented 3-manifold or the flat space is too large.")
+      .def("partitionFunctionByCohomology",
+           &DijkgraafWitten::partitionFunctionByCohomology,
+           "The same Z(W), summed over the 2^{b_1(W;Z_2)} cohomology classes "
+           "[g] in H^1(W;Z_2) instead of all 2^{dim Z^1} flat cocycles: "
+           "Z(W) = 2^{-b_0} sum_{[g]} weight([g]). Identical in value to "
+           "partitionFunction() but feasible where the brute force is not (e.g. "
+           "T^3, dim Z^1 = 29). A runtime guard checks the weight is constant on "
+           "each class. Raises if W is not a closed oriented 3-manifold.")
+      .def("stateSumTerms", &DijkgraafWitten::stateSumTerms,
+           "A StateSumTerms reporting the enumeration sizes of the two paths "
+           "(2^{b_1} cohomology classes vs 2^{dim Z^1} flat cocycles) and the "
+           "speedup. Raises if W is not a 3-manifold.")
       .def("boundaryVector", &DijkgraafWitten::boundaryVector,
            "The element of Z(dW) for a 3-manifold W with boundary: the amplitude "
            "for every joint boundary flat-connection class, flattened row-major "

--- a/src/cobordism/DijkgraafWitten.cpp
+++ b/src/cobordism/DijkgraafWitten.cpp
@@ -166,6 +166,136 @@ std::complex<double> DijkgraafWitten::partitionFunction() const {
   return total;
 }
 
+std::complex<double> DijkgraafWitten::partitionFunctionByCohomology() const {
+  if (W_ == nullptr)
+    throw std::runtime_error(
+        "DijkgraafWitten::partitionFunctionByCohomology: the spacetime is null");
+
+  const ChainComplex chain = ChainComplex::fromSpacetime(*W_);
+  if (chain.dimension() != 3)
+    throw std::runtime_error(
+        "DijkgraafWitten::partitionFunctionByCohomology: a closed oriented "
+        "3-manifold is required (dimension must be 3)");
+
+  const int numEdges = static_cast<int>(chain.numSimplices(1));
+  const int numTriangles = static_cast<int>(chain.numSimplices(2));
+
+  // Cocycles Z^1 = ker(d_1 mod 2), d_1 = ∂_2^T (triangles × edges) — the flat
+  // ℤ₂ connections, exactly as in partitionFunction().
+  const std::vector<long> &boundaryTwo = chain.boundaryMatrix(2);
+  std::vector<int> coboundaryOne(
+      static_cast<std::size_t>(numTriangles) * numEdges, 0);
+  for (int edge = 0; edge < numEdges; ++edge)
+    for (int triangle = 0; triangle < numTriangles; ++triangle)
+      coboundaryOne[static_cast<std::size_t>(triangle) * numEdges + edge] =
+          static_cast<int>(
+              boundaryTwo[static_cast<std::size_t>(edge) * numTriangles +
+                          triangle] &
+              1L);
+  const std::vector<std::vector<int>> cocycleBasis =
+      gf2Nullspace(coboundaryOne, numTriangles, numEdges);
+
+  // Map a sorted vertex pair (v_i, v_j) to its C_1 (edge) index, as in
+  // partitionFunction() — the row order of ∂_2 / kSimplexVertices(1).
+  const std::vector<std::vector<std::uint64_t>> edges = chain.kSimplexVertices(1);
+  std::map<std::pair<std::uint64_t, std::uint64_t>, int> edgeIndex;
+  for (int e = 0; e < numEdges; ++e) edgeIndex[{edges[e][0], edges[e][1]}] = e;
+
+  // Coboundaries B^1 = im(d_0): each vertex's edge-incidence vector (mod 2 it is
+  // d_0 of the vertex indicator — an elementary gauge transformation).
+  std::vector<std::vector<int>> coboundaryBasis;
+  for (const std::vector<std::uint64_t> &vertex : chain.kSimplexVertices(0)) {
+    const std::uint64_t id = vertex[0];
+    std::vector<int> incidence(numEdges, 0);
+    for (int e = 0; e < numEdges; ++e)
+      if (edges[e][0] == id || edges[e][1] == id) incidence[e] = 1;
+    coboundaryBasis.push_back(std::move(incidence));
+  }
+
+  // H^1(W;ℤ₂) = Z^1/B^1: a complement basis of representatives, enumerated to the
+  // 2^{b_1} cohomology classes (one representative per gauge class).
+  const std::vector<std::vector<int>> cohomologyBasis =
+      gf2CohomologyBasis(cocycleBasis, coboundaryBasis, numEdges);
+  const std::vector<std::vector<int>> classes =
+      gf2Span(cohomologyBasis, numEdges);
+
+  // The DW weight ∏_t ω(g_01,g_12,g_23)^{ε_t} on a connection g, read exactly as
+  // in partitionFunction() (same edge map, same orientation signs ε_t from the
+  // fundamental class); for the real ℤ₂ cocycles ε_t is a no-op but kept faithful.
+  const std::vector<std::vector<std::uint64_t>> tetrahedra =
+      chain.orientedTopSimplices();
+  const std::vector<int> epsilon = chain.fundamentalClass();
+  auto weightOf = [&](const std::vector<int> &g) {
+    std::complex<double> weight{1.0, 0.0};
+    for (int t = 0; t < static_cast<int>(tetrahedra.size()); ++t) {
+      const std::vector<std::uint64_t> &v = tetrahedra[t];  // v0 < v1 < v2 < v3
+      const int g01 = g[static_cast<std::size_t>(edgeIndex.at({v[0], v[1]}))];
+      const int g12 = g[static_cast<std::size_t>(edgeIndex.at({v[1], v[2]}))];
+      const int g23 = g[static_cast<std::size_t>(edgeIndex.at({v[2], v[3]}))];
+      std::complex<double> tetWeight = omega(cocycle_, g01, g12, g23);
+      if (epsilon[static_cast<std::size_t>(t)] < 0) tetWeight = std::conj(tetWeight);
+      weight *= tetWeight;
+    }
+    return weight;
+  };
+
+  // Z(W) = (1/2^{b_0}) Σ_{[g] ∈ H^1} weight([g]). Per class, the weight is
+  // computed once for the sum and re-checked against every gauge shift g ⊕ c
+  // (c an elementary coboundary): a genuine 3-cocycle weight is constant on a
+  // class, so a mismatch flags a non-cocycle ω or inconsistent edge indexing —
+  // the same loud guard partitionFunction() applies to flatness.
+  const double tolerance = 1e-9;
+  std::complex<double> total{0.0, 0.0};
+  for (const std::vector<int> &g : classes) {
+    const std::complex<double> weight = weightOf(g);
+    for (const std::vector<int> &c : coboundaryBasis) {
+      std::vector<int> shifted(g.size());
+      for (std::size_t e = 0; e < g.size(); ++e)
+        shifted[e] = (g[e] ^ c[static_cast<std::size_t>(e)]) & 1;
+      if (std::abs(weightOf(shifted) - weight) > tolerance)
+        throw std::runtime_error(
+            "DijkgraafWitten::partitionFunctionByCohomology: the weight is not "
+            "constant on a cohomology class (gauge-shift mismatch) — ω is not a "
+            "3-cocycle or the coboundary/edge indexing is inconsistent");
+    }
+    total += weight;
+  }
+
+  // b_0 = dim H^0 = number of connected components: the residual gauge volume
+  // that makes the cohomology-class sum equal the 2^{-|V|} Σ_{flat g} brute force
+  // (|B^1| = 2^{|V|-b_0} cocycles collapse to each class).
+  const int b0 = chain.bettiNumbersGF2()[0];
+  total /= std::pow(2.0, static_cast<double>(b0));
+  return total;
+}
+
+DijkgraafWitten::StateSumTerms DijkgraafWitten::stateSumTerms() const {
+  if (W_ == nullptr)
+    throw std::runtime_error(
+        "DijkgraafWitten::stateSumTerms: the spacetime is null");
+
+  const ChainComplex chain = ChainComplex::fromSpacetime(*W_);
+  if (chain.dimension() != 3)
+    throw std::runtime_error(
+        "DijkgraafWitten::stateSumTerms: a 3-manifold (dimension 3) is required");
+
+  // dim Z^1 = b_1 + dim B^1 = b_1 + (|V| - b_0): the brute-force path enumerates
+  // all 2^{dim Z^1} flat cocycles, the cohomology path only the 2^{b_1} classes.
+  const std::vector<int> bettiGF2 = chain.bettiNumbersGF2();
+  const int b0 = bettiGF2[0];
+  const int b1 = bettiGF2[1];
+  const int numVertices = static_cast<int>(chain.numSimplices(0));
+  const int dimZ1 = b1 + numVertices - b0;
+
+  StateSumTerms terms;
+  terms.firstBetti = b1;
+  terms.cocycleDimension = dimZ1;
+  terms.cohomologyTerms = std::pow(2.0, static_cast<double>(b1));
+  terms.bruteForceTerms = std::pow(2.0, static_cast<double>(dimZ1));
+  terms.speedup = std::pow(2.0, static_cast<double>(dimZ1 - b1));
+  return terms;
+}
+
 DijkgraafWitten::Boundary DijkgraafWitten::computeBoundary() const {
   if (W_ == nullptr)
     throw std::runtime_error(
@@ -219,24 +349,9 @@ DijkgraafWitten::Boundary DijkgraafWitten::computeBoundary() const {
     for (int &c : v) c &= 1;
     return v;
   };
-  auto isZero = [](const std::vector<int> &v) {
-    return std::all_of(v.begin(), v.end(), [](int x) { return x == 0; });
-  };
-  // Representatives of H^1 = Z^1 / B^1: from the cocycle basis keep exactly those
-  // independent modulo the coboundaries already accumulated (b_1 of them).
-  auto cohomologyReps = [&](const std::vector<std::vector<int>> &cocycles,
-                            std::vector<std::vector<int>> coboundaries,
-                            int cols) {
-    std::vector<std::vector<int>> spanRows = echelon(coboundaries, cols);
-    std::vector<std::vector<int>> reps;
-    for (const std::vector<int> &z : cocycles)
-      if (!isZero(residue(z, spanRows))) {
-        reps.push_back(z);
-        coboundaries.push_back(z);
-        spanRows = echelon(coboundaries, cols);
-      }
-    return reps;
-  };
+  // Representatives of H^1 = Z^1 / B^1 (the b_1 cocycles independent modulo the
+  // coboundaries) come from IntegerLinalg::gf2CohomologyBasis; `echelon` and
+  // `residue` above remain for the per-component class-index lookup below.
 
   // --- bulk: enumerate the gauge classes [g] ∈ H^1(W; ℤ₂) --------------------
   // Flat connections Z^1(W) = ker(d_1 mod 2), d_1 = ∂_2^T (triangles × edges);
@@ -269,7 +384,7 @@ DijkgraafWitten::Boundary DijkgraafWitten::computeBoundary() const {
     coboundaryBasis.push_back(std::move(incidence));
   }
   const std::vector<std::vector<int>> bulkReps =
-      cohomologyReps(cocycleBasis, coboundaryBasis, numEdges);
+      gf2CohomologyBasis(cocycleBasis, coboundaryBasis, numEdges);
   const std::vector<std::vector<int>> bulkClasses = gf2Span(bulkReps, numEdges);
 
   // --- boundary ∂W: components, each a closed surface Σ_i --------------------
@@ -335,7 +450,7 @@ DijkgraafWitten::Boundary DijkgraafWitten::computeBoundary() const {
       localCoboundaryBasis.push_back(std::move(incidence));
     }
     const std::vector<std::vector<int>> localReps =
-        cohomologyReps(localCocycles, localCoboundaryBasis, numLocalEdges);
+        gf2CohomologyBasis(localCocycles, localCoboundaryBasis, numLocalEdges);
     const std::vector<std::vector<int>> localClasses =
         gf2Span(localReps, numLocalEdges);
 

--- a/src/cobordism/IntegerLinalg.cpp
+++ b/src/cobordism/IntegerLinalg.cpp
@@ -38,6 +38,48 @@ inline long &at(std::vector<long> &M, int cols, int i, int j) {
   return M[static_cast<std::size_t>(i) * cols + j];
 }
 
+// GF(2) row-echelon basis of the span of `gens` (each read mod 2), the rows
+// kept in increasing pivot-column order with dependent generators dropped. Each
+// row's leftmost 1 (its pivot) is unique to that row, so a vector reduces to
+// zero against the basis iff it lies in the span.
+std::vector<std::vector<int>> gf2Echelon(std::vector<std::vector<int>> gens,
+                                         int cols) {
+  std::vector<std::vector<int>> rows;
+  std::vector<int> pivots;
+  for (std::vector<int> g : gens) {
+    for (int &c : g) c &= 1;
+    for (std::size_t r = 0; r < rows.size(); ++r)
+      if (g[static_cast<std::size_t>(pivots[r])])
+        for (int c = pivots[r]; c < cols; ++c)
+          g[static_cast<std::size_t>(c)] ^= rows[r][static_cast<std::size_t>(c)];
+    int p = -1;
+    for (int c = 0; c < cols; ++c)
+      if (g[static_cast<std::size_t>(c)]) { p = c; break; }
+    if (p < 0) continue;  // dependent on the rows already collected
+    std::size_t pos = 0;
+    while (pos < pivots.size() && pivots[pos] < p) ++pos;
+    rows.insert(rows.begin() + static_cast<long>(pos), std::move(g));
+    pivots.insert(pivots.begin() + static_cast<long>(pos), p);
+  }
+  return rows;
+}
+
+// Reduce `v` against an echelon basis `rows`; the residue is zero iff v is in
+// the span. Linear over GF(2).
+std::vector<int> gf2Residue(std::vector<int> v,
+                            const std::vector<std::vector<int>> &rows) {
+  for (const std::vector<int> &row : rows) {
+    int p = -1;
+    for (int c = 0; c < static_cast<int>(row.size()); ++c)
+      if (row[static_cast<std::size_t>(c)]) { p = c; break; }
+    if (p >= 0 && (v[static_cast<std::size_t>(p)] & 1))
+      for (int c = p; c < static_cast<int>(v.size()); ++c)
+        v[static_cast<std::size_t>(c)] ^= row[static_cast<std::size_t>(c)];
+  }
+  for (int &c : v) c &= 1;
+  return v;
+}
+
 }  // namespace
 
 SmithNormalForm smithNormalForm(std::vector<long> M, int rows, int cols) {
@@ -201,6 +243,27 @@ std::vector<std::vector<int>> gf2Span(const std::vector<std::vector<int>> &basis
     out.push_back(std::move(v));
   }
   return out;
+}
+
+std::vector<std::vector<int>> gf2CohomologyBasis(
+    const std::vector<std::vector<int>> &cocycles,
+    const std::vector<std::vector<int>> &coboundaries, int cols) {
+  // Greedily keep each cocycle that is still independent modulo the coboundaries
+  // B and the representatives chosen so far: its residue against the running
+  // echelon span is nonzero. The kept vectors are a complement of B in Z, so
+  // their span is a transversal of Z/B (one representative per cohomology class).
+  std::vector<std::vector<int>> accumulated = coboundaries;
+  std::vector<std::vector<int>> spanRows = gf2Echelon(accumulated, cols);
+  std::vector<std::vector<int>> reps;
+  for (const std::vector<int> &z : cocycles) {
+    const std::vector<int> residue = gf2Residue(z, spanRows);
+    if (std::any_of(residue.begin(), residue.end(), [](int x) { return x != 0; })) {
+      reps.push_back(z);
+      accumulated.push_back(z);
+      spanRows = gf2Echelon(accumulated, cols);
+    }
+  }
+  return reps;
 }
 
 Inertia symmetricInertia(std::vector<long> Q, int n, double tol) {

--- a/tests/cobordism/test_dijkgraaf_witten_cohomology_python.py
+++ b/tests/cobordism/test_dijkgraaf_witten_cohomology_python.py
@@ -1,0 +1,251 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Cohomology-class Dijkgraaf–Witten state sum — T2 robustness (#139).
+
+The DW weight ∏_t ω(g_01,g_12,g_23)^{ε_t} depends only on the cohomology class
+[g] ∈ H¹(W;ℤ₂) (the cup-cube ⟨g³,[W]⟩ is a cohomology pairing; the trivial class
+has weight 1), so the gauge-redundant brute-force sum over all 2^{dim Z¹} flat
+cocycles collapses to a sum over the 2^{b₁} classes:
+
+    Z(W) = 2^{-b₀} · Σ_{[g] ∈ H¹(W;ℤ₂)} weight([g]).
+
+``DijkgraafWitten.partitionFunctionByCohomology`` enumerates H¹ = Z¹/B¹ — the
+cocycles ker(∂₂ᵀ) (``gf2_nullspace``) modulo the coboundaries im(∂₁ᵀ), quotiented
+by ``gf2_cohomology_basis`` — and sums one representative per class. It is the
+*same invariant* as the brute-force ``partitionFunction`` (cross-checked here on
+S³, S²×S¹, RP³), but feasible where the brute force is not: T³ has dim Z¹ = 29,
+beyond ``gf2_span``'s materializable cap of 24, yet only 2^{b₁} = 2³ = 8 classes.
+
+Acceptance (#139):
+  * Agrees with brute-force partitionFunction on S³, S²×S¹, RP³ (both cocycles).
+  * Z(T³): brute force is infeasible (raises); the cohomology sum gives
+    Z_Trivial = 2^{b₁-1} = 4 and Z_Sign = 4 (T³ is a sign negative control, the
+    cup cube g³ vanishes on every 1-class — H*(T³;ℤ₂) = Λ(x,y,z)).
+  * Reports the speedup 2^{b₁} vs 2^{dim Z¹} (= 2^{26} for T³) via stateSumTerms.
+"""
+
+import unittest
+
+import tessera
+
+cobordism = tessera.cobordism
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+
+
+def _build(topology):
+    """Build a closed oriented 3-manifold Spacetime from a fixture topology."""
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()  # delegates to topology.build(); the count is ignored
+    return spacetime
+
+
+def _chain(spacetime):
+    return cobordism.ChainComplex.fromSpacetime(spacetime)
+
+
+def _three_sphere():
+    # S³ = ∂Δ⁴: 5 vertices, betti (1,0,0,1); dim Z¹ = 4 (brute force feasible).
+    return _build(tessera.SimplexBoundarySphere(3))
+
+
+def _s2_cross_s1():
+    # S²×S¹ via the simplicial product: 12 vertices, betti (1,1,1,1); dim Z¹ = 12.
+    return _build(tessera.SimplicialProduct(tessera.SimplexBoundarySphere(2),
+                                            tessera.SimplexBoundarySphere(1)))
+
+
+def _rp3():
+    # RP³ (Walkup 11-vertex): betti (1,0,0,1), bettiGF2 (1,1,1,1); dim Z¹ = 11.
+    # The sign cocycle distinguishes it (cup cube t³ ≠ 0): Z_Sign = 0 ≠ 1.
+    return _build(tessera.RealProjectiveSpace())
+
+
+def _three_torus():
+    # T³ = S¹ × S¹ × S¹ via nested simplicial products: 3·3·3 = 27 vertices,
+    # betti (1,3,3,1). dim Z¹ = b₁ + |V| − b₀ = 3 + 27 − 1 = 29 > 24, so the
+    # brute-force state sum cannot materialize the flat space — only 2³ = 8
+    # cohomology classes do.
+    circle = tessera.SimplexBoundarySphere(1)          # S¹ = ∂Δ², 3 vertices
+    torus2 = tessera.SimplicialProduct(circle, circle)  # T² = S¹×S¹, 9 vertices
+    return _build(tessera.SimplicialProduct(torus2, circle))  # T³, 27 vertices
+
+
+def _dim_z1(spacetime):
+    """dim Z¹ = b₁(ℤ₂) + |V| − b₀(ℤ₂) (== nullity of the coboundary ∂₂ᵀ)."""
+    chain = _chain(spacetime)
+    betti_gf2 = chain.bettiNumbersGF2()
+    return betti_gf2[1] + chain.numSimplices(0) - betti_gf2[0]
+
+
+class TestCohomologyMatchesBruteForce(unittest.TestCase):
+    """The cohomology-class sum is the same invariant as the brute-force sum,
+    on every fixture small enough for the brute force, for both cocycles."""
+
+    def _check(self, spacetime, cocycle):
+        dw = DijkgraafWitten(spacetime, cocycle)
+        brute = dw.partitionFunction()
+        closed = dw.partitionFunctionByCohomology()
+        self.assertAlmostEqual(closed.imag, 0.0, places=9)
+        self.assertAlmostEqual(closed.real, brute.real, places=9)
+        self.assertAlmostEqual(abs(closed - brute), 0.0, places=9)
+
+    def test_three_sphere(self):
+        spacetime = _three_sphere()
+        for cocycle in (Cocycle.Trivial, Cocycle.Sign):
+            with self.subTest(cocycle=cocycle):
+                self._check(spacetime, cocycle)
+
+    def test_s2_cross_s1(self):
+        spacetime = _s2_cross_s1()
+        for cocycle in (Cocycle.Trivial, Cocycle.Sign):
+            with self.subTest(cocycle=cocycle):
+                self._check(spacetime, cocycle)
+
+    def test_rp3(self):
+        # RP³ is the positive control: the two cocycles disagree (1 vs 0), and
+        # the cohomology sum must reproduce *both* brute-force values exactly.
+        spacetime = _rp3()
+        for cocycle in (Cocycle.Trivial, Cocycle.Sign):
+            with self.subTest(cocycle=cocycle):
+                self._check(spacetime, cocycle)
+        self.assertAlmostEqual(
+            DijkgraafWitten(spacetime, Cocycle.Trivial)
+            .partitionFunctionByCohomology().real, 1.0, places=9)
+        self.assertAlmostEqual(
+            DijkgraafWitten(spacetime, Cocycle.Sign)
+            .partitionFunctionByCohomology().real, 0.0, places=9)
+
+    def test_matches_convention_anchor(self):
+        # Z_Trivial = 2^{b₁(ℤ₂) − 1} for a connected closed oriented W.
+        for fixture in (_three_sphere, _s2_cross_s1, _rp3):
+            spacetime = fixture()
+            b1 = _chain(spacetime).bettiNumbersGF2()[1]
+            z = DijkgraafWitten(spacetime, Cocycle.Trivial) \
+                .partitionFunctionByCohomology()
+            with self.subTest(fixture=fixture.__name__):
+                self.assertAlmostEqual(z.real, 2.0 ** (b1 - 1), places=9)
+
+
+class TestThreeTorus(unittest.TestCase):
+    """Z(T³): the headline case — brute force is infeasible, the cohomology sum
+    is not, and it lands on the convention value 2^{b₁-1} = 4 for both cocycles."""
+
+    def setUp(self):
+        self.t3 = _three_torus()
+
+    def test_fixture_really_is_t3(self):
+        chain = _chain(self.t3)
+        self.assertEqual(chain.dimension(), 3)
+        self.assertEqual(chain.numSimplices(0), 27)
+        self.assertEqual(chain.bettiNumbers(), [1, 3, 3, 1])
+        self.assertEqual(chain.bettiNumbersGF2(), [1, 3, 3, 1])
+        self.assertEqual(_dim_z1(self.t3), 29)
+
+    def test_brute_force_is_infeasible(self):
+        # dim Z¹ = 29 > 24: gf2_span refuses to materialize the flat space, so
+        # the brute-force partitionFunction cannot run on T³.
+        self.assertGreater(_dim_z1(self.t3), 24)
+        with self.assertRaises(ValueError):
+            DijkgraafWitten(self.t3, Cocycle.Trivial).partitionFunction()
+
+    def test_cohomology_trivial_is_four(self):
+        # Z_Trivial = 2^{-b₀} · 2^{b₁} = 2^{b₁-1} = 2² = 4.
+        z = DijkgraafWitten(self.t3, Cocycle.Trivial).partitionFunctionByCohomology()
+        self.assertAlmostEqual(z.imag, 0.0, places=9)
+        self.assertAlmostEqual(z.real, 4.0, places=9)
+
+    def test_cohomology_sign_is_four_negative_control(self):
+        # The cup cube g³ vanishes on every 1-class of T³ (H*(T³;ℤ₂) = Λ(x,y,z)),
+        # so the sign twist does not distinguish: Z_Sign = Z_Trivial = 4.
+        z = DijkgraafWitten(self.t3, Cocycle.Sign).partitionFunctionByCohomology()
+        self.assertAlmostEqual(z.imag, 0.0, places=9)
+        self.assertAlmostEqual(z.real, 4.0, places=9)
+
+    def test_sign_does_not_distinguish_t3(self):
+        z_trivial = DijkgraafWitten(self.t3, Cocycle.Trivial) \
+            .partitionFunctionByCohomology()
+        z_sign = DijkgraafWitten(self.t3, Cocycle.Sign) \
+            .partitionFunctionByCohomology()
+        self.assertAlmostEqual(abs(z_trivial - z_sign), 0.0, places=9)
+
+
+class TestSpeedupReport(unittest.TestCase):
+    """stateSumTerms reports the cohomology collapse's speedup: 2^{b₁} classes
+    versus 2^{dim Z¹} cocycles."""
+
+    def test_t3_speedup(self):
+        terms = DijkgraafWitten(_three_torus(), Cocycle.Trivial).stateSumTerms()
+        self.assertEqual(terms.first_betti, 3)
+        self.assertEqual(terms.cocycle_dimension, 29)
+        self.assertEqual(terms.cohomology_terms, 2.0 ** 3)        # 8
+        self.assertEqual(terms.brute_force_terms, 2.0 ** 29)
+        self.assertEqual(terms.speedup, 2.0 ** (29 - 3))          # 2^26
+        # Report it (visible with -s): the whole point of the ticket.
+        print(f"\nZ(T³) speedup: {terms.cohomology_terms:.0f} cohomology classes "
+              f"vs {terms.brute_force_terms:.0f} flat cocycles "
+              f"= {terms.speedup:.3g}x fewer terms")
+
+    def test_terms_consistent_on_small_fixtures(self):
+        for fixture in (_three_sphere, _s2_cross_s1, _rp3, _three_torus):
+            spacetime = fixture()
+            chain = _chain(spacetime)
+            terms = DijkgraafWitten(spacetime, Cocycle.Trivial).stateSumTerms()
+            with self.subTest(fixture=fixture.__name__):
+                self.assertEqual(terms.first_betti, chain.bettiNumbersGF2()[1])
+                self.assertEqual(terms.cocycle_dimension, _dim_z1(spacetime))
+                self.assertEqual(terms.cohomology_terms, 2.0 ** terms.first_betti)
+                self.assertEqual(terms.brute_force_terms,
+                                 2.0 ** terms.cocycle_dimension)
+                self.assertEqual(terms.speedup,
+                                 terms.brute_force_terms / terms.cohomology_terms)
+
+
+class TestCohomologyBasisHelper(unittest.TestCase):
+    """The GF(2) H¹-basis primitive ``gf2_cohomology_basis`` (Z/B quotient)."""
+
+    def test_quotient_of_full_space_by_a_line(self):
+        # Z = GF(2)³ (the three unit vectors), B = span{e0}; H = Z/B has dim 2.
+        cocycles = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        coboundaries = [[1, 0, 0]]
+        reps = cobordism.gf2_cohomology_basis(cocycles, coboundaries, 3)
+        self.assertEqual(len(reps), 2)  # dim Z − dim B = 3 − 1
+
+        # The span of the reps is a transversal: 2² = 4 elements, one per coset
+        # of B = {000, 100}, i.e. distinct on the non-pivot coordinates (1, 2).
+        classes = cobordism.gf2_span(reps, 3)
+        self.assertEqual(len(classes), 4)
+        self.assertEqual(len({(v[1], v[2]) for v in classes}), 4)
+
+    def test_trivial_quotient_is_empty(self):
+        # B already spans Z ⇒ H = 0 ⇒ no representatives.
+        reps = cobordism.gf2_cohomology_basis([[1, 0], [0, 1]],
+                                              [[1, 0], [0, 1]], 2)
+        self.assertEqual(reps, [])
+        self.assertEqual(cobordism.gf2_span(reps, 2), [[0, 0]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `DijkgraafWitten::partitionFunctionByCohomology()`: the same `Z(W)` summed over the `2^{b₁}` cohomology classes `[g] ∈ H¹(W;ℤ₂) = Z¹/B¹` (with the `2^{−b₀}` gauge normalization) instead of the gauge-redundant `2^{dim Z¹}` flat cocycles the brute-force `partitionFunction()` enumerates. The DW weight `∏_t ω(g)^{ε_t}` depends only on the class `[g]` (the cup-cube `⟨g³,[W]⟩` is a cohomology pairing), so the sum collapses.

- `H¹ = Z¹/B¹` via `gf2Nullspace` (`Z¹ = ker ∂₂ᵀ`) + new `IntegerLinalg::gf2CohomologyBasis` (quotient by the coboundaries `B¹ = im ∂₁ᵀ`) + `gf2Span` over the classes. `computeBoundary` now reuses the same helper.
- A per-class gauge-shift guard confirms the weight is class-invariant (agrees across representatives of each class).
- `stateSumTerms()` reports the `2^{b₁}` vs `2^{dim Z¹}` speedup.

Identical in value to the brute force, cross-checked on S³, S²×S¹, RP³ for both cocycles. **Z(T³) is now computable** (`dim Z¹ = 29`, beyond `gf2Span`'s materializable cap of 24, so brute force raises): `Z_Trivial = 2^{b₁−1} = 4` and `Z_Sign = 4` (T³ is a sign negative control, `g³ = 0`), at a `2^{26} ≈ 6.7×10⁷`× term reduction.

Tests: `tests/cobordism/test_dijkgraaf_witten_cohomology_python.py` (13 tests / 13 subtests); full `tests/cobordism` suite green (243 passed, 1 pre-existing skip).

Closes #139.
