### PR TITLE
cobordism: bulk eigenstate synthesis — fixed-boundary interior fill

### DIFF
--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -24,7 +24,9 @@
 
 #include <complex>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "cobordism/HodgeLaplacian.h"
@@ -72,6 +74,27 @@ using namespace ::tessera::spacetime;
 /// read them; `setWeights()` / `setPhases()` write them back in place — no mesh
 /// rebuild. `psi` components are indexed in the same sorted-vertex-id order as
 /// `HodgeLaplacian` (\f$ k=0 \f$), so they align with the operator.
+///
+/// ## Fixed-boundary interior fill (§5.0)
+///
+/// The realizability oracle (#138) fills the **interior** of a bulk \f$ W_{AB} \f$
+/// whose boundary is *pinned* — the §4b cone-and-retry restricted to the interior.
+/// The tunable edges split into the **boundary** set \f$ \partial W \f$ (those on a
+/// codimension-one face belonging to exactly one top cell — held fixed) and the
+/// **interior** set (everything else — free). `interiorWeights()` / `interiorPhases()`
+/// and `setInteriorWeights()` / `setInteriorPhases()` read/write *only* the interior
+/// edges, so a search drives \f$ r\to 0 \f$ for a target output eigenvector while
+/// \f$ \partial W \f$ stays byte-identical; `boundaryEdges()` exposes that fixed set
+/// for verification. `growInterior()` cones a fresh interior vertex into a top cell
+/// via the boundary-fixed pre-geometric Pachner add (#112) — a topology-preserving
+/// \f$ 1\!\to\!(d+1) \f$ stellar subdivision that enriches the interior with
+/// \f$ \partial W \f$ untouched — and re-captures the partition, so the loop can
+/// optimize, then grow, then re-optimize. `interiorVertexCount()` /
+/// `numInteriorEdges()` report the interior complexity reached: a reachable target
+/// drives \f$ r\to 0 \f$ at some minimal complexity, an unreachable one floors at a
+/// positive residual (the spectral obstruction the oracle consumes). The boundary
+/// edge classification needs genuine codim-one structure (top cells of \f$ \ge 3 \f$
+/// vertices); on a pure 1-complex every edge is interior (the free §4b regime).
 class EigenstateSynthesis {
   public:
     /// Construct over a fixed triangulation. The vertex order (sorted id) and the
@@ -118,6 +141,64 @@ class EigenstateSynthesis {
     /// @throws std::runtime_error if `theta.size() != numEdges()`.
     void setPhases(const std::vector<double> &theta);
 
+    // === Fixed-boundary interior fill (§5.0) ===
+
+    /// Number of interior tunable edges (not on \f$ \partial W \f$) — the length
+    /// of `interiorWeights()` / `interiorPhases()` and the free parameters a
+    /// fixed-boundary search varies.
+    [[nodiscard]] std::size_t numInteriorEdges() const noexcept {
+      return interiorEdgeIdx_.size();
+    }
+
+    /// Number of boundary tunable edges (on \f$ \partial W \f$, held fixed).
+    [[nodiscard]] std::size_t numBoundaryEdges() const noexcept {
+      return boundaryEdgeIdx_.size();
+    }
+
+    /// Number of interior vertices (on no boundary face) — the coned-in apexes;
+    /// the interior complexity the synthesis grows / reports.
+    [[nodiscard]] std::size_t interiorVertexCount() const noexcept {
+      return interiorVertexCount_;
+    }
+
+    /// The interior edge magnitudes \f$ \{w_{ij}\} \f$ in interior-edge order,
+    /// length `numInteriorEdges()`.
+    [[nodiscard]] std::vector<double> interiorWeights() const;
+
+    /// The interior edge phases \f$ \{\theta_{ij}\} \f$ in interior-edge order,
+    /// length `numInteriorEdges()`.
+    [[nodiscard]] std::vector<double> interiorPhases() const;
+
+    /// Write the interior edge magnitudes in place; the boundary edges are left
+    /// untouched. @throws std::runtime_error if `w.size() != numInteriorEdges()`.
+    void setInteriorWeights(const std::vector<double> &w);
+
+    /// Write the interior edge phases in place; the boundary edges are left
+    /// untouched. @throws std::runtime_error if `theta.size() != numInteriorEdges()`.
+    void setInteriorPhases(const std::vector<double> &theta);
+
+    /// The boundary tunable edges as sorted \f$ (\min\text{id},\max\text{id}) \f$
+    /// endpoint pairs — the fixed \f$ \partial W \f$ edge set, for asserting it is
+    /// untouched through an interior fill / growth sweep.
+    [[nodiscard]] std::vector<std::pair<std::uint64_t, std::uint64_t>>
+    boundaryEdges() const;
+
+    /// The interior tunable edges as sorted \f$ (\min\text{id},\max\text{id}) \f$
+    /// endpoint pairs (the complement of `boundaryEdges()`).
+    [[nodiscard]] std::vector<std::pair<std::uint64_t, std::uint64_t>>
+    interiorEdges() const;
+
+    /// Cone a fresh interior vertex into a top cell via the boundary-fixed
+    /// pre-geometric Pachner add (#112): a \f$ 1\!\to\!(d+1) \f$ stellar
+    /// subdivision that leaves \f$ \partial W \f$ exactly fixed while enriching the
+    /// interior. Re-captures the vertex order, tunable edges, and interior/boundary
+    /// partition, so `order()` grows by one (a `psi` must be extended on the new
+    /// apex, appended last in sorted-id order) and `numInteriorEdges()` grows. The
+    /// RNG `seed` makes the target-cell choice reproducible. Returns `false` if no
+    /// top cell can be subdivided (e.g. a 1-complex, top cells of \f$ <3 \f$
+    /// vertices), leaving the complex unchanged.
+    bool growInterior(std::uint64_t seed);
+
   private:
     std::shared_ptr<Spacetime> st_;
     // The k=0 Hermitian Laplacian operator over the same complex. laplacian(0)
@@ -128,8 +209,24 @@ class EigenstateSynthesis {
     std::size_t order_{0};  // N = |V|, the sorted-id vertex order
     // The tunable edges, in EdgeList order, restricted to those carrying weight
     // in L (both endpoints present, no self-loops). Raw pointers owned by the
-    // EdgeList; valid for the fixed complex's lifetime (kept alive via st_).
+    // EdgeList; valid for the complex's lifetime (kept alive via st_). Re-captured
+    // after growInterior() adds a vertex.
     std::vector<::tessera::mesh::Edge *> edges_{};
+
+    // Indices into edges_ partitioning the tunable edges into interior (free) and
+    // boundary (on ∂W, held fixed) by classifyBoundary(). Interior-order is the
+    // stable parameter order for setInteriorWeights / setInteriorPhases.
+    std::vector<std::size_t> interiorEdgeIdx_{};
+    std::vector<std::size_t> boundaryEdgeIdx_{};
+    std::size_t interiorVertexCount_{0};  // vertices on no boundary face
+
+    // (Re)build order_ and edges_ from the live vertex/edge lists. Called at
+    // construction and after growInterior() mutates the complex.
+    void capture();
+
+    // (Re)build the interior/boundary edge partition (∂W = codim-1 faces in
+    // exactly one top cell) and interiorVertexCount_ from the live complex.
+    void classifyBoundary();
 };
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -238,7 +238,17 @@ HodgeLaplacian (k=0).
 
 Parameters: the per-edge squared-length magnitudes {w_ij} (Edge.setSquaredLength)
 and U(1) phases {theta_ij} (Edge.setPhase), in a stable edge order fixed at
-construction (the weight-carrying edges: both endpoints present, no self-loops).)doc")
+construction (the weight-carrying edges: both endpoints present, no self-loops).
+
+Fixed-boundary interior fill (§5.0): the tunable edges split into a boundary set
+dW (edges on a codim-1 face in exactly one top cell — held fixed) and an interior
+set (free). interiorWeights / interiorPhases + setInteriorWeights /
+setInteriorPhases read/write only the interior edges, so a search drives r -> 0
+for a target output eigenvector while dW stays byte-identical (boundaryEdges()
+exposes that fixed set). growInterior() cones a fresh interior vertex via the
+boundary-fixed pre-geometric Pachner add (#112), enriching the interior with dW
+untouched; interiorVertexCount / numInteriorEdges report the interior complexity
+reached. On a 1-complex there is no boundary — every edge is interior.)doc")
       .def(py::init<std::shared_ptr<Spacetime>>(), py::arg("spacetime"),
            "Build the synthesizer over a fixed triangulation.")
       .def("order", &EigenstateSynthesis::order,
@@ -263,7 +273,44 @@ construction (the weight-carrying edges: both endpoints present, no self-loops).
       .def("setWeights", &EigenstateSynthesis::setWeights, py::arg("w"),
            "Write the edge magnitudes in place. Raises if len(w) != numEdges().")
       .def("setPhases", &EigenstateSynthesis::setPhases, py::arg("theta"),
-           "Write the edge phases in place. Raises if len(theta) != numEdges().");
+           "Write the edge phases in place. Raises if len(theta) != numEdges().")
+      // ----- Fixed-boundary interior fill (§5.0, #147) -----
+      .def("numInteriorEdges", &EigenstateSynthesis::numInteriorEdges,
+           "Number of interior tunable edges (not on dW) — the length of "
+           "interiorWeights() / interiorPhases() and the free parameters a "
+           "fixed-boundary search varies.")
+      .def("numBoundaryEdges", &EigenstateSynthesis::numBoundaryEdges,
+           "Number of boundary tunable edges (on dW, held fixed).")
+      .def("interiorVertexCount", &EigenstateSynthesis::interiorVertexCount,
+           "Number of interior vertices (on no boundary face) — the coned-in "
+           "apexes; the interior complexity the synthesis grows / reports.")
+      .def("interiorWeights", &EigenstateSynthesis::interiorWeights,
+           "Interior edge magnitudes {w_ij} in interior-edge order.")
+      .def("interiorPhases", &EigenstateSynthesis::interiorPhases,
+           "Interior edge phases {theta_ij} (radians) in interior-edge order.")
+      .def("setInteriorWeights", &EigenstateSynthesis::setInteriorWeights,
+           py::arg("w"),
+           "Write the interior edge magnitudes in place; the boundary edges are "
+           "left untouched. Raises if len(w) != numInteriorEdges().")
+      .def("setInteriorPhases", &EigenstateSynthesis::setInteriorPhases,
+           py::arg("theta"),
+           "Write the interior edge phases in place; the boundary edges are left "
+           "untouched. Raises if len(theta) != numInteriorEdges().")
+      .def("boundaryEdges", &EigenstateSynthesis::boundaryEdges,
+           "The boundary tunable edges as sorted (min_id, max_id) endpoint "
+           "tuples — the fixed dW edge set, for asserting it is untouched through "
+           "an interior fill / growth sweep.")
+      .def("interiorEdges", &EigenstateSynthesis::interiorEdges,
+           "The interior tunable edges as sorted (min_id, max_id) endpoint tuples "
+           "(the complement of boundaryEdges()).")
+      .def("growInterior", &EigenstateSynthesis::growInterior, py::arg("seed"),
+           "Cone a fresh interior vertex into a top cell via the boundary-fixed "
+           "pre-geometric Pachner add (#112): a 1->(d+1) stellar subdivision that "
+           "leaves dW exactly fixed while enriching the interior. Re-captures the "
+           "vertex order and interior/boundary partition, so order() grows by one "
+           "(extend psi on the new apex, appended last in sorted-id order) and "
+           "numInteriorEdges() grows. Returns False if no top cell can be "
+           "subdivided (e.g. a 1-complex), leaving the complex unchanged.");
 
   // Exact integer / GF(2) / inertia primitives (also exposed for direct
   // testing). Matrices are passed flat row-major with explicit dims.

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -24,16 +24,23 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <map>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "mesh/Edge.h"
 #include "mesh/EdgeList.h"
+#include "mesh/Simplex.h"
 #include "mesh/Vertex.h"
 #include "mesh/VertexList.h"
+#include "spacetime/Metric.h"
+#include "spacetime/Signature.h"
 #include "spacetime/Spacetime.h"
+#include "spacetime/pachner/AddMove.h"
 
 namespace tessera::cobordism {
 
@@ -41,6 +48,14 @@ using cd = std::complex<double>;
 
 EigenstateSynthesis::EigenstateSynthesis(std::shared_ptr<Spacetime> st)
     : st_(st), laplacian_(std::move(st)) {
+  if (!st_) return;
+  capture();
+  classifyBoundary();
+}
+
+void EigenstateSynthesis::capture() {
+  order_ = 0;
+  edges_.clear();
   if (!st_) return;
 
   // Stable vertex order (sorted id), matching HodgeLaplacian's k=0 indexing so a
@@ -64,6 +79,76 @@ EigenstateSynthesis::EigenstateSynthesis(std::shared_ptr<Spacetime> st)
         idset.find(t->getId()) == idset.end())
       continue;
     edges_.push_back(e);
+  }
+}
+
+void EigenstateSynthesis::classifyBoundary() {
+  interiorEdgeIdx_.clear();
+  boundaryEdgeIdx_.clear();
+  interiorVertexCount_ = 0;
+  if (!st_) return;
+
+  // Top cells have d+1 vertices (d = metric dimension), matching the
+  // Spacetime's own top-simplex bookkeeping (getRandomTopSimplex) so this
+  // partition agrees with the pre-geometric Pachner moves growInterior reuses.
+  const int d = st_->getMetric()->getSignature()->getDimensions();
+  const std::size_t topVerts = (d >= 0) ? static_cast<std::size_t>(d) + 1 : 0;
+
+  // ∂W: codim-1 faces (a top cell with one vertex dropped) belonging to exactly
+  // one top cell. An *edge* sits on the boundary only once codim-1 faces are at
+  // least edges themselves (topVerts >= 3); below that there is no boundary —
+  // every tunable edge is interior (the free §4b regime, owned by #134).
+  std::set<std::pair<std::uint64_t, std::uint64_t>> boundaryEdgeKeys;
+  std::unordered_set<std::uint64_t> boundaryVertexIds;
+  if (topVerts >= 3) {
+    std::map<std::vector<std::uint64_t>, int> facetCount;
+    for (const auto s : st_->getSimplices()) {
+      if (s == nullptr) continue;
+      if (s->size() != topVerts) continue;
+      std::vector<std::uint64_t> ids;
+      ids.reserve(topVerts);
+      for (const auto v : s->getVertices())
+        if (v != nullptr) ids.push_back(v->getId());
+      if (ids.size() != topVerts) continue;
+      std::sort(ids.begin(), ids.end());
+      for (std::size_t skip = 0; skip < ids.size(); ++skip) {
+        std::vector<std::uint64_t> facet;
+        facet.reserve(ids.size() - 1);
+        for (std::size_t i = 0; i < ids.size(); ++i)
+          if (i != skip) facet.push_back(ids[i]);
+        ++facetCount[facet];
+      }
+    }
+    for (const auto &[facet, count] : facetCount) {
+      if (count != 1) continue;  // interior facet (shared by two top cells)
+      for (const std::uint64_t id : facet) boundaryVertexIds.insert(id);
+      // facet is sorted ascending, so (facet[i], facet[j]) for i<j is ordered.
+      for (std::size_t i = 0; i + 1 < facet.size(); ++i)
+        for (std::size_t j = i + 1; j < facet.size(); ++j)
+          boundaryEdgeKeys.insert({facet[i], facet[j]});
+    }
+  }
+
+  // An edge is on ∂W iff some boundary facet contains both endpoints; otherwise
+  // it is interior (free).
+  for (std::size_t e = 0; e < edges_.size(); ++e) {
+    const std::uint64_t a = edges_[e]->getSource()->getId();
+    const std::uint64_t b = edges_[e]->getTarget()->getId();
+    const std::pair<std::uint64_t, std::uint64_t> key =
+        a < b ? std::make_pair(a, b) : std::make_pair(b, a);
+    if (boundaryEdgeKeys.find(key) != boundaryEdgeKeys.end())
+      boundaryEdgeIdx_.push_back(e);
+    else
+      interiorEdgeIdx_.push_back(e);
+  }
+
+  // Interior vertices: those on no boundary face (the coned-in apexes).
+  std::unordered_set<std::uint64_t> seen;
+  for (const auto v : st_->getVertexList()->toVector()) {
+    if (v == nullptr) continue;
+    if (!seen.insert(v->getId()).second) continue;
+    if (boundaryVertexIds.find(v->getId()) == boundaryVertexIds.end())
+      ++interiorVertexCount_;
   }
 }
 
