### PR TITLE
cobordism: realizability oracle — spectral bulk synthesis for U

### DIFF
--- a/include/cobordism/RealizabilityOracle.h
+++ b/include/cobordism/RealizabilityOracle.h
@@ -1,0 +1,202 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_REALIZABILITYORACLE_H
+#define TESSERA_COBORDISM_REALIZABILITYORACLE_H
+
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+class EigenstateSynthesis;
+
+/// # RealizabilityOracle
+///
+/// The §5.0 realizability oracle: decide whether an operation
+/// \f$ U:\mathcal{H}_B\to\mathcal{H}_A \f$ is realizable as a bulk cobordism
+/// \f$ W_{AB} \f$ by **synthesizing the bulk spectrally** — not by TQFT
+/// membership. \f$ U \f$ is bent to a boundary state via Choi–Jamiołkowski
+/// (\f$ \mathrm{vec}(U) \f$, the operator-as-state); the boundaries of
+/// \f$ W_{AB} \f$ are *pinned* (the synthesized \f$ \mathrm{geo} \f$'s / the
+/// output surface) and the **interior** is filled — its Hermitian edge weights
+/// and (via boundary-fixed Pachner growth) its topology — so the output-boundary
+/// graph-Laplacian eigenvector matches the bent target, i.e. the §4b residual
+/// \f$ r = \lVert (I-\psi\psi^\dagger)L\psi \rVert^2 \to 0 \f$.
+///
+/// **Realizability is itself the test.** A target is **realizable** iff the
+/// residual can be driven below \f$ \epsilon \f$, and **non-realizable** iff it
+/// *floors* away from zero under the pinned boundary — a spectral obstruction,
+/// the analogue of §4b's two-vertex floor \f$ w_{\min}^2(|c_0|^2-|c_1|^2)^2 \f$.
+/// The floor **is** the certificate: non-existence is certified by the residual
+/// floor, **not** by exhausting triangulations.
+///
+/// ## Pure orchestration (no new math)
+///
+/// This class composes the merged building blocks; it adds no numerics of its
+/// own:
+///   * `quantum::ChoiJamiolkowski` — bends \f$ U \f$ to \f$ \mathrm{vec}(U) \f$.
+///   * `cobordism::EigenstateSynthesis` — the fixed-boundary interior-fill engine
+///     (\f$ \partial W \f$ pinned; `setInteriorWeights` / `setInteriorPhases`
+///     vary only the interior; `growInterior` is the boundary-fixed Pachner add;
+///     `residual` / `rayleigh` / `apply` score the target).
+///   * `cobordism::LevenbergMarquardt` — the same bounded multi-restart
+///     least-squares solver the §4b `GeometrySynthesizer` drives, here over the
+///     **interior** parameters and the free auxiliary amplitudes.
+///
+/// The pipeline (one public entry point, a few private steps):
+///   1. **Bend** — `vec(U)` → the normalized target \f$ \psi_U \f$ (length
+///      \f$ d_A d_B \f$), the operator rendered as a boundary state.
+///   2. **Pin** — the bulk's boundary edges \f$ \partial W \f$ (the synthesized
+///      boundaries / output surface) are held byte-fixed throughout; the
+///      fixed-boundary engine only ever writes interior edges.
+///   3. **Fill** — the §4b cone-and-retry restricted to the interior: a
+///      multi-restart `LevenbergMarquardt` over the interior weights/phases and
+///      the auxiliary amplitudes drives \f$ r\to 0 \f$; if a pass cannot
+///      converge, `growInterior` cones a fresh interior vertex (boundary-fixed)
+///      and the pass retries, up to the cone budget.
+///   4. **Verdict** — realizable iff \f$ r<\epsilon \f$ (with the witness state
+///      and the bulk \f$ W_{AB} \f$); otherwise non-realizable, certified by the
+///      residual floor reached at the explored interior complexity.
+///
+/// ## Boundary support convention
+///
+/// \f$ \psi_U \f$ is carried by the **first** \f$ d_A d_B \f$ vertices in
+/// sorted-id order (the output-surface support, the
+/// `GeometrySynthesizer`/`EigenstateSynthesis` embedding idiom); any remaining
+/// vertices — interior vertices and the apices `growInterior` cones in (larger
+/// ids, appended last) — carry **free auxiliary amplitudes** the fill solves
+/// for. The caller assembles the bulk so its output surface occupies those ids
+/// and pins its boundary edges (`Spacetime` is built and pinned outside the
+/// synthesis classes, the established idiom). `decide` mutates the held bulk in
+/// place (the accepted interior weights/phases, plus any coned-in growth), and
+/// the returned `witness` is that realized \f$ W_{AB} \f$.
+class RealizabilityOracle {
+  public:
+    /// The oracle's verdict on \f$ U \f$: the realizability decision, the
+    /// residual (the obstruction floor when non-realizable), the witness state
+    /// and bulk, and the interior complexity reached.
+    struct Verdict {
+      /// True iff the interior fill drove \f$ r<\epsilon \f$ within the cone
+      /// budget — \f$ U \f$ is realizable, witnessed by `state` on `witness`.
+      bool realizable{false};
+      /// The best residual \f$ r=\lVert(I-\psi\psi^\dagger)L\psi\rVert^2 \f$
+      /// reached. \f$ <\epsilon \f$ when realizable; the certified obstruction
+      /// **floor** otherwise.
+      double residual{0.0};
+      /// The obstruction floor: `residual` when non-realizable, `0` when
+      /// realizable. The spectral certificate that no bulk of the explored
+      /// interior complexity realizes \f$ U \f$ under the pinned boundary.
+      double floor{0.0};
+      /// The realized eigenvalue \f$ \lambda=\psi^\dagger L\psi \f$ (Rayleigh
+      /// quotient) of the witness state — meaningful when realizable.
+      double eigenvalue{0.0};
+      /// Interior vertices coned in to reach the verdict (the interior
+      /// complexity, the §4b \f$ (|V|,|E|) \f$ analogue under fixed ends).
+      std::size_t interiorVertexCount{0};
+      /// Boundary-fixed cones applied during the fill (== `interiorVertexCount`
+      /// for a single-top-cell seed; reported for the cone-and-retry trace).
+      int conesApplied{0};
+      /// The witness state: the realized full Laplacian eigenvector on
+      /// \f$ W_{AB} \f$ (unit norm, length = the bulk's vertex count), whose
+      /// first \f$ d_A d_B \f$ components are the output-boundary block matching
+      /// `target`. A genuine eigenstate iff `realizable`.
+      std::vector<std::complex<double>> state{};
+      /// The bent target \f$ \psi_U=\mathrm{vec}(U)/\lVert\cdot\rVert \f$
+      /// (length \f$ d_A d_B \f$) the output boundary is matched against.
+      std::vector<std::complex<double>> target{};
+      /// The realized bulk \f$ W_{AB} \f$ — the witness cobordism (realizable),
+      /// or the complex on which the residual floors (non-realizable).
+      std::shared_ptr<Spacetime> witness{};
+    };
+
+    /// Construct over the assembled bulk \f$ W_{AB} \f$: a pre-geometric
+    /// `Spacetime` whose codimension-one boundary is the (pinned) output surface
+    /// plus input boundaries, with its output-surface vertices occupying the
+    /// smallest ids (see the boundary-support convention). The held `shared_ptr`
+    /// keeps the bulk alive; `decide` realizes it in place.
+    /// @throws std::invalid_argument if `bulk` is null.
+    explicit RealizabilityOracle(std::shared_ptr<Spacetime> bulk);
+
+    /// Decide whether the \f$ d_A\times d_B \f$ operator \f$ U \f$ (flat
+    /// row-major, \f$ U_{ij}=U[i\,d_B+j] \f$) is realizable as a bulk cobordism:
+    /// bend it to \f$ \psi_U=\mathrm{vec}(U) \f$, fill the pinned-boundary
+    /// interior to drive the §4b residual to zero, and return the `Verdict`.
+    /// @param epsilon  acceptance threshold on the residual (realizable iff
+    ///                 \f$ r<\epsilon \f$).
+    /// @param restarts random restarts per interior-fill pass (non-convex).
+    /// @param maxCones boundary-fixed interior cones to try (0 ⇒ decide at the
+    ///                 seed interior complexity — the bare obstruction floor).
+    /// @param seed     RNG seed for the restart draws (reproducible).
+    /// @throws std::invalid_argument if \f$ U \f$'s size \f$ \neq d_A d_B \f$, a
+    ///   dimension is non-positive, or the bulk has fewer vertices than
+    ///   \f$ d_A d_B \f$ (no room for the output-boundary support).
+    [[nodiscard]] Verdict decide(const std::vector<std::complex<double>> &U,
+                                 int dA, int dB, double epsilon = 1e-10,
+                                 int restarts = 64, int maxCones = 4,
+                                 std::uint64_t seed = 0);
+
+  private:
+    // §4b search box — identical to GeometrySynthesizer so the interior fill is
+    // the same machinery applied to the interior: per-edge magnitudes in
+    // [kWMin, kWMax], U(1) phases in [-kThetaBound, kThetaBound]. kAuxBound
+    // clamps the free auxiliary amplitudes on interior / coned-in vertices.
+    static constexpr double kPi = 3.14159265358979323846;
+    static constexpr double kWMin = 0.1;
+    static constexpr double kWMax = 10.0;
+    static constexpr double kThetaBound = 2.0 * kPi;
+    static constexpr double kAuxBound = 5.0;
+    static constexpr int kMaxIterations = 200;  // LM iterations per descent
+
+    std::shared_ptr<Spacetime> bulk_;
+
+    // Bend U to its normalized boundary state psi_U = vec(U)/||vec(U)||
+    // (ChoiJamiolkowski::vectorize; the residual is scale-invariant, but a unit
+    // target gives a unit witness and a clean output-boundary match). Length
+    // dA*dB.
+    [[nodiscard]] static std::vector<std::complex<double>> bend(
+        const std::vector<std::complex<double>> &U, int dA, int dB);
+
+    // The §4b cone-and-retry restricted to the interior: drive r(psi) -> 0 for
+    // the target on its first `target.size()` (boundary-support) components with
+    // the remaining (interior/auxiliary) components free, varying only the
+    // interior edge weights/phases via `es`; grow the interior (boundary-fixed
+    // Pachner add) and retry while unconverged and within `maxCones`. Leaves
+    // `es`'s complex realized at the best parameters, writes the realized unit
+    // witness state to `witnessOut`, records the cones applied, and returns the
+    // best residual (the floor if it never converges). Reuses LevenbergMarquardt
+    // exactly as GeometrySynthesizer::runOptimizer does.
+    [[nodiscard]] double fillInterior(
+        EigenstateSynthesis &es,
+        const std::vector<std::complex<double>> &target, double epsilon,
+        int restarts, int maxCones, std::uint64_t seed,
+        std::vector<std::complex<double>> &witnessOut, int &conesApplied) const;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_REALIZABILITYORACLE_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -37,6 +37,7 @@
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
+#include "cobordism/RealizabilityOracle.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
 
 namespace py = pybind11;
@@ -387,6 +388,91 @@ synthesized only after coning in one auxiliary vertex (the minimal complex).)doc
            "|E| of the current complex.")
       .def("spacetime", &GeometrySynthesizer::spacetime,
            "The current (growing) complex.");
