### PR TITLE
docs: complete the C++ API documentation (all modules)

### DIFF
--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -6,6 +6,24 @@ simplicial complexes.
 Below the C++ API is documented for users. To document for developers you can edit the Doxyfile and comment out
 exclusions to see the entire interface.
 
+<!--
+  MAINTENANCE / DURABILITY
+  ------------------------
+  This page must list *every* public header under ``include/`` via a Breathe
+  ``{doxygenfile}`` directive, grouped into the per-module sections below.
+  The sections mirror the ``include/`` directory tree one-to-one.
+
+  Doxygen's INPUT (see ../Doxyfile: ``INPUT = ../src ../include`` with
+  ``RECURSIVE = YES``) already covers the entire tree, so every header has a
+  Breathe-addressable file compound — entries here only need the header's
+  *basename* (there are no duplicate header basenames in the tree).
+
+  When you add a new header under ``include/``, add a matching
+  ``{doxygenfile}`` entry to the correct section here. The guard test
+  ``tests/test_cpp_api_docs_coverage.py`` fails CI if a header is missing
+  from (or stale in) this page, so this list cannot silently rot.
+-->
+
 ## Core Spacetime
 
 ```{doxygenfile} Spacetime.h
@@ -13,6 +31,8 @@ exclusions to see the entire interface.
 ```{doxygenfile} Metric.h
 ```
 ```{doxygenfile} Signature.h
+```
+```{doxygenfile} Foliation.h
 ```
 
 ## Simplicial Complex
@@ -23,21 +43,36 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} Vertex.h
 ```
+```{doxygenfile} VertexList.h
+```
 ```{doxygenfile} Edge.h
 ```
-
-## Simulations
-
-```{doxygenfile} Simulation.h
+```{doxygenfile} EdgeKey.h
 ```
-```{doxygenfile} CDT.h
+```{doxygenfile} EdgeList.h
+```
+```{doxygenfile} Fingerprint.h
+```
+```{doxygenfile} SimplexFilter.h
+```
+```{doxygenfile} FlatHashMap.h
+```
+```{doxygenfile} ForwardDeclarations.h
 ```
 
-## Observables
+## Pachner Moves
 
-```{doxygenfile} Observable.h
+```{doxygenfile} PachnerMove.h
 ```
-```{doxygenfile} VolumeProfile.h
+```{doxygenfile} AddMove.h
+```
+```{doxygenfile} RemoveMove.h
+```
+```{doxygenfile} FlipMove.h
+```
+```{doxygenfile} IFlipMove.h
+```
+```{doxygenfile} ShiftMove.h
 ```
 
 ## Topologies
@@ -50,8 +85,142 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} Sphere.h
 ```
+```{doxygenfile} SimplicialProduct.h
+```
+```{doxygenfile} SphereCircleProduct.h
+```
+```{doxygenfile} SimplexBoundarySphere.h
+```
+```{doxygenfile} SolidSimplex.h
+```
+```{doxygenfile} StellarSubdivision.h
+```
+```{doxygenfile} RealProjectivePlane.h
+```
+```{doxygenfile} RealProjectiveSpace.h
+```
+```{doxygenfile} ComplexProjectivePlane.h
+```
+
+## Simulations
+
+```{doxygenfile} Simulation.h
+```
+```{doxygenfile} CDT.h
+```
+```{doxygenfile} ReggeSolver.h
+```
+```{doxygenfile} InteractionSimulation.h
+```
+
+## Observables
+
+```{doxygenfile} Observable.h
+```
+```{doxygenfile} VolumeProfile.h
+```
+```{doxygenfile} SpacetimeVolume.h
+```
+```{doxygenfile} Spectral.h
+```
+```{doxygenfile} WilsonLoop.h
+```
+```{doxygenfile} MIUnits.hpp
+```
+```{doxygenfile} ModularityOptimizer.h
+```
+```{doxygenfile} SparseGraph.h
+```
+
+## Cobordism
+
+```{doxygenfile} Cobordism.h
+```
+```{doxygenfile} ChainComplex.h
+```
+```{doxygenfile} HodgeLaplacian.h
+```
+```{doxygenfile} IntegerLinalg.h
+```
+```{doxygenfile} DijkgraafWitten.h
+```
+```{doxygenfile} EigenstateSynthesis.h
+```
+```{doxygenfile} Characteristic.h
+```
+```{doxygenfile} CombinatorialDimension.h
+```
+
+## Quantum
+
+```{doxygenfile} SchwingerModel.hpp
+```
+```{doxygenfile} DMRGRunner.hpp
+```
+```{doxygenfile} TDVPRunner.hpp
+```
+```{doxygenfile} Quench.hpp
+```
+```{doxygenfile} ChoiJamiolkowski.h
+```
+```{doxygenfile} ChoiState.hpp
+```
+```{doxygenfile} Holography.hpp
+```
+```{doxygenfile} MutualInformation.hpp
+```
+```{doxygenfile} Majorization.hpp
+```
+```{doxygenfile} KoashiImoto.hpp
+```
+```{doxygenfile} Schmidt.hpp
+```
+```{doxygenfile} CausalCompare.hpp
+```
+```{doxygenfile} CausetChain.hpp
+```
+```{doxygenfile} QuantumSimplex.hpp
+```
+```{doxygenfile} QuantumVertex.hpp
+```
+
+## Graph
+
+```{doxygenfile} DualGraph.hpp
+```
+```{doxygenfile} SpectralGraph.hpp
+```
+```{doxygenfile} CSRBuilder.hpp
+```
+```{doxygenfile} COO.hpp
+```
+```{doxygenfile} IndexByKey.hpp
+```
+
+## Matter
+
+```{doxygenfile} MatterConfiguration.h
+```
 
 ## Constraints
 
 ```{doxygenfile} Constraint.h
