### PR TITLE
cobordism: twisted gluing + T² Dehn twists (§5.0)

### DIFF
--- a/include/cobordism/Cobordism.h
+++ b/include/cobordism/Cobordism.h
@@ -23,6 +23,7 @@
 #define TESSERA_COBORDISM_COBORDISM_H
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -117,6 +118,24 @@ class Cobordism {
     [[nodiscard]] static std::shared_ptr<Spacetime> glue(const Spacetime &W1,
                                                          const Spacetime &W2);
 
+    /// # Twisted gluing along a *specified* boundary identification
+    ///
+    /// Like `glue(W1, W2)`, but the shared surface \f$ \Sigma_C \f$ is identified
+    /// by the **caller-supplied** vertex bijection rather than the canonical
+    /// order-preserving isomorphism. `boundaryBijection` must map the vertex ids
+    /// of one whole boundary component of \f$ W_2 \f$ onto the vertex ids of one
+    /// whole boundary component of \f$ W_1 \f$, and do so as a *simplicial
+    /// isomorphism* (it carries the \f$ W_2 \f$ component's face set exactly onto
+    /// the \f$ W_1 \f$ component's). This is the building block for gluing through
+    /// a non-trivial mapping-class element (a Dehn twist of the boundary torus):
+    /// pass a twist composed with the canonical correspondence. With the identity
+    /// (order-preserving) correspondence it reproduces `glue(W1, W2)` exactly.
+    /// @throws std::invalid_argument if the inputs are empty / differ in top
+    ///   dimension, or the bijection is not such a simplicial isomorphism.
+    [[nodiscard]] static std::shared_ptr<Spacetime> glue(
+        const Spacetime &W1, const Spacetime &W2,
+        const std::map<std::uint64_t, std::uint64_t> &boundaryBijection);
+
     /// Close a cobordism by gluing its two boundary components to each other
     /// (the categorical trace / mapping torus): \f$ \partial W \f$ must have
     /// exactly two isomorphic components \f$ \Sigma_C^{(0)}, \Sigma_C^{(1)} \f$,
@@ -130,6 +149,27 @@ class Cobordism {
     ///   two isomorphic components; `std::runtime_error` if the identification
     ///   collapses a top simplex (collar too thin).
     [[nodiscard]] static std::shared_ptr<Spacetime> selfGlue(const Spacetime &W);
+
+    /// # Twisted self-gluing (the mapping torus of a boundary self-map)
+    ///
+    /// Like `selfGlue(W)`, but the two boundary components are identified by the
+    /// caller-supplied `boundaryBijection` instead of the canonical
+    /// order-preserving isomorphism. Its key set must be exactly one boundary
+    /// component's vertex ids and its value set exactly the other's, and it must
+    /// be a simplicial isomorphism between them; the keyed component is folded
+    /// onto the valued one. Closing \f$ \Sigma\times[0,T] \f$ this way realizes
+    /// the **mapping torus** \f$ \Sigma\times_\varphi S^1 \f$ of the boundary
+    /// self-map \f$ \varphi \f$ (the bijection): with the identity it is the
+    /// trivial bundle \f$ \Sigma\times S^1 \f$, and with a non-trivial torus
+    /// automorphism it is a non-trivial torus bundle. The collar must be thick
+    /// enough (no top simplex touching both components), exactly as for
+    /// `selfGlue(W)`.
+    /// @throws std::invalid_argument if \f$ \partial W \f$ does not have exactly
+    ///   two components or the bijection is not a simplicial isomorphism between
+    ///   them; `std::runtime_error` if the identification collapses a top simplex.
+    [[nodiscard]] static std::shared_ptr<Spacetime> selfGlue(
+        const Spacetime &W,
+        const std::map<std::uint64_t, std::uint64_t> &boundaryBijection);
 };
 
 }  // namespace tessera::cobordism

