### PR TITLE
tests: ChoiJamiolkowski + EigenstateSynthesis hardening

### DIFF
--- a/tests/cobordism/test_eigenstate_synthesis_hardening_python.py
+++ b/tests/cobordism/test_eigenstate_synthesis_hardening_python.py
@@ -1,0 +1,403 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""EigenstateSynthesis hardening — hand-checkable spectra + random complexes.
+
+Complements tests/cobordism/test_eigenstate_synthesis_python.py (residual /
+Rayleigh on the two-vertex edge and the square+diagonal testbed) and
+test_bulk_eigenstate_synthesis_python.py (the fixed-boundary interior fill).
+The gaps closed here:
+
+  * CLOSED-FORM spectra on tiny graphs derived by hand and asserted against
+    residual / Rayleigh / apply, not merely against numpy eigh:
+      - the triangle K_3, uniform weight w, phase 0  -> spectrum {0, 3w, 3w};
+        the constant vector is the harmonic zero mode and (1,0,0) has the exact
+        residual 2 w^2;
+      - K_3 with a flux Phi = pi threaded through the cycle -> spectrum
+        {w, w, 4w}: the magnetic-Laplacian holonomy destroys the zero mode (the
+        constant vector floors at the exact residual 8 w^2 / 9);
+      - the path P_3 -> spectrum {0, w, 3w}; being a tree (b1 = 0) its spectrum
+        is theta-independent (all phases are pure gauge).
+  * residual == 0  <=>  L psi || psi, and Rayleigh = realized eigenvalue, on
+    RANDOM connected complexes with random Hermitian weights/phases, against a
+    numpy eigendecomposition (the base suite only checks two fixed complexes).
+  * weight/phase get-set round-trips over the stable EdgeList order — phases
+    included, with negative and >2*pi values — with the operator (apply)
+    reflecting that order.
+  * the general-amplitude two-vertex floor w_min^2 (|c0|^2 - |c1|^2)^2 matched by
+    an independent numpy grid+refine GLOBAL-min oracle across amplitudes/seeds
+    (the base suite asserts only the analytic closed form).
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders (the hand-crafted-complex idiom shared with the #133 tests).
+# --------------------------------------------------------------------------- #
+def _from_simplices(num_vertices, simplices):
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    verts = [st.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        st.createSimplex([verts[i] for i in simplex])
+    return st
+
+
+def _set_uniform(st, squared_length=1.0, phase=0.0):
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(squared_length)
+        e.setPhase(phase)
+
+
+def _triangle():
+    """K_3: vertices 0-1-2, edges (0,1) (1,2) (0,2). A cycle (b1 = 1)."""
+    return _from_simplices(3, [(0, 1), (1, 2), (0, 2)])
+
+
+def _path3():
+    """P_3: 0-1-2, edges (0,1) (1,2). A tree (b1 = 0)."""
+    return _from_simplices(3, [(0, 1), (1, 2)])
+
+
+# --------------------------------------------------------------------------- #
+# numpy oracle + helpers (the D - A magnitude convention the Hodge / #133 tests
+# use, in the operator's sorted-vertex-id order).
+# --------------------------------------------------------------------------- #
+def _cvec(v):
+    return [complex(z) for z in v]
+
+
+def _edge_key(e):
+    a, b = e.getSource().getId(), e.getTarget().getId()
+    return (min(a, b), max(a, b))
+
+
+def _np_L(st):
+    ids = sorted(v.getId() for v in st.getVertexList().toVector())
+    idx = {vid: i for i, vid in enumerate(ids)}
+    n = len(ids)
+    A = np.zeros((n, n), dtype=complex)
+    D = np.zeros(n)
+    for e in st.getEdgeList().toVector():
+        s, t = e.getSource().getId(), e.getTarget().getId()
+        if s == t:
+            continue
+        i, j = idx[s], idx[t]
+        w = e.getSquaredLength()
+        z = w * np.exp(1j * e.getPhase())
+        A[i, j] += z
+        A[j, i] += np.conj(z)
+        D[i] += abs(w)
+        D[j] += abs(w)
+    return np.diag(D).astype(complex) - A
+
+
+def _np_residual(L, psi):
+    psi = np.asarray(psi, dtype=complex)
+    psi = psi / np.linalg.norm(psi)
+    Lp = L @ psi
+    lam = np.vdot(psi, Lp).real
+    r = Lp - lam * psi
+    return float(np.vdot(r, r).real)
+
+
+# --------------------------------------------------------------------------- #
+class HandCheckableTriangleTest(unittest.TestCase):
+    """K_3 with closed-form spectra — zero flux and a pi flux through the cycle."""
+
+    def test_zero_flux_spectrum_and_residuals(self):
+        w = 1.3
+        st = _triangle()
+        _set_uniform(st, w, 0.0)
+        es = cob.EigenstateSynthesis(st)
+
+        # Hand spectrum of L = 3w I - w J (J the all-ones block): {0, 3w, 3w}.
+        evals = np.linalg.eigvalsh(_np_L(st))
+        np.testing.assert_allclose(sorted(evals), [0.0, 3 * w, 3 * w], atol=1e-9)
+
+        # The constant vector is the harmonic zero mode.
+        const = np.ones(3) / math.sqrt(3)
+        self.assertLess(es.residual(_cvec(const)), 1e-18)
+        self.assertAlmostEqual(es.rayleigh(_cvec(const)), 0.0, places=10)
+        np.testing.assert_allclose(es.apply(_cvec(const)), 0.0, atol=1e-10)
+
+        # The sum-zero modes realise the degenerate eigenvalue 3w exactly.
+        for v in (np.array([1.0, -1.0, 0.0]), np.array([1.0, 1.0, -2.0])):
+            vv = v / np.linalg.norm(v)
+            self.assertLess(es.residual(_cvec(vv)), 1e-18)
+            self.assertAlmostEqual(es.rayleigh(_cvec(vv)), 3 * w, places=9)
+            np.testing.assert_allclose(
+                np.asarray(es.apply(_cvec(vv))), 3 * w * vv, atol=1e-9)
+
+        # A localised non-eigenvector (1,0,0): L psi = (2w, -w, -w), lambda = 2w,
+        # so r = ||(0, -w, -w)||^2 = 2 w^2 exactly.
+        e0 = np.array([1.0, 0.0, 0.0], dtype=complex)
+        self.assertAlmostEqual(es.residual(_cvec(e0)), 2 * w * w, places=10)
+        self.assertAlmostEqual(es.rayleigh(_cvec(e0)), 2 * w, places=10)
+        self.assertAlmostEqual(es.residual(_cvec(e0)),
+                               _np_residual(_np_L(st), e0), places=12)
+
+    def test_flux_pi_destroys_the_zero_mode(self):
+        # Thread a holonomy Phi = pi around the triangle by putting phase pi on a
+        # single edge. The magnetic Laplacian then has spectrum {w, w, 4w}: the
+        # zero eigenvalue is gone, so the constant vector is no longer harmonic.
+        w = 1.3
+        st = _triangle()
+        _set_uniform(st, w, 0.0)
+        for e in st.getEdgeList().toVector():
+            if _edge_key(e) == (0, 1):
+                e.setPhase(math.pi)
+        es = cob.EigenstateSynthesis(st)
+
+        evals, evecs = np.linalg.eigh(_np_L(st))
+        np.testing.assert_allclose(sorted(evals), [w, w, 4 * w], atol=1e-9)
+
+        # The constant vector floors at the exact residual 8 w^2 / 9 > 0.
+        const = np.ones(3, dtype=complex) / math.sqrt(3)
+        self.assertGreater(es.residual(_cvec(const)), 1e-3)
+        self.assertAlmostEqual(es.residual(_cvec(const)), 8 * w * w / 9.0,
+                               places=10)
+        self.assertAlmostEqual(es.residual(_cvec(const)),
+                               _np_residual(_np_L(st), const), places=12)
+
+        # The genuine min eigenvector is harmonic at eigenvalue w.
+        vmin = evecs[:, 0]
+        self.assertLess(es.residual(_cvec(vmin)), 1e-16)
+        self.assertAlmostEqual(es.rayleigh(_cvec(vmin)), w, places=9)
+
+
+class HandCheckablePathTest(unittest.TestCase):
+    """P_3 closed-form spectrum, and tree => the spectrum is phase-independent."""
+
+    def test_path_spectrum(self):
+        w = 1.3
+        st = _path3()
+        _set_uniform(st, w, 0.0)
+        es = cob.EigenstateSynthesis(st)
+
+        evals = np.linalg.eigvalsh(_np_L(st))
+        np.testing.assert_allclose(sorted(evals), [0.0, w, 3 * w], atol=1e-9)
+
+        # Hand eigenvectors of the P_3 Laplacian.
+        cases = [(np.array([1.0, 1.0, 1.0]), 0.0),       # constant -> 0
+                 (np.array([1.0, 0.0, -1.0]), w),        # antisymmetric -> w
+                 (np.array([1.0, -2.0, 1.0]), 3 * w)]    # curvature -> 3w
+        for v, lam in cases:
+            vv = v / np.linalg.norm(v)
+            self.assertLess(es.residual(_cvec(vv)), 1e-18)
+            self.assertAlmostEqual(es.rayleigh(_cvec(vv)), lam, places=9)
+            np.testing.assert_allclose(
+                np.asarray(es.apply(_cvec(vv))), lam * vv, atol=1e-9)
+
+    def test_tree_spectrum_is_phase_independent(self):
+        # On a tree every phase is pure gauge (b1 = 0): the spectrum is fixed at
+        # {0, w, 3w} for any phase assignment, and the constant mode rephases into
+        # the (still harmonic) zero mode the C++ residual confirms.
+        w = 1.3
+        st = _path3()
+        _set_uniform(st, w, 0.0)
+        es = cob.EigenstateSynthesis(st)
+        for seed in range(5):
+            rng = np.random.default_rng(seed)
+            for e in st.getEdgeList().toVector():
+                e.setPhase(float(rng.uniform(-3.5, 3.5)))
+            L = _np_L(st)
+            evals, evecs = np.linalg.eigh(L)
+            np.testing.assert_allclose(sorted(evals), [0.0, w, 3 * w], atol=1e-9)
+            # The numpy zero-mode (a rephased constant) is harmonic for the C++ op.
+            zero_mode = evecs[:, int(np.argmin(evals))]
+            self.assertLess(es.residual(_cvec(zero_mode)), 1e-16)
+            self.assertAlmostEqual(es.rayleigh(_cvec(zero_mode)), 0.0, places=9)
+
+
+class RandomComplexResidualTest(unittest.TestCase):
+    """residual == 0 <=> L psi || psi and Rayleigh = eigenvalue, on random
+    connected complexes with random Hermitian weights/phases."""
+
+    @staticmethod
+    def _random_complex(seed, n):
+        rng = np.random.default_rng(seed)
+        # A random spanning tree (connected), then a few extra chords.
+        perm = list(rng.permutation(n))
+        edges = set()
+        for k in range(1, n):
+            j = perm[int(rng.integers(0, k))]
+            edges.add((min(perm[k], j), max(perm[k], j)))
+        extra = rng.integers(1, n)
+        while len(edges) < (n - 1) + extra:
+            a, b = int(rng.integers(0, n)), int(rng.integers(0, n))
+            if a != b:
+                edges.add((min(a, b), max(a, b)))
+        st = _from_simplices(n, sorted(edges))
+        for e in st.getEdgeList().toVector():
+            e.setSquaredLength(float(rng.uniform(0.4, 3.0)))
+            e.setPhase(float(rng.uniform(-math.pi, math.pi)))
+        return st
+
+    def test_eigenvectors_are_harmonic_and_random_vector_is_not(self):
+        for seed in range(6):
+            n = 4 + (seed % 3)  # 4, 5, 6 vertices
+            with self.subTest(seed=seed, n=n):
+                st = self._random_complex(seed, n)
+                es = cob.EigenstateSynthesis(st)
+                self.assertEqual(es.order(), n)
+                L = _np_L(st)
+                evals, evecs = np.linalg.eigh(L)
+                for k in range(n):
+                    v = evecs[:, k]
+                    self.assertLess(es.residual(_cvec(v)), 1e-10)
+                    self.assertAlmostEqual(es.rayleigh(_cvec(v)), evals[k],
+                                           places=8)
+                    Lv = np.asarray(es.apply(_cvec(v)))
+                    np.testing.assert_allclose(Lv, evals[k] * v, atol=1e-8)
+                    # L v genuinely parallel to v: |<v, Lv>| == ||Lv||.
+                    self.assertAlmostEqual(abs(np.vdot(v, Lv)),
+                                           np.linalg.norm(Lv), places=8)
+
+                # A generic vector is not an eigenvector: r > 0, matching numpy,
+                # and L u is not parallel to u.
+                rng = np.random.default_rng(1000 + seed)
+                u = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+                u /= np.linalg.norm(u)
+                r = es.residual(_cvec(u))
+                self.assertGreater(r, 1e-6)
+                self.assertAlmostEqual(r, _np_residual(L, u), places=10)
+                Lu = np.asarray(es.apply(_cvec(u)))
+                self.assertLess(abs(np.vdot(u, Lu)), np.linalg.norm(Lu) - 1e-9)
+
+
+class ParameterOrderTest(unittest.TestCase):
+    """weights() / phases() get-set round-trips, in the stable EdgeList order,
+    with the operator reflecting that order. Extends the base round-trip test to
+    the phase channel and to out-of-range phase values."""
+
+    def test_weight_phase_order_matches_edgelist_and_operator(self):
+        st = _from_simplices(4, [(0, 1), (1, 2), (2, 3), (3, 0), (0, 2)])
+        es = cob.EigenstateSynthesis(st)
+        m = es.numEdges()
+        self.assertEqual(m, 5)
+
+        # Distinct weights and phases including a negative and a > 2*pi value
+        # (the phase must round-trip verbatim — no wrapping or clamping).
+        w = [0.4 + 0.7 * i for i in range(m)]
+        th = [-3.7, 0.0, 7.25, -0.4, 5.9]
+        es.setWeights(w)
+        es.setPhases(th)
+        self.assertTrue(np.allclose(es.weights(), w))
+        self.assertTrue(np.allclose(es.phases(), th))
+
+        # The k-th parameter is the k-th EdgeList edge (the stable order).
+        live = st.getEdgeList().toVector()
+        self.assertTrue(np.allclose([e.getSquaredLength() for e in live], w))
+        self.assertTrue(np.allclose([e.getPhase() for e in live], th))
+
+        # And the operator (apply) is built in that same edge order: it agrees
+        # with the numpy L assembled directly from the live edges.
+        rng = np.random.default_rng(0)
+        psi = rng.standard_normal(4) + 1j * rng.standard_normal(4)
+        np.testing.assert_allclose(
+            np.asarray(es.apply(_cvec(psi))), _np_L(st) @ psi, atol=1e-10)
+
+
+class GeneralAmplitudeFloorOracleTest(unittest.TestCase):
+    """The two-vertex floor w_min^2 (|c0|^2 - |c1|^2)^2 confirmed against an
+    INDEPENDENT numpy grid+refine global-min oracle (not just the closed form),
+    and reached by a scipy search over the C++ residual."""
+
+    W_MIN, W_MAX = 0.1, 10.0
+
+    def _two_vertex(self):
+        st = _from_simplices(2, [(0, 1)])
+        _set_uniform(st, 1.0, 0.0)
+        return st
+
+    def _cpp_floor(self, es, psi, seed, restarts=40):
+        from scipy.optimize import minimize
+        psi = _cvec(psi)
+        rng = np.random.default_rng(seed)
+        bounds = [(self.W_MIN, self.W_MAX), (-2.0 * math.pi, 2.0 * math.pi)]
+
+        def objective(x):
+            es.setWeights([x[0]])
+            es.setPhases([x[1]])
+            return es.residual(psi)
+
+        best = np.inf
+        for _ in range(restarts):
+            x0 = [rng.uniform(self.W_MIN, self.W_MAX), rng.uniform(-math.pi, math.pi)]
+            res = minimize(objective, x0, method="L-BFGS-B", bounds=bounds)
+            best = min(best, float(res.fun))
+        return best
+
+    def _oracle_floor(self, st, psi):
+        # Brute-force global min of the numpy residual over the single edge
+        # (w, theta), then a local refine from the best grid point — fully
+        # independent of the C++ code and of the analytic closed form.
+        from scipy.optimize import minimize
+        edge = st.getEdgeList().toVector()[0]
+
+        def f(x):
+            edge.setSquaredLength(x[0])
+            edge.setPhase(x[1])
+            return _np_residual(_np_L(st), psi)
+
+        best, bx = np.inf, None
+        for ww in np.linspace(self.W_MIN, self.W_MAX, 40):
+            for th in np.linspace(-math.pi, math.pi, 40):
+                val = f([ww, th])
+                if val < best:
+                    best, bx = val, [ww, th]
+        ref = minimize(f, bx, method="L-BFGS-B",
+                       bounds=[(self.W_MIN, self.W_MAX), (-2 * math.pi, 2 * math.pi)])
+        return float(ref.fun)
+
+    def test_floor_matches_global_min_oracle(self):
+        for i, p0 in enumerate((0.6, 0.75, 0.85, 0.95)):
+            with self.subTest(p0=p0):
+                psi = np.array([math.sqrt(p0), math.sqrt(1.0 - p0)], dtype=complex)
+                closed = self.W_MIN ** 2 * (2.0 * p0 - 1.0) ** 2
+
+                oracle = self._oracle_floor(self._two_vertex(), psi)
+                cpp = self._cpp_floor(cob.EigenstateSynthesis(self._two_vertex()),
+                                      psi, seed=i + 1)
+
+                # A positive floor (the obstruction motivating coning): it scales
+                # as d^2 = (2 p0 - 1)^2, so it can be small for a mild imbalance,
+                # but it is strictly nonzero (a balanced qubit reaches ~0 instead).
+                self.assertGreater(oracle, 1e-5)
+                # The brute-force global min equals the analytic closed form ...
+                self.assertAlmostEqual(oracle, closed, delta=max(2e-3, 0.02 * closed))
+                # ... and the scipy search over the C++ residual reaches it.
+                self.assertAlmostEqual(cpp, oracle, delta=max(2e-3, 0.05 * closed))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/quantum/test_choi_jamiolkowski_hardening_python.py
+++ b/tests/quantum/test_choi_jamiolkowski_hardening_python.py
@@ -1,0 +1,275 @@
+"""Hardening for the C++ ChoiJamiolkowski map-state duality ("bending").
+
+Complements tests/quantum/test_choi_jamiolkowski_python.py, which pins the core
+duality on 2x2 operators. Here every claim is checked against an independent
+numpy oracle on RECTANGULAR / higher-dimensional operators and Haar-ish
+unitaries, and the convention / validation surface the base suite leaves open:
+
+  * map-state duality  <psiA|U|psiB> = <vec(U_T)|vec(U)> = Tr(U_T^H.U)  on random
+    rectangular U (dA != dB) across several shapes and seeds;
+  * vec(|a><b|) = a (x) conj(b) — the separable, Schmidt-rank-1 structure — for
+    rectangular, non-unit a, b (the kron identity directly);
+  * singularValues == the numpy SVD spectrum, and the SVD of U is literally the
+    Schmidt decomposition of vec(U):  vec(U) = sum_k sigma_k (u_k (x) vbar_k);
+  * schmidtRank == numpy matrix rank for prescribed-rank rectangular operators,
+    and the sigma_max-relative `tol` threshold gates a near-singular value;
+  * choiState / choiMatrix on Haar unitaries (d = 2, 3, 5): pure unit state,
+    Hermitian J, Tr J = 1, rank 1, BOTH marginals = I/d; plus the non-unitary
+    convention Tr J = ||U||_F^2 / d and the marginal U U^H / d;
+  * the std::invalid_argument validation surface (-> ValueError).
+
+Conventions (locked, see the header of include/quantum/ChoiJamiolkowski.h):
+operators are flat ROW-MAJOR (U[i*dB + j] = U_{ij}); vec(U) = sum_{ij} U_{ij}
+|i> (x) |j> is that flatten; vec(|a><b|) = a (x) conj(b).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+try:
+    from tessera.quantum import ChoiJamiolkowski
+    HAVE_QUANTUM = True
+except ImportError:
+    HAVE_QUANTUM = False
+
+
+def _rand_complex(rng: "np.random.Generator", *shape: int) -> np.ndarray:
+    """A complex array of the given shape with iid standard-normal parts."""
+    return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+
+def _unit(v: np.ndarray) -> np.ndarray:
+    return v / np.linalg.norm(v)
+
+
+def _flat(matrix) -> list:
+    """Row-major (C-order) flatten as a list of Python complex numbers."""
+    return np.asarray(matrix, dtype=complex).flatten().tolist()
+
+
+def _haar_unitary(rng: "np.random.Generator", d: int) -> np.ndarray:
+    """A Haar-distributed d x d unitary (QR with the standard phase fix)."""
+    q, r = np.linalg.qr(_rand_complex(rng, d, d))
+    ph = np.diag(r) / np.abs(np.diag(r))
+    return q * ph  # rescale each column j by ph[j] -> Haar measure
+
+
+# Random rectangular and square shapes that exercise dA != dB and dim > 2.
+_SHAPES = [(2, 3), (3, 2), (4, 4), (1, 4), (4, 1), (5, 3), (3, 5)]
+
+
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without the quantum subsystem")
+class TestRectangularDuality(unittest.TestCase):
+    """C1 on rectangular / higher-dim operators: the base suite only does 2x2."""
+
+    def test_duality_on_rectangular_operators(self) -> None:
+        for dA, dB in _SHAPES:
+            for seed in (0, 3, 17):
+                with self.subTest(dA=dA, dB=dB, seed=seed):
+                    rng = np.random.default_rng(seed)
+                    U = _rand_complex(rng, dA, dB)
+                    psiA = _unit(_rand_complex(rng, dA))
+                    psiB = _unit(_rand_complex(rng, dB))
+
+                    # Independent numpy oracle: the bare sandwich.
+                    amp_ref = complex(psiA.conj() @ U @ psiB)
+
+                    amp = ChoiJamiolkowski.transitionAmplitude(
+                        psiA.tolist(), _flat(U), psiB.tolist(), dA, dB)
+                    UT = np.array(ChoiJamiolkowski.transitionOperator(
+                        psiA.tolist(), psiB.tolist(), dA, dB)).reshape(dA, dB)
+                    vecU = np.array(ChoiJamiolkowski.vectorize(_flat(U), dA, dB))
+                    vecUT = np.array(ChoiJamiolkowski.vectorize(_flat(UT), dA, dB))
+
+                    # transitionAmplitude == <vec(U_T)|vec(U)> == Tr(U_T^H U) == oracle.
+                    self.assertAlmostEqual(abs(amp - amp_ref), 0.0, delta=1e-10)
+                    self.assertAlmostEqual(
+                        abs(amp - np.vdot(vecUT, vecU)), 0.0, delta=1e-10)
+                    self.assertAlmostEqual(
+                        abs(amp - np.trace(UT.conj().T @ U)), 0.0, delta=1e-10)
+                    # U_T = |psiA><psiB|.
+                    np.testing.assert_allclose(
+                        UT, np.outer(psiA, psiB.conj()), atol=1e-12)
+
+    def test_vec_of_outer_product_is_a_kron_conj_b(self) -> None:
+        # vec(|a><b|) = a (x) conj(b), for rectangular, non-unit a and b.
+        for dA, dB in [(2, 3), (4, 2), (3, 3), (1, 5)]:
+            with self.subTest(dA=dA, dB=dB):
+                rng = np.random.default_rng(dA * 10 + dB)
+                a = _rand_complex(rng, dA)          # deliberately not normalised
+                b = _rand_complex(rng, dB)
+                UT = ChoiJamiolkowski.transitionOperator(
+                    a.tolist(), b.tolist(), dA, dB)
+                vecUT = np.array(ChoiJamiolkowski.vectorize(UT, dA, dB))
+                np.testing.assert_allclose(vecUT, np.kron(a, b.conj()), atol=1e-12)
+                # And rank one (separable / disconnected cobordism), rectangular.
+                self.assertEqual(ChoiJamiolkowski.schmidtRank(UT, dA, dB), 1)
+
+
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without the quantum subsystem")
+class TestSchmidtStructure(unittest.TestCase):
+    """Schmidt rank == #nonzero singular values, beyond the base suite's 2x2."""
+
+    def test_singular_values_match_numpy(self) -> None:
+        for dA, dB in _SHAPES:
+            with self.subTest(dA=dA, dB=dB):
+                rng = np.random.default_rng(100 + dA * 7 + dB)
+                U = _rand_complex(rng, dA, dB)
+                sv = ChoiJamiolkowski.singularValues(_flat(U), dA, dB)
+                sv_ref = np.linalg.svd(U, compute_uv=False)  # descending
+                self.assertEqual(len(sv), min(dA, dB))
+                np.testing.assert_allclose(sv, sv_ref, atol=1e-10)
+
+    def test_svd_is_schmidt_decomposition_of_vec(self) -> None:
+        # The header's claim: the SVD of U IS the Schmidt decomposition of vec(U).
+        for dA, dB in [(3, 4), (4, 3), (5, 5), (2, 6)]:
+            with self.subTest(dA=dA, dB=dB):
+                rng = np.random.default_rng(900 + dA + dB)
+                U = _rand_complex(rng, dA, dB)
+                u, s, vh = np.linalg.svd(U, full_matrices=False)
+                # vec(U) = sum_k sigma_k (u_k (x) conj(v_k)) with conj(v_k) = vh[k].
+                recon = sum(s[k] * np.kron(u[:, k], vh[k, :])
+                            for k in range(len(s)))
+                vecU = np.array(ChoiJamiolkowski.vectorize(_flat(U), dA, dB))
+                np.testing.assert_allclose(vecU, recon, atol=1e-10)
+                np.testing.assert_allclose(vecU, U.flatten(), atol=1e-12)
+                # Full-rank generic operator: Schmidt rank = min(dA, dB).
+                self.assertEqual(
+                    ChoiJamiolkowski.schmidtRank(_flat(U), dA, dB), min(dA, dB))
+
+    def test_schmidt_rank_tracks_prescribed_rank(self) -> None:
+        # Build an exactly rank-r operator from orthonormal singular vectors and a
+        # prescribed positive spectrum; schmidtRank and numpy agree on the rank.
+        for dA, dB in [(4, 4), (5, 3), (3, 6)]:
+            for r in range(1, min(dA, dB) + 1):
+                with self.subTest(dA=dA, dB=dB, r=r):
+                    rng = np.random.default_rng(7 * dA + 11 * dB + r)
+                    uq, _ = np.linalg.qr(_rand_complex(rng, dA, dA))
+                    vq, _ = np.linalg.qr(_rand_complex(rng, dB, dB))
+                    sig = np.array([3.0 - 0.5 * k for k in range(r)])  # distinct >0
+                    U = uq[:, :r] @ np.diag(sig) @ vq[:, :r].conj().T
+                    self.assertEqual(
+                        ChoiJamiolkowski.schmidtRank(_flat(U), dA, dB), r)
+                    self.assertEqual(np.linalg.matrix_rank(U), r)
+                    sv = ChoiJamiolkowski.singularValues(_flat(U), dA, dB)
+                    np.testing.assert_allclose(
+                        sorted(sv, reverse=True)[:r], sorted(sig, reverse=True),
+                        atol=1e-10)
+                    np.testing.assert_allclose(
+                        sorted(sv, reverse=True)[r:], 0.0, atol=1e-10)
+
+    def test_tol_threshold_gates_a_near_singular_value(self) -> None:
+        # diag(1, 1e-7): a tiny-but-nonzero second singular value.  schmidtRank
+        # counts it iff it exceeds tol * sigma_max (sigma_max = 1 here).
+        U = _flat(np.diag([1.0, 1e-7]))
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(U, 2, 2), 2)            # default 1e-10
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(U, 2, 2, 1e-9), 2)     # 1e-7 > 1e-9
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(U, 2, 2, 1e-5), 1)     # 1e-7 < 1e-5
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(U, 2, 2, 1e-3), 1)
+        # The same gating embedded in a rectangular operator.
+        rng = np.random.default_rng(42)
+        uq, _ = np.linalg.qr(_rand_complex(rng, 3, 3))
+        vq, _ = np.linalg.qr(_rand_complex(rng, 2, 2))
+        Ur = uq[:, :2] @ np.diag([1.0, 1e-7]) @ vq.conj().T  # 3x2, svals (1, 1e-7)
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(_flat(Ur), 3, 2), 2)
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(_flat(Ur), 3, 2, 1e-5), 1)
+        # The zero operator has rank 0 (no positive singular value).
+        Z = _flat(np.zeros((3, 4)))
+        self.assertEqual(ChoiJamiolkowski.schmidtRank(Z, 3, 4), 0)
+        np.testing.assert_allclose(
+            ChoiJamiolkowski.singularValues(Z, 3, 4), 0.0, atol=1e-12)
+
+
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without the quantum subsystem")
+class TestChoiOnHaarUnitaries(unittest.TestCase):
+    """choiState / choiMatrix on Haar unitaries across d, and the non-unitary
+    scaling that pins the convention. The base suite checks these properties
+    only piecemeal at single dimensions."""
+
+    def test_state_and_matrix_properties_across_dimensions(self) -> None:
+        for d in (2, 3, 5):
+            n = d * d
+            for seed in (1, 8):
+                with self.subTest(d=d, seed=seed):
+                    rng = np.random.default_rng(seed * 100 + d)
+                    Q = _haar_unitary(rng, d)
+
+                    state = np.array(ChoiJamiolkowski.choiState(_flat(Q), d))
+                    self.assertAlmostEqual(np.linalg.norm(state), 1.0, delta=1e-12)
+                    np.testing.assert_allclose(state, Q.flatten() / np.sqrt(d),
+                                               atol=1e-12)
+
+                    J = np.array(ChoiJamiolkowski.choiMatrix(_flat(Q), d)).reshape(n, n)
+                    np.testing.assert_allclose(J, J.conj().T, atol=1e-12)        # Hermitian
+                    self.assertAlmostEqual(np.trace(J).real, 1.0, delta=1e-12)   # Tr = 1
+                    np.testing.assert_allclose(
+                        J, np.outer(state, state.conj()), atol=1e-12)            # = |s><s|
+                    evals = np.linalg.eigvalsh(J)
+                    self.assertAlmostEqual(evals[-1], 1.0, delta=1e-10)          # rank 1
+                    np.testing.assert_allclose(evals[:-1], 0.0, atol=1e-10)
+
+                    # BOTH marginals of a unitary's Choi state are maximally mixed.
+                    J4 = J.reshape(d, d, d, d)
+                    rho_A = np.einsum("ijkj->ik", J4)   # trace out factor B
+                    rho_B = np.einsum("ijil->jl", J4)   # trace out factor A
+                    np.testing.assert_allclose(rho_A, np.eye(d) / d, atol=1e-10)
+                    np.testing.assert_allclose(rho_B, np.eye(d) / d, atol=1e-10)
+
+    def test_non_unitary_choi_matrix_convention(self) -> None:
+        # For a general (non-unitary) U the bend is still a pure state, so J is
+        # rank 1 and Hermitian, but Tr J = ||U||_F^2 / d and the A-marginal is
+        # U U^H / d (= I/d only when U is unitary) — the statement that pins the
+        # row-major (1/sqrt d) vec convention.
+        for d in (3, 4):
+            with self.subTest(d=d):
+                rng = np.random.default_rng(2024 + d)
+                U = _rand_complex(rng, d, d)            # generic, not unitary
+                n = d * d
+                J = np.array(ChoiJamiolkowski.choiMatrix(_flat(U), d)).reshape(n, n)
+                np.testing.assert_allclose(J, J.conj().T, atol=1e-12)
+                self.assertAlmostEqual(
+                    np.trace(J).real, np.linalg.norm(U) ** 2 / d, delta=1e-10)
+                evals = np.linalg.eigvalsh(J)           # still a pure state -> rank 1
+                np.testing.assert_allclose(evals[:-1], 0.0, atol=1e-10)
+                rho_A = np.einsum("ijkj->ik", J.reshape(d, d, d, d))
+                np.testing.assert_allclose(rho_A, U @ U.conj().T / d, atol=1e-10)
+
+
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without the quantum subsystem")
+class TestValidation(unittest.TestCase):
+    """The std::invalid_argument surface: pybind maps it to ValueError. The base
+    suite exercises none of the throw paths."""
+
+    def test_bad_dimensions_raise_value_error(self) -> None:
+        good2 = _flat(np.eye(2))
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.vectorize([1 + 0j, 2 + 0j, 3 + 0j], 2, 2)   # 3 != 2*2
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.vectorize([1 + 0j], 0, 1)                   # dim <= 0
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.singularValues([1 + 0j, 2 + 0j], 2, 2)      # 2 != 4
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.schmidtRank([1 + 0j], 2, 2)                 # 1 != 4
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.transitionOperator([1 + 0j], [1 + 0j, 0j], 2, 2)  # psiA
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.transitionOperator([1 + 0j, 0j], [1 + 0j], 2, 2)  # psiB
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.transitionAmplitude(
+                [1 + 0j, 0j], [1 + 0j], [1 + 0j, 0j], 2, 2)             # U length
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.transitionAmplitude(
+                [1 + 0j], good2, [1 + 0j, 0j], 2, 2)                    # psiA length
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.choiState([1 + 0j, 2 + 0j], 2)            # 2 != 2*2
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.choiState(good2, 0)                        # d <= 0
+        with self.assertRaises(ValueError):
+            ChoiJamiolkowski.choiMatrix([1 + 0j, 2 + 0j, 3 + 0j], 2)    # 3 != 2*2
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Test-only hardening for the merged map–state and synthesis layers (ChoiJamiolkowski + the #133 EigenstateSynthesis residual/optimizer). No production C++ changes. Every claim is checked against an independent numpy/scipy oracle.

**ChoiJamiolkowski** — `tests/quantum/test_choi_jamiolkowski_hardening_python.py`
- map–state duality `⟨ψ_A|U|ψ_B⟩ = ⟨vec(U_T)|vec(U)⟩ = Tr(U_TᴴU)` on random **rectangular / higher-dim** `U` (the base suite only covered 2×2)
- `vec(|a⟩⟨b|) = a ⊗ conj(b)` (the kron identity) for rectangular, non-unit `a, b`
- `singularValues` == numpy SVD, and the SVD of `U` reconstructed as the Schmidt decomposition of `vec(U)`
- `schmidtRank` == numpy matrix rank for prescribed-rank operators, plus the σ_max-relative `tol` threshold gating a near-singular value (and rank 0 on the zero operator)
- `choiState`/`choiMatrix` on Haar unitaries (d = 2, 3, 5): pure unit state, Hermitian, Tr = 1, rank 1, **both** marginals = I/d; plus the non-unitary convention `Tr J = ‖U‖_F²/d`, marginal `U Uᴴ/d`
- the `std::invalid_argument → ValueError` validation surface (untested before)

**EigenstateSynthesis** — `tests/cobordism/test_eigenstate_synthesis_hardening_python.py`
- hand-checkable closed-form spectra: triangle K₃ (zero flux {0, 3w, 3w}; a π-flux holonomy {w, w, 4w} that destroys the zero mode, with the constant vector flooring at the exact residual 8w²/9) and path P₃ ({0, w, 3w}, tree ⇒ θ-independent spectrum)
- `residual == 0 ⟺ Lψ ∥ ψ` and Rayleigh = realized eigenvalue on **random** connected complexes vs a numpy eigendecomposition
- weight/phase get-set round-trips over the stable EdgeList order (phases incl. negative / >2π), with `apply` reflecting that order
- the two-vertex amplitude floor `w_min²(|c₀|²−|c₁|²)²` matched by an independent numpy grid+refine **global-min oracle** across amplitudes/seeds

New tests: 16 tests / 64 subtests, all green. GeometrySynthesizer (#134) is out of scope per the issue ("merged parts only") and already well-covered by its existing suite.

Note: a cold build of this branch shows 9 failures in unrelated, already-merged files (`test_dijkgraaf_witten_hardening_python.py`, `test_homology_hardening_python.py` from #153/#158) — environment-sensitive `expectedFailure` xpasses tied to the Eigen version, reproducible on pristine `main`; not touched here.

Closes #155