@@ -165,6 +250,86 @@ void EigenstateSynthesis::setPhases(const std::vector<double> &theta) {
         " phases, expected " + std::to_string(edges_.size()));
   for (std::size_t i = 0; i < edges_.size(); ++i)
     edges_[i]->setPhase(theta[i]);
+}
+
+// === Fixed-boundary interior fill (§5.0) ===
+
+std::vector<double> EigenstateSynthesis::interiorWeights() const {
+  std::vector<double> w;
+  w.reserve(interiorEdgeIdx_.size());
+  for (const auto i : interiorEdgeIdx_) w.push_back(edges_[i]->getSquaredLength());
+  return w;
+}
+
+std::vector<double> EigenstateSynthesis::interiorPhases() const {
+  std::vector<double> th;
+  th.reserve(interiorEdgeIdx_.size());
+  for (const auto i : interiorEdgeIdx_) th.push_back(edges_[i]->getPhase());
+  return th;
+}
+
+void EigenstateSynthesis::setInteriorWeights(const std::vector<double> &w) {
+  if (w.size() != interiorEdgeIdx_.size())
+    throw std::runtime_error(
+        "EigenstateSynthesis::setInteriorWeights: got " +
+        std::to_string(w.size()) + " weights, expected " +
+        std::to_string(interiorEdgeIdx_.size()));
+  for (std::size_t k = 0; k < interiorEdgeIdx_.size(); ++k)
+    edges_[interiorEdgeIdx_[k]]->setSquaredLength(w[k]);
+}
+
+void EigenstateSynthesis::setInteriorPhases(const std::vector<double> &theta) {
+  if (theta.size() != interiorEdgeIdx_.size())
+    throw std::runtime_error(
+        "EigenstateSynthesis::setInteriorPhases: got " +
+        std::to_string(theta.size()) + " phases, expected " +
+        std::to_string(interiorEdgeIdx_.size()));
+  for (std::size_t k = 0; k < interiorEdgeIdx_.size(); ++k)
+    edges_[interiorEdgeIdx_[k]]->setPhase(theta[k]);
+}
+
+std::vector<std::pair<std::uint64_t, std::uint64_t>>
+EigenstateSynthesis::boundaryEdges() const {
+  std::vector<std::pair<std::uint64_t, std::uint64_t>> out;
+  out.reserve(boundaryEdgeIdx_.size());
+  for (const auto i : boundaryEdgeIdx_) {
+    const std::uint64_t a = edges_[i]->getSource()->getId();
+    const std::uint64_t b = edges_[i]->getTarget()->getId();
+    out.emplace_back(std::min(a, b), std::max(a, b));
+  }
+  return out;
+}
+
+std::vector<std::pair<std::uint64_t, std::uint64_t>>
+EigenstateSynthesis::interiorEdges() const {
+  std::vector<std::pair<std::uint64_t, std::uint64_t>> out;
+  out.reserve(interiorEdgeIdx_.size());
+  for (const auto i : interiorEdgeIdx_) {
+    const std::uint64_t a = edges_[i]->getSource()->getId();
+    const std::uint64_t b = edges_[i]->getTarget()->getId();
+    out.emplace_back(std::min(a, b), std::max(a, b));
+  }
+  return out;
+}
+
+bool EigenstateSynthesis::growInterior(std::uint64_t seed) {
+  if (!st_) return false;
+  // Cone a fresh interior vertex via the boundary-fixed pre-geometric Pachner
+  // add (#112): a 1→(d+1) stellar subdivision, always interior, so ∂W is left
+  // exactly fixed (the move never touches a boundary face).
+  ::tessera::spacetime::AddMove move(
+      st_.get(), seed, /*relabelEnabled=*/false,
+      ::tessera::spacetime::PachnerMode::PreGeometric, /*boundaryFixed=*/true);
+  if (!move.propose()) return false;
+  if (!move.apply()) return false;
+  // The vertex set changed: rebuild the operator over the fresh vertex order
+  // (the new apex has the largest id, so it appends last in sorted order and
+  // the existing psi indices are preserved), then re-capture the tunable edges
+  // and the interior/boundary partition.
+  laplacian_ = HodgeLaplacian(st_);
+  capture();
+  classifyBoundary();
+  return true;
 }
 
 }  // namespace tessera::cobordism