+```
+
+## GPU / CUDA acceleration
+
+```{doxygenfile} regge_cuda.h
+```
+
+## Core utilities & infrastructure
+
+```{doxygenfile} Poset.h
+```
+```{doxygenfile} Renderer.h
+```
+```{doxygenfile} ForceLayout.h
+```
+```{doxygenfile} Logger.h
+```
+```{doxygenfile} utils.h
 ```

--- a/include/cobordism/HodgeLaplacian.h
+++ b/include/cobordism/HodgeLaplacian.h
@@ -195,7 +195,7 @@ class HodgeLaplacian {
     /// Eigenvectors of the signed-weight \f$ L_k \f$ as a flat row-major
     /// \f$ M\times M \f$ complex array; column \f$ j \f$ (entries \f$ iM + j \f$)
     /// is the eigenvector for the \f$ j \f$-th eigenvalue of
-    /// `lorentzianEigenvalues(k, metric)` (same order). @throws for \f$ k < 0 \f$.
+    /// `lorentzianEigenvalues(k, metric)` (same order). @throws std::runtime_error for \f$ k < 0 \f$.
     [[nodiscard]] std::vector<std::complex<double>> lorentzianEigenvectors(
         int k, bool metric = true) const;
 
@@ -203,7 +203,7 @@ class HodgeLaplacian {
     /// eigenvectors with \f$ |\lambda| < \text{tol} \f$, as a flat row-major
     /// \f$ M\times H \f$ complex array (\f$ H \f$ columns). For an all-spacelike
     /// complex \f$ H = b_k \f$; with genuine timelike cells the count can differ
-    /// (the pseudo-Hodge decomposition). @throws for \f$ k < 0 \f$.
+    /// (the pseudo-Hodge decomposition). @throws std::runtime_error for \f$ k < 0 \f$.
     [[nodiscard]] std::vector<std::complex<double>> lorentzianHarmonics(
         int k, double tol = 1e-9, bool metric = true) const;
 
@@ -211,8 +211,8 @@ class HodgeLaplacian {
     /// (signed \f$ W_k \f$) of the near-kernel representatives, one per column of
     /// `lorentzianHarmonics(k, tol, metric)` and in the same order. A value
     /// \f$ \approx 0 \f$ flags a **null** harmonic (a lightlike kernel direction);
-    /// all entries are positive on an all-spacelike complex. @throws for
-    /// \f$ k < 0 \f$.
+    /// all entries are positive on an all-spacelike complex.
+    /// @throws std::runtime_error for \f$ k < 0 \f$.
     [[nodiscard]] std::vector<double> lorentzianNullNorms(
         int k, double tol = 1e-9, bool metric = true) const;
 

--- a/tests/test_cpp_api_docs_coverage.py
+++ b/tests/test_cpp_api_docs_coverage.py
@@ -1,0 +1,89 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Durability guard for the C++ API documentation page.
+
+``docs/source/cpp_api.md`` lists every public header under ``include/`` via a
+Breathe ``{doxygenfile} <header>`` directive. This test keeps that list honest:
+it fails CI if a header is added under ``include/`` without a matching entry on
+the page (so the docs can't silently rot), and equally if the page references a
+header that no longer exists (catches typos / removed files).
+
+Pure filesystem/text check — it does not import ``tessera`` and needs no C++
+build, so it runs in the docs-only environment too.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INCLUDE_DIR = REPO_ROOT / "include"
+CPP_API_PAGE = REPO_ROOT / "docs" / "source" / "cpp_api.md"
+
+# ``{doxygenfile} Foo.h`` / ``{doxygenfile} Foo.hpp`` — capture the basename.
+_DOXYGENFILE_RE = re.compile(r"\{doxygenfile\}\s+(\S+\.(?:h|hpp))\s*$", re.MULTILINE)
+
+
+class TestCppApiDocsCoverage(unittest.TestCase):
+    """Every public C++ header must be reachable from the C++ API page."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.headers = {
+            p.name
+            for p in INCLUDE_DIR.rglob("*")
+            if p.suffix in (".h", ".hpp")
+        }
+        text = CPP_API_PAGE.read_text(encoding="utf-8")
+        cls.documented = set(_DOXYGENFILE_RE.findall(text))
+
+    def test_include_dir_is_populated(self):
+        """Sanity: we actually found headers and directives to compare."""
+        self.assertTrue(self.headers, f"no headers found under {INCLUDE_DIR}")
+        self.assertTrue(
+            self.documented,
+            f"no {{doxygenfile}} directives found in {CPP_API_PAGE}",
+        )
+
+    def test_every_header_is_documented(self):
+        """No header under include/ may be missing from cpp_api.md."""
+        missing = sorted(self.headers - self.documented)
+        self.assertFalse(
+            missing,
+            "Public C++ headers missing a {doxygenfile} entry in "
+            f"docs/source/cpp_api.md: {missing}. Add each to the matching "
+            "per-module section so it is reachable from the C++ API docs.",
+        )
+
+    def test_no_stale_documented_headers(self):
+        """No {doxygenfile} entry may point at a header that no longer exists."""
+        stale = sorted(self.documented - self.headers)
+        self.assertFalse(
+            stale,
+            "docs/source/cpp_api.md references headers that do not exist under "
+            f"include/: {stale}. Remove or rename the stale {{doxygenfile}} "
+            "entries.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The C++ API page (`docs/source/cpp_api.md`) previously listed only ~16 headers and was badly out of date. It now lists **every public header under `include/` (81 total)** via Breathe `{doxygenfile}` directives, grouped into per-module sections that mirror the `include/` tree.

## Modules / headers added
Newly documented (previously absent) headers, by section:

- **Cobordism** (`cobordism/`): ChainComplex, Cobordism, HodgeLaplacian, IntegerLinalg, DijkgraafWitten, EigenstateSynthesis, Characteristic, CombinatorialDimension
- **Quantum** (`quantum/`): SchwingerModel, DMRGRunner, TDVPRunner, Quench, ChoiJamiolkowski, ChoiState, Holography, MutualInformation, Majorization, KoashiImoto, Schmidt, CausalCompare, CausetChain, QuantumSimplex, QuantumVertex
- **Observables** (`observables/`): SpacetimeVolume, Spectral, WilsonLoop, MIUnits, ModularityOptimizer, SparseGraph (added alongside the existing Observable, VolumeProfile)
- **Topologies** (`spacetime/topologies/`): SimplicialProduct, SphereCircleProduct, SimplexBoundarySphere, SolidSimplex, StellarSubdivision, RealProjectivePlane, RealProjectiveSpace, ComplexProjectivePlane (added alongside Topology, Toroid, Cylinder, Sphere)
- **Pachner moves** (`spacetime/PachnerMove.h` + `spacetime/pachner/`): PachnerMove, AddMove, RemoveMove, FlipMove, IFlipMove, ShiftMove
- **Simulations** (`simulations/`): ReggeSolver, InteractionSimulation (added alongside Simulation, CDT)
- **Mesh** (`mesh/`): VertexList, EdgeKey, EdgeList, Fingerprint, SimplexFilter, FlatHashMap, ForwardDeclarations (added alongside Simplex, SimplexOrientation, Vertex, Edge)
- **Graph** (`graph/`): DualGraph, SpectralGraph, CSRBuilder, COO, IndexByKey
- **Matter** (`matter/`): MatterConfiguration
- **Core spacetime**: Foliation (added alongside Spacetime, Metric, Signature)
- **GPU/CUDA** (`cuda/`): regge_cuda
- **Core utilities & infrastructure**: Poset, Renderer, ForceLayout, Logger, utils

## Doxyfile INPUT
No change was needed: `docs/Doxyfile` already has `INPUT = ../src ../include` with `RECURSIVE = YES`, so Doxygen generates an XML file compound for every header. Verified that all 81 `include/` headers appear as file compounds in `_doxygen/xml/index.xml` (and there are no duplicate header basenames, so the `{doxygenfile}` basename references are unambiguous).

## Durability
- A maintenance comment at the top of `cpp_api.md` documents the per-module layout and the rule that every new header gets a matching entry.
- `tests/test_cpp_api_docs_coverage.py` is a build-free guard (pure filesystem/text check, no `tessera` import) that fails CI if any `include/` header lacks a `{doxygenfile}` entry, or if the page references a header that no longer exists.

## Cleanup
- Fixed three malformed `@throws for` Doxygen comments in `cobordism/HodgeLaplacian.h` (missing exception type) that caused Breathe to emit `Unparseable C++ expression: for` once the header was rendered. Now `@throws std::runtime_error for ...`, matching the rest of the file (doc-comment only; no code change).

## Verification
- `make -C docs doxygen` regenerates `docs/_doxygen/xml` cleanly.
- `sphinx-build -E -b html docs/source` builds with **zero** Breathe/cpp/Doxygen warnings; all new modules render. The only remaining warning is the pre-existing, environmental `autodoc: failed to import module 'quantum' from module 'tessera'` (a stale editable pointer; `tessera` is not built in the docs-only env) — unrelated to this change.

Closes #149.