--- a/include/cobordism/TorusTwist.h
+++ b/include/cobordism/TorusTwist.h
@@ -1,0 +1,125 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_TORUSTWIST_H
+#define TESSERA_COBORDISM_TORUSTWIST_H
+
+#include <array>
+#include <cstdint>
+#include <map>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # Mapping-class elements of the torus \f$ T^2 \f$ (the modular group)
+///
+/// The mapping class group of the torus is \f$ \mathrm{GL}(2,\mathbb{Z}) \f$
+/// (orientation-preserving part \f$ \mathrm{SL}(2,\mathbb{Z}) \f$), acting on
+/// \f$ H_1(T^2)=\mathbb{Z}^2 \f$. `TorusTwist` wraps an integer
+/// \f$ 2\times 2 \f$ matrix \f$ \begin{psmallmatrix} a & b \\ c & d
+/// \end{psmallmatrix} \f$ and realizes its action on the product-lattice torus
+/// `SimplicialProduct(S¹,S¹)` — whose vertices are the pairs
+/// \f$ (i,j)\in\mathbb{Z}_n\times\mathbb{Z}_n \f$ with id \f$ i\cdot n + j \f$
+/// (\f$ n = |V(S^1)| \f$) — as the vertex permutation
+/// \f$ (i,j)\mapsto(ai+bj,\,ci+dj)\bmod n \f$.
+///
+/// The two \f$ \mathrm{SL}(2,\mathbb{Z}) \f$ generators are provided: the Dehn
+/// twist \f$ T=\begin{psmallmatrix}1&1\\0&1\end{psmallmatrix} \f$ (the shear
+/// \f$ (i,j)\mapsto(i+j,j) \f$) and \f$ S=\begin{psmallmatrix}0&-1\\1&0
+/// \end{psmallmatrix} \f$ (the \f$ (i,j)\mapsto(-j,i) \f$ rotation). They obey
+/// the modular relations \f$ S^4=I \f$ and \f$ (ST)^3=S^2 \f$ as exact integer
+/// matrices (see `satisfiesModularRelations`).
+///
+/// ## Simplicial realization (the subtle point)
+///
+/// A vertex permutation is a *simplicial* automorphism only when it carries the
+/// triangulation's top simplices to top simplices. For the staircase product
+/// torus this is genuinely restrictive: that triangulation is **not**
+/// vertex-transitive (its diagonals follow the global vertex order), so its only
+/// linear simplicial automorphisms are the identity and the coordinate flip
+/// \f$ (i,j)\mapsto(j,i) \f$ (`flip()`). Neither \f$ S \f$ (order 4) nor the
+/// Dehn twist \f$ T \f$ preserves it — consistent with the classical fact that a
+/// parabolic/finite-order-incompatible mapping class cannot be a simplicial
+/// automorphism of a *fixed* torus triangulation. `isSimplicialAutomorphism`
+/// reports this per matrix. The realizable `flip()` self-map is what
+/// `Cobordism::selfGlue` uses to build a genuine (non-trivial, non-orientable)
+/// torus bundle; \f$ S,T \f$ are still well-defined boundary vertex
+/// permutations (their action on \f$ H_1 \f$ is exact) for the explicit-bijection
+/// gluing once a compatible (e.g. layered) triangulation is supplied.
+class TorusTwist {
+  public:
+    /// The mapping class with matrix \f$ \begin{psmallmatrix} a & b \\ c & d
+    /// \end{psmallmatrix} \f$ acting on \f$ H_1(T^2)=\mathbb{Z}^2 \f$.
+    TorusTwist(long a, long b, long c, long d) : a_(a), b_(b), c_(c), d_(d) {}
+
+    /// The identity \f$ I \f$.
+    [[nodiscard]] static TorusTwist identity();
+    /// The \f$ \mathrm{SL}(2,\mathbb{Z}) \f$ generator
+    /// \f$ S=\begin{psmallmatrix}0&-1\\1&0\end{psmallmatrix} \f$ (order 4).
+    [[nodiscard]] static TorusTwist S();
+    /// The Dehn twist \f$ T=\begin{psmallmatrix}1&1\\0&1\end{psmallmatrix} \f$
+    /// (the shear \f$ (i,j)\mapsto(i+j,j) \f$).
+    [[nodiscard]] static TorusTwist T();
+    /// The coordinate flip \f$ \begin{psmallmatrix}0&1\\1&0\end{psmallmatrix} \f$
+    /// — the one non-trivial linear *simplicial* automorphism of the staircase
+    /// product torus (orientation-reversing; its mapping torus is a non-trivial
+    /// torus bundle).
+    [[nodiscard]] static TorusTwist flip();
+
+    /// Matrix product \f$ (\text{this})\cdot(\text{rhs}) \f$.
+    [[nodiscard]] TorusTwist compose(const TorusTwist &rhs) const;
+    /// The \f$ k \f$-th power (\f$ k\ge 0 \f$; \f$ k=0 \f$ is the identity).
+    [[nodiscard]] TorusTwist power(int k) const;
+    /// Entry-wise equality of the two matrices.
+    [[nodiscard]] bool equals(const TorusTwist &rhs) const;
+    /// \f$ ad-bc \f$ (\f$ +1 \f$ orientation-preserving, \f$ -1 \f$ reversing).
+    [[nodiscard]] long determinant() const;
+    /// The matrix entries \f$ \{a,b,c,d\} \f$ (row-major).
+    [[nodiscard]] std::array<long, 4> matrix() const;
+
+    /// The vertex permutation \f$ (i,j)\mapsto(ai+bj,\,ci+dj)\bmod n \f$ on the
+    /// \f$ n\times n \f$ product torus (vertex id \f$ i\cdot n+j \f$), as a real
+    /// id→id map ready to pass to `Cobordism::selfGlue`/`glue`. Requires
+    /// \f$ n\ge 1 \f$.
+    [[nodiscard]] std::map<std::uint64_t, std::uint64_t> vertexPermutation(
+        int n) const;
+
+    /// Whether `permutation` (a vertex id→id bijection) carries every top
+    /// simplex of `torus` to a top simplex — i.e. is a genuine simplicial
+    /// automorphism of that complex.
+    [[nodiscard]] static bool isSimplicialAutomorphism(
+        const Spacetime &torus,
+        const std::map<std::uint64_t, std::uint64_t> &permutation);
+
+    /// Whether the defining \f$ \mathrm{SL}(2,\mathbb{Z}) \f$ relations hold:
+    /// \f$ S^4=I \f$ and \f$ (ST)^3=S^2 \f$ (checked as exact integer matrices,
+    /// hence independent of any triangulation).
+    [[nodiscard]] static bool satisfiesModularRelations();
+
+  private:
+    long a_, b_, c_, d_;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_TORUSTWIST_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -35,6 +35,7 @@
 #include "cobordism/DijkgraafWitten.h"
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
+#include "cobordism/TorusTwist.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
 
 namespace py = pybind11;
@@ -312,23 +313,112 @@ Euclidean spectrum/kernel.)doc")
       .def_static("verify", &Cobordism::verify, py::arg("W"), py::arg("M1"),
                   py::arg("M2"),
                   "Verify W is a cobordism from M1 to M2 (boundary structure).")