--- a/tests/cobordism/test_bulk_eigenstate_synthesis_python.py
+++ b/tests/cobordism/test_bulk_eigenstate_synthesis_python.py
@@ -1,0 +1,545 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""§5.0 bulk eigenstate synthesis — fixed-boundary interior fill (#147).
+
+The realizability oracle (#138) fills the *interior* of a bulk W_AB whose boundary
+is pinned, matching a target output eigenstate. This extends EigenstateSynthesis
+(#133) with a fixed-boundary mode: the tunable edges split into a boundary set dW
+(edges on a codim-1 face in exactly one top cell — held fixed) and an interior set
+(free). setInteriorWeights / setInteriorPhases drive only the interior, so a search
+drives the §4b residual r = ||(I - psi psi^dagger) L psi||^2 -> 0 for a target while
+dW stays byte-identical; growInterior() cones a fresh interior vertex via the
+boundary-fixed pre-geometric Pachner add (#112), the §4b cone-and-retry restricted
+to the interior.
+
+What is verified here:
+
+  * **Partition** — on a solid triangle (dW = the 3 sides) every edge is boundary;
+    one interior cone adds an apex with 3 interior edges while dW is unchanged; the
+    class's dW agrees with cobordism.Cobordism.boundaryFaces; a 1-complex has no
+    boundary (every edge interior) and cannot be grown.
+  * **dW provably untouched** — across an interior-fill + growth sweep the boundary
+    edge set, the boundary faces, AND the fixed boundary edge weights/phases are
+    byte-identical throughout.
+  * **Reachable matched (r < 1e-10)** — after interior fill a reachable target
+    eigenvector is matched: the constant zero-mode (boundary phases 0), and a
+    generic eigenvector reconstructed from a realized fixed-boundary Laplacian.
+  * **Unreachable floors** — a generic target the interior cannot realize floors at
+    a positive residual, matching an independent numpy global-min oracle (the
+    obstruction signal, the analogue of §4b's two-vertex floor).
+  * **Cone-and-retry** — a target unreachable at base complexity is matched after
+    interior growth; the loop reports the minimal interior complexity reached.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders (Signature(d) so the d-cells register as top simplices, the
+# pre-geometric idiom shared with the boundary-fixed Pachner tests #112).
+# --------------------------------------------------------------------------- #
+def _spacetime(dim, topology):
+    sig = tessera.Signature(dim, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, topology)
+
+
+def _solid_triangle():
+    """Δ^2: a single triangle 0-1-2 whose boundary ∂W is the three sides
+    (S^1). Built through the topology so the vertex-id counter advances —
+    growInterior()'s coned-in apex gets a collision-free id."""
+    st = _spacetime(2, tessera.SolidSimplex(2))
+    st.build()
+    return st
+
+
+def _bipyramid():
+    """Two triangles 012 and 013 sharing the single interior edge 01; the four
+    outer edges 02,12,03,13 are the fixed boundary ∂W. The smallest fixed-
+    boundary complex with exactly one interior parameter — the analogue of §4b's
+    two-vertex single edge, with the boundary pinned."""
+    st = _solid_triangle()  # triangle 012, vertex-id counter at 3
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    st.createSimplex([v[0], v[1], v3])  # triangle 013
+    return st
+
+
+def _two_vertex_edge():
+    """The §4b 1-complex: two vertices, one edge (no boundary structure)."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    a = st.createVertex(0)
+    b = st.createVertex(1)
+    st.createSimplex([a, b])
+    return st
+
+
+# --------------------------------------------------------------------------- #
+# numpy oracle + helpers (the same D - A magnitude convention the Hodge / #133
+# tests use, in the operator's sorted-vertex-id order).
+# --------------------------------------------------------------------------- #
+def _cvec(v):
+    return [complex(z) for z in v]
+
+
+def _edge_map(st):
+    """{(min_id, max_id): Edge} over the live edges."""
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _edge_values(st):
+    """{(min_id, max_id): (squaredLength, phase)} snapshot of the live edges."""
+    return {k: (e.getSquaredLength(), e.getPhase())
+            for k, e in _edge_map(st).items()}
+
+
+def _boundary_faces(st):
+    return frozenset(tuple(f) for f in cob.Cobordism.boundaryFaces(st))
+
+
+def _np_L(st):
+    ids = sorted(v.getId() for v in st.getVertexList().toVector())
+    idx = {vid: i for i, vid in enumerate(ids)}
+    n = len(ids)
+    A = np.zeros((n, n), dtype=complex)
+    D = np.zeros(n)
+    for e in st.getEdgeList().toVector():
+        s, t = e.getSource().getId(), e.getTarget().getId()
+        if s == t:
+            continue
+        i, j = idx[s], idx[t]
+        w = e.getSquaredLength()
+        z = w * np.exp(1j * e.getPhase())
+        A[i, j] += z
+        A[j, i] += np.conj(z)
+        D[i] += abs(w)
+        D[j] += abs(w)
+    return np.diag(D).astype(complex) - A
+
+
+def _np_residual(L, psi):
+    psi = np.asarray(psi, dtype=complex)
+    psi = psi / np.linalg.norm(psi)
+    Lp = L @ psi
+    lam = np.vdot(psi, Lp).real
+    r = Lp - lam * psi
+    return float(np.vdot(r, r).real)
+
+
+def _set_boundary(st, es, weights=None, phase_scale=0.0, base_w=1.0):
+    """Pin the boundary edges to fixed Hermitian values, in es.boundaryEdges()
+    order. Returns the snapshot of the boundary edge values so a test can prove
+    they never move."""
+    em = _edge_map(st)
+    bedges = es.boundaryEdges()
+    for k, key in enumerate(bedges):
+        w = base_w if weights is None else weights[k]
+        em[key].setSquaredLength(w)
+        em[key].setPhase(phase_scale * (k + 1))
+    return {key: (em[key].getSquaredLength(), em[key].getPhase())
+            for key in bedges}
+
+
+# --------------------------------------------------------------------------- #
+# Fixed-boundary searches: scipy L-BFGS-B over the *interior* parameters only,
+# leaving dW fixed (the §4b multi-restart machinery, restricted to the interior).
+# --------------------------------------------------------------------------- #
+def _interior_search(es, psi, n_restarts=40, seed=0, w_bounds=(0.1, 10.0)):
+    """Minimize r(psi) over the interior edge weights/phases (boundary fixed).
+    Returns the best residual; leaves the complex at the best parameters."""
+    from scipy.optimize import minimize
+
+    m = es.numInteriorEdges()
+    psi = _cvec(psi)
+    if m == 0:
+        return es.residual(psi)
+    rng = np.random.default_rng(seed)
+    th_bounds = (-2.0 * math.pi, 2.0 * math.pi)
+    bounds = [w_bounds] * m + [th_bounds] * m
+
+    def objective(x):
+        es.setInteriorWeights(x[:m].tolist())
+        es.setInteriorPhases(x[m:].tolist())
+        return es.residual(psi)
+
+    best_r, best_x = np.inf, None
+    for _ in range(n_restarts):
+        x0 = np.concatenate([rng.uniform(w_bounds[0], w_bounds[1], size=m),
+                             rng.uniform(-math.pi, math.pi, size=m)])
+        res = minimize(objective, x0, method="L-BFGS-B", bounds=bounds)
+        if res.fun < best_r:
+            best_r, best_x = float(res.fun), np.asarray(res.x, dtype=float)
+    if best_x is not None:
+        objective(best_x)
+    return best_r
+
+
+def _fill_interior(es, target_support, n_restarts=40, seed=0, max_cones=4,
+                   tol=1e-10, w_bounds=(0.1, 10.0)):
+    """The §4b cone-and-retry, restricted to the interior. Holds the target
+    fixed on its boundary support (the first len(target_support) sorted-id
+    vertices); the auxiliary amplitudes on coned-in apexes are free. Optimizes
+    the interior, then grows (boundary-fixed cone), then re-optimizes, until
+    r < tol or the growth budget is spent.
+
+    Returns (best_r, interior_vertex_count) — the minimal interior complexity at
+    convergence, or the residual floor if it cannot converge."""
+    from scipy.optimize import minimize
+
+    support = len(target_support)
+    target_support = _cvec(target_support)
+    th_bounds = (-2.0 * math.pi, 2.0 * math.pi)
+    aux_bounds = (-5.0, 5.0)
+
+    best_r = np.inf
+    for _cone in range(max_cones + 1):
+        m = es.numInteriorEdges()
+        n_aux = es.order() - support
+        if m == 0 and n_aux == 0:
+            best_r = es.residual(target_support)  # base: no interior freedom yet
+        else:
+            rng = np.random.default_rng(seed + _cone)
+            bounds = ([w_bounds] * m + [th_bounds] * m
+                      + [aux_bounds] * (2 * n_aux))
+
+            def build_psi(x):
+                aux = x[2 * m:]
+                return target_support + [complex(aux[2 * k], aux[2 * k + 1])
+                                         for k in range(n_aux)]
+
+            def objective(x):
+                if m:
+                    es.setInteriorWeights(x[:m].tolist())
+                    es.setInteriorPhases(x[m:2 * m].tolist())
+                return es.residual(build_psi(x))
+
+            cone_best, cone_x = np.inf, None
+            for _ in range(n_restarts):
+                x0 = np.concatenate([
+                    rng.uniform(w_bounds[0], w_bounds[1], size=m),
+                    rng.uniform(-math.pi, math.pi, size=m),
+                    rng.uniform(-1.0, 1.0, size=2 * n_aux)])
+                res = minimize(objective, x0, method="L-BFGS-B", bounds=bounds)
+                if res.fun < cone_best:
+                    cone_best, cone_x = float(res.fun), np.asarray(res.x, float)
+            if cone_x is not None:
+                objective(cone_x)
+            best_r = cone_best
+
+        if best_r < tol:
+            break
+        if _cone < max_cones:
+            es.growInterior(1000 + _cone)
+    return best_r, es.interiorVertexCount()
+
+
+# --------------------------------------------------------------------------- #
+class FixedBoundaryPartitionTest(unittest.TestCase):
+    """The interior/boundary edge split, and that growth enriches the interior
+    while ∂W is untouched."""
+
+    def test_solid_triangle_is_all_boundary(self):
+        st = _solid_triangle()
+        es = cob.EigenstateSynthesis(st)
+        self.assertEqual(es.order(), 3)
+        self.assertEqual(es.numEdges(), 3)
+        self.assertEqual(es.numInteriorEdges(), 0)
+        self.assertEqual(es.numBoundaryEdges(), 3)
+        self.assertEqual(es.interiorVertexCount(), 0)
+        self.assertEqual(sorted(es.boundaryEdges()), [(0, 1), (0, 2), (1, 2)])
+        self.assertEqual(es.interiorEdges(), [])
+        # The class's ∂W agrees with the cobordism boundary operator.
+        self.assertEqual(frozenset(es.boundaryEdges()), _boundary_faces(st))
+
+    def test_bipyramid_has_one_interior_edge(self):
+        st = _bipyramid()
+        es = cob.EigenstateSynthesis(st)
+        self.assertEqual(es.order(), 4)
+        self.assertEqual(es.numEdges(), 5)
+        self.assertEqual(es.numInteriorEdges(), 1)
+        self.assertEqual(es.numBoundaryEdges(), 4)
+        self.assertEqual(es.interiorEdges(), [(0, 1)])
+        self.assertEqual(sorted(es.boundaryEdges()),
+                         [(0, 2), (0, 3), (1, 2), (1, 3)])
+        # The shared edge is interior even though both its endpoints lie on ∂W.
+        self.assertEqual(es.interiorVertexCount(), 0)
+        self.assertEqual(frozenset(es.boundaryEdges()), _boundary_faces(st))
+
+    def test_grow_enriches_interior_fixes_boundary(self):
+        st = _solid_triangle()
+        es = cob.EigenstateSynthesis(st)
+        boundary_before = frozenset(es.boundaryEdges())
+        faces_before = _boundary_faces(st)
+
+        self.assertTrue(es.growInterior(0))
+        self.assertEqual(es.order(), 4)             # one apex coned in
+        self.assertEqual(es.numInteriorEdges(), 3)  # apex to each corner
+        self.assertEqual(es.numBoundaryEdges(), 3)
+        self.assertEqual(es.interiorVertexCount(), 1)
+        # ∂W exactly fixed.
+        self.assertEqual(frozenset(es.boundaryEdges()), boundary_before)
+        self.assertEqual(_boundary_faces(st), faces_before)
+        # The interior edges are precisely those incident to the new apex (id 3).
+        self.assertEqual(sorted(es.interiorEdges()), [(0, 3), (1, 3), (2, 3)])
+
+    def test_one_complex_has_no_boundary_and_cannot_grow(self):
+        st = _two_vertex_edge()
+        es = cob.EigenstateSynthesis(st)
+        # No codim-1 boundary structure: the lone edge is interior (free regime).
+        self.assertEqual(es.numBoundaryEdges(), 0)
+        self.assertEqual(es.numInteriorEdges(), 1)
+        # Nothing to subdivide -> growth is a no-op.
+        self.assertFalse(es.growInterior(0))
+        self.assertEqual(es.order(), 2)
+
+    def test_interior_setters_size_mismatch_raises(self):
+        es = cob.EigenstateSynthesis(_bipyramid())  # one interior edge
+        with self.assertRaises(Exception):
+            es.setInteriorWeights([1.0, 2.0])
+        with self.assertRaises(Exception):
+            es.setInteriorPhases([])
+
+
+class BoundaryUntouchedTest(unittest.TestCase):
+    """∂ fixed: the boundary face/edge set AND the fixed boundary edge
+    weights/phases are byte-identical through an interior-fill + growth sweep."""
+
+    def test_boundary_invariant_through_fill_and_growth(self):
+        st = _solid_triangle()
+        es = cob.EigenstateSynthesis(st)
+        # Pin the three boundary edges to distinct Hermitian values.
+        boundary_vals = _set_boundary(
+            st, es, weights=[0.7, 1.3, 2.1], phase_scale=0.37)
+        boundary_edges0 = frozenset(es.boundaryEdges())
+        faces0 = _boundary_faces(st)
+
+        def assert_boundary_fixed():
+            self.assertEqual(frozenset(es.boundaryEdges()), boundary_edges0)
+            self.assertEqual(_boundary_faces(st), faces0)
+            live = _edge_values(st)
+            for key, (w, ph) in boundary_vals.items():
+                self.assertIn(key, live)
+                self.assertEqual(live[key][0], w)   # exact: never written
+                self.assertEqual(live[key][1], ph)
+
+        for step in range(3):
+            self.assertTrue(es.growInterior(step))
+            assert_boundary_fixed()
+            # An interior fill (random interior weights/phases) touches nothing
+            # on ∂W.
+            m = es.numInteriorEdges()
+            rng = np.random.default_rng(step)
+            es.setInteriorWeights(rng.uniform(0.2, 4.0, size=m).tolist())
+            es.setInteriorPhases(rng.uniform(-2.0, 2.0, size=m).tolist())
+            assert_boundary_fixed()
+
+
+class ReachableInteriorFillTest(unittest.TestCase):
+    """A reachable target eigenvector is matched (r < 1e-10) by the interior
+    fill, with the boundary held fixed."""
+
+    def test_constant_zero_mode_is_matched(self):
+        # Boundary edges pinned at phase 0 -> the constant vector is the zero
+        # mode of L = D - A for any positive interior weights with phase 0, so
+        # it is reachable by an interior fill.
+        st = _solid_triangle()
+        es = cob.EigenstateSynthesis(st)
+        es.setWeights([1.0] * es.numEdges())
+        es.setPhases([0.0] * es.numEdges())
+        es.growInterior(0)
+        es.growInterior(1)
+
+        n = es.order()
+        target = np.ones(n) / math.sqrt(n)
+        # Break it with a random interior config, then fill.
+        m = es.numInteriorEdges()
+        rng = np.random.default_rng(5)
+        es.setInteriorWeights(rng.uniform(0.5, 3.0, size=m).tolist())
+        es.setInteriorPhases(rng.uniform(-1.0, 1.0, size=m).tolist())
+        self.assertGreater(es.residual(_cvec(target)), 1e-2)
+
+        best_r = _interior_search(es, target, n_restarts=30, seed=1)
+        self.assertLess(best_r, 1e-10)
+        # The C++ residual at the realized config matches the numpy oracle, and
+        # the matched state is genuinely an eigenvector (L psi parallel to psi).
+        self.assertAlmostEqual(es.residual(_cvec(target)),
+                               _np_residual(_np_L(st), target), places=12)
+        Lp = np.asarray(es.apply(_cvec(target)))
+        self.assertAlmostEqual(abs(np.vdot(target, Lp)),
+                               np.linalg.norm(Lp), places=6)
+
+    def test_reconstructed_eigenvector_is_matched(self):
+        # Grow a richer interior, pin a generic Hermitian boundary, realize a
+        # config, and read off a genuine eigenvector of the resulting fixed-
+        # boundary Laplacian. It is reachable by construction; the interior fill
+        # recovers it from a fresh random start.
+        st = _solid_triangle()
+        es = cob.EigenstateSynthesis(st)
+        es.setWeights([1.0] * es.numEdges())
+        es.setPhases([0.0] * es.numEdges())
+        es.growInterior(0)
+        es.growInterior(1)
+
+        em = _edge_map(st)
+        for k, key in enumerate(es.boundaryEdges()):
+            em[key].setSquaredLength(0.7 + 0.2 * k)
+            em[key].setPhase(0.1 * (k + 1))
+
+        n, m = es.order(), es.numInteriorEdges()
+        rng = np.random.default_rng(9)
+        es.setInteriorWeights(rng.uniform(0.5, 2.0, size=m).tolist())
+        es.setInteriorPhases(rng.uniform(-1.0, 1.0, size=m).tolist())
+        L = _np_L(st)
+        evals, evecs = np.linalg.eigh(L)
+        vstar = evecs[:, n // 2]
+        # Reachable: it is exactly an eigenvector of the realized L.
+        self.assertLess(es.residual(_cvec(vstar)), 1e-18)
+
+        # Perturb the interior away, then fill back to match it.
+        es.setInteriorWeights(rng.uniform(0.5, 2.0, size=m).tolist())
+        es.setInteriorPhases(rng.uniform(-1.0, 1.0, size=m).tolist())
+        self.assertGreater(es.residual(_cvec(vstar)), 1e-6)
+
+        best_r = _interior_search(es, vstar, n_restarts=60, seed=0)
+        self.assertLess(best_r, 1e-10)
+
+
+class UnreachableFloorTest(unittest.TestCase):
+    """A target the fixed-boundary interior cannot realize floors at a positive
+    residual — the spectral obstruction, the analogue of §4b's two-vertex
+    floor — verified against an independent numpy global-min oracle."""
+
+    def test_generic_target_floors_above_zero(self):
+        st = _bipyramid()  # one interior edge (0,1); four boundary edges fixed
+        es = cob.EigenstateSynthesis(st)
+        em = _edge_map(st)
+        for key in es.boundaryEdges():
+            em[key].setSquaredLength(1.0)
+            em[key].setPhase(0.0)
+        em[(0, 1)].setSquaredLength(1.0)
+        em[(0, 1)].setPhase(0.0)
+
+        # A generic, fully-specified target; not realizable by any single
+        # interior (w, theta) against the pinned boundary.
+        target = np.array([1.0, 2.0, 3.0, 4.0], dtype=complex)
+        target /= np.linalg.norm(target)
+
+        w_bounds = (0.1, 10.0)
+        best_r = _interior_search(es, target, n_restarts=30, seed=0,
+                                  w_bounds=w_bounds)
+
+        # Oracle: the true min over the single interior edge (grid + refine).
+        from scipy.optimize import minimize
+        edge01 = em[(0, 1)]
+
+        def oracle(x):
+            edge01.setSquaredLength(x[0])
+            edge01.setPhase(x[1])
+            return _np_residual(_np_L(st), target)
+
+        grid = np.inf
+        gx = None
+        for w in np.linspace(w_bounds[0], w_bounds[1], 60):
+            for th in np.linspace(-math.pi, math.pi, 60):
+                val = oracle([w, th])
+                if val < grid:
+                    grid, gx = val, [w, th]
+        ref = minimize(oracle, gx, method="L-BFGS-B",
+                       bounds=[w_bounds, (-2 * math.pi, 2 * math.pi)])
+        oracle_floor = float(ref.fun)
+
+        # Floors bounded away from zero, and the C++ search reaches that floor.
+        self.assertGreater(oracle_floor, 1e-2)
+        self.assertGreater(best_r, 1e-2)
+        self.assertAlmostEqual(best_r, oracle_floor, delta=2e-3)
+
+
+class ConeAndRetryTest(unittest.TestCase):
+    """The §4b cone-and-retry restricted to the interior: a target unreachable at
+    base complexity is matched after interior growth, and the loop reports the
+    minimal interior complexity reached (or the floor if it cannot converge)."""
+
+    def test_reachable_after_interior_growth_reports_complexity(self):
+        st = _solid_triangle()
+        es = cob.EigenstateSynthesis(st)
+        es.setWeights([1.0] * es.numEdges())   # boundary pinned (phase 0)
+        es.setPhases([0.0] * es.numEdges())
+        boundary_vals = {key: (e.getSquaredLength(), e.getPhase())
+                         for key, e in _edge_map(st).items()
+                         if key in set(es.boundaryEdges())}
+
+        # A generic target on the three boundary vertices; the auxiliary apex
+        # amplitudes added by growth are free.
+        target_support = [1.0 + 0.0j, 0.3 + 0.5j, -0.8 + 0.2j]
+
+        # Base complex has no interior freedom -> unreachable.
+        self.assertEqual(es.numInteriorEdges(), 0)
+        self.assertGreater(es.residual(_cvec(target_support)), 1e-2)
+
+        best_r, complexity = _fill_interior(
+            es, target_support, n_restarts=40, seed=0, max_cones=4)
+
+        # Matched after interior fill, at a small reported interior complexity.
+        self.assertLess(best_r, 1e-10)
+        self.assertGreaterEqual(complexity, 1)
+        self.assertEqual(complexity, es.interiorVertexCount())
+
+        # ∂W untouched throughout the whole cone-and-retry.
+        live = _edge_values(st)
+        for key, (w, ph) in boundary_vals.items():
+            self.assertEqual(live[key], (w, ph))
+
+    def test_loop_returns_floor_when_it_cannot_converge(self):
+        # Same generic, fully-specified target as the floor test, with no growth
+        # budget: the loop returns the positive residual floor (the obstruction
+        # signal #138 consumes), not a spurious zero.
+        st = _bipyramid()
+        es = cob.EigenstateSynthesis(st)
+        em = _edge_map(st)
+        for key in es.boundaryEdges():
+            em[key].setSquaredLength(1.0)
+            em[key].setPhase(0.0)
+        target = [1.0, 2.0, 3.0, 4.0]
+
+        best_r, complexity = _fill_interior(
+            es, target, n_restarts=30, seed=0, max_cones=0)
+        self.assertGreater(best_r, 1e-2)   # floored, not matched
+        self.assertEqual(complexity, es.interiorVertexCount())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extends `cobordism::EigenstateSynthesis` (#133) with a **fixed-boundary mode** for §5.0 bulk synthesis: the realizability oracle (#138) fills the *interior* of a bulk `W_AB` whose boundary is pinned, matching a target output eigenstate.

## What's added (C++ `EigenstateSynthesis`, namespaced `tessera::cobordism`)

- **Interior/boundary partition.** The tunable edges split into the boundary set `∂W` (edges on a codim-1 face belonging to exactly one top cell — held fixed) and the interior set (free). Classification reads top cells as the `d+1`-vertex simplices, so it agrees with the Spacetime's own top-simplex bookkeeping and with `Cobordism::boundaryFaces`.
- **Interior-only parameter access.** `interiorWeights()` / `interiorPhases()` + `setInteriorWeights()` / `setInteriorPhases()` drive only the interior edges, so a search drives `r = ‖(I−ψψ†)Lψ‖² → 0` for a target while `∂W` stays byte-identical. `boundaryEdges()` / `interiorEdges()` expose the partition; `numInteriorEdges()` / `numBoundaryEdges()` / `interiorVertexCount()` report the interior complexity.
- **Interior growth.** `growInterior(seed)` cones a fresh interior vertex into a top cell by **reusing the boundary-fixed pre-geometric Pachner add (#112)** — a topology-preserving `1→(d+1)` stellar subdivision that leaves `∂W` exactly fixed — then re-captures the vertex order, operator, and partition (the §4b cone-and-retry restricted to the interior). On a 1-complex (no codim-1 structure) every edge is interior and growth is a no-op.

Bindings localized in `src/cobordism/Bindings.cpp`; no time-dating; `poetry.lock` left untracked.

## Results (`tests/cobordism/test_bulk_eigenstate_synthesis_python.py`, 11 tests)

- **Reachable matched (r < 1e-10) after interior fill** — the constant zero-mode (boundary phases 0), and a generic eigenvector reconstructed from a realized fixed-boundary Laplacian (≈6e-13).
- **Unreachable floors at a positive residual** — a generic target the interior cannot realize floors at ≈0.024, matching an independent numpy global-min oracle (the obstruction signal, the analogue of §4b's two-vertex floor).
- **∂ provably untouched throughout** — the boundary face/edge set AND the fixed boundary edge weights/phases are byte-identical across an interior-fill + growth sweep; the class's `∂W` agrees with `Cobordism.boundaryFaces`.
- **Cone-and-retry** — a target unreachable at base complexity (r≈0.97) is matched after one interior cone (r≈3e-12); the loop reports the minimal interior complexity reached, or the floor if it cannot converge.

Full suite green: `pytest tests/cobordism` → 249 passed, 1 skipped; pre-geometric Pachner suite unaffected (15 passed).

Closes #147.
