### PR TITLE
tests: DijkgraafWitten + homology hardening

### DIFF
--- a/tests/cobordism/test_dijkgraaf_witten_hardening_python.py
+++ b/tests/cobordism/test_dijkgraaf_witten_hardening_python.py
@@ -1,0 +1,395 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Dijkgraaf–Witten ℤ₂ state-sum hardening (#153).
+
+A property-test pass over the closed (#108) and bounded (#109) Dijkgraaf–Witten
+state sums, layering an independent numpy oracle and a few structural identities
+on top of the capability tests in ``test_dijkgraaf_witten*`` and
+``test_rp3_fixture``. Acceptance, in dependency order:
+
+1. **3-cocycle (pentagon) identity, both classes.** ω must be a genuine
+   3-cocycle or the state sum is not gauge-invariant. ``isCocycle`` is checked
+   against a numpy pentagon oracle that has teeth (a deliberately non-cocycle
+   cochain must fail it).
+
+2. **Convention anchor.** ``Z_Trivial(W) = 2^{b₁(W;ℤ₂) − 1}`` for a connected
+   closed oriented 3-manifold, swept across S³, S²×S¹, and RP³ with b₁ read from
+   the chain complex.
+
+3. **The Sign twist.** ``Z_Sign`` differs from ``Z_Trivial`` iff the mod-2 cup
+   cube is nonzero on W. The positive control is RP³ (Z_Sign = 0 ≠ 1); the
+   negatives are S³ and S²×S¹ (Z_Sign = Z_Trivial). T³ is the third negative,
+   but its flat space (dim Z¹ = 29) overflows the brute-force closed sum
+   (gf2Span refuses a nullity > 24), so — as the existing tests do — it is
+   distinguished from RP³ by its torsion-free H₁ (RP³ carries the 2-torsion that
+   supports t³ ≠ 0; T³ does not). The closed-sum guard is asserted to fire.
+
+4. **Independent numpy state-sum oracle.** ``Z(W)`` is recomputed from the chain
+   complex through a separate numpy path (GF(2) nullspace of ∂₂ᵀ, the flat
+   span, the ω product, the gauge volume) and matched against the C++ value for
+   both cocycles on S³, S²×S¹, and RP³.
+
+5. **Boundary map.** The cylinder Σ×[0,T] is the identity on Z(Σ), and its
+   categorical trace closes it to the mapping torus Σ×S¹, so
+   ``Tr(map(Σ×I)) = Z(Σ×S¹)``: checked numerically on S² (closed sum
+   computable) and against the convention formula on T² (T³ closed sum too
+   large).
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+
+import tessera
+
+cobordism = tessera.cobordism
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures.
+# --------------------------------------------------------------------------- #
+def _build(topology):
+    signature = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()
+    return spacetime
+
+
+def _circle():
+    return tessera.SimplexBoundarySphere(1)            # S¹ = ∂Δ²
+
+
+def _interval():
+    return tessera.SolidSimplex(1)                     # [0, 1]
+
+
+def _three_sphere():
+    return _build(tessera.SimplexBoundarySphere(3))    # S³, b₁=0
+
+
+def _s2_cross_s1():
+    # S²×S¹ via the simplicial product (dim Z¹ = 12 ≤ 24, so brute-forceable).
+    return _build(tessera.SimplicialProduct(tessera.SimplexBoundarySphere(2),
+                                            _circle()))
+
+
+def _rp3():
+    return _build(tessera.RealProjectiveSpace())       # RP³, t³ ≠ 0
+
+
+def _three_torus_topology():
+    # T³ = S¹×S¹×S¹; dim Z¹ = 29, too large for the closed brute-force sum.
+    return tessera.SimplicialProduct(
+        tessera.SimplicialProduct(_circle(), _circle()), _circle())
+
+
+def _sphere_cylinder():
+    # S²×[0,T]: trivial cobordism S² → S² (Z(S²) is one-dimensional).
+    return _build(tessera.SimplicialProduct(tessera.SimplexBoundarySphere(2),
+                                            _interval()))
+
+
+def _torus_cylinder():
+    # T²×[0,T]: trivial cobordism T² → T² (Z(T²) is four-dimensional).
+    torus = tessera.SimplicialProduct(_circle(), _circle())
+    return _build(tessera.SimplicialProduct(torus, _interval()))
+
+
+def _chain(spacetime):
+    return cobordism.ChainComplex.fromSpacetime(spacetime)
+
+
+def _first_betti_gf2(spacetime):
+    return _chain(spacetime).bettiNumbersGF2()[1]
+
+
+# --------------------------------------------------------------------------- #
+# Independent numpy reimplementation (oracle for the C++ state sum).
+# --------------------------------------------------------------------------- #
+def _gf2_nullspace(matrix):
+    """Basis of {x : matrix·x ≡ 0 (mod 2)} as rows, via RREF (pure numpy)."""
+    a = (np.asarray(matrix, dtype=np.int64) & 1).copy()
+    rows, cols = a.shape
+    pivots, r = [], 0
+    for col in range(cols):
+        if r >= rows:
+            break
+        piv = next((i for i in range(r, rows) if a[i, col] & 1), None)
+        if piv is None:
+            continue
+        a[[r, piv]] = a[[piv, r]]
+        for i in range(rows):
+            if i != r and (a[i, col] & 1):
+                a[i] ^= a[r]
+        pivots.append(col)
+        r += 1
+    is_pivot = [False] * cols
+    for c in pivots:
+        is_pivot[c] = True
+    basis = []
+    for free in range(cols):
+        if is_pivot[free]:
+            continue
+        x = np.zeros(cols, dtype=np.int64)
+        x[free] = 1
+        for t, pc in enumerate(pivots):
+            x[pc] = a[t, free] & 1
+        basis.append(x)
+    return basis
+
+
+def _omega(kind, a, b, c):
+    """ω(a,b,c) for a cochain ``kind`` ∈ {trivial, sign, broken}."""
+    if kind == "trivial":
+        return 1
+    if kind == "sign":               # the nontrivial generator (-1)^{abc}
+        return -1 if (a & b & c) else 1
+    if kind == "broken":             # NOT a 3-cocycle — gives the oracle teeth
+        return -1 if (a & b) else 1
+    raise ValueError(kind)
+
+
+def _satisfies_pentagon(kind):
+    """Normalized 3-cocycle (pentagon) identity over ℤ₂, brute-forced over ℤ₂⁴."""
+    for a, b, c, d in itertools.product((0, 1), repeat=4):
+        left = _omega(kind, b, c, d) * _omega(kind, a, b ^ c, d) * _omega(kind, a, b, c)
+        right = _omega(kind, a ^ b, c, d) * _omega(kind, a, b, c ^ d)
+        if left != right:
+            return False
+    return True
+
+
+def _dw_partition_oracle(spacetime, kind):
+    """Recompute Z(W) independently from the chain complex (numpy GF(2))."""
+    chain = _chain(spacetime)
+    num_vertices = chain.numSimplices(0)
+    num_edges = chain.numSimplices(1)
+    num_triangles = chain.numSimplices(2)
+
+    boundary2 = (np.asarray(chain.boundaryMatrix(2), dtype=np.int64)
+                 .reshape(num_edges, num_triangles)) & 1   # edges × triangles
+    coboundary1 = boundary2.T                              # triangles × edges
+    basis = _gf2_nullspace(coboundary1)
+
+    edges = [tuple(e) for e in chain.kSimplexVertices(1)]
+    edge_index = {e: i for i, e in enumerate(edges)}
+    tets = [tuple(t) for t in chain.orientedTopSimplices()]
+
+    total = 0.0
+    k = len(basis)
+    for mask in range(1 << k):
+        g = np.zeros(num_edges, dtype=np.int64)
+        for b in range(k):
+            if (mask >> b) & 1:
+                g ^= basis[b]
+        weight = 1
+        for tet in tets:
+            g01 = int(g[edge_index[(tet[0], tet[1])]])
+            g12 = int(g[edge_index[(tet[1], tet[2])]])
+            g23 = int(g[edge_index[(tet[2], tet[3])]])
+            # value**ε_t is a no-op for the real ±1 values of these cocycles.
+            weight *= _omega(kind, g01, g12, g23)
+        total += weight
+    return total / (2.0 ** num_vertices)
+
+
+# --------------------------------------------------------------------------- #
+# 1. 3-cocycle (pentagon) identity — both classes.
+# --------------------------------------------------------------------------- #
+class TestThreeCocycleIdentity(unittest.TestCase):
+
+    def test_numpy_pentagon_oracle_has_teeth(self):
+        # The oracle accepts the two genuine cocycles and rejects a non-cocycle,
+        # so the C++ cross-check below is not vacuous.
+        self.assertTrue(_satisfies_pentagon("trivial"))
+        self.assertTrue(_satisfies_pentagon("sign"))
+        self.assertFalse(_satisfies_pentagon("broken"))
+
+    def test_cpp_iscocycle_matches_oracle(self):
+        self.assertEqual(DijkgraafWitten.isCocycle(Cocycle.Trivial),
+                         _satisfies_pentagon("trivial"))
+        self.assertEqual(DijkgraafWitten.isCocycle(Cocycle.Sign),
+                         _satisfies_pentagon("sign"))
+        self.assertTrue(DijkgraafWitten.isCocycle(Cocycle.Trivial))
+        self.assertTrue(DijkgraafWitten.isCocycle(Cocycle.Sign))
+
+
+# --------------------------------------------------------------------------- #
+# 2. Convention anchor: Z_Trivial(W) = 2^{b₁(W;ℤ₂) − 1} across all small closed
+#    fixtures (S³, S²×S¹, RP³).
+# --------------------------------------------------------------------------- #
+class TestTrivialConventionAnchor(unittest.TestCase):
+
+    CASES = (("S^3", _three_sphere, 0, 0.5),
+             ("S^2xS^1", _s2_cross_s1, 1, 1.0),
+             ("RP^3", _rp3, 1, 1.0))
+
+    def test_trivial_partition_function_matches_formula(self):
+        for name, factory, expected_b1, expected_z in self.CASES:
+            with self.subTest(manifold=name):
+                spacetime = factory()
+                b1 = _first_betti_gf2(spacetime)
+                self.assertEqual(b1, expected_b1)
+                z = DijkgraafWitten(spacetime, Cocycle.Trivial).partitionFunction()
+                self.assertAlmostEqual(z.imag, 0.0, places=9)
+                self.assertAlmostEqual(z.real, 2.0 ** (b1 - 1), places=9)
+                self.assertAlmostEqual(z.real, expected_z, places=9)
+
+
+# --------------------------------------------------------------------------- #
+# 3. The Sign twist distinguishes RP³ and not the negatives (T³, S²×S¹, S³).
+# --------------------------------------------------------------------------- #
+class TestSignCocycleDistinction(unittest.TestCase):
+
+    @staticmethod
+    def _z(spacetime, cocycle):
+        return DijkgraafWitten(spacetime, cocycle).partitionFunction()
+
+    def test_sign_distinguishes_rp3(self):
+        # Positive control: t³ ≠ 0 on RP³ ⇒ Z_Sign = 0 ≠ 1 = Z_Trivial.
+        spacetime = _rp3()
+        z_trivial = self._z(spacetime, Cocycle.Trivial)
+        z_sign = self._z(spacetime, Cocycle.Sign)
+        self.assertAlmostEqual(z_trivial.real, 1.0, places=9)
+        self.assertAlmostEqual(z_sign.real, 0.0, places=9)
+        self.assertGreater(abs(z_trivial - z_sign), 0.5)
+
+    def test_sign_does_not_distinguish_s3_or_s2s1(self):
+        # Negatives with a computable closed sum: the cup cube vanishes, so the
+        # Sign twist agrees with the trivial value.
+        for name, factory in (("S^3", _three_sphere), ("S^2xS^1", _s2_cross_s1)):
+            with self.subTest(manifold=name):
+                spacetime = factory()
+                z_trivial = self._z(spacetime, Cocycle.Trivial)
+                z_sign = self._z(spacetime, Cocycle.Sign)
+                self.assertAlmostEqual(abs(z_trivial - z_sign), 0.0, places=9)
+
+    def test_three_torus_negative_control_via_torsion(self):
+        # T³'s flat space is too large for the brute-force closed sum, so it is
+        # separated from the RP³ positive control by its torsion-free H₁: RP³
+        # carries the 2-torsion (Bockstein) that supports a nonzero cup cube,
+        # T³ (like S²×S¹) does not.
+        t3 = _chain(_build(_three_torus_topology()))
+        self.assertEqual(t3.torsion(1), [])               # H₁(T³) = ℤ³, no torsion
+        self.assertEqual(t3.torsion(2), [])
+        self.assertEqual(_chain(_rp3()).torsion(1), [2])  # H₁(RP³) = ℤ₂
+        self.assertEqual(_chain(_s2_cross_s1()).torsion(1), [])
+
+    def test_three_torus_closed_sum_guard_fires(self):
+        # dim Z¹ = b₁(ℤ₂) + |V| − b₀(ℤ₂) = 3 + 27 − 1 = 29 > 24, so gf2Span
+        # refuses to materialize the flat space — the reason T³ uses the torsion
+        # proxy above rather than a direct Z_Sign computation.
+        t3 = _chain(_build(_three_torus_topology()))
+        betti_gf2 = t3.bettiNumbersGF2()
+        dim_z1 = betti_gf2[1] + t3.numSimplices(0) - betti_gf2[0]
+        self.assertEqual(t3.numSimplices(0), 27)
+        self.assertEqual(dim_z1, 29)
+        self.assertGreater(dim_z1, 24)
+        with self.assertRaises((ValueError, RuntimeError)):
+            DijkgraafWitten(_build(_three_torus_topology()),
+                            Cocycle.Sign).partitionFunction()
+
+
+# --------------------------------------------------------------------------- #
+# 4. Independent numpy state-sum oracle for the closed partition function.
+# --------------------------------------------------------------------------- #
+class TestPartitionFunctionAgainstOracle(unittest.TestCase):
+
+    def _check(self, spacetime):
+        for cocycle, kind in ((Cocycle.Trivial, "trivial"), (Cocycle.Sign, "sign")):
+            with self.subTest(cocycle=kind):
+                z = DijkgraafWitten(spacetime, cocycle).partitionFunction()
+                self.assertAlmostEqual(z.imag, 0.0, places=9)
+                self.assertAlmostEqual(z.real, _dw_partition_oracle(spacetime, kind),
+                                       places=9)
+
+    def test_three_sphere(self):
+        self._check(_three_sphere())
+
+    def test_s2_cross_s1(self):
+        self._check(_s2_cross_s1())
+
+    def test_rp3(self):
+        # RP³ is the discriminating case the existing oracle test omits.
+        self._check(_rp3())
+
+
+# --------------------------------------------------------------------------- #
+# 5. Boundary map: cylinder = identity, and Tr(map) = Z(mapping torus).
+# --------------------------------------------------------------------------- #
+class TestCylinderIsIdentity(unittest.TestCase):
+
+    def test_sphere_cylinder_is_identity(self):
+        for cocycle in (Cocycle.Trivial, Cocycle.Sign):
+            with self.subTest(cocycle=cocycle):
+                matrix = np.asarray(DijkgraafWitten(_sphere_cylinder(), cocycle).map())
+                self.assertEqual(matrix.shape, (1, 1))     # Z(S²) is 1-dimensional
+                np.testing.assert_allclose(matrix, np.eye(1), atol=1e-9)
+
+    def test_torus_cylinder_is_identity(self):
+        for cocycle in (Cocycle.Trivial, Cocycle.Sign):
+            with self.subTest(cocycle=cocycle):
+                matrix = np.asarray(DijkgraafWitten(_torus_cylinder(), cocycle).map())
+                self.assertEqual(matrix.shape, (4, 4))     # 2^{b₁(T²)} = 4
+                np.testing.assert_allclose(matrix, np.eye(4), atol=1e-9)
+
+
+class TestTraceEqualsClosedPartitionFunction(unittest.TestCase):
+    """Closing the cylinder Σ×[0,T] by identifying its two ends is the mapping
+    torus Σ×S¹; the categorical trace of the boundary map realizes that gluing,
+    so Tr(map(Σ×I)) = Z(Σ×S¹). For the identity map the trace is dim Z(Σ) =
+    2^{b₁(Σ)}, matching Z(Σ×S¹) = 2^{b₁(Σ×S¹;ℤ₂) − 1} = 2^{b₁(Σ)}."""
+
+    @staticmethod
+    def _trace(matrix):
+        m = np.asarray(matrix)
+        return complex(np.trace(m))
+
+    def test_sphere_trace_equals_three_manifold_partition_function(self):
+        # Σ = S²: both sides computable. Tr(map(S²×I)) = Z(S²×S¹) = 1.
+        for cocycle in (Cocycle.Trivial, Cocycle.Sign):
+            with self.subTest(cocycle=cocycle):
+                trace = self._trace(DijkgraafWitten(_sphere_cylinder(), cocycle).map())
+                z_closed = DijkgraafWitten(_s2_cross_s1(), cocycle).partitionFunction()
+                self.assertAlmostEqual(trace.imag, 0.0, places=9)
+                self.assertAlmostEqual(trace.real, 1.0, places=9)
+                self.assertAlmostEqual(trace.real, z_closed.real, places=9)
+
+    def test_torus_trace_matches_three_torus_formula(self):
+        # Σ = T²: Tr(map(T²×I)) = 2^{b₁(T²)} = 4. The closed sum Z(T³) overflows
+        # the brute-force enumeration, so it is cross-checked against the
+        # convention value 2^{b₁(T³;ℤ₂) − 1}, with b₁ read from the T³ complex.
+        trace = self._trace(DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial).map())
+        b1_t3 = _first_betti_gf2(_build(_three_torus_topology()))
+        self.assertEqual(b1_t3, 3)
+        self.assertAlmostEqual(trace.imag, 0.0, places=9)
+        self.assertAlmostEqual(trace.real, 4.0, places=9)
+        self.assertAlmostEqual(trace.real, 2.0 ** (b1_t3 - 1), places=9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_homology_hardening_python.py
+++ b/tests/cobordism/test_homology_hardening_python.py
@@ -1,0 +1,435 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""ChainComplex + IntegerLinalg homology hardening (#153).
+
+A single comprehensive sweep of the simplicial homology (#64) over **every**
+cobordism topology fixture, plus property tests for the exact linear-algebra
+primitives (#106) against independent numpy / number-theoretic oracles.
+
+* **Homology sweep.** For each fixture the chain complex must reproduce its
+  known Betti numbers over ℚ and GF(2), its torsion coefficients at every
+  degree, its Euler characteristic (matching both the face-count χ and the
+  alternating Betti sum), the chain-complex axiom ∂²=0, and — for the closed
+  oriented manifolds — a fundamental class of ±1 signs whose signed top chain is
+  a cycle. The non-closed / non-orientable fixtures (balls, RP²) must instead
+  *raise* when a fundamental class is requested.
+
+* **orientedTopSimplices consistency.** The top-simplex list lines up with the
+  d-th column basis kSimplexVertices(d), the boundary-matrix column count, the
+  fundamental-class length, and the manifold's actual top simplices.
+
+* **GF(2) primitives.** gf2Rank / gf2Nullspace match a numpy GF(2) oracle on
+  random binary matrices, and — applied to the fixtures' boundary matrices —
+  reconstruct bettiNumbersGF2 from the GF(2) rank–nullity identity.
+
+* **Smith normal form.** smith_normal_form matches an independent determinantal-
+  divisor oracle on random small integer matrices (rank, invariant factors,
+  transpose invariance, det = ∏ factors) and recovers the fixtures' torsion.
+"""
+
+import collections
+import itertools
+import unittest
+from math import gcd
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders.
+# --------------------------------------------------------------------------- #
+def _build(topology):
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, topology)
+    st.build()
+    return st
+
+
+def _chain(topology):
+    return cob.ChainComplex.fromSpacetime(_build(topology))
+
+
+def _torus2():
+    return tessera.SimplicialProduct(tessera.SimplexBoundarySphere(1),
+                                     tessera.SimplexBoundarySphere(1))
+
+
+def _torus3():
+    return tessera.SimplicialProduct(_torus2(), tessera.SimplexBoundarySphere(1))
+
+
+def _sphere_circle():
+    return tessera.SphereCircleProduct()                    # S²×S¹
+
+
+def _sphere_sphere():
+    return tessera.SimplicialProduct(tessera.SimplexBoundarySphere(2),
+                                     tessera.SimplexBoundarySphere(2))  # S²×S²
+
+
+def _stellar_t3():
+    return tessera.StellarSubdivision(_torus3())
+
+
+def _stellar_sphere_circle():
+    return tessera.StellarSubdivision(tessera.SphereCircleProduct())
+
+
+# (name, topology factory, Betti over ℚ, Betti over GF(2), {degree: torsion},
+#  Euler characteristic, is-closed-oriented). Torsion defaults to [] per degree.
+Fixture = collections.namedtuple(
+    "Fixture", "name make betti_q betti_gf2 torsion euler closed_oriented")
+
+FIXTURES = []
+for _n in range(1, 6):  # S^1 .. S^5
+    _b = [1] + [0] * (_n - 1) + [1]
+    FIXTURES.append(Fixture(f"S^{_n}", (lambda n=_n: tessera.SimplexBoundarySphere(n)),
+                            _b, _b, {}, 1 + (-1) ** _n, True))
+for _n in range(1, 5):  # D^1 .. D^4 (contractible balls, with boundary)
+    _b = [1] + [0] * _n
+    FIXTURES.append(Fixture(f"D^{_n}", (lambda n=_n: tessera.SolidSimplex(n)),
+                            _b, _b, {}, 1, False))
+FIXTURES += [
+    Fixture("RP^2", tessera.RealProjectivePlane, [1, 0, 0], [1, 1, 1], {1: [2]}, 1, False),
+    Fixture("CP^2", tessera.ComplexProjectivePlane,
+            [1, 0, 1, 0, 1], [1, 0, 1, 0, 1], {}, 3, True),
+    Fixture("RP^3", tessera.RealProjectiveSpace, [1, 0, 0, 1], [1, 1, 1, 1], {1: [2]}, 0, True),
+    Fixture("S^2xS^1", _sphere_circle, [1, 1, 1, 1], [1, 1, 1, 1], {}, 0, True),
+    Fixture("T^2", _torus2, [1, 2, 1], [1, 2, 1], {}, 0, True),
+    Fixture("T^3", _torus3, [1, 3, 3, 1], [1, 3, 3, 1], {}, 0, True),
+    Fixture("S^2xS^2", _sphere_sphere, [1, 0, 2, 0, 1], [1, 0, 2, 0, 1], {}, 4, True),
+    Fixture("stellar(T^3)", _stellar_t3, [1, 3, 3, 1], [1, 3, 3, 1], {}, 0, True),
+    Fixture("stellar(S^2xS^1)", _stellar_sphere_circle,
+            [1, 1, 1, 1], [1, 1, 1, 1], {}, 0, True),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Independent oracles.
+# --------------------------------------------------------------------------- #
+def _gf2_rank_np(matrix):
+    """GF(2) rank of a 0/1 matrix via Gaussian elimination (pure numpy)."""
+    a = (np.asarray(matrix, dtype=np.int64) & 1).copy()
+    if a.ndim == 1:
+        a = a.reshape(1, -1) if a.size else a.reshape(0, 0)
+    rows, cols = a.shape
+    rank = 0
+    for col in range(cols):
+        if rank >= rows:
+            break
+        piv = next((i for i in range(rank, rows) if a[i, col] & 1), None)
+        if piv is None:
+            continue
+        a[[rank, piv]] = a[[piv, rank]]
+        for i in range(rows):
+            if i != rank and (a[i, col] & 1):
+                a[i] ^= a[rank]
+        rank += 1
+    return rank
+
+
+def _determinantal_invariant_factors(matrix):
+    """Invariant factors of an integer matrix via determinantal divisors.
+
+    D_k = gcd of all k×k minors; the k-th invariant factor is D_k / D_{k-1}
+    (D_0 = 1), and the rank is the number of nonzero D_k. An exact, independent
+    construction of the Smith normal form for small matrices (the minors are
+    evaluated through numpy and rounded — kept exact by small entries/sizes).
+    """
+    m = np.asarray(matrix, dtype=np.int64)
+    rows, cols = m.shape
+    prev, factors = 1, []
+    for k in range(1, min(rows, cols) + 1):
+        divisor = 0
+        for ri in itertools.combinations(range(rows), k):
+            for ci in itertools.combinations(range(cols), k):
+                minor = int(round(np.linalg.det(m[np.ix_(ri, ci)].astype(float))))
+                divisor = gcd(divisor, abs(minor))
+        if divisor == 0:
+            break
+        factors.append(divisor // prev)
+        prev = divisor
+    return factors
+
+
+# --------------------------------------------------------------------------- #
+# 1. Homology across every topology fixture.
+# --------------------------------------------------------------------------- #
+class TestHomologySweep(unittest.TestCase):
+
+    def _signed_top_chain_boundary(self, chain, d, epsilon):
+        """Coefficients of ∂_d(Σ_t ε_t·t) over the (d-1)-simplices."""
+        flat = chain.boundaryMatrix(d)
+        cols = len(epsilon)
+        rows = len(flat) // cols if cols else 0
+        return [sum(flat[r * cols + c] * epsilon[c] for c in range(cols))
+                for r in range(rows)]
+
+    def test_all_fixtures(self):
+        for fx in FIXTURES:
+            with self.subTest(fixture=fx.name):
+                chain = _chain(fx.make())
+                dimension = chain.dimension()
+
+                # Betti over ℚ and GF(2).
+                self.assertEqual(chain.bettiNumbers(), fx.betti_q)
+                self.assertEqual(chain.bettiNumbersGF2(), fx.betti_gf2)
+
+                # Torsion at every degree.
+                for k in range(dimension + 1):
+                    self.assertEqual(list(chain.torsion(k)), fx.torsion.get(k, []),
+                                     f"{fx.name}: torsion({k})")
+
+                # Euler characteristic: face-count and homological agree.
+                self.assertEqual(chain.eulerCharacteristic(), fx.euler)
+                self.assertEqual(
+                    sum((-1) ** k * b for k, b in enumerate(chain.bettiNumbers())),
+                    fx.euler)
+
+                # Chain-complex axiom.
+                self.assertTrue(chain.boundaryComposesToZero())
+
+                # Fundamental class: a ±1 cycle exactly for the closed oriented
+                # fixtures (b_d = 1). The non-closed / non-orientable ones have
+                # trivial top homology (b_d ≠ 1); the contract for *requesting* a
+                # fundamental class there is exercised in TestFundamentalClassContract.
+                if fx.closed_oriented:
+                    self.assertEqual(chain.bettiNumbers()[dimension], 1)
+                    epsilon = list(chain.fundamentalClass())
+                    self.assertEqual(len(epsilon), chain.numSimplices(dimension))
+                    self.assertTrue(all(e in (-1, 1) for e in epsilon))
+                    self.assertEqual(next(e for e in epsilon if e != 0), 1)  # normalized
+                    self.assertTrue(
+                        all(c == 0 for c in
+                            self._signed_top_chain_boundary(chain, dimension, epsilon)))
+                else:
+                    self.assertNotEqual(chain.bettiNumbers()[dimension], 1)
+
+
+# --------------------------------------------------------------------------- #
+# 2. orientedTopSimplices consistency.
+# --------------------------------------------------------------------------- #
+class TestOrientedTopSimplices(unittest.TestCase):
+
+    @staticmethod
+    def _actual_top_tuples(spacetime):
+        tuples = [tuple(sorted(v.getId() for v in s.getVertices()))
+                  for s in spacetime.getSimplices()]
+        top_size = max(len(t) for t in tuples)
+        return {t for t in tuples if len(t) == top_size}
+
+    def test_consistency_on_closed_fixtures(self):
+        for fx in FIXTURES:
+            if not fx.closed_oriented:
+                continue
+            with self.subTest(fixture=fx.name):
+                spacetime = _build(fx.make())               # held alive locally
+                chain = cob.ChainComplex.fromSpacetime(spacetime)
+                dimension = chain.dimension()
+                tops = [tuple(t) for t in chain.orientedTopSimplices()]
+                column_basis = [tuple(t) for t in chain.kSimplexVertices(dimension)]
+
+                # Same length as the d-th cell count, the column basis, and ε.
+                self.assertEqual(len(tops), chain.numSimplices(dimension))
+                self.assertEqual(tops, column_basis)
+                self.assertEqual(len(tops), len(chain.fundamentalClass()))
+
+                # Each is a sorted, unique vertex-id tuple.
+                for t in tops:
+                    self.assertEqual(list(t), sorted(t))
+                self.assertEqual(len(set(tops)), len(tops))
+
+                # The boundary matrix ∂_d has exactly |tops| columns.
+                flat = chain.boundaryMatrix(dimension)
+                rows = chain.numSimplices(dimension - 1)
+                self.assertEqual(len(flat), rows * len(tops))
+
+                # They are the manifold's actual top simplices.
+                self.assertEqual(set(tops), self._actual_top_tuples(spacetime))
+
+
+# --------------------------------------------------------------------------- #
+# 2b. fundamentalClass() contract — documents a real production bug (#153).
+# --------------------------------------------------------------------------- #
+class TestFundamentalClassContract(unittest.TestCase):
+    """``ChainComplex.fundamentalClass()`` is contracted to *raise* when no
+    fundamental class exists — when ``dim ker ∂_d ≠ 1`` (the header's @throws,
+    and ChainComplex.cpp's own comment: "anything else has no fundamental class
+    … and the call throws"). It does not, for any complex whose top boundary
+    ``∂_d`` has full column rank (trivial kernel, ``b_d = 0``): every ball
+    ``Δⁿ`` and the non-orientable ``RP²``.
+
+    Root cause (ChainComplex.cpp ``fundamentalClass()``): Eigen's
+    ``FullPivLU::kernel()`` returns a single all-zero *column* — never a
+    zero-column matrix — when the kernel is 0-dimensional, so the guard
+    ``kernel.cols() != 1`` never fires; the method then returns an all-zero ε
+    vector (and divides by ``generator[firstNonzero]`` with
+    ``firstNonzero == generator.size()``, reading one past the end). A correct
+    guard would test the kernel column for nonzero / compare the rank, but #153
+    is test-only — no production change here.
+
+    The two contract checks are marked ``expectedFailure`` rather than rewritten
+    to accept the buggy output, so the assertion stays the *correct* contract and
+    flips to an unexpected pass the moment the guard is fixed. The closed
+    oriented case (``b_d = 1``, where the kernel genuinely has one column) is
+    correct and covered by the homology sweep above.
+    """
+
+    @unittest.expectedFailure
+    def test_ball_should_raise_without_fundamental_class(self):
+        # Δ³ is contractible (b_3 = 0): no fundamental class ⇒ must raise.
+        with self.assertRaises(RuntimeError):
+            _chain(tessera.SolidSimplex(3)).fundamentalClass()
+
+    @unittest.expectedFailure
+    def test_non_orientable_should_raise_without_fundamental_class(self):
+        # RP² is closed but non-orientable (b_2 = 0): must raise.
+        with self.assertRaises(RuntimeError):
+            _chain(tessera.RealProjectivePlane()).fundamentalClass()
+
+
+# --------------------------------------------------------------------------- #
+# 3. GF(2) primitives vs a numpy oracle + the homology rank–nullity identity.
+# --------------------------------------------------------------------------- #
+class TestGf2Primitives(unittest.TestCase):
+
+    def test_random_binary_matrices(self):
+        rng = np.random.default_rng(153)
+        shapes = [(1, 1), (2, 3), (3, 2), (4, 4), (5, 8), (8, 5), (6, 6), (7, 9)]
+        for rows, cols in shapes:
+            for trial in range(6):
+                with self.subTest(rows=rows, cols=cols, trial=trial):
+                    a = rng.integers(0, 2, size=(rows, cols))
+                    flat = [int(v) for v in a.reshape(-1)]
+                    rank = cob.gf2_rank(flat, rows, cols)
+                    basis = [list(v) for v in cob.gf2_nullspace(flat, rows, cols)]
+
+                    self.assertEqual(rank, _gf2_rank_np(a))
+                    self.assertEqual(rank + len(basis), cols)        # rank–nullity
+                    for x in basis:
+                        self.assertEqual(len(x), cols)
+                        self.assertTrue(set(x) <= {0, 1})
+                        self.assertTrue(np.all((a @ np.asarray(x)) % 2 == 0))
+                    if basis:                                        # independent
+                        self.assertEqual(_gf2_rank_np(basis), len(basis))
+
+    def test_betti_gf2_from_boundary_ranks(self):
+        # b_k(GF2) = |C_k| − rank₂ ∂_k − rank₂ ∂_{k+1}, with the boundary ranks
+        # taken from the C++ gf2_rank and cross-checked against the numpy oracle;
+        # the assembled vector must equal bettiNumbersGF2().
+        for fx in (Fixture("S^2", lambda: tessera.SimplexBoundarySphere(2),
+                           [1, 0, 1], [1, 0, 1], {}, 2, True),
+                   FIXTURES[next(i for i, f in enumerate(FIXTURES) if f.name == "RP^2")],
+                   FIXTURES[next(i for i, f in enumerate(FIXTURES) if f.name == "RP^3")],
+                   FIXTURES[next(i for i, f in enumerate(FIXTURES) if f.name == "T^2")]):
+            with self.subTest(fixture=fx.name):
+                chain = _chain(fx.make())
+                dimension = chain.dimension()
+
+                def gf2_boundary_rank(k):
+                    if k <= 0 or k > dimension:
+                        return 0
+                    rows = chain.numSimplices(k - 1)
+                    cols = chain.numSimplices(k)
+                    if rows == 0 or cols == 0:
+                        return 0
+                    flat = [int(v) & 1 for v in chain.boundaryMatrix(k)]
+                    cpp = cob.gf2_rank(flat, rows, cols)
+                    self.assertEqual(cpp, _gf2_rank_np(np.asarray(flat).reshape(rows, cols)))
+                    return cpp
+
+                betti = []
+                for k in range(dimension + 1):
+                    ck = chain.numSimplices(k)
+                    betti.append(ck - gf2_boundary_rank(k) - gf2_boundary_rank(k + 1))
+                self.assertEqual(betti, chain.bettiNumbersGF2())
+                self.assertEqual(betti, fx.betti_gf2)
+
+
+# --------------------------------------------------------------------------- #
+# 4. Smith normal form vs a determinantal-divisor oracle.
+# --------------------------------------------------------------------------- #
+class TestSmithNormalForm(unittest.TestCase):
+
+    def test_diagonal_anchors(self):
+        # SNF(diag(2,3)) = diag(1,6) (gcd then lcm); SNF(diag(2,4,8)) = diag(2,4,8).
+        snf = cob.smith_normal_form([2, 0, 0, 0, 3, 0, 0, 0, 0], 3, 3)
+        self.assertEqual(snf.rank, 2)
+        self.assertEqual(list(snf.invariant_factors), [1, 6])
+        snf = cob.smith_normal_form([2, 0, 0, 0, 4, 0, 0, 0, 8], 3, 3)
+        self.assertEqual(snf.rank, 3)
+        self.assertEqual(list(snf.invariant_factors), [2, 4, 8])
+
+    def test_random_integer_matrices_against_oracle(self):
+        rng = np.random.default_rng(64064)
+        shapes = [(2, 2), (3, 3), (4, 4), (2, 4), (4, 2), (3, 5), (4, 3)]
+        for rows, cols in shapes:
+            for trial in range(8):
+                with self.subTest(rows=rows, cols=cols, trial=trial):
+                    m = rng.integers(-2, 3, size=(rows, cols))
+                    flat = [int(v) for v in m.reshape(-1)]
+                    snf = cob.smith_normal_form(flat, rows, cols)
+                    factors = list(snf.invariant_factors)
+                    oracle = _determinantal_invariant_factors(m)
+
+                    self.assertEqual(snf.rank, len(oracle))
+                    self.assertEqual(factors, oracle)
+                    self.assertEqual(snf.rank, cob.integer_rank(flat, rows, cols))
+                    self.assertEqual(snf.rank, int(np.linalg.matrix_rank(m)))
+                    # Each invariant factor divides the next.
+                    for a, b in zip(factors, factors[1:]):
+                        self.assertEqual(b % a, 0)
+                    # Transpose has the same invariant factors.
+                    snf_t = cob.smith_normal_form(
+                        [int(v) for v in m.T.reshape(-1)], cols, rows)
+                    self.assertEqual(list(snf_t.invariant_factors), factors)
+                    # Square & full rank: ∏ factors = |det|.
+                    if rows == cols and snf.rank == rows:
+                        det = int(round(np.linalg.det(m.astype(float))))
+                        product = 1
+                        for f in factors:
+                            product *= f
+                        self.assertEqual(product, abs(det))
+
+    def test_torsion_recovered_from_boundary_snf(self):
+        # torsion(k) = the invariant factors > 1 of ∂_{k+1}: RP² and RP³ each
+        # have a single 2 (from ∂₂ and ∂₂ respectively).
+        for name, make in (("RP^2", tessera.RealProjectivePlane),
+                           ("RP^3", tessera.RealProjectiveSpace)):
+            with self.subTest(fixture=name):
+                chain = _chain(make())
+                rows = chain.numSimplices(1)        # |C_1|
+                cols = chain.numSimplices(2)        # |C_2|
+                snf = cob.smith_normal_form(list(chain.boundaryMatrix(2)), rows, cols)
+                nontrivial = [int(f) for f in snf.invariant_factors if f > 1]
+                self.assertEqual(nontrivial, [2])
+                self.assertEqual(list(chain.torsion(1)), [2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Test-only hardening of the topological layer (DijkgraafWitten + ChainComplex/IntegerLinalg), with numpy / number-theoretic oracles. No production changes.

## Added

`tests/cobordism/test_dijkgraaf_witten_hardening_python.py`
- 3-cocycle (pentagon) identity for both classes vs a numpy oracle that has teeth (a non-cocycle control must fail it).
- Convention anchor `Z_Trivial = 2^{b₁(ℤ₂)−1}` swept across S³, S²×S¹, RP³ (b₁ read from the chain complex).
- Sign twist distinguishes **RP³** (`Z_Sign=0≠1`) and not the negatives: S³, S²×S¹ checked directly; **T³** (dim Z¹=29) is too large for the brute-force closed sum, so it is separated from RP³ by its torsion-free H₁ and the `gf2Span` size guard is asserted to fire.
- Independent numpy state-sum oracle matched against the C++ `partitionFunction` on S³, S²×S¹, **and RP³** (the discriminating case the prior oracle test omitted).
- Boundary map: cylinder = identity (S²×I, T²×I; both cocycles) and `Tr(map(Σ×I)) = Z(Σ×S¹)` — checked numerically on S² (Z(S²×S¹)=1) and against the convention value on T² (Z(T³)=4 via b₁, the closed sum being too large).

`tests/cobordism/test_homology_hardening_python.py`
- One homology sweep over **every** topology fixture (S¹–S⁵, Δ¹–Δ⁴, RP², CP², RP³, S²×S¹, T², T³, S²×S², and two stellar subdivisions): Betti over ℚ and GF(2), torsion at every degree, Euler χ (face-count = alternating Betti sum), `∂²=0`, and the ±1 fundamental-class cycle for the closed oriented ones.
- `orientedTopSimplices` consistency: lines up with `kSimplexVertices(d)`, the `∂_d` column count, the fundamental-class length, and the manifold's actual top simplices.
- `gf2Rank`/`gf2Nullspace` vs a numpy GF(2) oracle on random binary matrices, plus reconstruction of `bettiNumbersGF2` from the GF(2) rank–nullity identity on the fixtures' boundary matrices.
- Smith normal form vs an independent determinantal-divisor oracle on random small integer matrices (rank, invariant factors, transpose invariance, det = ∏ factors), and recovery of the RP²/RP³ torsion from `SNF(∂₂)`.

## Counts

Full `tests/cobordism` suite: **259 passed, 1 skipped, 2 xfailed, 553 subtests passed**. The two new files contribute ~120 test cases/subtests (16-fixture homology sweep, 48 random-SNF trials, 48 random-GF(2) trials, the DW oracle/anchor/trace checks). The 1 skip is the pre-existing deferred lens-space test.

## Bug found (documented, assertion not weakened)

The fundamental-class sweep surfaced a real production bug in `ChainComplex::fundamentalClass()`:

- **Contract** (header `@throws`, and the `.cpp` comment "anything else has no fundamental class … and the call throws"): it must raise when `dim ker ∂_d ≠ 1`.
- **Actual**: for any complex whose top boundary `∂_d` has full column rank (trivial kernel, `b_d = 0` — every ball `Δⁿ` and the non-orientable `RP²`), it returns an all-zero ε vector instead of raising.
- **Root cause** (`ChainComplex.cpp` ~L243): Eigen's `FullPivLU::kernel()` returns a single all-zero *column* (never a zero-column matrix) when the kernel is 0-dimensional, so the `kernel.cols() != 1` guard never fires; the method then also divides by `generator[firstNonzero]` with `firstNonzero == generator.size()`, reading one past the end. A correct guard would test the returned kernel column for nonzero / compare the rank.
- Downstream, an oriented-but-`b_2>0` non-orientable 4-manifold would get a silently-zero intersection form / signature rather than an error; no such fixture exists to exercise it.

Per #153 (test-only, no production change) the contract checks are kept as the **correct** assertion (must raise) and marked `expectedFailure` (the two xfails above), so they flip to an unexpected pass the moment the kernel guard is fixed.

Closes #153.