-      .def_static("glue", &Cobordism::glue, py::arg("W1"), py::arg("W2"),
-                  "Glue two cobordisms along a shared boundary surface Sigma_C "
-                  "(the first isomorphic boundary-component pair): identify its "
-                  "two copies by the order-preserving simplicial isomorphism, "
-                  "merge the complexes into one, and return the composite "
-                  "W2 cup_{Sigma_C} W1 as a new Spacetime. Its boundary is the "
-                  "remaining components (Sigma_A from W1, Sigma_B from W2). "
-                  "Raises if the inputs are empty, differ in top dimension, or "
-                  "share no isomorphic boundary surface.")
-      .def_static("selfGlue", &Cobordism::selfGlue, py::arg("W"),
-                  "Close a cobordism by gluing its two boundary components to "
-                  "each other (the mapping torus / categorical trace): they must "
-                  "be isomorphic, and the collar must be thick enough that no "
-                  "top simplex touches both (>= 3 layers in the glued "
-                  "direction). Returns the closed manifold as a new Spacetime. "
-                  "Raises unless dW has exactly two isomorphic components, or if "
-                  "the identification collapses a top simplex.");
+      .def_static(
+          "glue",
+          static_cast<std::shared_ptr<Spacetime> (*)(const Spacetime &,
+                                                     const Spacetime &)>(
+              &Cobordism::glue),
+          py::arg("W1"), py::arg("W2"),
+          "Glue two cobordisms along a shared boundary surface Sigma_C "
+          "(the first isomorphic boundary-component pair): identify its "
+          "two copies by the order-preserving simplicial isomorphism, "
+          "merge the complexes into one, and return the composite "
+          "W2 cup_{Sigma_C} W1 as a new Spacetime. Its boundary is the "
+          "remaining components (Sigma_A from W1, Sigma_B from W2). "
+          "Raises if the inputs are empty, differ in top dimension, or "
+          "share no isomorphic boundary surface.")
+      .def_static(
+          "glue",
+          static_cast<std::shared_ptr<Spacetime> (*)(
+              const Spacetime &, const Spacetime &,
+              const std::map<std::uint64_t, std::uint64_t> &)>(
+              &Cobordism::glue),
+          py::arg("W1"), py::arg("W2"), py::arg("boundary_bijection"),
+          "Twisted glue: identify the shared surface Sigma_C by the supplied "
+          "vertex bijection (a dict mapping one W2 boundary component's vertex "
+          "ids onto one W1 boundary component's, as a simplicial isomorphism) "
+          "instead of the auto-found order-preserving one. The identity "
+          "correspondence reproduces glue(W1, W2). Raises if the inputs are "
+          "empty / differ in top dimension, or the bijection is not such a "
+          "simplicial isomorphism of a shared boundary surface.")
+      .def_static(
+          "selfGlue",
+          static_cast<std::shared_ptr<Spacetime> (*)(const Spacetime &)>(
+              &Cobordism::selfGlue),
+          py::arg("W"),
+          "Close a cobordism by gluing its two boundary components to "
+          "each other (the mapping torus / categorical trace): they must "
+          "be isomorphic, and the collar must be thick enough that no "
+          "top simplex touches both (>= 3 layers in the glued "
+          "direction). Returns the closed manifold as a new Spacetime. "
+          "Raises unless dW has exactly two isomorphic components, or if "
+          "the identification collapses a top simplex.")
+      .def_static(
+          "selfGlue",
+          static_cast<std::shared_ptr<Spacetime> (*)(
+              const Spacetime &,
+              const std::map<std::uint64_t, std::uint64_t> &)>(
+              &Cobordism::selfGlue),
+          py::arg("W"), py::arg("boundary_bijection"),
+          "Twisted self-glue: fold the two boundary components together by the "
+          "supplied vertex bijection (a dict whose keys are one component's "
+          "vertex ids and values the other's, a simplicial isomorphism between "
+          "them) instead of the canonical one. Closing Sigma x [0,T] this way "
+          "builds the mapping torus of the boundary self-map; the identity gives "
+          "Sigma x S^1, while a non-trivial torus automorphism gives a "
+          "non-trivial torus bundle. Same thick-collar requirement as "
+          "selfGlue(W). Raises unless "
+          "dW has exactly two components and the bijection is a simplicial "
+          "isomorphism between them, or if a top simplex collapses.");
+
+  // ----- §5.0 (#135): torus mapping classes (modular S/T) for twisted gluing --
+  py::class_<TorusTwist>(m, "TorusTwist",
+      R"doc(A mapping-class element of the torus T^2 (an element of GL(2,Z)).
+
+Wraps an integer 2x2 matrix [[a,b],[c,d]] acting on H_1(T^2)=Z^2 and realizes it
+on the product-lattice torus SimplicialProduct(S^1,S^1): vertex (i,j) (id i*n+j,
+n = |V(S^1)|) maps to (a i + b j, c i + d j) mod n. Provides the SL(2,Z)
+generators S = [[0,-1],[1,0]] and the Dehn twist T = [[1,1],[0,1]] (which obey
+S^4 = I and (ST)^3 = S^2 exactly), plus the coordinate flip [[0,1],[1,0]] — the
+one non-trivial linear *simplicial* automorphism of the staircase product torus
+(S and T are not, since that triangulation is not vertex-transitive). The flip's
+mapping torus, built by Cobordism.selfGlue with flip's vertexPermutation, is a
+non-trivial torus bundle.)doc")
+      .def(py::init<long, long, long, long>(), py::arg("a"), py::arg("b"),
+           py::arg("c"), py::arg("d"),
+           "The mapping class with matrix [[a,b],[c,d]] on H_1(T^2)=Z^2.")
+      .def_static("identity", &TorusTwist::identity, "The identity I.")
+      .def_static("S", &TorusTwist::S,
+                  "The SL(2,Z) generator S = [[0,-1],[1,0]] (order 4).")
+      .def_static("T", &TorusTwist::T,
+                  "The Dehn twist T = [[1,1],[0,1]] (shear (i,j)->(i+j,j)).")
+      .def_static("flip", &TorusTwist::flip,
+                  "The coordinate flip [[0,1],[1,0]] — the realizable "
+                  "simplicial twist of the staircase product torus.")
+      .def("compose", &TorusTwist::compose, py::arg("rhs"),
+           "Matrix product (this)*(rhs).")
+      .def("power", &TorusTwist::power, py::arg("k"),
+           "The k-th power (k >= 0; 0 is the identity).")
+      .def("equals", &TorusTwist::equals, py::arg("rhs"),
+           "Entry-wise equality of the matrices.")
+      .def("determinant", &TorusTwist::determinant,
+           "ad - bc (+1 orientation-preserving, -1 reversing).")
+      .def("matrix", &TorusTwist::matrix,
+           "The matrix entries [a,b,c,d] (row-major).")
+      .def("vertexPermutation", &TorusTwist::vertexPermutation, py::arg("n"),
+           "The vertex permutation (i,j)->(a i+b j, c i+d j) mod n on the n x n "
+           "product torus (vertex id i*n+j), as a real id->id dict for "
+           "Cobordism.selfGlue / glue. Requires n >= 1.")
+      .def_static("isSimplicialAutomorphism",
+                  &TorusTwist::isSimplicialAutomorphism, py::arg("torus"),
+                  py::arg("permutation"),
+                  "Whether the vertex id->id permutation carries every top "
+                  "simplex of the torus complex to a top simplex (a genuine "
+                  "simplicial automorphism).")
+      .def_static("satisfiesModularRelations",
+                  &TorusTwist::satisfiesModularRelations,
+                  "Whether S^4 = I and (ST)^3 = S^2 hold (exact integer "
+                  "matrices; triangulation-independent).");
 
   // ----- Capability T3 (#108): Dijkgraaf-Witten Z_2 state sum -----
   py::enum_<Cocycle>(m, "Cocycle",

--- a/src/cobordism/Cobordism.cpp
+++ b/src/cobordism/Cobordism.cpp
@@ -245,6 +245,145 @@ std::vector<SimplexList> sortedBoundaryComponents(const Spacetime &W) {
   return components;
 }
 
+// The vertex ids appearing in a list of faces (a boundary component).
+std::set<std::uint64_t> componentVertexSet(const SimplexList &component) {
+  std::set<std::uint64_t> verts;
+  for (const auto &face : component)
+    for (std::uint64_t v : face) verts.insert(v);
+  return verts;
+}
+
+// The face set of a component as sorted vertex tuples (for iso comparison).
+std::set<Face> faceSet(const SimplexList &component) {
+  std::set<Face> faces;
+  for (Face face : component) {
+    std::sort(face.begin(), face.end());
+    faces.insert(std::move(face));
+  }
+  return faces;
+}
+
+std::set<std::uint64_t> mapKeys(
+    const std::map<std::uint64_t, std::uint64_t> &m) {
+  std::set<std::uint64_t> keys;
+  for (const auto &[k, v] : m) keys.insert(k);
+  return keys;
+}
+std::set<std::uint64_t> mapValues(
+    const std::map<std::uint64_t, std::uint64_t> &m) {
+  std::set<std::uint64_t> values;
+  for (const auto &[k, v] : m) values.insert(v);
+  return values;
+}
+
+// The boundary component whose vertex set equals `target`, or nullptr.
+const SimplexList *findComponentByVertexSet(
+    const std::vector<SimplexList> &components,
+    const std::set<std::uint64_t> &target) {
+  for (const SimplexList &component : components)
+    if (componentVertexSet(component) == target) return &component;
+  return nullptr;
+}
+
+// Whether `bijection` is a simplicial isomorphism carrying the surface `from`
+// onto the surface `to`: a vertex bijection between their vertex sets whose
+// induced map sends from's face set exactly onto to's. This is the check the
+// explicit-bijection glue/selfGlue use to certify the supplied identification
+// really is an isomorphism of the shared boundary surface Σ_C (not just any
+// vertex relabeling), so the merged complex stays a manifold.
+bool isSimplicialIsomorphism(
+    const SimplexList &from, const SimplexList &to,
+    const std::map<std::uint64_t, std::uint64_t> &bijection) {
+  const std::set<std::uint64_t> fromV = componentVertexSet(from);
+  if (bijection.size() != fromV.size()) return false;
+  std::set<std::uint64_t> image;
+  for (std::uint64_t v : fromV) {
+    auto it = bijection.find(v);
+    if (it == bijection.end()) return false;
+    image.insert(it->second);
+  }
+  if (image != componentVertexSet(to)) return false;  // sizes match ⇒ injective
+  std::set<Face> mapped;
+  for (const Face &face : from) {
+    Face img;
+    img.reserve(face.size());
+    for (std::uint64_t v : face) img.push_back(bijection.at(v));
+    std::sort(img.begin(), img.end());
+    mapped.insert(std::move(img));
+  }
+  return mapped == faceSet(to);
+}
+
+// Reindex W1 (vertices first, in id order) then W2's non-shared vertices into a
+// single dense range, collapsing each shared W2 vertex onto its W1 partner under
+// `correspondence` (real W2 id → real W1 id), and merge the two top-simplex sets
+// into one fresh Spacetime. The shared correspondence machinery behind both the
+// auto-found and the explicit-bijection glue.
+std::shared_ptr<Spacetime> mergeAlongSurface(
+    const SimplexList &tops1, const SimplexList &tops2,
+    const std::set<std::uint64_t> &sharedW2,
+    const std::map<std::uint64_t, std::uint64_t> &correspondence) {
+  std::set<std::uint64_t> vertices1;
+  for (const auto &top : tops1) for (std::uint64_t v : top) vertices1.insert(v);
+  std::map<std::uint64_t, std::uint64_t> dense1;
+  std::uint64_t next = 0;
+  for (std::uint64_t v : vertices1) dense1[v] = next++;
+
+  std::set<std::uint64_t> vertices2;
+  for (const auto &top : tops2) for (std::uint64_t v : top) vertices2.insert(v);
+  std::map<std::uint64_t, std::uint64_t> dense2;
+  for (std::uint64_t v : vertices2)
+    dense2[v] = sharedW2.count(v) ? dense1.at(correspondence.at(v)) : next++;
+  const std::size_t numVertices = next;
+
+  SimplexList merged;
+  merged.reserve(tops1.size() + tops2.size());
+  for (std::vector<std::uint64_t> top : tops1) {
+    for (std::uint64_t &v : top) v = dense1.at(v);
+    std::sort(top.begin(), top.end());
+    merged.push_back(std::move(top));
+  }
+  for (std::vector<std::uint64_t> top : tops2) {
+    for (std::uint64_t &v : top) v = dense2.at(v);
+    std::sort(top.begin(), top.end());
+    merged.push_back(std::move(top));
+  }
+  return buildSpacetime(numVertices, merged);
+}
+
+// Fold the `identified` boundary vertices onto their partners under
+// `correspondence` (real identified id → real kept id), densely reindex the
+// kept vertices, and rebuild — the shared machinery behind both the auto-found
+// and the explicit-bijection selfGlue. Throws if the identification collapses a
+// top simplex (collar too thin).
+std::shared_ptr<Spacetime> foldBoundary(
+    const SimplexList &tops, const std::set<std::uint64_t> &identified,
+    const std::map<std::uint64_t, std::uint64_t> &correspondence) {
+  std::set<std::uint64_t> allVertices;
+  for (const auto &top : tops) for (std::uint64_t v : top) allVertices.insert(v);
+  std::map<std::uint64_t, std::uint64_t> dense;
+  std::uint64_t next = 0;
+  for (std::uint64_t v : allVertices)
+    if (!identified.count(v)) dense[v] = next++;
+  for (std::uint64_t v : identified)
+    dense[v] = dense.at(correspondence.at(v));
+  const std::size_t numVertices = next;
+
+  SimplexList merged;
+  merged.reserve(tops.size());
+  for (std::vector<std::uint64_t> top : tops) {
+    for (std::uint64_t &v : top) v = dense.at(v);
+    std::sort(top.begin(), top.end());
+    if (std::adjacent_find(top.begin(), top.end()) != top.end())
+      throw std::runtime_error(
+          "Cobordism::selfGlue: the identification collapsed a top simplex (a "
+          "top simplex touches both boundary components — the collar is too "
+          "thin; thicken the glued direction to at least three layers)");
+    merged.push_back(std::move(top));
+  }
+  return buildSpacetime(numVertices, merged);
+}
+
 }  // namespace
 
 SimplexList Cobordism::boundaryFaces(const Spacetime &W) {
@@ -386,34 +525,38 @@ std::shared_ptr<Spacetime> Cobordism::glue(const Spacetime &W1,
        components2[static_cast<std::size_t>(sharedComponent2)])
     for (std::uint64_t v : face) sharedW2.insert(v);
 
-  // Dense reindexing: W1's vertices first (in id order), then W2's non-shared
-  // vertices; each shared W2 vertex collapses onto its W1 partner.
-  std::set<std::uint64_t> vertices1;
-  for (const auto &top : tops1) for (std::uint64_t v : top) vertices1.insert(v);
-  std::map<std::uint64_t, std::uint64_t> dense1;
-  std::uint64_t next = 0;
-  for (std::uint64_t v : vertices1) dense1[v] = next++;
+  return mergeAlongSurface(tops1, tops2, sharedW2, *correspondence);
+}
 