+
+  // ----- §5.0 realizability oracle: spectral bulk synthesis for U (#138) -----
+  py::class_<RealizabilityOracle> ro(m, "RealizabilityOracle",
+      R"doc(§5.0 realizability oracle — spectral bulk synthesis for an operation U.
+
+Decides whether U : H_B -> H_A is realizable as a bulk cobordism W_AB by
+*synthesizing the bulk spectrally*, not by TQFT membership. U is bent to a
+boundary state via Choi-Jamiolkowski (vec(U), the operator-as-state); the bulk's
+boundary dW (the synthesized geo's / output surface) is *pinned*, and the
+interior — its Hermitian edge weights and, via boundary-fixed Pachner growth, its
+topology — is filled so the output-boundary k=0 graph-Laplacian eigenvector
+matches the bent target, i.e. the §4b residual r = ||(I - psi psi^dagger) L psi||^2
+is driven to 0.
+
+Realizability is itself the test: U is realizable iff r can be driven below
+epsilon, and non-realizable iff r floors away from 0 under the pinned boundary —
+a spectral obstruction, the analogue of §4b's two-vertex floor
+w_min^2(|c0|^2-|c1|^2)^2. The floor IS the certificate (non-existence is certified
+by the residual floor at the explored interior complexity, not by exhausting
+triangulations).
+
+Pure orchestration of the merged building blocks (no new math):
+ChoiJamiolkowski (the bend), EigenstateSynthesis (the fixed-boundary interior-fill
+engine: setInteriorWeights/Phases vary only dW's complement, growInterior is the
+boundary-fixed Pachner add), and LevenbergMarquardt (the same bounded multi-restart
+least-squares solver the §4b GeometrySynthesizer drives, here over the interior
+parameters + the free auxiliary amplitudes).
+
+vec(U) is carried by the first dA*dB sorted-id vertices (the output-surface
+support); remaining vertices (interior + coned-in apices, larger ids) carry free
+auxiliary amplitudes the fill solves for. The caller assembles the bulk and pins
+its boundary edges (Spacetime is built/pinned outside the synthesis classes);
+decide() realizes the held bulk in place and returns it as the witness.)doc");
+
+  py::class_<RealizabilityOracle::Verdict>(ro, "Verdict",
+      "The oracle's verdict on U: the realizability decision, the residual (the "
+      "obstruction floor when non-realizable), the realized witness state and "
+      "bulk W_AB, the realized eigenvalue, and the interior complexity reached.")
+      .def_readonly("realizable", &RealizabilityOracle::Verdict::realizable,
+                    "True iff the interior fill drove r < epsilon within the cone "
+                    "budget (U realizable, witnessed by state on witness).")
+      .def_readonly("residual", &RealizabilityOracle::Verdict::residual,
+                    "Best residual r = ||(I - psi psi^dagger) L psi||^2 reached: "
+                    "< epsilon when realizable, the certified floor otherwise.")
+      .def_readonly("floor", &RealizabilityOracle::Verdict::floor,
+                    "The obstruction floor (== residual when non-realizable, 0 "
+                    "when realizable): no bulk of the explored interior complexity "
+                    "realizes U under the pinned boundary.")
+      .def_readonly("eigenvalue", &RealizabilityOracle::Verdict::eigenvalue,
+                    "Realized eigenvalue lambda = psi^dagger L psi (Rayleigh "
+                    "quotient) of the witness state — meaningful when realizable.")
+      .def_readonly("interior_vertex_count",
+                    &RealizabilityOracle::Verdict::interiorVertexCount,
+                    "Interior vertices coned in to reach the verdict (the interior "
+                    "complexity, the §4b (|V|,|E|) analogue under fixed ends).")
+      .def_readonly("cones_applied", &RealizabilityOracle::Verdict::conesApplied,
+                    "Boundary-fixed cones applied during the interior fill.")
+      .def_readonly("state", &RealizabilityOracle::Verdict::state,
+                    "The witness state: the realized unit Laplacian eigenvector on "
+                    "W_AB (length = the bulk's vertex count); its first dA*dB "
+                    "components are the output-boundary block matching target. A "
+                    "genuine eigenstate iff realizable.")
+      .def_readonly("target", &RealizabilityOracle::Verdict::target,
+                    "The bent target psi_U = vec(U)/||vec(U)|| (length dA*dB) the "
+                    "output boundary is matched against.")
+      .def_readonly("witness", &RealizabilityOracle::Verdict::witness,
+                    "The realized bulk W_AB: the witness cobordism (realizable), or "
+                    "the complex on which the residual floors (non-realizable).");
+
+  ro.def(py::init<std::shared_ptr<Spacetime>>(), py::arg("bulk"),
+          "Build the oracle over the assembled bulk W_AB: a pre-geometric "
+          "Spacetime whose codim-1 boundary is the (pinned) output surface plus "
+          "input boundaries, output-surface vertices on the smallest ids. Raises "
+          "if bulk is null.")
+      .def("decide", &RealizabilityOracle::decide, py::arg("U"), py::arg("dA"),
+           py::arg("dB"), py::arg("epsilon") = 1e-10, py::arg("restarts") = 64,
+           py::arg("max_cones") = 4, py::arg("seed") = 0,
+           "Decide whether the dA x dB operator U (flat row-major) is realizable "
+           "as a bulk cobordism: bend it to vec(U), fill the pinned-boundary "
+           "interior to drive the §4b residual to zero (multi-restart "
+           "Levenberg-Marquardt over the interior weights/phases + auxiliary "
+           "amplitudes, growing the interior up to max_cones times), and return "
+           "the Verdict. Realizes the held bulk in place. Raises if U.size() != "
+           "dA*dB, a dimension is non-positive, or the bulk has fewer vertices "
+           "than dA*dB.");
 
   // Exact integer / GF(2) / inertia primitives (also exposed for direct
   // testing). Matrices are passed flat row-major with explicit dims.

--- a/src/cobordism/RealizabilityOracle.cpp
+++ b/src/cobordism/RealizabilityOracle.cpp
@@ -1,0 +1,213 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/RealizabilityOracle.h"
+
+#include <Eigen/Dense>
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+#include "cobordism/EigenstateSynthesis.h"
+#include "cobordism/LevenbergMarquardt.h"
+#include "quantum/ChoiJamiolkowski.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+using cd = std::complex<double>;
+
+RealizabilityOracle::RealizabilityOracle(std::shared_ptr<Spacetime> bulk)
+    : bulk_(std::move(bulk)) {
+  if (!bulk_) throw std::invalid_argument("RealizabilityOracle: null bulk");
+}
+
+std::vector<cd> RealizabilityOracle::bend(const std::vector<cd> &U, int dA,
+                                          int dB) {
+  // Choi–Jamiołkowski bend: vec(U) = Σ_{ij} U_{ij} |i⟩_A ⊗ |j⟩_B, the row-major
+  // flatten (#vectorize validates the dims and U.size() == dA·dB).
+  std::vector<cd> psi = ::tessera::quantum::ChoiJamiolkowski::vectorize(U, dA, dB);
+  double nrm = 0.0;
+  for (const cd &z : psi) nrm += std::norm(z);
+  if (nrm > 0.0) {
+    const double inv = 1.0 / std::sqrt(nrm);
+    for (cd &z : psi) z *= inv;
+  }
+  return psi;
+}
+
+double RealizabilityOracle::fillInterior(EigenstateSynthesis &es,
+                                         const std::vector<cd> &target,
+                                         double epsilon, int restarts,
+                                         int maxCones, std::uint64_t seed,
+                                         std::vector<cd> &witnessOut,
+                                         int &conesApplied) const {
+  const std::size_t L = target.size();  // the pinned boundary-support length
+  double bestR = std::numeric_limits<double>::infinity();
+  conesApplied = 0;
+
+  for (int cone = 0;; ++cone) {
+    const std::size_t order = es.order();       // total vertices this pass
+    const std::size_t m = es.numInteriorEdges();  // free interior edges
+    const std::size_t nAux = order - L;           // free auxiliary amplitudes
+    const std::size_t nParams = 2 * m + 2 * nAux;
+
+    // Assemble ψ from a parameter vector: the boundary support is the fixed
+    // target (first L sorted-id vertices); the auxiliary amplitudes (interior /
+    // coned-in apices) come from the tail of x (real, imag per vertex).
+    const auto buildPsi = [&target, L, m, nAux,
+                           order](const Eigen::VectorXd &x) -> std::vector<cd> {
+      std::vector<cd> psi = target;
+      psi.resize(order, cd(0.0, 0.0));
+      for (std::size_t k = 0; k < nAux; ++k) {
+        const auto re = static_cast<Eigen::Index>(2 * m + 2 * k);
+        psi[L + k] = cd(x[re], x[re + 1]);
+      }
+      return psi;
+    };
+
+    // Residual: write the interior weights/phases onto ∂W's complement (∂W
+    // itself is never touched), normalize the assembled ψ, and return the
+    // stacked g = Lψ - λψ ([Re; Im], length 2·order) whose ‖g‖² is r(ψ) — the
+    // §4b residual the Levenberg–Marquardt loop drives to zero.
+    const auto residual =
+        [&es, &buildPsi, m, order](const Eigen::VectorXd &x) -> Eigen::VectorXd {
+      if (m > 0) {
+        std::vector<double> w(m), th(m);
+        for (std::size_t i = 0; i < m; ++i) {
+          w[i] = x[static_cast<Eigen::Index>(i)];
+          th[i] = x[static_cast<Eigen::Index>(m + i)];
+        }
+        es.setInteriorWeights(w);
+        es.setInteriorPhases(th);
+      }
+      std::vector<cd> psi = buildPsi(x);
+      double nrm = 0.0;
+      for (const cd &z : psi) nrm += std::norm(z);
+      if (nrm > 0.0) {
+        const double inv = 1.0 / std::sqrt(nrm);
+        for (cd &z : psi) z *= inv;
+      }
+      const std::vector<cd> Lp = es.apply(psi);
+      cd lam(0.0, 0.0);
+      for (std::size_t i = 0; i < order; ++i) lam += std::conj(psi[i]) * Lp[i];
+      const double lambda = lam.real();
+      Eigen::VectorXd f(static_cast<Eigen::Index>(2 * order));
+      for (std::size_t i = 0; i < order; ++i) {
+        const cd g = Lp[i] - lambda * psi[i];
+        f[static_cast<Eigen::Index>(i)] = g.real();
+        f[static_cast<Eigen::Index>(order + i)] = g.imag();
+      }
+      return f;
+    };
+
+    // Clamp interior weights/phases into the §4b box and the auxiliary
+    // amplitudes into [-kAuxBound, kAuxBound].
+    const auto clamp = [m, nAux](const Eigen::VectorXd &x) -> Eigen::VectorXd {
+      Eigen::VectorXd c = x;
+      for (std::size_t i = 0; i < m; ++i) {
+        const auto wi = static_cast<Eigen::Index>(i);
+        const auto ti = static_cast<Eigen::Index>(m + i);
+        c[wi] = std::min(std::max(c[wi], kWMin), kWMax);
+        c[ti] = std::min(std::max(c[ti], -kThetaBound), kThetaBound);
+      }
+      for (std::size_t k = 0; k < 2 * nAux; ++k) {
+        const auto ai = static_cast<Eigen::Index>(2 * m + k);
+        c[ai] = std::min(std::max(c[ai], -kAuxBound), kAuxBound);
+      }
+      return c;
+    };
+
+    // Sample a restart: w ∈ [kWMin, kWMax], θ ∈ [-π, π], aux ∈ [-1, 1]. Built
+    // once and captured (the single-rng draw convention GeometrySynthesizer uses).
+    std::uniform_real_distribution<double> wDist(kWMin, kWMax);
+    std::uniform_real_distribution<double> tDist(-kPi, kPi);
+    std::uniform_real_distribution<double> aDist(-1.0, 1.0);
+    const auto sample = [m, nAux, wDist, tDist,
+                         aDist](std::mt19937_64 &rng) mutable -> Eigen::VectorXd {
+      Eigen::VectorXd x0(static_cast<Eigen::Index>(2 * m + 2 * nAux));
+      for (std::size_t i = 0; i < m; ++i) {
+        x0[static_cast<Eigen::Index>(i)] = wDist(rng);
+        x0[static_cast<Eigen::Index>(m + i)] = tDist(rng);
+      }
+      for (std::size_t k = 0; k < 2 * nAux; ++k)
+        x0[static_cast<Eigen::Index>(2 * m + k)] = aDist(rng);
+      return x0;
+    };
+
+    const LevenbergMarquardt lm(kMaxIterations, epsilon);
+    const LevenbergMarquardt::Result best =
+        lm.multiRestart(residual, clamp, sample, nParams, restarts,
+                        seed + static_cast<std::uint64_t>(cone), epsilon);
+
+    // Leave the complex realized at the best parameters and read off the unit
+    // witness state there (multiRestart leaves `residual` evaluated last at
+    // best.parameters; re-evaluate so the witness ψ matches the live complex).
+    residual(best.parameters);
+    witnessOut = buildPsi(best.parameters);
+    double wn = 0.0;
+    for (const cd &z : witnessOut) wn += std::norm(z);
+    if (wn > 0.0) {
+      const double inv = 1.0 / std::sqrt(wn);
+      for (cd &z : witnessOut) z *= inv;
+    }
+    bestR = best.cost;
+
+    // Stop on convergence, an exhausted budget, or a complex that cannot grow
+    // (growInterior is the capacity/structure gate; it leaves ∂W byte-fixed).
+    if (bestR < epsilon) break;
+    if (cone >= maxCones) break;
+    if (!es.growInterior(seed + 1000 + static_cast<std::uint64_t>(cone))) break;
+    ++conesApplied;
+  }
+  return bestR;
+}
+
+RealizabilityOracle::Verdict RealizabilityOracle::decide(
+    const std::vector<cd> &U, int dA, int dB, double epsilon, int restarts,
+    int maxCones, std::uint64_t seed) {
+  const std::vector<cd> target = bend(U, dA, dB);  // ψ_U, length dA·dB
+
+  EigenstateSynthesis es(bulk_);
+  if (es.order() < target.size())
+    throw std::invalid_argument(
+        "RealizabilityOracle: the bulk has fewer vertices than the bent target "
+        "needs on its output-boundary support (dA*dB).");
+
+  Verdict v;
+  v.target = target;
+  const double r =
+      fillInterior(es, target, epsilon, restarts, maxCones, seed, v.state,
+                   v.conesApplied);
+  v.residual = r;
+  v.realizable = (r < epsilon);
+  v.floor = v.realizable ? 0.0 : r;
+  v.eigenvalue = es.rayleigh(v.state);
+  v.interiorVertexCount = es.interiorVertexCount();
+  v.witness = bulk_;
+  return v;
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_realizability_oracle_python.py
+++ b/tests/cobordism/test_realizability_oracle_python.py
@@ -1,0 +1,357 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""§5.0 realizability oracle — spectral bulk synthesis for U (#138).
+
+`RealizabilityOracle` decides whether an operation U : H_B -> H_A is realizable as
+a bulk cobordism W_AB by *synthesizing the bulk spectrally*, not by TQFT
+membership. U is bent to a boundary state via Choi-Jamiolkowski (vec(U), the
+operator-as-state); the bulk's boundary dW is *pinned* (the synthesized geo's /
+the output surface) and the interior is filled — its Hermitian edge weights and,
+via the boundary-fixed Pachner add (#112), its topology — so the output-boundary
+k=0 graph-Laplacian eigenvector matches the bent target, driving the §4b residual
+r = ||(I - psi psi^dagger) L psi||^2 to 0.
+
+The oracle is pure orchestration of merged classes: ChoiJamiolkowski (the bend),
+EigenstateSynthesis (the fixed-boundary interior-fill engine #147), and
+LevenbergMarquardt (the same multi-restart least-squares solver the §4b
+GeometrySynthesizer drives, here over the interior parameters + free auxiliary
+amplitudes).
+
+Acceptance (#138):
+
+  * **Realizable U realized with its W_AB (r < 1e-10).** A uniform U (vec(U) the
+    constant vector — the exact zero mode of L = D - A for a phase-0 boundary) is
+    realized at the minimal interior complexity: r < 1e-10, the witness's output-
+    boundary block is proportional to vec(U), and the witness is a genuine
+    Laplacian eigenstate (L psi parallel to psi). A second realizable U is matched
+    only after the fixed-boundary cone-and-retry grows the interior (cones > 0).
+
+  * **Obstructed U certified non-realizable by a residual floor.** A generic U on
+    a one-interior-edge bulk floors at a positive residual bounded away from 0
+    (the analogue of §4b's two-vertex floor), cross-checked against an independent
+    numpy global-min oracle; the verdict is non-realizable.
+
+  * **Determinism.** The seeded synthesis is reproducible.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures (the #147 bulk-synthesis idiom: Signature(d) so the d-cells register
+# as top simplices; built through the topology so the vertex-id counter advances).
+# --------------------------------------------------------------------------- #
+def _spacetime(dim, topology):
+    sig = tessera.Signature(dim, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, topology)
+
+
+def _solid_triangle():
+    """Delta^2: a single triangle 0-1-2 whose boundary dW is the three sides
+    (S^1); 0 interior edges (every edge is boundary)."""
+    st = _spacetime(2, tessera.SolidSimplex(2))
+    st.build()
+    return st
+
+
+def _bipyramid():
+    """Two triangles 012 and 013 sharing the interior edge 01; the four outer
+    edges 02,12,03,13 are the pinned boundary dW. The smallest fixed-boundary
+    complex with exactly one interior parameter — the §5.0 analogue of §4b's
+    two-vertex single edge, with the boundary pinned."""
+    st = _solid_triangle()            # triangle 012, vertex-id counter at 3
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    st.createSimplex([v[0], v[1], v3])  # triangle 013
+    return st
+
+
+# --------------------------------------------------------------------------- #
+# numpy oracle + helpers (the D - A magnitude convention, sorted-vertex-id order).
+# --------------------------------------------------------------------------- #
+def _cvec(v):
+    return [complex(z) for z in v]
+
+
+def _edge_map(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _pin_all(st, w=1.0, phase=0.0):
+    """Pin every edge to a fixed Hermitian value. The oracle's fill only ever
+    rewrites the interior edges, so this fixes dW; the interior values are merely
+    a starting point the fill overwrites."""
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(w)
+        e.setPhase(phase)
+
+
+def _np_L(st):
+    ids = sorted(v.getId() for v in st.getVertexList().toVector())
+    idx = {vid: i for i, vid in enumerate(ids)}
+    n = len(ids)
+    A = np.zeros((n, n), dtype=complex)
+    D = np.zeros(n)
+    for e in st.getEdgeList().toVector():
+        s, t = e.getSource().getId(), e.getTarget().getId()
+        if s == t:
+            continue
+        i, j = idx[s], idx[t]
+        w = e.getSquaredLength()
+        z = w * np.exp(1j * e.getPhase())
+        A[i, j] += z
+        A[j, i] += np.conj(z)
+        D[i] += abs(w)
+        D[j] += abs(w)
+    return np.diag(D).astype(complex) - A
+
+
+def _np_residual(L, psi):
+    psi = np.asarray(psi, dtype=complex)
+    psi = psi / np.linalg.norm(psi)
+    Lp = L @ psi
+    lam = np.vdot(psi, Lp).real
+    r = Lp - lam * psi
+    return float(np.vdot(r, r).real)
+
+
+def _vec(U):
+    """Row-major vec(U) — the Choi bend; matches ChoiJamiolkowski.vectorize."""
+    return np.asarray(U, dtype=complex).reshape(-1)
+
+
+# --------------------------------------------------------------------------- #
+class RealizableTest(unittest.TestCase):
+    """A realizable U is realized with its W_AB: r < 1e-10, the output-boundary
+    eigenvector matches vec(U), and the witness is a genuine eigenstate."""
+
+    def test_uniform_operator_is_realized_at_minimal_complexity(self):
+        # U = [[1,1],[1,1]] (= 2|+><+|, a rank-1 transition operation): vec(U) is
+        # the constant vector, the exact zero mode of L = D - A for any phase-0
+        # positive-weight boundary. Realizable with its W_AB at minimal interior
+        # complexity — the fill only has to drive the lone interior edge to phase 0.
+        st = _bipyramid()
+        _pin_all(st, w=1.0, phase=0.0)
+        boundary_before = {k: (e.getSquaredLength(), e.getPhase())
+                           for k, e in _edge_map(st).items()
+                           if k != (0, 1)}
+
+        U = [[1.0 + 0j, 1.0 + 0j], [1.0 + 0j, 1.0 + 0j]]
+        oracle = cob.RealizabilityOracle(st)
+        v = oracle.decide(_cvec(_vec(U)), 2, 2, epsilon=1e-10, restarts=48,
+                          max_cones=0, seed=1)
+
+        # Realizable, with r driven below the acceptance threshold.
+        self.assertTrue(v.realizable)
+        self.assertLess(v.residual, 1e-10)
+        self.assertEqual(v.floor, 0.0)
+        self.assertEqual(v.interior_vertex_count, 0)   # minimal W_AB: no growth
+
+        # The bent target is vec(U) normalized.
+        target = _vec(U) / np.linalg.norm(_vec(U))
+        np.testing.assert_allclose(np.asarray(v.target), target, atol=1e-12)
+
+        # The witness's output-boundary block (first dA*dB = 4 components) is
+        # proportional to vec(U): the output-boundary eigenvector matches it.
+        state = np.asarray(v.state)
+        self.assertEqual(state.shape, (4,))            # no auxiliary vertices
+        block = state[:4]
+        overlap = abs(np.vdot(block / np.linalg.norm(block), target))
+        self.assertAlmostEqual(overlap, 1.0, places=10)
+
+        # The witness is a genuine Laplacian eigenstate of the realized W_AB:
+        # the C++ residual certifies it, and an independent numpy check confirms
+        # L psi = lambda psi (robust at the zero mode, where ||L psi|| ~ 0).
+        es = cob.EigenstateSynthesis(v.witness)
+        self.assertLess(es.residual(_cvec(state)), 1e-10)
+        L = _np_L(v.witness)
+        Lp = L @ state
+        lam = np.vdot(state, Lp).real
+        np.testing.assert_allclose(Lp, lam * state, atol=1e-5)
+        self.assertAlmostEqual(lam, v.eigenvalue, places=8)
+        self.assertAlmostEqual(es.rayleigh(_cvec(state)), v.eigenvalue, places=10)
+
+        # dW was pinned: the boundary edges are byte-identical (the fill never
+        # touched them).
+        live = _edge_map(st)
+        for k, (w, ph) in boundary_before.items():
+            self.assertEqual((live[k].getSquaredLength(), live[k].getPhase()),
+                             (w, ph))
+
+    def test_realizable_only_after_interior_growth(self):
+        # A generic U : H_B(dim 3) -> H_A(dim 1) on the solid triangle (3 boundary
+        # vertices, 0 interior edges at the seed): not an eigenvector of the bare
+        # pinned triangle, so it floors at the seed complexity, but the fixed-
+        # boundary cone-and-retry grows the interior and realizes it (the §5.0
+        # analogue of §4b coning, with the boundary pinned).
+        st = _solid_triangle()
+        _pin_all(st, w=1.0, phase=0.0)
+
+        U = [[1.0 + 0j, 0.3 + 0.5j, -0.8 + 0.2j]]   # 1 x 3
+        oracle = cob.RealizabilityOracle(st)
+        v = oracle.decide(_cvec(_vec(U)), 1, 3, epsilon=1e-10, restarts=80,
+                          max_cones=4, seed=0)
+
+        self.assertTrue(v.realizable)
+        self.assertLess(v.residual, 1e-10)
+        self.assertGreaterEqual(v.cones_applied, 1)    # growth was needed
+        self.assertEqual(v.interior_vertex_count, v.cones_applied)
+
+        # The witness is a genuine eigenstate, and its output-boundary block is
+        # proportional to vec(U).
+        state = np.asarray(v.state)
+        es = cob.EigenstateSynthesis(v.witness)
+        self.assertLess(es.residual(_cvec(state)), 1e-10)
+        target = _vec(U) / np.linalg.norm(_vec(U))
+        block = state[:3]
+        overlap = abs(np.vdot(block / np.linalg.norm(block), target))
+        self.assertAlmostEqual(overlap, 1.0, places=8)
+
+
+class ObstructedFloorTest(unittest.TestCase):
+    """A deliberately obstructed U is certified non-realizable by a residual floor
+    bounded away from 0 — the analogue of §4b's two-vertex floor — cross-checked
+    against an independent numpy global-min oracle."""
+
+    def test_generic_operator_floors_and_is_certified_non_realizable(self):
+        # U = [[1,2],[3,4]]: vec(U) = [1,2,3,4], a generic state not realizable as
+        # a bipyramid-boundary eigenvector against the pinned boundary with a
+        # single interior edge. With no growth budget the residual floors.
+        st = _bipyramid()
+        _pin_all(st, w=1.0, phase=0.0)
+
+        U = [[1.0 + 0j, 2.0 + 0j], [3.0 + 0j, 4.0 + 0j]]
+        oracle = cob.RealizabilityOracle(st)
+        v = oracle.decide(_cvec(_vec(U)), 2, 2, epsilon=1e-10, restarts=40,
+                          max_cones=0, seed=0)
+
+        # Certified non-realizable: the residual floors, and floor == residual.
+        self.assertFalse(v.realizable)
+        self.assertGreater(v.residual, 1e-2)
+        self.assertEqual(v.floor, v.residual)
+        self.assertEqual(v.interior_vertex_count, 0)
+
+        # Independent numpy oracle: the true global min over the single interior
+        # edge (0,1) (grid + L-BFGS-B refine), boundary pinned at weight 1 phase 0.
+        from scipy.optimize import minimize
+        fresh = _bipyramid()
+        _pin_all(fresh, w=1.0, phase=0.0)
+        edge01 = _edge_map(fresh)[(0, 1)]
+        target = _vec(U)
+
+        def floor_at(x):
+            edge01.setSquaredLength(x[0])
+            edge01.setPhase(x[1])
+            return _np_residual(_np_L(fresh), target)
+
+        w_bounds = (0.1, 10.0)
+        grid, gx = np.inf, None
+        for w in np.linspace(w_bounds[0], w_bounds[1], 60):
+            for th in np.linspace(-math.pi, math.pi, 60):
+                val = floor_at([w, th])
+                if val < grid:
+                    grid, gx = val, [w, th]
+        ref = minimize(floor_at, gx, method="L-BFGS-B",
+                       bounds=[w_bounds, (-2 * math.pi, 2 * math.pi)])
+        oracle_floor = float(ref.fun)
+
+        # The certified floor is bounded away from zero and matches the hand
+        # computation.
+        self.assertGreater(oracle_floor, 1e-2)
+        self.assertAlmostEqual(v.floor, oracle_floor, delta=2e-3)
+
+    def test_floor_is_seed_independent(self):
+        # The certified floor is the genuine global minimum, not a seed-specific
+        # local min: independent restart seeds reach the same floor. (This is the
+        # certificate's robustness — the spec decides non-realizability by the
+        # floor, so the floor must be the true one.)
+        U = [[1.0 + 0j, 2.0 + 0j], [3.0 + 0j, 4.0 + 0j]]
+        floors = []
+        for s in (0, 11, 23):
+            st = _bipyramid()
+            _pin_all(st, w=1.0, phase=0.0)
+            v = cob.RealizabilityOracle(st).decide(
+                _cvec(_vec(U)), 2, 2, epsilon=1e-10, restarts=40, max_cones=0,
+                seed=s)
+            self.assertFalse(v.realizable)
+            floors.append(v.floor)
+        for f in floors[1:]:
+            self.assertAlmostEqual(f, floors[0], delta=1e-3)
+
+
+class DeterminismTest(unittest.TestCase):
+    """The seeded synthesis is reproducible: same seed -> identical verdict."""
+
+    def test_same_seed_same_verdict(self):
+        U = [[1.0 + 0j, 2.0 + 0j], [3.0 + 0j, 4.0 + 0j]]
+        results = []
+        for _ in range(2):
+            st = _bipyramid()
+            _pin_all(st, w=1.0, phase=0.0)
+            v = cob.RealizabilityOracle(st).decide(
+                _cvec(_vec(U)), 2, 2, epsilon=1e-10, restarts=24, max_cones=0,
+                seed=7)
+            results.append(v)
+        self.assertEqual(results[0].realizable, results[1].realizable)
+        self.assertEqual(results[0].residual, results[1].residual)
+        np.testing.assert_array_equal(np.asarray(results[0].state),
+                                      np.asarray(results[1].state))
+
+
+class GuardrailTest(unittest.TestCase):
+    """Input validation."""
+
+    def test_null_bulk_raises(self):
+        with self.assertRaises(Exception):
+            cob.RealizabilityOracle(None)
+
+    def test_dimension_mismatch_raises(self):
+        st = _bipyramid()
+        _pin_all(st)
+        oracle = cob.RealizabilityOracle(st)
+        with self.assertRaises(Exception):
+            oracle.decide(_cvec([1, 2, 3]), 2, 2)   # 3 != 2*2
+
+    def test_bulk_too_small_for_target_raises(self):
+        # A triangle (3 vertices) cannot carry a dA*dB = 4 output boundary.
+        st = _solid_triangle()
+        _pin_all(st)
+        oracle = cob.RealizabilityOracle(st)
+        with self.assertRaises(Exception):
+            oracle.decide(_cvec([1, 1, 1, 1]), 2, 2, max_cones=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`tessera::cobordism::RealizabilityOracle` — the §5.0 headline capability: decide whether an operation `U : H_B → H_A` is realizable as a bulk cobordism `W_AB` by **synthesizing the bulk spectrally**, not by TQFT membership. Pure orchestration of the merged building blocks (no new math): `ChoiJamiolkowski`, `EigenstateSynthesis` (the fixed-boundary interior-fill engine), and `LevenbergMarquardt`.

Public API: `RealizabilityOracle(bulk: Spacetime)` + `decide(U, dA, dB, epsilon=1e-10, restarts=64, max_cones=4, seed=0) -> Verdict`. The `Verdict` carries `realizable`, `residual`, `floor`, `eigenvalue`, `interior_vertex_count`, `cones_applied`, `state` (the realized witness eigenvector), `target` (vec(U)), and `witness` (the realized `W_AB`).

## Pipeline (one entry point, small private steps)

1. **Bend** — `ChoiJamiolkowski::vectorize` bends `U` to `vec(U)`, normalized to the target `ψ_U` (length `dA·dB`), carried on the first `dA·dB` sorted-id vertices (the output-surface support).
2. **Pin** — the bulk's boundary edges `∂W` (the synthesized geo's / output surface) are held byte-fixed; the fixed-boundary engine only ever writes interior edges.
3. **Fill** — the §4b cone-and-retry restricted to the **interior**: a multi-restart `LevenbergMarquardt` over the interior weights/phases + the free auxiliary amplitudes drives the residual `r = ||(I − ψψ†)Lψ||²` to 0, growing the interior via the boundary-fixed Pachner add (`growInterior`) and retrying up to the cone budget.
4. **Verdict** — realizable iff `r < ε` (with the witness `state` + `W_AB`); otherwise **non-realizable**, certified by the residual **floor** at the explored interior complexity. The floor *is* the certificate (the analogue of §4b's two-vertex floor `w_min²(|c₀|²−|c₁|²)²`) — no exhaustive triangulation/vertex search.

## Acceptance tests (`tests/cobordism/test_realizability_oracle_python.py`, numpy oracle)

- **Realizable U realized with its `W_AB`.** A uniform `U = [[1,1],[1,1]]` (its `vec(U)` is the constant vector — the exact zero mode of `L = D − A` on a phase-0 boundary) is realized at minimal interior complexity: `r ≈ 3.4e-11 < 1e-10`, the witness's output-boundary block is proportional to `vec(U)`, and the witness is a genuine Laplacian eigenstate (`Lψ = λψ`, cross-checked in numpy). A second, generic `U : H_B(3) → H_A(1)` is realized only after the fixed-boundary cone-and-retry grows the interior (`cones_applied ≥ 1`).
- **Obstructed U certified non-realizable.** A generic `U = [[1,2],[3,4]]` on a one-interior-edge bulk floors at `r ≈ 0.0235` (bounded away from 0), cross-checked against an independent numpy global-min oracle (grid + L-BFGS-B over the lone interior edge), and the verdict is non-realizable. The floor is seed-independent (the genuine global minimum).
- **Determinism.** The seeded synthesis is reproducible (same seed → identical verdict).

## Validation

`poetry run pytest tests/cobordism tests/quantum -q` → **566 passed, 1 skipped, 702 subtests passed**, plus the new 8 oracle tests green. The only failures (9) are **pre-existing on `origin/main`** — in `test_dijkgraaf_witten_hardening` / `test_homology_hardening`, unrelated to this change (verified by rebuilding clean `origin/main` without these additions and reproducing the identical 9 failures; they predate this PR, likely from #162's `getBoundary` consolidation vs #153's hardening tests).

Closes #138