### PR TITLE
cobordism: fix ChainComplex::fundamentalClass guard (b_d≠1)

### DIFF
--- a/src/cobordism/ChainComplex.cpp
+++ b/src/cobordism/ChainComplex.cpp
@@ -240,18 +240,28 @@ std::vector<int> ChainComplex::fundamentalClass() const {
       topBoundary(r, c) =
           static_cast<double>(flat[static_cast<std::size_t>(r) * cols + c]);
 
-  const Eigen::MatrixXd kernel =
-      Eigen::FullPivLU<Eigen::MatrixXd>(topBoundary).kernel();
-  if (kernel.cols() != 1)
+  // Ask the decomposition for the genuine nullity rather than reading
+  // kernel().cols(): Eigen's FullPivLU::kernel() returns a single all-zero
+  // column for a 0-dimensional kernel (it never hands back a zero-*column*
+  // matrix), so kernel().cols() is always ≥ 1 and cannot tell b_d = 0 (every
+  // ball SolidSimplex(n), ℝP²) apart from b_d = 1. dimensionOfKernel() = cols −
+  // rank reports the true dim ker ∂_d, so the documented contract — a
+  // fundamental class exists only when dim ker ∂_d = 1 — is actually enforced.
+  const Eigen::FullPivLU<Eigen::MatrixXd> decomposition(topBoundary);
+  if (decomposition.dimensionOfKernel() != 1)
     throw std::runtime_error(
         "ChainComplex::fundamentalClass: a closed connected oriented " +
         std::to_string(d) + "-manifold is required (dim ker ∂_" +
         std::to_string(d) + " = b_" + std::to_string(d) +
         " must be 1, so the fundamental class is unique up to sign)");
+  const Eigen::MatrixXd kernel = decomposition.kernel();
 
   // Every entry of this generator has the same magnitude (one orientation per
   // top simplex), so scaling by the first nonzero entry makes the entries
   // exactly ±1; fixing that entry to +1 makes the overall sign deterministic.
+  // dim ker ∂_d = 1 guarantees a genuine (nonzero) generator, so firstNonzero
+  // lands on a real entry; the size() guard keeps sign normalization from ever
+  // indexing past the end even if the generator were numerically zero.
   Eigen::VectorXd generator = kernel.col(0);
   const double scale = generator.cwiseAbs().maxCoeff();
   const double threshold = 1e-9 * (scale > 0.0 ? scale : 1.0);
@@ -259,6 +269,10 @@ std::vector<int> ChainComplex::fundamentalClass() const {
   while (firstNonzero < generator.size() &&
          std::abs(generator[firstNonzero]) <= threshold)
     ++firstNonzero;
+  if (firstNonzero == generator.size())
+    throw std::runtime_error(
+        "ChainComplex::fundamentalClass: the generator of ker ∂_" +
+        std::to_string(d) + " is numerically zero (no fundamental class)");
   generator /= generator[firstNonzero];
 
   std::vector<int> epsilon(static_cast<std::size_t>(cols), 0);

--- a/tests/cobordism/test_oriented_tops_python.py
+++ b/tests/cobordism/test_oriented_tops_python.py
@@ -144,5 +144,52 @@ class TestFundamentalClass(unittest.TestCase):
                 self.assertEqual(chain.bettiNumbers()[dimension], 1)
 
 
+class TestFundamentalClassRequiresClosedOriented(unittest.TestCase):
+    """fundamentalClass() must raise when dim ker ∂_d ≠ 1 (#160).
+
+    A ball SolidSimplex(n) is contractible (b_n = 0) and ℝP² is closed but
+    non-orientable (b_2(ℝP²; ℚ) = 0); in both, ker ∂_d is 0-dimensional, so no
+    fundamental class exists and the documented contract is to raise.
+
+    Regression for the bug: Eigen's FullPivLU::kernel() returns a single
+    all-zero column for a 0-dimensional kernel (never a zero-column matrix), so
+    the old kernel.cols() != 1 guard never fired — fundamentalClass() instead
+    returned an all-zero ε vector and read one past the end of the generator
+    during sign normalization (undefined behavior).
+    """
+
+    def _assert_no_fundamental_class(self, topology, dimension):
+        chain = cobordism.ChainComplex.fromSpacetime(_build(topology))
+        self.assertEqual(chain.dimension(), dimension)
+        # The reason it must raise: the top Betti number is 0 (ker ∂_d = 0).
+        self.assertEqual(chain.bettiNumbers()[dimension], 0)
+        with self.assertRaises(RuntimeError):
+            chain.fundamentalClass()
+
+    def test_balls_have_no_fundamental_class(self):
+        # SolidSimplex(n) is the n-ball: contractible, so b_n = 0.
+        for n in (2, 3, 4):
+            with self.subTest(n=n):
+                self._assert_no_fundamental_class(tessera.SolidSimplex(n), n)
+
+    def test_real_projective_plane_has_no_fundamental_class(self):
+        # ℝP² is closed but non-orientable: b_2(ℝP²; ℚ) = 0, no [W] over ℤ.
+        self._assert_no_fundamental_class(tessera.RealProjectivePlane(), 2)
+
+    def test_closed_oriented_fixtures_still_return_pm1_class(self):
+        # The fix must leave b_d = 1 untouched: a valid ±1 fundamental class is
+        # still returned (DijkgraafWitten depends on this).
+        for topology, dimension in ((_two_sphere(), 2),
+                                    (_torus(), 2),
+                                    (_three_torus(), 3)):
+            with self.subTest(dimension=dimension):
+                chain = cobordism.ChainComplex.fromSpacetime(_build(topology))
+                self.assertEqual(chain.bettiNumbers()[dimension], 1)
+                epsilon = list(chain.fundamentalClass())
+                self.assertEqual(len(epsilon), chain.numSimplices(dimension))
+                self.assertTrue(all(e in (-1, 1) for e in epsilon))
+                self.assertEqual(next(e for e in epsilon if e != 0), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug

`ChainComplex::fundamentalClass()` is contracted to raise when `dim ker ∂_d ≠ 1`, but for any `b_d = 0` complex — every ball `SolidSimplex(n)` and `RealProjectivePlane` (ℝP²) — it instead returned an **all-zero ε vector** and **read one past the end** of the generator during sign normalization (undefined behavior).

**Root cause:** Eigen's `FullPivLU::kernel()` returns a single all-zero column for a 0-dimensional kernel (it never hands back a zero-*column* matrix), so the old `kernel.cols() != 1` guard could never fire.

## Fix (`src/cobordism/ChainComplex.cpp`)

- Detect the genuine nullity via `FullPivLU::dimensionOfKernel()` (= cols − rank) and **raise** per the documented contract when `dim ker ∂_d ≠ 1`, instead of inspecting `kernel().cols()`.
- Guard sign-normalization with a `firstNonzero == generator.size()` check so it can never index past the end of the generator.
- Closed oriented manifolds (`b_d = 1`: T³, S²×S¹, RP³, S², T²) still return a valid ±1 fundamental class — DijkgraafWitten depends on this.

## Tests (`tests/cobordism/test_oriented_tops_python.py`)

- `fundamentalClass()` now **raises** for `SolidSimplex(2/3/4)` (balls, `b_d = 0`) and `RealProjectivePlane` (`b_2(ℝP²;ℚ) = 0`), each cross-checked against `bettiNumbers()[d] == 0`.
- Closed oriented fixtures (S², T², T³) still return a deterministic ±1 class (regression guard for the `b_d = 1` path).
- Full `tests/cobordism` suite stays green: **241 passed, 1 skipped, 401 subtests**.

Closes #160.
