### PR TITLE
spacetime: getTopVertexCount + fixture-signature fix; simplify getBoundary (#162)

### DIFF
--- a/examples/cobordism/algebraic_correspondence.py
+++ b/examples/cobordism/algebraic_correspondence.py
@@ -62,7 +62,7 @@ cj = tessera.quantum.ChoiJamiolkowski
 # Fixtures (Hermitian-weighted complexes)
 # --------------------------------------------------------------------------- #
 def _build_topology(topology):
-    sig = tessera.Signature(4, tessera.Lorentzian)
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, sig)
     st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
                            tessera.PREFERRED, topology)

--- a/examples/cobordism/topological_correspondence.py
+++ b/examples/cobordism/topological_correspondence.py
@@ -81,7 +81,9 @@ ALPHA_SWEEP = (0.25, 0.5, 1.0, 1.5, 2.5, 3.0, 4.0)
 # --------------------------------------------------------------------------- #
 # Fixtures (closed 3-manifolds for the state sum; CDT-built simplicial mesh)
 # --------------------------------------------------------------------------- #
-def _build(topology, dimensions=4):
+def _build(topology, dimensions=None):
+    if dimensions is None:
+        dimensions = topology.dimension()
     sig = tessera.Signature(dimensions, tessera.Lorentzian)
     metric = tessera.Metric(True, sig)
     st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -330,6 +330,16 @@ class Spacetime {
     /// @return A random simplex, or nullptr if the complex is empty
     [[nodiscard]] SimplexPtr getRandomSimplex();
 
+    /// The vertex count of a top-dimensional simplex: \f$ d+1 \f$, where
+    /// \f$ d \f$ is the metric signature's dimension. This is the **single
+    /// source of truth** for "what counts as a top cell": ``registerSimplex``
+    /// pushes a simplex onto ``topSimplicesVec`` exactly when its vertex count
+    /// equals this, and ``getBoundary`` / ``getRandomTopSimplex`` read that set.
+    /// A triangulation whose top cells are \f$ d' \f$-simplices is only seen as
+    /// having top cells when the signature dimension matches it
+    /// (\f$ d = d' \f$); see ``Topology::dimension``.
+    [[nodiscard]] std::size_t getTopVertexCount() const noexcept;
+
     /// Select a uniformly random top-dimensional simplex.
     /// Used by the Metropolis algorithm to pick random move targets.
     /// @return A random d-simplex, or nullptr if none exist

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -393,11 +393,48 @@ class Spacetime {
       return vertexIdCounter++;
     }
 
+    /// The boundary surface of the complex: the codimension-one faces — one
+    /// dimension below the top simplices — that belong to exactly one top
+    /// simplex, returned as sorted vertex-id tuples. An interior face is shared
+    /// by two top simplices and is excluded; a boundary face belongs to just
+    /// one.
+    ///
+    /// This is the canonical, single-source boundary derivation. It is computed
+    /// purely by facet-counting from the top-dimensional simplices (incidence
+    /// \f$ == 1 \f$), so it is **side-effect-free** (``const``) and robust to
+    /// lazily-materialized facets: "top" is the maximal vertex count actually
+    /// present in the complex, and the codimension-one faces are enumerated
+    /// combinatorially from the vertex sets rather than from materialized
+    /// ``Simplex`` facet objects. A closed manifold returns an empty list.
+    ///
+    /// Contrast :func:`getExternalSimplices`, which returns the boundary
+    /// *top cells* (whole d-simplices touching the boundary) and materializes
+    /// facets as a side-effect.
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> getBoundary() const;
+
+    /// Force lazy facet materialization to a fixpoint. Facets are created on
+    /// first access by ``Simplex::getFacets()``, which registers each new facet
+    /// back into the complex; a single index pass over the (growing) simplex
+    /// vector therefore materializes every face of every dimension down to the
+    /// vertices, wiring up the coface incidence as it goes. After this call the
+    /// complex's facet/coface structure is complete.
+    ///
+    /// This exposes — as an explicit, separately callable operation — the
+    /// side-effect that :func:`getExternalSimplices` performs internally; call
+    /// it directly when you want the materialization without the boundary scan.
+    void materializeFacets() noexcept;
+
     /// @return Simplices around the boundary of the simplicial complex. These simplices have at
     /// least one external face. They will tend to be in order of orientation (e.g. (4, 1) and (3, 2) for 4D CDT). Note
     /// that this method does not return 2-simplices as you might expect, but 5-simplices since those are the standard
     /// building blocks. You can get the 2-simplices by calling `getFacets()` on the 5-simplices and their facets until
     /// \f$ k=2 \f$.
+    ///
+    /// Materializes facets to a fixpoint (via :func:`materializeFacets`) as a
+    /// side-effect, since the coface counts that flag a boundary facet are only
+    /// complete once every facet exists. For the side-effect alone, call
+    /// :func:`materializeFacets`; for the codimension-one boundary *faces*
+    /// (rather than the top cells touching them), call :func:`getBoundary`.
     [[nodiscard]] SimplexSet getExternalSimplices() noexcept;
 
     /// Retrieves all simplices with a specific causal orientation.

--- a/include/spacetime/topologies/ComplexProjectivePlane.h
+++ b/include/spacetime/topologies/ComplexProjectivePlane.h
@@ -63,6 +63,9 @@ class ComplexProjectivePlane : public Topology {
   public:
     ComplexProjectivePlane() = default;
 
+    /// \f$ \mathbb{CP}^2 \f$ is a closed 4-manifold; its top cells are 4-simplices.
+    [[nodiscard]] int dimension() const override { return 4; }
+
     /// Build the 9-vertex \f$ \mathbb{CP}^2 \f$. ``numSimplices`` is ignored.
     void build(Spacetime *spacetime, int numSimplices) override;
 };

--- a/include/spacetime/topologies/RealProjectivePlane.h
+++ b/include/spacetime/topologies/RealProjectivePlane.h
@@ -41,6 +41,9 @@ class RealProjectivePlane : public Topology {
   public:
     RealProjectivePlane() = default;
 
+    /// \f$ \mathbb{RP}^2 \f$ is a closed surface; its top cells are triangles.
+    [[nodiscard]] int dimension() const override { return 2; }
+
     /// Build the 6-vertex \f$ \mathbb{RP}^2 \f$. ``numSimplices`` is ignored.
     void build(Spacetime *spacetime, int numSimplices) override;
 };

--- a/include/spacetime/topologies/RealProjectiveSpace.h
+++ b/include/spacetime/topologies/RealProjectiveSpace.h
@@ -64,6 +64,9 @@ class RealProjectiveSpace : public Topology {
   public:
     RealProjectiveSpace() = default;
 
+    /// \f$ \mathbb{RP}^3 \f$ is a closed 3-manifold; its top cells are tetrahedra.
+    [[nodiscard]] int dimension() const override { return 3; }
+
     /// Build the 11-vertex \f$ \mathbb{RP}^3 \f$. ``numSimplices`` is ignored.
     void build(Spacetime *spacetime, int numSimplices) override;
 };

--- a/include/spacetime/topologies/SimplexBoundarySphere.h
+++ b/include/spacetime/topologies/SimplexBoundarySphere.h
@@ -47,6 +47,9 @@ class SimplexBoundarySphere : public Topology {
 
     [[nodiscard]] int n() const noexcept { return n_; }
 
+    /// \f$ S^n \f$ is an n-manifold; its top cells are n-simplices.
+    [[nodiscard]] int dimension() const override { return n_; }
+
     /// Build \f$ S^n = \partial\Delta^{n+1} \f$. ``numSimplices`` is ignored
     /// (the triangulation is fixed).
     void build(Spacetime *spacetime, int numSimplices) override;

--- a/include/spacetime/topologies/SimplicialProduct.h
+++ b/include/spacetime/topologies/SimplicialProduct.h
@@ -53,6 +53,11 @@ class SimplicialProduct : public Topology {
     SimplicialProduct(std::shared_ptr<Topology> left, std::shared_ptr<Topology> right)
         : left_(std::move(left)), right_(std::move(right)) {}
 
+    /// \f$ \dim(K \times L) = \dim K + \dim L \f$.
+    [[nodiscard]] int dimension() const override {
+      return left_->dimension() + right_->dimension();
+    }
+
     /// Build \f$ K \times L \f$. ``numSimplices`` is ignored.
     void build(Spacetime *spacetime, int numSimplices) override;
 

--- a/include/spacetime/topologies/SolidSimplex.h
+++ b/include/spacetime/topologies/SolidSimplex.h
@@ -45,6 +45,10 @@ class SolidSimplex : public Topology {
 
     [[nodiscard]] int n() const noexcept { return n_; }
 
+    /// \f$ \Delta^n \f$ is an n-ball (n-manifold with boundary); its single top
+    /// cell is an n-simplex.
+    [[nodiscard]] int dimension() const override { return n_; }
+
     /// Build the solid n-simplex. ``numSimplices`` is ignored.
     void build(Spacetime *spacetime, int numSimplices) override;
 

--- a/include/spacetime/topologies/SphereCircleProduct.h
+++ b/include/spacetime/topologies/SphereCircleProduct.h
@@ -51,6 +51,9 @@ class SphereCircleProduct : public Topology {
   public:
     SphereCircleProduct() = default;
 
+    /// \f$ S^2 \times S^1 \f$ is a closed 3-manifold; its top cells are tetrahedra.
+    [[nodiscard]] int dimension() const override { return 3; }
+
     /// Build \f$ S^2 \times S^1 \f$ via the staircase product. ``numSimplices``
     /// is ignored.
     void build(Spacetime *spacetime, int numSimplices) override;

--- a/include/spacetime/topologies/StellarSubdivision.h
+++ b/include/spacetime/topologies/StellarSubdivision.h
@@ -55,6 +55,9 @@ class StellarSubdivision : public Topology {
     explicit StellarSubdivision(std::shared_ptr<Topology> base)
         : base_(std::move(base)) {}
 
+    /// A stellar subdivision is a PL homeomorphism, so it preserves dimension.
+    [[nodiscard]] int dimension() const override { return base_->dimension(); }
+
     /// Build the base topology and apply one stellar subdivision.
     /// ``numSimplices`` is ignored.
     void build(Spacetime *spacetime, int numSimplices) override;

--- a/include/spacetime/topologies/Topology.h
+++ b/include/spacetime/topologies/Topology.h
@@ -74,6 +74,24 @@ class Topology {
     /// @param numSimplices Target number of top-dimensional simplices to create
     virtual void build(Spacetime *spacetime, int numSimplices) = 0;
 
+    /// The intrinsic dimension \f$ d \f$ of the manifold this topology
+    /// triangulates — i.e. its top cells are \f$ d \f$-simplices on
+    /// \f$ d+1 \f$ vertices. This is the single source of truth a caller uses
+    /// to pick the matching ``Signature(d, …)`` so the complex's top cells
+    /// register as top-dimensional (``Spacetime::getTopVertexCount`` == d+1);
+    /// without that match ``topSimplicesVec`` stays empty and boundary / random-
+    /// top queries see nothing.
+    ///
+    /// The fixed-triangulation fixtures (``SimplexBoundarySphere``,
+    /// ``SolidSimplex``, ``RealProjectivePlane``, ``RealProjectiveSpace``,
+    /// ``SphereCircleProduct``, ``ComplexProjectivePlane``, ``SimplicialProduct``,
+    /// ``StellarSubdivision``) each report their manifold dimension. The
+    /// dimension-parametric CDT topologies (``Toroid``, ``Sphere``,
+    /// ``Cylinder``) have no intrinsic dimension — theirs is read from the
+    /// spacetime's signature at ``build()`` time — so they inherit this base
+    /// implementation, which throws.
+    [[nodiscard]] virtual int dimension() const;
+
   protected:
     /// Build an explicit, *pre-geometric* triangulation from a combinatorial
     /// description: create `numVertices` **coordinate-free** vertices

--- a/src/cobordism/Cobordism.cpp
+++ b/src/cobordism/Cobordism.cpp
@@ -219,7 +219,21 @@ std::optional<std::map<std::uint64_t, std::uint64_t>> vertexCorrespondence(
 // state-sum computations these complexes feed.
 std::shared_ptr<Spacetime> buildSpacetime(std::size_t numVertices,
                                           const SimplexList &topSimplices) {
-  auto spacetime = std::make_shared<Spacetime>();
+  // Match the spacetime's signature dimension to the glued triangulation's
+  // top-cell dimension (top vertex count − 1). ``getBoundary`` — reached
+  // downstream through ``verify`` / a subsequent ``glue`` — reads the top set
+  // off ``topSimplicesVec``, which ``registerSimplex`` keys to the signature's
+  // d+1. The default ``Spacetime()`` pins ``Signature(4)``, which would
+  // silently leave ``topSimplicesVec`` (and hence the boundary) empty for a
+  // glued 3-manifold. An empty input falls back to a harmless default.
+  std::size_t topVertexCount = 0;
+  for (const auto &simplex : topSimplices)
+    topVertexCount = std::max(topVertexCount, simplex.size());
+  const int d = topVertexCount > 0 ? static_cast<int>(topVertexCount) - 1 : 4;
+  auto metric =
+      std::make_shared<Metric>(true, Signature(d, SignatureType::Lorentzian));
+  auto spacetime = std::make_shared<Spacetime>(
+      metric, SpacetimeType::CDT, 1.0, 1.0, Foliation::PREFERRED, std::nullopt);
   std::vector<VertexPtr> verts;
   verts.reserve(numVertices);
   for (std::size_t i = 0; i < numVertices; ++i)

--- a/src/cobordism/Cobordism.cpp
+++ b/src/cobordism/Cobordism.cpp
@@ -248,17 +248,13 @@ std::vector<SimplexList> sortedBoundaryComponents(const Spacetime &W) {
 }  // namespace
 
 SimplexList Cobordism::boundaryFaces(const Spacetime &W) {
-  const SimplexList tops = topSimplices(W);
-  if (tops.empty()) return {};
-  const std::size_t topVertexCount = tops.front().size();
-  // Count how many top simplices each codimension-one face belongs to.
-  std::map<Face, int> incidence;
-  for (const auto &top : tops)
-    for (auto &face : subfaces(top, topVertexCount - 1)) ++incidence[face];
-  SimplexList boundary;
-  for (auto &[face, count] : incidence)
-    if (count == 1) boundary.push_back(face);
-  return boundary;
+  // Thin wrapper over the canonical, Spacetime-owned boundary derivation
+  // (#162). ``Spacetime::getBoundary`` does the same facet-counting from the
+  // top simplices (codimension-one faces with incidence == 1), returning the
+  // identical sorted vertex-id tuples. Kept as a static entry point for the
+  // existing cobordism callers (``verify``, ``connectedComponents`` consumers,
+  // ``DijkgraafWitten``) and their tests.
+  return W.getBoundary();
 }
 
 std::vector<SimplexList> Cobordism::connectedComponents(const SimplexList &simplices) {

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -382,6 +382,24 @@ may differ slightly due to slab quantization.)doc")
              return out;
            },
            "Return simplices on the boundary of the complex.")
+      .def("getBoundary", &Spacetime::getBoundary,
+           R"doc(Return the boundary surface as codimension-one faces.
+
+The faces (one dimension below the top simplices) that belong to exactly
+one top simplex, as sorted vertex-id tuples. Computed by facet-counting
+from the top simplices, so it is side-effect-free and robust to lazily
+materialized facets. A closed manifold returns an empty list.
+
+Unlike getExternalSimplices (which returns whole boundary top cells and
+materializes facets as a side-effect), this returns the boundary faces
+themselves and leaves the complex untouched.)doc")
+      .def("materializeFacets", &Spacetime::materializeFacets,
+           R"doc(Force lazy facet materialization to a fixpoint.
+
+Creates and registers every face of every dimension (down to the
+vertices) and wires up the coface incidence. This is the side-effect
+getExternalSimplices performs internally, exposed for callers that want
+the materialization without the boundary scan.)doc")
       .def("createEdge",
            static_cast<EdgePtr (Spacetime::*)(const VertexPtr &, const VertexPtr &) const>(&
              Spacetime::createEdge),

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -79,7 +79,15 @@ void register_spacetime(py::module_ m) {
   // Topologies
   // ========================================
   py::class_<Topology, std::shared_ptr<Topology> >(m, "Topology",
-      "Base class for spatial topologies (Toroid, Sphere, etc.).");
+      "Base class for spatial topologies (Toroid, Sphere, etc.).")
+      .def("dimension", &Topology::dimension,
+           R"doc(The intrinsic manifold dimension d of this topology (top cells
+are d-simplices on d+1 vertices). Use it to pick the matching
+Signature(d, ...) when building a fixture so its top cells register as
+top-dimensional. The fixed-triangulation fixtures report their dimension;
+the dimension-parametric CDT topologies (Toroid, Sphere, Cylinder) raise
+RuntimeError — their dimension comes from the signature, not the
+topology.)doc");
 
   py::class_<Sphere, Topology, std::shared_ptr<Sphere> >(m, "Sphere",
       "Spherical spatial topology S^{d-1}.")
@@ -485,6 +493,14 @@ This is the volume-fixing target per [RU] eq. 6.)doc")
       .def("getRandomTopSimplex", &Spacetime::getRandomTopSimplex, py::return_value_policy::reference,
            py::keep_alive<0, 1>(),
            "Return a uniformly random top-dimensional simplex.")
+      .def("getTopVertexCount", &Spacetime::getTopVertexCount,
+           R"doc(Return the vertex count of a top-dimensional simplex (d+1).
+
+d is the metric signature's dimension. This is the single source of truth
+for what registers as a top cell: a simplex joins topSimplicesVec (and is
+seen by getBoundary/getRandomTopSimplex) exactly when its vertex count
+equals this. Build a fixture with Signature(topology.dimension(), ...) so
+its top cells match.)doc")
       .def("getRandomVertex", &Spacetime::getRandomVertex, py::return_value_policy::reference,
            py::keep_alive<0, 1>(),
            "Return a uniformly random vertex.")

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -405,6 +405,13 @@ const std::shared_ptr<VertexList> &Spacetime::getVertexList() const noexcept {
   return vertexList;
 }
 
+std::size_t Spacetime::getTopVertexCount() const noexcept {
+  // d+1, the vertex count of a top-dimensional simplex. Single source of truth
+  // for "what is a top cell" (see registerSimplex / updateOrientationCounters /
+  // getBoundary).
+  return static_cast<std::size_t>(metric->getSignature()->getDimensions()) + 1;
+}
+
 std::vector<std::vector<std::uint64_t>> Spacetime::getBoundary() const {
   // Canonical boundary derivation: facet-counting from the top simplices.
   // A codimension-one face is on the boundary iff exactly one top simplex
@@ -413,25 +420,22 @@ std::vector<std::vector<std::uint64_t>> Spacetime::getBoundary() const {
   // lazy-facet problem that the coface-based ``getExternalSimplices`` has to
   // work around — no ``Simplex`` facet objects need to exist.
 
-  // "Top" is the maximal vertex count actually present in the complex. We read
-  // it off ``simplicesVec`` (rather than ``topSimplicesVec``, which is keyed to
-  // the metric dimension d+1) so this is correct for pre-geometric complexes of
-  // any dimension, and robust when ``simplicesVec`` also holds lazily-
-  // materialized lower-dimensional faces.
-  std::size_t topVertexCount = 0;
-  for (const auto &simplex : simplicesVec)
-    topVertexCount = std::max<std::size_t>(topVertexCount, simplex->size());
-  if (topVertexCount == 0) return {};
+  // The top set is ``topSimplicesVec`` — the simplices ``registerSimplex``
+  // keyed as top-dimensional, i.e. those whose vertex count equals
+  // ``getTopVertexCount()`` (= signature d+1). This is exactly the set of top
+  // cells *provided the signature dimension matches the triangulation's*
+  // dimension; build fixtures with ``Signature(Topology::dimension(), …)`` so
+  // it does. (For a complex of the wrong signature ``topSimplicesVec`` is
+  // empty and the boundary comes back empty.)
+  const std::size_t topVertexCount = getTopVertexCount();
 
   // Count, per codimension-one face, how many top simplices own it. Each top
   // simplex's codim-1 faces are obtained by dropping one vertex in turn from
   // its sorted vertex tuple (the remainder stays sorted, so the face is a
-  // canonical key). The ``std::map`` keeps the result in the same sorted face
-  // order the previous facet-counting implementation produced.
+  // canonical key). The ``std::map`` keeps the result in sorted face order.
   std::map<std::vector<std::uint64_t>, int> incidence;
   std::vector<std::uint64_t> verts;
-  for (const auto &simplex : simplicesVec) {
-    if (simplex->size() != topVertexCount) continue;
+  for (const auto &simplex : topSimplicesVec) {
     verts.clear();
     verts.reserve(topVertexCount);
     for (const auto &v : simplex->getVertices()) verts.push_back(v->getId());
@@ -709,8 +713,7 @@ SimplexPtr Spacetime::registerSimplex(const SimplexPtr &simplex, bool internal) 
   simplicesVec.push_back(simplex);
   simplexIndex_.insert(fp, simplex);
 
-  auto d = metric->getSignature()->getDimensions();
-  if (simplex->size() == static_cast<std::size_t>(d + 1)) {
+  if (simplex->size() == getTopVertexCount()) {
     simplex->topVecIdx_ = static_cast<std::uint32_t>(topSimplicesVec.size());
     topSimplicesVec.push_back(simplex);
   }
@@ -858,7 +861,7 @@ void Spacetime::updateOrientationCounters(const SimplexPtr &simplex, int delta) 
   auto d = metric->getSignature()->getDimensions();
   auto nVerts = simplex->size();
   // Only count top-dimensional simplices (d-simplices have d+1 vertices)
-  if (nVerts != static_cast<std::size_t>(d + 1)) return;
+  if (nVerts != getTopVertexCount()) return;
   auto [ti, tf] = simplex->getOrientation().numeric();
   // (d, 1) or (1, d) type
   if ((ti == d && tf == 1) || (ti == 1 && tf == d)) {

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -25,7 +25,9 @@
 
 // (was: #include <pybind11/pybind11.h> — removed; unreferenced.)
 #include "Logger.h"
+#include <algorithm>
 #include <cmath>
+#include <map>
 #include <memory>
 #include <queue>
 #include <set>
@@ -403,23 +405,67 @@ const std::shared_ptr<VertexList> &Spacetime::getVertexList() const noexcept {
   return vertexList;
 }
 
-SimplexSet Spacetime::getExternalSimplices() noexcept {
-  // Boundary detection needs every facet's coface count to be complete:
-  // a facet is on the boundary iff it has fewer than two cofaces. Facets
-  // are materialized lazily — ``Simplex::getFacets()`` creates them on first
-  // access and registers each one back into ``simplicesVec`` (via
+std::vector<std::vector<std::uint64_t>> Spacetime::getBoundary() const {
+  // Canonical boundary derivation: facet-counting from the top simplices.
+  // A codimension-one face is on the boundary iff exactly one top simplex
+  // contains it (an interior face is shared by two). This is computed purely
+  // from the vertex sets, so it is side-effect-free and immune to the
+  // lazy-facet problem that the coface-based ``getExternalSimplices`` has to
+  // work around — no ``Simplex`` facet objects need to exist.
+
+  // "Top" is the maximal vertex count actually present in the complex. We read
+  // it off ``simplicesVec`` (rather than ``topSimplicesVec``, which is keyed to
+  // the metric dimension d+1) so this is correct for pre-geometric complexes of
+  // any dimension, and robust when ``simplicesVec`` also holds lazily-
+  // materialized lower-dimensional faces.
+  std::size_t topVertexCount = 0;
+  for (const auto &simplex : simplicesVec)
+    topVertexCount = std::max<std::size_t>(topVertexCount, simplex->size());
+  if (topVertexCount == 0) return {};
+
+  // Count, per codimension-one face, how many top simplices own it. Each top
+  // simplex's codim-1 faces are obtained by dropping one vertex in turn from
+  // its sorted vertex tuple (the remainder stays sorted, so the face is a
+  // canonical key). The ``std::map`` keeps the result in the same sorted face
+  // order the previous facet-counting implementation produced.
+  std::map<std::vector<std::uint64_t>, int> incidence;
+  std::vector<std::uint64_t> verts;
+  for (const auto &simplex : simplicesVec) {
+    if (simplex->size() != topVertexCount) continue;
+    verts.clear();
+    verts.reserve(topVertexCount);
+    for (const auto &v : simplex->getVertices()) verts.push_back(v->getId());
+    std::sort(verts.begin(), verts.end());
+    for (std::size_t omit = 0; omit < verts.size(); ++omit) {
+      std::vector<std::uint64_t> face;
+      face.reserve(verts.size() - 1);
+      for (std::size_t i = 0; i < verts.size(); ++i)
+        if (i != omit) face.push_back(verts[i]);
+      ++incidence[face];
+    }
+  }
+
+  std::vector<std::vector<std::uint64_t>> boundary;
+  for (auto &[face, count] : incidence)
+    if (count == 1) boundary.push_back(face);
+  return boundary;
+}
+
+void Spacetime::materializeFacets() noexcept {
+  // Facets are materialized lazily — ``Simplex::getFacets()`` creates them on
+  // first access and registers each one back into ``simplicesVec`` (via
   // ``registerSimplex``). For CDT-built complexes this already happened during
-  // gluing, so the loop below would converge immediately. For complexes
-  // assembled from scratch (e.g. a hand-built triangulation), the facets do
-  // not exist yet, and materializing them *during* a range-for over
-  // ``simplicesVec`` would both invalidate the iterator (the vector grows) and
-  // read incomplete coface counts (a shared facet looks like a boundary facet
-  // until its second coface registers).
+  // gluing, so the loop below converges immediately. For complexes assembled
+  // from scratch (e.g. a hand-built triangulation), the facets do not exist
+  // yet, and materializing them *during* a range-for over ``simplicesVec``
+  // would both invalidate the iterator (the vector grows) and read incomplete
+  // coface counts (a shared facet looks like a boundary facet until its second
+  // coface registers).
   //
-  // Force lazy facet materialization first. ``getFacets()`` appends any
-  // newly-created facet simplices to ``simplicesVec``; index iteration walks
-  // into them too, so a single pass reaches a fixpoint (dimension strictly
-  // decreases, terminating at vertices whose ``getFacets()`` is a no-op).
+  // ``getFacets()`` appends any newly-created facet simplices to
+  // ``simplicesVec``; index iteration walks into them too, so a single pass
+  // reaches a fixpoint (dimension strictly decreases, terminating at vertices
+  // whose ``getFacets()`` is a no-op).
   //
   // Index iteration — re-reading ``simplicesVec[i]`` and ``size()`` each step —
   // is safe under the growth a range-for would not survive: reallocation moves
@@ -429,6 +475,13 @@ SimplexSet Spacetime::getExternalSimplices() noexcept {
   for (std::size_t i = 0; i < simplicesVec.size(); ++i) {
     simplicesVec[i]->getFacets();
   }
+}
+
+SimplexSet Spacetime::getExternalSimplices() noexcept {
+  // Boundary detection needs every facet's coface count to be complete: a facet
+  // is on the boundary iff it has fewer than two cofaces. Force lazy facet
+  // materialization to a fixpoint first so the coface counts are final.
+  materializeFacets();
 
   // Cofaces are now fully linked; no further simplices will be created, so a
   // direct scan is safe.

--- a/src/spacetime/topologies/Topology.cpp
+++ b/src/spacetime/topologies/Topology.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <memory>
 #include <iostream>
+#include <stdexcept>
 
 #include "spacetime/Spacetime.h"
 #include "mesh/Vertex.h"
@@ -43,6 +44,17 @@ Topology::~Topology() = default;
 // std::vector<std::shared_ptr<Constraint> > Topology::getConstraints() {return {};}
 void Topology::build(Spacetime *spacetime, int numSimplices) {
   std::cout << "Building Topology (base)" << std::endl;
+}
+
+int Topology::dimension() const {
+  // Only the fixed-triangulation fixtures have an intrinsic manifold dimension;
+  // the dimension-parametric CDT topologies (Toroid, Sphere, Cylinder) take
+  // theirs from the spacetime's signature at build() time and so do not
+  // override this.
+  throw std::logic_error(
+      "Topology::dimension(): this topology has no intrinsic manifold dimension "
+      "(it is parametric in the spacetime signature). Build it with an explicit "
+      "Signature(d, …) instead of deriving d from the topology.");
 }
 
 void Topology::buildExplicit(

--- a/tests/cobordism/test_chaincomplex_python.py
+++ b/tests/cobordism/test_chaincomplex_python.py
@@ -34,7 +34,7 @@ cob = tessera.cobordism
 
 
 def _build(topology):
-    sig = tessera.Signature(4, tessera.Lorentzian)
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, sig)
     st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                            tessera.PREFERRED, topology)

--- a/tests/cobordism/test_characteristic_python.py
+++ b/tests/cobordism/test_characteristic_python.py
@@ -49,7 +49,7 @@ _RP2_TRIANGLES = [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5), (0, 1, 5),
 
 
 def _build(topology):
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, topology)

--- a/tests/cobordism/test_cobordism_verify_python.py
+++ b/tests/cobordism/test_cobordism_verify_python.py
@@ -109,6 +109,55 @@ class TestBoundaryFaces(unittest.TestCase):
         self.assertEqual(len(comps), 2)
 
 
+class TestSpacetimeGetBoundary(unittest.TestCase):
+    """Spacetime.getBoundary() is the canonical, side-effect-free boundary
+    derivation that Cobordism.boundaryFaces() now delegates to (#162). It must
+    agree with boundaryFaces() and reproduce the known boundary on the fixtures:
+    SolidSimplex -> sphere boundary, cylinder -> two components, closed
+    manifolds -> empty."""
+
+    @staticmethod
+    def _as_set(faces):
+        return {tuple(f) for f in faces}
+
+    def test_agrees_with_boundary_faces(self):
+        for topology in (tessera.SolidSimplex(2), tessera.SolidSimplex(3),
+                         tessera.SolidSimplex(4), tessera.SimplexBoundarySphere(3),
+                         tessera.RealProjectivePlane()):
+            with self.subTest(topology=type(topology).__name__):
+                st = _build(topology)
+                self.assertEqual(
+                    self._as_set(st.getBoundary()),
+                    self._as_set(cobordism.Cobordism.boundaryFaces(st)))
+
+    def test_solid_simplex_boundary_is_a_sphere(self):
+        # The boundary of Delta^n is its n+1 facets = S^{n-1} (each on n verts).
+        for n in range(2, 6):
+            with self.subTest(ball=n):
+                boundary = _build(tessera.SolidSimplex(n)).getBoundary()
+                self.assertEqual(len(boundary), n + 1)
+                self.assertTrue(all(len(f) == n for f in boundary))
+
+    def test_closed_manifold_has_empty_boundary(self):
+        for topology in (tessera.SimplexBoundarySphere(2),
+                         tessera.SimplexBoundarySphere(4),
+                         tessera.RealProjectivePlane()):
+            with self.subTest(manifold=type(topology).__name__):
+                self.assertEqual(_build(topology).getBoundary(), [])
+
+    def test_cylinder_boundary_has_two_components(self):
+        comps = cobordism.Cobordism.connectedComponents(_cylinder(2).getBoundary())
+        self.assertEqual(len(comps), 2)
+
+    def test_get_boundary_is_side_effect_free(self):
+        # Unlike getExternalSimplices, getBoundary() must not materialize facets:
+        # the registered-simplex set is unchanged by the call.
+        st = _build(tessera.SolidSimplex(4))
+        before = len(st.getSimplices())
+        st.getBoundary()
+        self.assertEqual(len(st.getSimplices()), before)
+
+
 class TestIsomorphism(unittest.TestCase):
 
     def test_same_sphere_is_isomorphic(self):

--- a/tests/cobordism/test_cobordism_verify_python.py
+++ b/tests/cobordism/test_cobordism_verify_python.py
@@ -37,7 +37,7 @@ cobordism = tessera.cobordism
 
 
 def _build(topology):
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, topology)
@@ -74,7 +74,11 @@ def _product(*topologies):
 def _from_simplices(num_vertices, simplices):
     """Build a Spacetime directly from explicit top-simplex vertex tuples
     (vertices 0..num_vertices-1), for hand-crafted / pathological complexes."""
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    # Signature dimension must match the hand-built top cells (d = max cell
+    # vertex count - 1) so they register as top simplices and getBoundary sees
+    # them. These complexes are not topology-driven, so derive d from the data.
+    dimension = max(len(simplex) for simplex in simplices) - 1
+    signature = tessera.Signature(dimension, tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, tessera.Toroid())

--- a/tests/cobordism/test_dijkgraaf_witten_boundary_python.py
+++ b/tests/cobordism/test_dijkgraaf_witten_boundary_python.py
@@ -57,7 +57,7 @@ Cocycle = cobordism.Cocycle
 # Fixtures.
 # --------------------------------------------------------------------------- #
 def _build(topology):
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, topology)

--- a/tests/cobordism/test_dijkgraaf_witten_python.py
+++ b/tests/cobordism/test_dijkgraaf_witten_python.py
@@ -89,7 +89,9 @@ Cocycle = cobordism.Cocycle
 # --------------------------------------------------------------------------- #
 # Fixtures: closed oriented 3-manifolds small enough for the brute-force sum.
 # --------------------------------------------------------------------------- #
-def _build(topology, dimensions=4):
+def _build(topology, dimensions=None):
+    if dimensions is None:
+        dimensions = topology.dimension()
     signature = tessera.Signature(dimensions, tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,

--- a/tests/cobordism/test_fixtures_python.py
+++ b/tests/cobordism/test_fixtures_python.py
@@ -55,7 +55,7 @@ STRUCT_MAX = 7
 
 
 def _build(topology):
-    sig = tessera.Signature(4, tessera.Lorentzian)
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, sig)
     st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                            tessera.PREFERRED, topology)

--- a/tests/cobordism/test_fixtures_python.py
+++ b/tests/cobordism/test_fixtures_python.py
@@ -91,8 +91,8 @@ def _euler(fvec):
 
 def _materialized_face_counts(st):
     """Count tessera's own k-simplices once all facets are materialized.
-    getExternalSimplices() forces lazy facet materialization to a fixpoint."""
-    st.getExternalSimplices()
+    materializeFacets() forces lazy facet materialization to a fixpoint."""
+    st.materializeFacets()
     counts = {}
     for s in st.getSimplices():
         k = len(s.getVertices()) - 1
@@ -143,7 +143,7 @@ class TestSimplexBoundarySphere(unittest.TestCase):
         for n in range(1, STRUCT_MAX + 1):
             with self.subTest(n=n):
                 st = _build(tessera.SimplexBoundarySphere(n))
-                st.getExternalSimplices()  # materialize facets/cofaces
+                st.materializeFacets()  # materialize facets/cofaces
                 checked = 0
                 for s in st.getSimplices():
                     if len(s.getVertices()) == n + 1:  # a top n-simplex

--- a/tests/cobordism/test_gluing_t5_python.py
+++ b/tests/cobordism/test_gluing_t5_python.py
@@ -68,7 +68,7 @@ COCYCLES = ((Cocycle.Trivial, "trivial"), (Cocycle.Sign, "sign"))
 # Fixtures (identical conventions to the #109 boundary-map tests).
 # --------------------------------------------------------------------------- #
 def _build(topology):
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, topology)

--- a/tests/cobordism/test_hodge_laplacian_python.py
+++ b/tests/cobordism/test_hodge_laplacian_python.py
@@ -48,7 +48,7 @@ cob = tessera.cobordism
 # Fixture builders
 # --------------------------------------------------------------------------- #
 def _build_topology(topology):
-    sig = tessera.Signature(4, tessera.Lorentzian)
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, sig)
     st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
                            tessera.PREFERRED, topology)

--- a/tests/cobordism/test_oriented_tops_python.py
+++ b/tests/cobordism/test_oriented_tops_python.py
@@ -59,7 +59,7 @@ def _three_torus():
 
 
 def _build(topology):
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, topology)

--- a/tests/cobordism/test_rp3_fixture_python.py
+++ b/tests/cobordism/test_rp3_fixture_python.py
@@ -51,7 +51,7 @@ Cocycle = cobordism.Cocycle
 
 
 def _build(topology):
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, topology)

--- a/tests/cobordism/test_simplicial_product_python.py
+++ b/tests/cobordism/test_simplicial_product_python.py
@@ -54,7 +54,7 @@ def _product(*factors):
 
 
 def _build(topology):
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, topology)

--- a/tests/cobordism/test_spectral_observables_python.py
+++ b/tests/cobordism/test_spectral_observables_python.py
@@ -41,7 +41,7 @@ obs = tessera.observables  # SpectralGap / HarmonicDimension live in the observa
 # Fixtures (same idioms as the HodgeLaplacian operator tests)
 # --------------------------------------------------------------------------- #
 def _build_topology(topology):
-    sig = tessera.Signature(4, tessera.Lorentzian)
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, sig)
     st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
                            tessera.PREFERRED, topology)

--- a/tests/cobordism/test_t2_retriangulation_python.py
+++ b/tests/cobordism/test_t2_retriangulation_python.py
@@ -81,7 +81,7 @@ TOLERANCE = 1e-12
 
 def _build(topology):
     """Build a closed oriented 3-manifold Spacetime from a topology."""
-    signature = tessera.Signature(4, tessera.Lorentzian)
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, signature)
     spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                                   tessera.PREFERRED, topology)

--- a/tests/cobordism/test_three_manifold_fixtures_python.py
+++ b/tests/cobordism/test_three_manifold_fixtures_python.py
@@ -41,7 +41,7 @@ cobordism = tessera.cobordism
 
 
 def _build(topology):
-    sig = tessera.Signature(4, tessera.Lorentzian)
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
     metric = tessera.Metric(True, sig)
     st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
                            tessera.PREFERRED, topology)

--- a/tests/test_pachner_characterization.py
+++ b/tests/test_pachner_characterization.py
@@ -497,9 +497,9 @@ class TestLazyFacetMaterializationIsBenign(unittest.TestCase):
         before = _bookkeeping(st)
         simplices_before = len(st.getSimplices())
 
-        # getExternalSimplices() forces facet materialization to a fixpoint —
-        # the same lazy getFacets() machinery a move's propose() triggers.
-        st.getExternalSimplices()
+        # materializeFacets() forces facet materialization to a fixpoint — the
+        # same lazy getFacets() machinery a move's propose() triggers.
+        st.materializeFacets()
 
         self.assertEqual(_bookkeeping(st), before,
                          "facet materialization changed the CDT bookkeeping")
@@ -512,7 +512,7 @@ class TestLazyFacetMaterializationIsBenign(unittest.TestCase):
         # dimensions; _top_simplex_size must still report the true top (d+1=5).
         cdt, st = _make_cdt(d=4)
         _grow(cdt, n=100)
-        st.getExternalSimplices()
+        st.materializeFacets()
         sizes = {len(s.getVertices()) for s in st.getSimplices()}
         self.assertIn(5, sizes)            # top simplices present
         self.assertTrue(sizes - {5})       # and lower-dim faces too


### PR DESCRIPTION
Fixes boundary detection for the cobordism manifold fixtures and makes the
spacetime's signature dimension the single source of truth for "what is a top
cell." Builds on the original `getBoundary`/`materializeFacets` work.

## The root problem

`topSimplicesVec` is signature-keyed: `registerSimplex` pushes a simplex only
when `size() == d+1` (`d` = signature dimension). But the cobordism 3-manifold
fixtures were all built with `Signature(4)` while being lower-dimensional
manifolds (4-vertex tetrahedra), so `topSimplicesVec` was **empty** for them.
The first cut of `getBoundary()` worked around this by max-scanning
`simplicesVec`. This PR fixes the signatures instead, so the canonical top set
is correct, and the same mismatch no longer silently hides tops from
`getRandomTopSimplex`.

## What landed

**Single source of truth**
- **`Spacetime::getTopVertexCount()`** → `signature d+1`. `registerSimplex` and
  `updateOrientationCounters` now use it; bound as `Spacetime.getTopVertexCount()`.

**Fixture signatures (durable, via the topology)**
- **`Topology::dimension()`** — each fixed-triangulation fixture reports its
  intrinsic manifold dimension:
  - `SimplexBoundarySphere(n)` → `n`, `SolidSimplex(n)` → `n`
  - `RealProjectivePlane` → 2, `RealProjectiveSpace` → 3
  - `SphereCircleProduct` (S²×S¹) → 3, `ComplexProjectivePlane` → 4
  - `SimplicialProduct` → sum of factor dimensions
  - `StellarSubdivision` → base dimension (PL homeomorphism)
  - The dimension-parametric CDT topologies (`Toroid`/`Sphere`/`Cylinder`) take
    their dimension from the signature at build time, so they inherit a base
    impl that throws. Bound as `Topology.dimension()`.
- The cobordism test `_build`/`_build_topology` helpers and
  `examples/cobordism/*.py` now build with `Signature(topology.dimension(), …)`.
  The verify test's hand-built `_from_simplices` derives `d` from the cell data.
- `Cobordism::buildSpacetime` (the `glue`/`selfGlue` result builder) now builds
  its output with a signature matching the glued triangulation's top-cell
  dimension, so re-glued / verified results keep a populated `topSimplicesVec`
  (the default `Spacetime()` pins `Signature(4)`, which would have emptied it for
  a glued 3-manifold).

**`getBoundary()` simplified**
- Now derives the top set from `topSimplicesVec` + `getTopVertexCount()` and
  facet-counts (codim-one faces with incidence `== 1`) over those tops; the
  `simplicesVec` max-scan is gone. Still `const` / side-effect-free.

**Original boundary/materialization work (retained from the first commit)**
- `Cobordism::boundaryFaces` is a thin wrapper delegating to `getBoundary()`.
- `Spacetime::materializeFacets()` exposes the lazy-facet fixpoint as an explicit
  op; `getExternalSimplices()` calls it then does its coface-based top-cell scan.
  The side-effect-only call sites (`test_pachner_characterization`,
  `test_fixtures_python`) are repointed at `materializeFacets()`.

## Audit

`getRandomTopSimplex()` reads `topSimplicesVec` and is the consumer most exposed
to the old mismatch (Pachner add/flip/iflip/shift, CDT growth, the interaction
simulation). With the fixture signatures fixed it now returns tops on these
complexes; the Pachner suites and the pre-geometric move suite stay green.
`test_pachner_pregeometric` already built its complexes with the matching
signature for exactly this reason (its `_spacetime` docstring spells it out), so
the cobordism fixtures now follow the same rule. The cobordism capabilities
themselves (`ChainComplex`, characteristic numbers, Hodge Laplacian, the
DijkgraafWitten dimension guard) read the complex via their own max-scan and were
already signature-independent.

## Full-suite result

`poetry run pytest tests/ -q`: **966 passed, 5 skipped, 1 failed**. The single
failure is the known flaky `test_regge_solver::TestActionGradientNorm::test_solver_reduces_gradient_norm`
— a CUDA out-of-memory (`regge_cuda.cu:796`) under GPU contention, unrelated to
this change (pure C++/Python boundary + signature logic, no CUDA).

Closes #162.