### PR TITLE
docs: wire the v0.3 realizability report into the toctree

### DIFF
--- a/docs/source/quantum-experiments/index.md
+++ b/docs/source/quantum-experiments/index.md
@@ -17,6 +17,7 @@ charged-cartan/index
 cobordism
 cobordism-plan
 cobordism-stage2-report
+cobordism-realizability-report
 ```
 
 ## Reproducing


### PR DESCRIPTION
Wires `docs/source/quantum-experiments/cobordism-realizability-report.md` (#141) into the quantum-experiments toctree after the Stage-2 report. `sphinx-build -E -W` clean (0 warnings); report page renders (48 KB). Closes #142