-  std::set<std::uint64_t> vertices2;
-  for (const auto &top : tops2) for (std::uint64_t v : top) vertices2.insert(v);
-  std::map<std::uint64_t, std::uint64_t> dense2;
-  for (std::uint64_t v : vertices2)
-    dense2[v] = sharedW2.count(v) ? dense1.at(correspondence->at(v)) : next++;
-  const std::size_t numVertices = next;
+std::shared_ptr<Spacetime> Cobordism::glue(
+    const Spacetime &W1, const Spacetime &W2,
+    const std::map<std::uint64_t, std::uint64_t> &boundaryBijection) {
+  const SimplexList tops1 = topSimplices(W1);
+  const SimplexList tops2 = topSimplices(W2);
+  if (tops1.empty() || tops2.empty())
+    throw std::invalid_argument(
+        "Cobordism::glue: both inputs must be non-empty triangulations");
+  if (tops1.front().size() != tops2.front().size())
+    throw std::invalid_argument(
+        "Cobordism::glue: the two complexes must have the same top dimension");
 
-  SimplexList merged;
-  merged.reserve(tops1.size() + tops2.size());
-  for (std::vector<std::uint64_t> top : tops1) {
-    for (std::uint64_t &v : top) v = dense1.at(v);
-    std::sort(top.begin(), top.end());
-    merged.push_back(std::move(top));
-  }
-  for (std::vector<std::uint64_t> top : tops2) {
-    for (std::uint64_t &v : top) v = dense2.at(v);
-    std::sort(top.begin(), top.end());
-    merged.push_back(std::move(top));
-  }
-  return buildSpacetime(numVertices, merged);
+  // The supplied bijection must identify a whole boundary component of W2 with
+  // a whole boundary component of W1, as a simplicial isomorphism (the shared
+  // surface Σ_C). The W2 component is the "from" side (its ids are the keys),
+  // collapsing onto the matching W1 component.
+  const std::set<std::uint64_t> sharedW2 = mapKeys(boundaryBijection);
+  const std::set<std::uint64_t> sharedW1 = mapValues(boundaryBijection);
+  const std::vector<SimplexList> components1 = sortedBoundaryComponents(W1);
+  const std::vector<SimplexList> components2 = sortedBoundaryComponents(W2);
+  const SimplexList *from = findComponentByVertexSet(components2, sharedW2);
+  const SimplexList *to = findComponentByVertexSet(components1, sharedW1);
+  if (from == nullptr || to == nullptr ||
+      !isSimplicialIsomorphism(*from, *to, boundaryBijection))
+    throw std::invalid_argument(
+        "Cobordism::glue: the supplied boundary bijection is not a simplicial "
+        "isomorphism from a boundary component of W2 onto one of W1");
+
+  return mergeAlongSurface(tops1, tops2, sharedW2, boundaryBijection);
 }
 
 std::shared_ptr<Spacetime> Cobordism::selfGlue(const Spacetime &W) {
@@ -437,31 +580,36 @@ std::shared_ptr<Spacetime> Cobordism::selfGlue(const Spacetime &W) {
   for (const std::vector<std::uint64_t> &face : components[1])
     for (std::uint64_t v : face) identified.insert(v);
 
-  // Dense ids for the kept vertices (everything except component 1); each
-  // component-1 vertex takes the id of its component-0 partner.
-  std::set<std::uint64_t> allVertices;
-  for (const auto &top : tops) for (std::uint64_t v : top) allVertices.insert(v);
-  std::map<std::uint64_t, std::uint64_t> dense;
-  std::uint64_t next = 0;
-  for (std::uint64_t v : allVertices)
-    if (!identified.count(v)) dense[v] = next++;
-  for (std::uint64_t v : identified)
-    dense[v] = dense.at(correspondence->at(v));
-  const std::size_t numVertices = next;
+  return foldBoundary(tops, identified, *correspondence);
+}
 
-  SimplexList merged;
-  merged.reserve(tops.size());
-  for (std::vector<std::uint64_t> top : tops) {
-    for (std::uint64_t &v : top) v = dense.at(v);
-    std::sort(top.begin(), top.end());
-    if (std::adjacent_find(top.begin(), top.end()) != top.end())
-      throw std::runtime_error(
-          "Cobordism::selfGlue: the identification collapsed a top simplex (a "
-          "top simplex touches both boundary components — the collar is too "
-          "thin; thicken the glued direction to at least three layers)");
-    merged.push_back(std::move(top));
-  }
-  return buildSpacetime(numVertices, merged);
+std::shared_ptr<Spacetime> Cobordism::selfGlue(
+    const Spacetime &W,
+    const std::map<std::uint64_t, std::uint64_t> &boundaryBijection) {
+  const SimplexList tops = topSimplices(W);
+  if (tops.empty())
+    throw std::invalid_argument(
+        "Cobordism::selfGlue: the input must be a non-empty triangulation");
+  const std::vector<SimplexList> components = sortedBoundaryComponents(W);
+  if (components.size() != 2)
+    throw std::invalid_argument(
+        "Cobordism::selfGlue: ∂W must have exactly two components to glue to "
+        "each other; got " + std::to_string(components.size()));
+
+  // The bijection's keys are the folded (identified) component, its values the
+  // kept one; they must be the two distinct boundary components and the map a
+  // simplicial isomorphism between them.
+  const std::set<std::uint64_t> identified = mapKeys(boundaryBijection);
+  const std::set<std::uint64_t> kept = mapValues(boundaryBijection);
+  const SimplexList *from = findComponentByVertexSet(components, identified);
+  const SimplexList *to = findComponentByVertexSet(components, kept);
+  if (from == nullptr || to == nullptr || from == to ||
+      !isSimplicialIsomorphism(*from, *to, boundaryBijection))
+    throw std::invalid_argument(
+        "Cobordism::selfGlue: the supplied boundary bijection is not a "
+        "simplicial isomorphism between the two boundary components");
+
+  return foldBoundary(tops, identified, boundaryBijection);
 }
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/TorusTwist.cpp
+++ b/src/cobordism/TorusTwist.cpp
@@ -1,0 +1,131 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/TorusTwist.h"
+
+#include <algorithm>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+#include "mesh/Simplex.h"
+#include "mesh/Vertex.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+namespace {
+
+// Top simplices of a complex, as sorted vertex-id tuples ("top" = maximal
+// dimension present). Mirrors the helper in Cobordism.cpp (kept local so this
+// translation unit has no dependence on that one's anonymous namespace).
+std::set<std::vector<std::uint64_t>> topSimplexSet(const Spacetime &complex) {
+  std::vector<std::vector<std::uint64_t>> all;
+  std::size_t topVertexCount = 0;
+  for (const auto &simplex : complex.getSimplices()) {
+    std::vector<std::uint64_t> vertices;
+    for (const auto &v : simplex->getVertices()) vertices.push_back(v->getId());
+    std::sort(vertices.begin(), vertices.end());
+    topVertexCount = std::max(topVertexCount, vertices.size());
+    all.push_back(std::move(vertices));
+  }
+  std::set<std::vector<std::uint64_t>> tops;
+  for (auto &s : all)
+    if (s.size() == topVertexCount) tops.insert(std::move(s));
+  return tops;
+}
+
+}  // namespace
+
+TorusTwist TorusTwist::identity() { return TorusTwist(1, 0, 0, 1); }
+TorusTwist TorusTwist::S() { return TorusTwist(0, -1, 1, 0); }
+TorusTwist TorusTwist::T() { return TorusTwist(1, 1, 0, 1); }
+TorusTwist TorusTwist::flip() { return TorusTwist(0, 1, 1, 0); }
+
+TorusTwist TorusTwist::compose(const TorusTwist &rhs) const {
+  // [[a b][c d]] * [[e f][g h]]
+  return TorusTwist(a_ * rhs.a_ + b_ * rhs.c_, a_ * rhs.b_ + b_ * rhs.d_,
+                    c_ * rhs.a_ + d_ * rhs.c_, c_ * rhs.b_ + d_ * rhs.d_);
+}
+
+TorusTwist TorusTwist::power(int k) const {
+  if (k < 0)
+    throw std::invalid_argument("TorusTwist::power: exponent must be >= 0");
+  TorusTwist result = identity();
+  for (int i = 0; i < k; ++i) result = result.compose(*this);
+  return result;
+}
+
+bool TorusTwist::equals(const TorusTwist &rhs) const {
+  return a_ == rhs.a_ && b_ == rhs.b_ && c_ == rhs.c_ && d_ == rhs.d_;
+}
+
+long TorusTwist::determinant() const { return a_ * d_ - b_ * c_; }
+
+std::array<long, 4> TorusTwist::matrix() const { return {a_, b_, c_, d_}; }
+
+std::map<std::uint64_t, std::uint64_t> TorusTwist::vertexPermutation(
+    int n) const {
+  if (n < 1)
+    throw std::invalid_argument(
+        "TorusTwist::vertexPermutation: n must be >= 1");
+  const long m = n;
+  auto mod = [m](long x) { return static_cast<std::uint64_t>(((x % m) + m) % m); };
+  std::map<std::uint64_t, std::uint64_t> perm;
+  for (long i = 0; i < m; ++i)
+    for (long j = 0; j < m; ++j) {
+      const std::uint64_t ni = mod(a_ * i + b_ * j);
+      const std::uint64_t nj = mod(c_ * i + d_ * j);
+      perm[static_cast<std::uint64_t>(i * m + j)] =
+          ni * static_cast<std::uint64_t>(m) + nj;
+    }
+  return perm;
+}
+
+bool TorusTwist::isSimplicialAutomorphism(
+    const Spacetime &torus,
+    const std::map<std::uint64_t, std::uint64_t> &permutation) {
+  const std::set<std::vector<std::uint64_t>> tops = topSimplexSet(torus);
+  std::set<std::vector<std::uint64_t>> image;
+  for (const auto &top : tops) {
+    std::vector<std::uint64_t> mapped;
+    mapped.reserve(top.size());
+    for (std::uint64_t v : top) {
+      auto it = permutation.find(v);
+      if (it == permutation.end()) return false;  // not defined on a vertex
+      mapped.push_back(it->second);
+    }
+    std::sort(mapped.begin(), mapped.end());
+    // A simplicial map must stay injective on each simplex's vertices.
+    if (std::adjacent_find(mapped.begin(), mapped.end()) != mapped.end())
+      return false;
+    image.insert(std::move(mapped));
+  }
+  return image == tops;
+}
+
+bool TorusTwist::satisfiesModularRelations() {
+  const bool s4 = S().power(4).equals(identity());
+  const bool st3 = S().compose(T()).power(3).equals(S().power(2));
+  return s4 && st3;
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_twisted_gluing_python.py
+++ b/tests/cobordism/test_twisted_gluing_python.py
@@ -1,0 +1,315 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Twisted gluing + T² Dehn twists (#135, spec §5.0).
+
+`Cobordism.glue`/`selfGlue` gained an overload that identifies the shared
+boundary surface Σ_C by a *caller-supplied* vertex bijection instead of the
+canonical order-preserving isomorphism. Self-gluing T²×[0,T] through such a
+bijection realizes the **mapping torus** of the boundary self-map — the
+building block for the modular S/T data (#136).
+
+`TorusTwist` wraps the GL(2,ℤ) mapping classes of T² and realizes them on the
+product-lattice torus `SimplicialProduct(S¹,S¹)`. The SL(2,ℤ) generators are
+S = [[0,-1],[1,0]] and the Dehn twist T = [[1,1],[0,1]].
+
+Acceptance (spec §5.0):
+
+* **Identity-bijection glue reproduces #113.** Gluing the standard torus
+  cylinders through the canonical (order-preserving) vertex correspondence gives
+  the same composite as the auto-finding `glue`/`selfGlue` — the DW boundary map
+  is `id_{Z(T²)}` and the self-glued T²×[0,T] is T³.
+
+* **Twisted self-glue = mapping torus.** Self-gluing a thick T²×[0,T] through a
+  non-trivial torus automorphism yields a valid closed 3-manifold that is a
+  *non-trivial torus bundle* (its Betti numbers differ from T³'s).
+
+* **Modular relations.** The S/T generators obey S⁴ = I and (ST)³ = S² (as exact
+  integer matrices and as the induced vertex permutations).
+
+The realizable simplicial twist is the coordinate flip (i,j)↦(j,i): the staircase
+product triangulation is not vertex-transitive, so S and T are *not* simplicial
+automorphisms of it (verified below) — the classical obstruction to realizing a
+parabolic / order-4 mapping class on a fixed torus triangulation.
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+
+import tessera
+
+cobordism = tessera.cobordism
+Cobordism = cobordism.Cobordism
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+TorusTwist = cobordism.TorusTwist
+ChainComplex = cobordism.ChainComplex
+
+COCYCLES = ((Cocycle.Trivial, "trivial"), (Cocycle.Sign, "sign"))
+
+CIRCLE_VERTS = 3          # S¹ = ∂Δ² has 3 vertices
+TORUS_VERTS = CIRCLE_VERTS * CIRCLE_VERTS  # 9
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures.
+# --------------------------------------------------------------------------- #
+def _build(topology):
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()
+    return spacetime
+
+
+def _circle():
+    return tessera.SimplexBoundarySphere(1)          # S¹ = ∂Δ²
+
+
+def _torus_topology():
+    return tessera.SimplicialProduct(_circle(), _circle())  # T² = S¹ × S¹
+
+
+def _interval():
+    return tessera.SolidSimplex(1)                    # [0, 1]
+
+
+def _torus_cylinder():
+    # T²×I, two layers; SimplicialProduct(torus, interval) ⇒ vertex (u, v) has
+    # id u*2 + v, so the bottom torus (v=0) is the even ids and the top (v=1)
+    # the odd ids — a known layout we use to build explicit identifications.
+    return _build(tessera.SimplicialProduct(_torus_topology(), _interval()))
+
+
+def _from_simplices(num_vertices, simplices):
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, tessera.Toroid())
+    verts = [spacetime.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        spacetime.createSimplex([verts[i] for i in simplex])
+    return spacetime
+
+
+def _top_simplices(spacetime):
+    tuples = [tuple(sorted(v.getId() for v in s.getVertices()))
+              for s in spacetime.getSimplices()]
+    top = max(len(t) for t in tuples)
+    return [t for t in tuples if len(t) == top]
+
+
+def _torus_triangles():
+    """The 18 triangles of SimplicialProduct(S¹,S¹) on torus vertices 0..8."""
+    return _top_simplices(_build(_torus_topology()))
+
+
+def _prism_tets(triangle, t):
+    # Staircase of (2-simplex × edge): triangle (s0<s1<s2) over the edge
+    # (t, t+1) → three tetrahedra, vertices written as (torus_vertex, layer).
+    s0, s1, s2 = triangle
+    return [((s0, t), (s1, t), (s2, t), (s2, t + 1)),
+            ((s0, t), (s1, t), (s1, t + 1), (s2, t + 1)),
+            ((s0, t), (s0, t + 1), (s1, t + 1), (s2, t + 1))]
+
+
+def _thick_torus_cylinder(layers):
+    """T²×[0,layers] as an explicit triangulation; vertex (u,t)→u*(layers+1)+t.
+
+    Bottom torus is layer 0, top torus is layer `layers`. Returns the Spacetime
+    and the (u,t)→id indexer."""
+    triangles = _torus_triangles()
+    def pid(u, t):
+        return u * (layers + 1) + t
+    tets = []
+    for tri in triangles:
+        for t in range(layers):
+            for tet in _prism_tets(tri, t):
+                tets.append(tuple(sorted(pid(u, tt) for (u, tt) in tet)))
+    spacetime = _from_simplices(TORUS_VERTS * (layers + 1), tets)
+    return spacetime, pid
+
+
+def _seam_bijection(twist_perm, layers, pid):
+    """Identify the top torus (u, layers) with the bottom (φ(u), 0)."""
+    return {pid(u, layers): pid(twist_perm[u], 0) for u in range(TORUS_VERTS)}
+
+
+def _is_closed_manifold(spacetime):
+    counts = {}
+    for top in _top_simplices(spacetime):
+        for drop in range(len(top)):
+            facet = top[:drop] + top[drop + 1:]
+            counts[facet] = counts.get(facet, 0) + 1
+    return bool(counts) and all(c == 2 for c in counts.values())
+
+
+def _perm_compose(p, q):       # p after q
+    return {v: p[q[v]] for v in q}
+
+
+def _perm_power(p, k):
+    out = {v: v for v in p}
+    for _ in range(k):
+        out = _perm_compose(p, out)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Acceptance 1 — identity-bijection gluing reproduces #113.
+# --------------------------------------------------------------------------- #
+class TestIdentityBijectionReproducesAutoGlue(unittest.TestCase):
+
+    def test_explicit_canonical_glue_matches_auto_glue(self):
+        # Stack two torus cylinders by identifying W2's bottom torus (even ids
+        # 2u) with W1's top torus (odd ids 2u+1) via the identity on u — exactly
+        # the order-preserving correspondence the auto-glue uses.
+        w1, w2 = _torus_cylinder(), _torus_cylinder()
+        canonical = {2 * u: 2 * u + 1 for u in range(TORUS_VERTS)}
+        glued_explicit = Cobordism.glue(w1, w2, canonical)
+        glued_auto = Cobordism.glue(w1, w2)
+        # Same size and same homology as the auto composite, and #113's result:
+        # the DW boundary map is the 4×4 identity (a product cobordism).
+        self.assertEqual(glued_explicit.getVertexCount(),
+                         glued_auto.getVertexCount())
+        self.assertEqual(glued_explicit.getVertexCount(),
+                         2 * w1.getVertexCount() - TORUS_VERTS)
+        for cocycle, kind in COCYCLES:
+            with self.subTest(cocycle=kind):
+                m_explicit = np.asarray(DijkgraafWitten(glued_explicit, cocycle).map())
+                m_auto = np.asarray(DijkgraafWitten(glued_auto, cocycle).map())
+                self.assertEqual(m_explicit.shape, (4, 4))
+                np.testing.assert_allclose(m_explicit, np.eye(4), atol=1e-12)
+                np.testing.assert_allclose(m_explicit, m_auto, atol=1e-12)
+
+    def test_explicit_identity_selfglue_is_three_torus(self):
+        # The canonical (identity-on-(i,j)) self-glue of a thick T²×[0,3] is T³,
+        # the same closed manifold the auto selfGlue produces.
+        cylinder, pid = _thick_torus_cylinder(3)
+        identity = TorusTwist.identity().vertexPermutation(CIRCLE_VERTS)
+        bijection = _seam_bijection(identity, 3, pid)
+        closed_explicit = Cobordism.selfGlue(cylinder, bijection)
+        closed_auto = Cobordism.selfGlue(cylinder)
+        for closed in (closed_explicit, closed_auto):
+            self.assertEqual(len(Cobordism.boundaryFaces(closed)), 0)
+            self.assertTrue(_is_closed_manifold(closed))
+            chain = ChainComplex.fromSpacetime(closed)
+            self.assertEqual(chain.dimension(), 3)
+            self.assertTrue(chain.boundaryComposesToZero())
+            self.assertEqual(chain.bettiNumbers(), [1, 3, 3, 1])  # T³
+
+
+# --------------------------------------------------------------------------- #
+# Acceptance 2 — twisted self-glue is the mapping torus (a torus bundle).
+# --------------------------------------------------------------------------- #
+class TestTwistedMappingTorus(unittest.TestCase):
+
+    def test_flip_twisted_selfglue_is_nontrivial_torus_bundle(self):
+        # Self-gluing the thick cylinder through the coordinate flip (i,j)↦(j,i)
+        # — a genuine simplicial automorphism of the product torus — builds the
+        # mapping torus of that automorphism: a valid closed 3-manifold whose
+        # homology differs from T³, i.e. a non-trivial torus bundle.
+        cylinder, pid = _thick_torus_cylinder(3)
+        flip = TorusTwist.flip().vertexPermutation(CIRCLE_VERTS)
+        bundle = Cobordism.selfGlue(cylinder, _seam_bijection(flip, 3, pid))
+
+        self.assertEqual(len(Cobordism.boundaryFaces(bundle)), 0)  # closed
+        self.assertTrue(_is_closed_manifold(bundle))
+        chain = ChainComplex.fromSpacetime(bundle)
+        self.assertEqual(chain.dimension(), 3)
+        self.assertTrue(chain.boundaryComposesToZero())
+        self.assertEqual(chain.eulerCharacteristic(), 0)  # closed 3-manifold
+        # The orientation-reversing flip [[0,1],[1,0]] gives the non-orientable
+        # T²-bundle with H_* = (Z, Z², Z⊕Z₂, 0): Betti [1,2,1,0] over Q.
+        betti = chain.bettiNumbers()
+        self.assertEqual(betti, [1, 2, 1, 0])
+        self.assertNotEqual(betti, [1, 3, 3, 1])  # ≠ T³ ⇒ non-trivial bundle
+
+    def test_flip_is_a_simplicial_automorphism_but_S_and_T_are_not(self):
+        # The flip preserves the staircase product triangulation; S and the Dehn
+        # twist T do not (it is not vertex-transitive). This is why the mapping
+        # torus above uses the flip — the classical obstruction to realizing a
+        # parabolic / order-4 mapping class simplicially on a fixed triangulation.
+        torus = _build(_torus_topology())
+        flip = TorusTwist.flip().vertexPermutation(CIRCLE_VERTS)
+        ident = TorusTwist.identity().vertexPermutation(CIRCLE_VERTS)
+        s = TorusTwist.S().vertexPermutation(CIRCLE_VERTS)
+        t = TorusTwist.T().vertexPermutation(CIRCLE_VERTS)
+        self.assertTrue(TorusTwist.isSimplicialAutomorphism(torus, ident))
+        self.assertTrue(TorusTwist.isSimplicialAutomorphism(torus, flip))
+        self.assertFalse(TorusTwist.isSimplicialAutomorphism(torus, s))
+        self.assertFalse(TorusTwist.isSimplicialAutomorphism(torus, t))
+
+    def test_thin_collar_twisted_selfglue_is_rejected(self):
+        # A two-layer cylinder is too thin: folding its ends collapses a
+        # tetrahedron, so the twisted selfGlue must refuse it (same guard as the
+        # canonical selfGlue).
+        cylinder, pid = _thick_torus_cylinder(1)
+        flip = TorusTwist.flip().vertexPermutation(CIRCLE_VERTS)
+        with self.assertRaises(RuntimeError):
+            Cobordism.selfGlue(cylinder, _seam_bijection(flip, 1, pid))
+
+
+# --------------------------------------------------------------------------- #
+# Acceptance 3 — the modular S/T relations.
+# --------------------------------------------------------------------------- #
+class TestModularRelations(unittest.TestCase):
+
+    def test_relations_hold_as_exact_matrices(self):
+        self.assertTrue(TorusTwist.satisfiesModularRelations())
+        S, T, I = TorusTwist.S(), TorusTwist.T(), TorusTwist.identity()
+        # S⁴ = I and (ST)³ = S² as integer matrices.
+        self.assertTrue(S.power(4).equals(I))
+        self.assertTrue(S.compose(T).power(3).equals(S.power(2)))
+        # S² = −I is the central involution; S is order 4, not 2.
+        self.assertTrue(S.power(2).equals(TorusTwist(-1, 0, 0, -1)))
+        self.assertFalse(S.power(2).equals(I))
+        # Orientation: S, T preserve it; the realizable flip reverses it.
+        self.assertEqual(S.determinant(), 1)
+        self.assertEqual(T.determinant(), 1)
+        self.assertEqual(TorusTwist.flip().determinant(), -1)
+
+    def test_relations_hold_as_vertex_permutations(self):
+        # The same relations as the induced permutations of the torus vertices.
+        s = TorusTwist.S().vertexPermutation(CIRCLE_VERTS)
+        t = TorusTwist.T().vertexPermutation(CIRCLE_VERTS)
+        ident = TorusTwist.identity().vertexPermutation(CIRCLE_VERTS)
+        self.assertEqual(_perm_power(s, 4), ident)                 # S⁴ = id
+        st = _perm_compose(s, t)
+        self.assertEqual(_perm_power(st, 3), _perm_power(s, 2))    # (ST)³ = S²
+
+    def test_T_matches_the_shear_and_S_the_rotation(self):
+        # T is the shear (i,j)↦(i+j, j); S is (i,j)↦(−j, i). Spot-check the
+        # vertex permutation against these closed forms (id = i*n + j).
+        n = CIRCLE_VERTS
+        t = TorusTwist.T().vertexPermutation(n)
+        s = TorusTwist.S().vertexPermutation(n)
+        for i in range(n):
+            for j in range(n):
+                self.assertEqual(t[i * n + j], ((i + j) % n) * n + j)
+                self.assertEqual(s[i * n + j], ((-j) % n) * n + (i % n))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## cobordism: twisted gluing + T² Dehn twists (§5.0)

Extends `Cobordism::glue`/`selfGlue` to identify the shared boundary surface by a **caller-supplied** vertex bijection (a Dehn-twist / mapping-class boundary self-map) instead of the canonical order-preserving isomorphism, and adds the `TorusTwist` helper for the modular `S`/`T` generators of `SL(2,ℤ)`. This is the gluing building block for the modular data (#136).

### What's here

- **Explicit-bijection gluing.** New overloads
  `Cobordism::glue(W1, W2, boundaryBijection)` and
  `Cobordism::selfGlue(W, boundaryBijection)` (`std::map<uint64_t,uint64_t>`),
  reusing the existing reindex/merge machinery (refactored into shared
  `mergeAlongSurface` / `foldBoundary` helpers). The bijection is validated to be
  a genuine simplicial isomorphism between two whole boundary components before
  it is used, so the merged complex stays a manifold.
- **`TorusTwist`** — wraps a `GL(2,ℤ)` matrix acting on the product-lattice torus
  `SimplicialProduct(S¹,S¹)` (vertex `(i,j)` → id `i·n+j`): the shear
  `T = [[1,1],[0,1]]` (`(i,j)↦(i+j,j)`), `S = [[0,-1],[1,0]]` (`(i,j)↦(-j,i)`),
  the coordinate flip, matrix `compose`/`power`/`equals`/`determinant`, the
  induced `vertexPermutation(n)`, `isSimplicialAutomorphism`, and
  `satisfiesModularRelations`.

### SL(2,ℤ) relation checks (acceptance 3)

Verified both as **exact integer matrices** and as the induced **vertex
permutations** mod n (`tests/cobordism/test_twisted_gluing_python.py`):

- `S⁴ = I`  ✓
- `(ST)³ = S²`  ✓   (with `S² = −I`, the central involution; `S` is order 4)
- `T` is the shear `(i,j)↦(i+j,j)`, `S` the rotation `(i,j)↦(−j,i)`.

### Mapping torus (acceptance 2)

Self-gluing a thick `T²×[0,3]` through a non-trivial torus automorphism builds
the mapping torus of that automorphism. Using the realizable simplicial twist
(the coordinate flip `(i,j)↦(j,i)`) yields a valid **closed 3-manifold that is a
non-trivial torus bundle**: Betti `[1,2,1,0]` (the orientation-reversing
`[[0,1],[1,0]]` bundle, `H_* = (ℤ, ℤ², ℤ⊕ℤ₂, 0)`), distinct from `T³`'s
`[1,3,3,1]`. The identity (canonical) self-glue reproduces `T³` exactly, matching
the auto `selfGlue` and #113 (acceptance 1).

### Where the Dehn-twist construction stands (the subtle point)

Per the ticket's note to take care here: the **staircase product torus is not
vertex-transitive** (vertex degrees 8/6/4 — its diagonals follow the global
vertex order), so its only linear *simplicial* automorphisms are the identity and
the coordinate flip. Neither `S` (order 4) nor the parabolic Dehn twist `T` is a
simplicial automorphism of a fixed torus triangulation — the classical
obstruction (a parabolic / order-4-incompatible mapping class cannot have finite
order as a triangulation automorphism; brute force over `GL(2,ℤ₃)` confirms only
`{I, flip}`, and no `SL(2,ℤ₃)`-invariant 9-vertex torus triangulation exists).

Accordingly `S`/`T` are provided as well-defined boundary **vertex permutations**
(their action on `H₁` is exact, and they satisfy the modular relations), and
`isSimplicialAutomorphism` reports honestly that they are not automorphisms of
the product triangulation while the flip is. The genuine twisted mapping torus is
demonstrated with the realizable flip; the explicit-bijection gluing accepts any
`S`/`T` identification once a compatible (e.g. layered) triangulation is supplied
for #136.

### Tests

`tests/cobordism/test_twisted_gluing_python.py` (8 tests). Full `tests/cobordism`
suite green (238 passed, 1 pre-existing skip).

Closes #135.
