### PR TITLE
test: harden Pachner _top_size helper against lazily-materialized facets

### DIFF
--- a/tests/test_pachner_add_move.py
+++ b/tests/test_pachner_add_move.py
@@ -26,9 +26,13 @@ def _make_st(d=4, n_simplices=200):
 
 
 def _top_size(st):
-    for s in st.getSimplices():
-        return len(s.getVertices())
-    return 0
+    # CDT top simplices are (d+1)-vertex; d is the spacetime's declared
+    # (signature) dimension. getTopVertexCount() == signature.dimensions + 1,
+    # the engine's single source of truth for top-cell membership -- O(1) and
+    # immune to the lazily-materialized lower-dimensional facets that
+    # propose()/getFacets() register into getSimplices() (where the first
+    # scanned simplex may be a lower-dimensional face).
+    return st.getTopVertexCount()
 
 
 def _full_snapshot(st):

--- a/tests/test_pachner_characterization.py
+++ b/tests/test_pachner_characterization.py
@@ -63,16 +63,18 @@ def _make_cdt(d=4, n_simplices=200, k0=2.2, k4=0.5, delta=0.6,
 def _top_simplex_size(st):
     """Return d+1 (the vertex count of a top simplex) for this spacetime.
 
-    ``getSimplices()`` can contain lazily-materialized lower-dimensional faces:
-    a move's ``propose()`` inspects a simplex's facets via ``getFacets()``,
-    which creates and registers those facet simplices on demand. So the *first*
-    registered simplex is not necessarily top-dimensional — take the maximum
-    vertex count over all simplices to find the true top dimension. (Using the
-    first simplex's size here was the cause of an intermittent failure in
+    ``getTopVertexCount()`` returns ``signature.dimensions + 1`` directly --
+    the engine's single source of truth for top-cell membership -- so it is
+    O(1) and immune to the lazily-materialized lower-dimensional faces that
+    ``getSimplices()`` accumulates. A move's ``propose()`` inspects a simplex's
+    facets via ``getFacets()``, which creates and registers those
+    lower-dimensional facet simplices on demand; scanning ``getSimplices()``
+    for the top dimension is therefore order-dependent. (Using the *first*
+    simplex's size here was the cause of an intermittent failure in
     TestStateUnchangedOnRejection: when a tetrahedron sorted first the snapshot
     began counting tetrahedra, which then grew as more facets materialized.)
     """
-    return max((len(s.getVertices()) for s in st.getSimplices()), default=0)
+    return st.getTopVertexCount()
 
 
 def _state_snapshot(st):

--- a/tests/test_pachner_flip_move.py
+++ b/tests/test_pachner_flip_move.py
@@ -23,9 +23,13 @@ def _make_st(d=4, n_simplices=200):
 
 
 def _top_size(st):
-    for s in st.getSimplices():
-        return len(s.getVertices())
-    return 0
+    # CDT top simplices are (d+1)-vertex; d is the spacetime's declared
+    # (signature) dimension. getTopVertexCount() == signature.dimensions + 1,
+    # the engine's single source of truth for top-cell membership -- O(1) and
+    # immune to the lazily-materialized lower-dimensional facets that
+    # propose()/getFacets() register into getSimplices() (where the first
+    # scanned simplex may be a lower-dimensional face).
+    return st.getTopVertexCount()
 
 
 def _full_snapshot(st):

--- a/tests/test_pachner_iflip_move.py
+++ b/tests/test_pachner_iflip_move.py
@@ -23,9 +23,13 @@ def _make_st(d=4, n_simplices=200):
 
 
 def _top_size(st):
-    for s in st.getSimplices():
-        return len(s.getVertices())
-    return 0
+    # CDT top simplices are (d+1)-vertex; d is the spacetime's declared
+    # (signature) dimension. getTopVertexCount() == signature.dimensions + 1,
+    # the engine's single source of truth for top-cell membership -- O(1) and
+    # immune to the lazily-materialized lower-dimensional facets that
+    # propose()/getFacets() register into getSimplices() (where the first
+    # scanned simplex may be a lower-dimensional face).
+    return st.getTopVertexCount()
 
 
 def _full_snapshot(st):

--- a/tests/test_pachner_remove_move.py
+++ b/tests/test_pachner_remove_move.py
@@ -59,9 +59,13 @@ def _make_st_with_addgrowth(d=4, n_simplices=200,
 
 
 def _top_size(st):
-    for s in st.getSimplices():
-        return len(s.getVertices())
-    return 0
+    # CDT top simplices are (d+1)-vertex; d is the spacetime's declared
+    # (signature) dimension. getTopVertexCount() == signature.dimensions + 1,
+    # the engine's single source of truth for top-cell membership -- O(1) and
+    # immune to the lazily-materialized lower-dimensional facets that
+    # propose()/getFacets() register into getSimplices() (where the first
+    # scanned simplex may be a lower-dimensional face).
+    return st.getTopVertexCount()
 
 
 def _full_snapshot(st):

--- a/tests/test_pachner_shift_move.py
+++ b/tests/test_pachner_shift_move.py
@@ -47,9 +47,13 @@ def _make_st(d=4, n_simplices=200):
 
 
 def _top_size(st):
-    for s in st.getSimplices():
-        return len(s.getVertices())
-    return 0
+    # CDT top simplices are (d+1)-vertex; d is the spacetime's declared
+    # (signature) dimension. getTopVertexCount() == signature.dimensions + 1,
+    # the engine's single source of truth for top-cell membership -- O(1) and
+    # immune to the lazily-materialized lower-dimensional facets that
+    # propose()/getFacets() register into getSimplices() (where the first
+    # scanned simplex may be a lower-dimensional face).
+    return st.getTopVertexCount()
 
 
 def _full_snapshot(st):


### PR DESCRIPTION
## What

Replace the fragile `_top_size` / `_top_simplex_size` helpers in the Pachner test files with the O(1) signature-dimension form, via `st.getTopVertexCount()`.

Files changed (test-only):
- `tests/test_pachner_add_move.py`
- `tests/test_pachner_flip_move.py`
- `tests/test_pachner_remove_move.py`
- `tests/test_pachner_iflip_move.py`
- `tests/test_pachner_shift_move.py`
- `tests/test_pachner_characterization.py` (retrofits #81's max-vertex-count workaround to the cleaner form)

## Why

The snapshot helpers identified the top-simplex dimension by scanning `getSimplices()` -- taking the *first* simplex's vertex count (the five move files) or the *max* vertex count (characterization). A move's `propose()` calls `Simplex::getFacets()`, which **lazily materializes and registers** lower-dimensional facet simplices, so `getSimplices()` ends up holding faces of several dimensions. When the first registered simplex is a lower-dimensional face, the snapshot counts the wrong-dimension cells and a rollback / state-unchanged-on-rejection assertion fails **intermittently** (order- and RNG-dependent in the full suite; passes in isolation). The engine bookkeeping is correct -- this is purely test fragility.

`st.getTopVertexCount()` returns `signature.dimensions + 1` directly -- the engine's single source of truth for top-cell membership. O(1), unambiguous, immune to lazily-materialized lower-dimensional faces.

Note on the prescribed code: the issue suggests `st.getMetric().getSignature().getDimensions() + 1`, but those three intermediate accessors are not bound to Python. `getTopVertexCount()` is bound and its C++ body is exactly `metric->getSignature()->getDimensions() + 1`, so it is the bound equivalent (one C++ call instead of three Python round-trips) and keeps this a strictly test-only change.

The cobordism verifier (`Cobordism::topSimplices`) is **untouched** -- it deliberately keeps the intrinsic max-vertex-count form because its hand-built fixtures live in a 4D-signature `Spacetime` with intrinsic dimension != the signature dimension.

## Validation (local; reliability, not a single pass)

- 6 affected files: `103 passed, 1 skipped`
- `flip_move::TestFlipStress::test_chained_flips_roll_back_in_lifo` x40: **40/40**
- `characterization::TestStateUnchangedOnRejection` x40: **40/40**
- whole `TestFlipStress` class x40: **40/40**
- full 6-file affected set x25: **25/25**
- `tests/ -k pachner` (whole suite, filtered): `216 passed, 1 skipped, 881 deselected, 31 subtests passed`

Closes #85