### PR TITLE
cobordism: spectral→DW boundary preparation map (ker L₁ → ℂ[H¹(Σ;ℤ₂)])

### DIFF
--- a/include/cobordism/BoundaryStatePrep.h
+++ b/include/cobordism/BoundaryStatePrep.h
@@ -1,0 +1,168 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_BOUNDARYSTATEPREP_H
+#define TESSERA_COBORDISM_BOUNDARYSTATEPREP_H
+
+#include <complex>
+#include <memory>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # BoundaryStatePrep
+///
+/// The **spectral → Dijkgraaf–Witten boundary preparation map** for a closed
+/// surface \f$ \Sigma \f$, and its readout (the adjoint).
+///
+/// Two distinct objects live on \f$ \Sigma \f$:
+///
+/// - The **Hodge harmonic 1-forms** \f$ \ker L_1(\Sigma) \f$ — the *spectral
+///   qubit*, a complex vector space of dimension \f$ b_1(\Sigma) \f$, whose
+///   elements are 1-forms (cochains of length \f$ |C_1(\Sigma)| \f$). This is
+///   `HodgeLaplacian(\Sigma).harmonics(1)`.
+/// - The **DW boundary Hilbert space**
+///   \f$ Z(\Sigma) = \mathbb{C}[H^1(\Sigma;\mathbb{Z}_2)] \f$ — the
+///   flat-connection-class basis, of dimension \f$ 2^{b_1(\Sigma)} \f$, indexed
+///   by the holonomy class of a flat \f$ \mathbb{Z}_2 \f$ connection. This is the
+///   space `DijkgraafWitten::amplitude()` / `map()` / `boundaryVector()` consume.
+///
+/// `DijkgraafWitten::amplitude()` already sandwiches the topological state sum
+/// between boundary states *prepared from* the harmonics, but that preparation
+/// was caller-side and implicit. This class makes it a first-class, tested
+/// operation.
+///
+/// ## The \f$ b_1 \f$ vs \f$ 2^{b_1} \f$ reconciliation
+///
+/// \f$ H^1(\Sigma;\mathbb{Z}_2) \cong (\mathbb{Z}_2)^{b_1} \f$ has \f$ b_1 \f$
+/// distinguished **single-generator** classes — the weight-one holonomy patterns
+/// \f$ e_i \f$ ("holonomy 1 around the \f$ i \f$-th cycle, 0 around the rest").
+/// In the `gf2Span` enumeration that orders \f$ Z(\Sigma) \f$ (mask
+/// \f$ 0\dots2^{b_1}-1 \f$, basis vector \f$ i \f$ alone at mask \f$ 2^i \f$),
+/// these are exactly the amplitudes at indices \f$ 2^0, 2^1, \dots, 2^{b_1-1} \f$.
+///
+/// The preparation **embeds the spectral qubit onto those generator slots**:
+/// the \f$ i \f$-th orthonormal harmonic 1-form (column \f$ i \f$ of
+/// `harmonics()`, ascending-eigenvalue order) carries its amplitude to the
+/// flat-connection class at \f$ Z(\Sigma) \f$-index \f$ 2^i \f$. The trivial
+/// class (index 0) and **all** multi-generator classes (indices that are not
+/// powers of two) carry amplitude 0. So a prepared state occupies a
+/// \f$ b_1 \f$-dimensional coordinate subspace of the \f$ 2^{b_1} \f$-dimensional
+/// \f$ Z(\Sigma) \f$.
+///
+/// ## The maps
+///
+/// `prepare`: \f$ \ker L_1(\Sigma) \to Z(\Sigma) \f$. Project a harmonic 1-form
+/// \f$ \psi \f$ (length \f$ |C_1| \f$) onto the orthonormal harmonic basis
+/// \f$ \{h_i\} \f$ to get coordinates \f$ c_i = \langle h_i, \psi\rangle \f$, then
+/// scatter \f$ c_i \f$ onto the amplitude at index \f$ 2^i \f$. (Any component of
+/// the input outside \f$ \ker L_1 \f$ is projected out.)
+///
+/// `readout`: \f$ Z(\Sigma) \to \ker L_1(\Sigma) \f$, the adjoint of `prepare`.
+/// Gather the generator amplitudes \f$ c_i = \psi_{Z}[2^i] \f$ and reconstruct
+/// the 1-form \f$ \sum_i c_i h_i \f$.
+///
+/// Because the harmonic basis is orthonormal (the `SelfAdjointEigenSolver`
+/// eigenvectors of the symmetric Hodge Laplacian) `prepare` is an **isometry**
+/// \f$ \langle \mathrm{prepare}(\psi)\,|\,\mathrm{prepare}(\phi)\rangle =
+/// \langle\psi|\phi\rangle \f$ for \f$ \psi,\phi\in\ker L_1 \f$, and
+/// `readout` \f$ \circ \f$ `prepare` is the **identity** on \f$ \ker L_1 \f$.
+/// Consequently, on the trivial cobordism \f$ \Sigma\times[0,T] \f$ (where
+/// \f$ Z(W)=\mathrm{id} \f$) `DijkgraafWitten::amplitude(prepare(ψ), prepare(φ))`
+/// reproduces \f$ \langle\psi|\phi\rangle \f$.
+///
+/// Reuses `HodgeLaplacian` (\f$ k=1 \f$) for the harmonics — it does not
+/// reimplement them; the basis is computed once at construction and cached.
+class BoundaryStatePrep {
+  public:
+    /// Build the preparation map over a closed surface \f$ \Sigma \f$. The
+    /// harmonic 1-form basis \f$ \ker L_1(\Sigma) \f$ is computed once
+    /// (`HodgeLaplacian` at \f$ k=1 \f$) and cached; the held `shared_ptr` keeps
+    /// \f$ \Sigma \f$ alive. `tol` is the \f$ |\lambda|<\text{tol} \f$ harmonic
+    /// threshold and `metric` selects volume vs. unit Hodge weights — both
+    /// forwarded to `HodgeLaplacian::harmonics(1, tol, metric)`; the embedding is
+    /// isometric for either choice (orthonormal eigenvectors).
+    /// @throws std::runtime_error if \f$ \Sigma \f$ is null, or if
+    ///   \f$ b_1(\Sigma) > 24 \f$ (the `gf2Span` materialization cap — the
+    ///   \f$ 2^{b_1} \f$ boundary space would be too large).
+    explicit BoundaryStatePrep(std::shared_ptr<Spacetime> sigma,
+                               double tol = 1e-9, bool metric = true);
+
+    /// \f$ b_1(\Sigma) = \dim\ker L_1(\Sigma) \f$: the spectral-qubit dimension
+    /// (the number of harmonic 1-forms).
+    [[nodiscard]] int harmonicDimension() const;
+
+    /// \f$ \dim Z(\Sigma) = 2^{b_1(\Sigma)} \f$: the DW boundary Hilbert-space
+    /// dimension (the length of a prepared state).
+    [[nodiscard]] int boundaryDimension() const;
+
+    /// \f$ |C_1(\Sigma)| \f$: the number of edges — the length of a harmonic
+    /// 1-form (the input to `prepare` / output of `readout`).
+    [[nodiscard]] int numEdges() const;
+
+    /// The orthonormal harmonic 1-form basis as a flat row-major
+    /// \f$ |C_1|\times b_1 \f$ array (column \f$ i \f$, entries at indices
+    /// \f$ e\cdot b_1 + i \f$, is the \f$ i \f$-th basis form) — the deterministic
+    /// basis `prepare` / `readout` use, exposed for a numpy/Hodge cross-check.
+    [[nodiscard]] std::vector<std::complex<double>> harmonics() const;
+
+    /// The \f$ b_1 \f$ flat-connection-class indices in \f$ Z(\Sigma) \f$ that
+    /// carry harmonic data: \f$ (2^0, 2^1, \dots, 2^{b_1-1}) \f$, the
+    /// single-generator classes. (Documents the \f$ b_1 \f$ vs \f$ 2^{b_1} \f$
+    /// reconciliation: harmonic \f$ i \f$ lands on index \f$ 2^i \f$.)
+    [[nodiscard]] std::vector<int> generatorIndices() const;
+
+    /// Prepare a DW boundary state from a harmonic 1-form: \f$ \ker L_1(\Sigma)
+    /// \to Z(\Sigma) \f$. `form` is a 1-form of length \f$ |C_1| \f$; its
+    /// harmonic-basis coordinates \f$ c_i=\langle h_i,\text{form}\rangle \f$ are
+    /// scattered onto the amplitudes at indices \f$ 2^i \f$, the rest zero.
+    /// Returns a vector of length \f$ 2^{b_1} \f$. A non-harmonic component of
+    /// `form` is projected out (dropped).
+    /// @throws std::invalid_argument if `form.size() != numEdges()`.
+    [[nodiscard]] std::vector<std::complex<double>> prepare(
+        const std::vector<std::complex<double>> &form) const;
+
+    /// Read a harmonic 1-form back out of a DW boundary state (the adjoint of
+    /// `prepare`): \f$ Z(\Sigma) \to \ker L_1(\Sigma) \f$. Gathers the generator
+    /// amplitudes \f$ c_i = \text{state}[2^i] \f$ and returns the 1-form
+    /// \f$ \sum_i c_i h_i \f$ (length \f$ |C_1| \f$). `readout(prepare(form)) ==
+    /// form` for `form` \f$ \in \ker L_1(\Sigma) \f$; amplitudes off the generator
+    /// indices are ignored.
+    /// @throws std::invalid_argument if `state.size() != boundaryDimension()`.
+    [[nodiscard]] std::vector<std::complex<double>> readout(
+        const std::vector<std::complex<double>> &state) const;
+
+  private:
+    std::shared_ptr<Spacetime> sigma_;
+    int numEdges_{0};
+    int b1_{0};
+    // Flat row-major |C_1| x b_1 orthonormal harmonic basis (columns), exactly
+    // HodgeLaplacian::harmonics(1, tol, metric); element (edge e, harmonic i) is
+    // at index e * b1_ + i.
+    std::vector<std::complex<double>> harmonics_{};
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_BOUNDARYSTATEPREP_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -29,6 +29,7 @@
 #include <pybind11/stl.h>
 
 #include "cobordism/GeometrySynthesizer.h"
+#include "cobordism/BoundaryStatePrep.h"
 #include "cobordism/ChainComplex.h"
 #include "cobordism/Characteristic.h"
 #include "cobordism/Cobordism.h"
@@ -644,4 +645,66 @@ triangulations; a flat space too large to materialize is refused.)doc")
                   "Whether omega satisfies the normalized 3-cocycle (pentagon) "
                   "identity over Z_2 (brute-forced over all 16 tuples of "
                   "Z_2^4). True for both Trivial and Sign.");
+
+  // ----- §5 spectral→DW boundary preparation: ker L_1(Sigma) → Z(Sigma) (#175) -----
+  py::class_<BoundaryStatePrep>(m, "BoundaryStatePrep",
+      R"doc(Spectral->DW boundary preparation map for a closed surface Sigma.
+
+Makes explicit (and invertible) the preparation DijkgraafWitten.amplitude() uses
+internally: the Hodge harmonic 1-forms ker L_1(Sigma) (the spectral qubit, dim
+b_1, HodgeLaplacian at k=1) -> the DW boundary Hilbert space
+Z(Sigma) = C[H^1(Sigma; Z_2)] (the flat-connection-class basis, dim 2^{b_1}).
+
+b_1 vs 2^{b_1}: H^1(Sigma; Z_2) = (Z_2)^{b_1} has b_1 single-generator classes,
+the weight-one holonomy patterns, sitting at gf2Span indices 2^0, 2^1, ...,
+2^{b_1-1} (mask 2^i = basis vector i alone). prepare embeds the spectral qubit
+onto those slots: the i-th orthonormal harmonic 1-form (column i of harmonics(),
+ascending-eigenvalue order) carries its amplitude to Z(Sigma) index 2^i. The
+trivial class (0) and every multi-generator class (non-power-of-two index) carry
+amplitude 0.
+
+prepare(form): project the 1-form form (length |C_1|) onto the harmonic basis,
+c_i = <h_i, form>, and scatter c_i to index 2^i. readout(state): the adjoint —
+gather c_i = state[2^i] and rebuild sum_i c_i h_i. The harmonic basis is
+orthonormal, so prepare is an isometry (<prepare(psi)|prepare(phi)> = <psi|phi>
+on ker L_1) and readout o prepare = identity on ker L_1; hence on the trivial
+cobordism Sigma x [0,T] (Z(W)=id) DijkgraafWitten.amplitude(prepare(psi),
+prepare(phi)) reproduces <psi|phi>. Reuses HodgeLaplacian (k=1); the basis is
+computed once at construction and cached.)doc")
+      .def(py::init<std::shared_ptr<Spacetime>, double, bool>(),
+           py::arg("sigma"), py::arg("tol") = 1e-9, py::arg("metric") = true,
+           "Build the preparation map over a closed surface Sigma. Computes and "
+           "caches ker L_1(Sigma) (HodgeLaplacian k=1); tol is the |lambda|<tol "
+           "harmonic threshold and metric selects volume vs unit weights (both "
+           "forwarded to harmonics(1, tol, metric); the embedding is isometric "
+           "either way). Raises if Sigma is null or b_1(Sigma) > 24.")
+      .def("harmonicDimension", &BoundaryStatePrep::harmonicDimension,
+           "b_1(Sigma) = dim ker L_1(Sigma): the spectral-qubit dimension (the "
+           "number of harmonic 1-forms).")
+      .def("boundaryDimension", &BoundaryStatePrep::boundaryDimension,
+           "dim Z(Sigma) = 2^{b_1(Sigma)}: the DW boundary Hilbert-space "
+           "dimension (the length of a prepared state).")
+      .def("numEdges", &BoundaryStatePrep::numEdges,
+           "|C_1(Sigma)|: the number of edges — the length of a harmonic 1-form "
+           "(the input to prepare / output of readout).")
+      .def("harmonics", &BoundaryStatePrep::harmonics,
+           "The orthonormal harmonic 1-form basis as a flat row-major "
+           "|C_1| x b_1 array (column i, entries at e*b_1 + i, is the i-th basis "
+           "form) — the deterministic basis prepare/readout use.")
+      .def("generatorIndices", &BoundaryStatePrep::generatorIndices,
+           "The b_1 flat-connection-class indices in Z(Sigma) carrying harmonic "
+           "data: (2^0, 2^1, ..., 2^{b_1-1}), the single-generator classes "
+           "(harmonic i lands on index 2^i).")
+      .def("prepare", &BoundaryStatePrep::prepare, py::arg("form"),
+           "Prepare a DW boundary state from a harmonic 1-form: ker L_1(Sigma) "
+           "-> Z(Sigma). form is length |C_1|; its harmonic coordinates "
+           "c_i = <h_i, form> are scattered onto the amplitudes at indices 2^i, "
+           "the rest zero. Returns length 2^{b_1}. A non-harmonic component is "
+           "projected out. Raises if len(form) != numEdges().")
+      .def("readout", &BoundaryStatePrep::readout, py::arg("state"),
+           "Read a harmonic 1-form back out of a DW boundary state (the adjoint "
+           "of prepare): Z(Sigma) -> ker L_1(Sigma). Gathers c_i = state[2^i] and "
+           "returns sum_i c_i h_i (length |C_1|). readout(prepare(form)) == form "
+           "for form in ker L_1(Sigma). Raises if len(state) != "
+           "boundaryDimension().");
 }

--- a/src/cobordism/BoundaryStatePrep.cpp
+++ b/src/cobordism/BoundaryStatePrep.cpp
@@ -1,0 +1,125 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/BoundaryStatePrep.h"
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "cobordism/ChainComplex.h"
+#include "cobordism/HodgeLaplacian.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+BoundaryStatePrep::BoundaryStatePrep(std::shared_ptr<Spacetime> sigma,
+                                     double tol, bool metric)
+    : sigma_(std::move(sigma)) {
+  if (sigma_ == nullptr)
+    throw std::runtime_error("BoundaryStatePrep: the surface Sigma is null");
+
+  // |C_1(Sigma)| fixes the harmonic-form length and lets us recover b_1 from the
+  // flat harmonics array (size = |C_1| * b_1).
+  numEdges_ = static_cast<int>(ChainComplex::fromSpacetime(*sigma_).numSimplices(1));
+
+  // ker L_1(Sigma) via the k=1 Hodge Laplacian — reused, not reimplemented. The
+  // columns are W_k-orthonormal (the symmetric SelfAdjointEigenSolver basis), so
+  // the standard inner product on them is the identity and `prepare` is an
+  // isometry for either weight choice.
+  harmonics_ = HodgeLaplacian(sigma_).harmonics(1, tol, metric);
+  if (numEdges_ > 0)
+    b1_ = static_cast<int>(harmonics_.size()) / numEdges_;
+  else
+    b1_ = 0;  // no edges ⇒ no 1-forms (e.g. a point/empty complex)
+
+  // Z(Sigma) = C[H^1(Sigma; Z_2)] has dimension 2^{b_1}; cap at the same nullity
+  // the gf2Span materialization refuses, so boundaryDimension() cannot overflow
+  // or demand an unmaterializable vector.
+  if (b1_ > 24)
+    throw std::runtime_error(
+        "BoundaryStatePrep: b_1(Sigma) = " + std::to_string(b1_) +
+        " is too large; Z(Sigma) = 2^{b_1} would exceed the materialization cap "
+        "(24)");
+}
+
+int BoundaryStatePrep::harmonicDimension() const { return b1_; }
+
+int BoundaryStatePrep::boundaryDimension() const { return 1 << b1_; }
+
+int BoundaryStatePrep::numEdges() const { return numEdges_; }
+
+std::vector<std::complex<double>> BoundaryStatePrep::harmonics() const {
+  return harmonics_;
+}
+
+std::vector<int> BoundaryStatePrep::generatorIndices() const {
+  // The b_1 single-generator flat-connection classes: gf2Span index 2^i carries
+  // the i-th harmonic 1-form's amplitude.
+  std::vector<int> indices;
+  indices.reserve(static_cast<std::size_t>(b1_));
+  for (int i = 0; i < b1_; ++i) indices.push_back(1 << i);
+  return indices;
+}
+
+std::vector<std::complex<double>> BoundaryStatePrep::prepare(
+    const std::vector<std::complex<double>> &form) const {
+  if (static_cast<int>(form.size()) != numEdges_)
+    throw std::invalid_argument(
+        "BoundaryStatePrep::prepare: the 1-form length must be |C_1(Sigma)| = " +
+        std::to_string(numEdges_));
+
+  // Scatter c_i = <h_i, form> onto the flat-connection class at index 2^i; all
+  // other amplitudes (the trivial class and every multi-generator class) are 0.
+  std::vector<std::complex<double>> state(
+      static_cast<std::size_t>(1 << b1_), {0.0, 0.0});
+  for (int i = 0; i < b1_; ++i) {
+    std::complex<double> coordinate{0.0, 0.0};
+    for (int e = 0; e < numEdges_; ++e)
+      coordinate +=
+          std::conj(harmonics_[static_cast<std::size_t>(e) * b1_ + i]) *
+          form[static_cast<std::size_t>(e)];
+    state[static_cast<std::size_t>(1 << i)] = coordinate;
+  }
+  return state;
+}
+
+std::vector<std::complex<double>> BoundaryStatePrep::readout(
+    const std::vector<std::complex<double>> &state) const {
+  if (static_cast<int>(state.size()) != (1 << b1_))
+    throw std::invalid_argument(
+        "BoundaryStatePrep::readout: the boundary state length must be "
+        "2^{b_1(Sigma)} = " + std::to_string(1 << b1_));
+
+  // Gather the generator amplitudes c_i = state[2^i] and rebuild sum_i c_i h_i,
+  // landing back in ker L_1(Sigma).
+  std::vector<std::complex<double>> form(
+      static_cast<std::size_t>(numEdges_), {0.0, 0.0});
+  for (int i = 0; i < b1_; ++i) {
+    const std::complex<double> coordinate = state[static_cast<std::size_t>(1 << i)];
+    for (int e = 0; e < numEdges_; ++e)
+      form[static_cast<std::size_t>(e)] +=
+          coordinate * harmonics_[static_cast<std::size_t>(e) * b1_ + i];
+  }
+  return form;
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_boundary_state_prep_python.py
+++ b/tests/cobordism/test_boundary_state_prep_python.py
@@ -1,0 +1,345 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Spectral->DW boundary preparation map (#175): ker L_1(Sigma) -> C[H^1(Sigma;Z_2)].
+
+`BoundaryStatePrep` makes explicit (and invertible) the preparation that
+`DijkgraafWitten.amplitude()` uses internally. Two distinct objects live on a
+closed surface Sigma:
+
+* the Hodge harmonic 1-forms ker L_1(Sigma) — the *spectral qubit*, dimension
+  b_1, an orthonormal basis of 1-forms (HodgeLaplacian at k=1); and
+* the DW boundary Hilbert space Z(Sigma) = C[H^1(Sigma; Z_2)] — the
+  flat-connection-class basis, dimension 2^{b_1}.
+
+The b_1 vs 2^{b_1} reconciliation: H^1(Sigma; Z_2) = (Z_2)^{b_1} has b_1
+single-generator classes at gf2Span indices 2^0, 2^1, ..., 2^{b_1-1}. prepare
+embeds the i-th harmonic 1-form onto the amplitude at index 2^i; the trivial
+class and every multi-generator class carry 0. Because the harmonic basis is
+orthonormal, prepare is an isometry and readout o prepare = id on ker L_1.
+
+Anchored on T^2 (b_1 = 2: ker L_1(T^2) = C^2 the qubit, Z(T^2) = C^4):
+
+* numpy/Hodge cross-check of the harmonic basis (metric + combinatorial weights),
+  with a stable, documented ordering;
+* the b_1 vs 2^{b_1} reconciliation (harmonic i -> index 2^i);
+* round-trip readout(prepare(psi)) = psi and the prepare isometry on ker L_1;
+* consistency with amplitude() and the trivial cylinder Sigma x [0,T]:
+  amplitude(prepare(psi), prepare(phi)) = <psi|phi>.
+"""
+
+import unittest
+
+import numpy as np
+
+import tessera
+
+cobordism = tessera.cobordism
+BoundaryStatePrep = cobordism.BoundaryStatePrep
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures (mirror test_dijkgraaf_witten_boundary_python.py).
+# --------------------------------------------------------------------------- #
+def _build(topology):
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()
+    return spacetime
+
+
+def _circle():
+    return tessera.SimplexBoundarySphere(1)  # S^1 = boundary of a triangle
+
+
+def _torus_topology():
+    return tessera.SimplicialProduct(_circle(), _circle())  # T^2 = S^1 x S^1
+
+
+def _torus():
+    return _build(_torus_topology())
+
+
+def _sphere2():
+    return _build(tessera.SimplexBoundarySphere(2))  # S^2: b_1 = 0
+
+
+def _torus_cylinder():
+    # W = T^2 x [0,T], the trivial cobordism T^2 -> T^2 (boundary T^2 ⊔ T^2).
+    return _build(tessera.SimplicialProduct(_torus_topology(),
+                                            tessera.SolidSimplex(1)))
+
+
+# --------------------------------------------------------------------------- #
+# Independent numpy Hodge oracle for ker L_1 (symmetric metric Laplacian).
+# --------------------------------------------------------------------------- #
+def _numpy_L1_symmetric(spacetime, metric):
+    """L_1^sym = B_1^T B_1 + B_2 B_2^T with B_k = W_{k-1}^{1/2} d_k W_k^{-1/2}."""
+    chain = cobordism.ChainComplex.fromSpacetime(spacetime)
+    num_verts = chain.numSimplices(0)
+    num_edges = chain.numSimplices(1)
+    num_tris = chain.numSimplices(2)
+    d1 = np.asarray(chain.boundaryMatrix(1), float).reshape(num_verts, num_edges)
+    d2 = np.asarray(chain.boundaryMatrix(2), float).reshape(num_edges, num_tris)
+    hodge = cobordism.HodgeLaplacian(spacetime)
+    if metric:
+        w1 = np.asarray(hodge.weights(1), float)
+        w2 = np.asarray(hodge.weights(2), float)
+    else:
+        w1 = np.ones(num_edges)
+        w2 = np.ones(num_tris)
+    b1mat = d1 * (1.0 / np.sqrt(w1))[None, :]            # W_0 = I
+    b2mat = np.sqrt(w1)[:, None] * d2 * (1.0 / np.sqrt(w2))[None, :]
+    return b1mat.T @ b1mat + b2mat @ b2mat.T, num_edges
+
+
+# --------------------------------------------------------------------------- #
+# The harmonic basis: numpy/Hodge cross-check + stable ordering.
+# --------------------------------------------------------------------------- #
+class TestHarmonicBasisHodgeCrossCheck(unittest.TestCase):
+
+    def test_torus_harmonic_count_is_b1(self):
+        prep = BoundaryStatePrep(_torus())
+        self.assertEqual(prep.harmonicDimension(), 2)        # b_1(T^2) = 2
+        self.assertEqual(prep.boundaryDimension(), 4)        # 2^{b_1} = 4
+        self.assertEqual(prep.numEdges(), 27)                # |C_1(T^2)|
+
+    def _harmonics_matrix(self, prep):
+        return np.asarray(prep.harmonics()).reshape(prep.numEdges(),
+                                                    prep.harmonicDimension())
+
+    def test_harmonics_orthonormal(self):
+        prep = BoundaryStatePrep(_torus())
+        harmonics = self._harmonics_matrix(prep)
+        gram = harmonics.conj().T @ harmonics
+        np.testing.assert_allclose(gram, np.eye(prep.harmonicDimension()),
+                                   atol=1e-9)
+
+    def test_harmonics_match_numpy_hodge_subspace(self):
+        # The C++ harmonics span exactly ker L_1 of an independent numpy assembly,
+        # for both volume (metric) and unit (combinatorial) Hodge weights.
+        torus = _torus()
+        for metric in (True, False):
+            with self.subTest(metric=metric):
+                prep = BoundaryStatePrep(torus, 1e-9, metric)
+                harmonics = self._harmonics_matrix(prep)
+                lap, num_edges = _numpy_L1_symmetric(torus, metric)
+                self.assertEqual(harmonics.shape, (num_edges, 2))
+                # nullity == b_1
+                evals = np.linalg.eigvalsh(lap)
+                self.assertEqual(int(np.sum(np.abs(evals) < 1e-9)), 2)
+                # harmonics annihilated by L_1
+                np.testing.assert_allclose(lap @ harmonics, 0.0, atol=1e-7)
+                # projector equality: same subspace as the numpy kernel
+                vals, vecs = np.linalg.eigh(lap)
+                kernel = vecs[:, np.abs(vals) < 1e-9]
+                np.testing.assert_allclose(kernel @ kernel.conj().T,
+                                           harmonics @ harmonics.conj().T,
+                                           atol=1e-7)
+
+    def test_harmonic_basis_ordering_is_stable(self):
+        # Deterministic, reproducible basis (the order prepare/readout rely on).
+        a = np.asarray(BoundaryStatePrep(_torus()).harmonics())
+        b = np.asarray(BoundaryStatePrep(_torus()).harmonics())
+        np.testing.assert_array_equal(a, b)
+
+
+# --------------------------------------------------------------------------- #
+# The b_1 vs 2^{b_1} reconciliation: harmonic i lands on flat-class index 2^i.
+# --------------------------------------------------------------------------- #
+class TestBasesReconciliation(unittest.TestCase):
+
+    def test_generator_indices_are_powers_of_two(self):
+        prep = BoundaryStatePrep(_torus())
+        self.assertEqual(list(prep.generatorIndices()), [1, 2])  # 2^0, 2^1
+
+    def test_each_harmonic_lands_on_its_generator_class(self):
+        prep = BoundaryStatePrep(_torus())
+        harmonics = np.asarray(prep.harmonics()).reshape(prep.numEdges(),
+                                                         prep.harmonicDimension())
+        for i, gen in enumerate(prep.generatorIndices()):
+            state = np.asarray(prep.prepare(list(harmonics[:, i])))
+            # Unit amplitude on its own generator class, zero everywhere else.
+            expected = np.zeros(prep.boundaryDimension(), dtype=complex)
+            expected[gen] = 1.0
+            np.testing.assert_allclose(state, expected, atol=1e-9)
+
+    def test_trivial_and_multi_generator_classes_stay_empty(self):
+        # An arbitrary harmonic form never excites the trivial class (index 0) or
+        # any multi-generator class (a non-power-of-two index, e.g. 3 = both).
+        prep = BoundaryStatePrep(_torus())
+        harmonics = np.asarray(prep.harmonics()).reshape(prep.numEdges(),
+                                                         prep.harmonicDimension())
+        form = harmonics @ np.array([0.7 + 0.2j, -0.4 + 1.1j])
+        state = np.asarray(prep.prepare(list(form)))
+        generators = set(prep.generatorIndices())
+        for idx in range(prep.boundaryDimension()):
+            if idx not in generators:
+                self.assertAlmostEqual(state[idx], 0.0, places=12)
+
+
+# --------------------------------------------------------------------------- #
+# Round-trip and the prepare isometry on ker L_1.
+# --------------------------------------------------------------------------- #
+class TestRoundTripAndIsometry(unittest.TestCase):
+
+    def _setup(self, metric=True):
+        prep = BoundaryStatePrep(_torus(), 1e-9, metric)
+        harmonics = np.asarray(prep.harmonics()).reshape(prep.numEdges(),
+                                                         prep.harmonicDimension())
+        return prep, harmonics
+
+    def test_readout_prepare_is_identity_on_ker_L1(self):
+        for metric in (True, False):
+            with self.subTest(metric=metric):
+                prep, harmonics = self._setup(metric)
+                rng = np.random.default_rng(175)
+                # Basis forms and random complex combinations, all in ker L_1.
+                forms = [harmonics[:, 0], harmonics[:, 1]]
+                for _ in range(5):
+                    coeffs = rng.standard_normal(2) + 1j * rng.standard_normal(2)
+                    forms.append(harmonics @ coeffs)
+                for form in forms:
+                    back = np.asarray(prep.readout(prep.prepare(list(form))))
+                    np.testing.assert_allclose(back, form, atol=1e-9)
+
+    def test_prepare_is_an_isometry(self):
+        # <prepare(psi)|prepare(phi)> = <psi|phi> for psi, phi in ker L_1.
+        prep, harmonics = self._setup()
+        rng = np.random.default_rng(424242)
+        for _ in range(6):
+            a = rng.standard_normal(2) + 1j * rng.standard_normal(2)
+            b = rng.standard_normal(2) + 1j * rng.standard_normal(2)
+            psi, phi = harmonics @ a, harmonics @ b
+            prepared_inner = np.vdot(np.asarray(prep.prepare(list(psi))),
+                                     np.asarray(prep.prepare(list(phi))))
+            self.assertAlmostEqual(prepared_inner, np.vdot(psi, phi), places=9)
+
+    def test_prepare_then_readout_projects_onto_generators(self):
+        # The other composition: prepare o readout zeroes the non-generator slots
+        # and is the identity on the generator subspace.
+        prep, _ = self._setup()
+        rng = np.random.default_rng(99)
+        state = rng.standard_normal(4) + 1j * rng.standard_normal(4)
+        projected = np.asarray(prep.prepare(prep.readout(list(state))))
+        expected = np.zeros(4, dtype=complex)
+        for gen in prep.generatorIndices():
+            expected[gen] = state[gen]
+        np.testing.assert_allclose(projected, expected, atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# Consistency with amplitude() and the trivial cylinder Sigma x [0,T].
+# --------------------------------------------------------------------------- #
+class TestAmplitudeConsistencyAndCylinder(unittest.TestCase):
+
+    def setUp(self):
+        self.prep = BoundaryStatePrep(_torus())
+        self.harmonics = np.asarray(self.prep.harmonics()).reshape(
+            self.prep.numEdges(), self.prep.harmonicDimension())
+
+    def _form(self, coeffs):
+        return self.harmonics @ np.asarray(coeffs, dtype=complex)
+
+    def test_prepared_state_feeds_amplitude(self):
+        # A state prepared via the new map, fed to amplitude(), reproduces the
+        # direct flat-connection-basis contraction conj(psi_A) . Z(W) . psi_B.
+        dw = DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial)
+        zmap = np.asarray(dw.map())
+        self.assertEqual(zmap.shape, (4, 4))
+        rng = np.random.default_rng(1750)
+        for _ in range(5):
+            psi = self._form(rng.standard_normal(2) + 1j * rng.standard_normal(2))
+            phi = self._form(rng.standard_normal(2) + 1j * rng.standard_normal(2))
+            prep_a = np.asarray(self.prep.prepare(list(psi)))
+            prep_b = np.asarray(self.prep.prepare(list(phi)))
+            amplitude = dw.amplitude(list(prep_a), list(prep_b))
+            direct = prep_a.conj() @ zmap @ prep_b
+            self.assertAlmostEqual(amplitude, direct, places=9)
+
+    def test_cylinder_amplitude_is_harmonic_inner_product(self):
+        # Trivial cobordism Z(W)=id: amplitude(prepare(psi), prepare(phi)) =
+        # <psi|phi> (the harmonic inner product on ker L_1).
+        dw = DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial)
+        rng = np.random.default_rng(8675309)
+        for _ in range(6):
+            psi = self._form(rng.standard_normal(2) + 1j * rng.standard_normal(2))
+            phi = self._form(rng.standard_normal(2) + 1j * rng.standard_normal(2))
+            amplitude = dw.amplitude(list(self.prep.prepare(list(psi))),
+                                     list(self.prep.prepare(list(phi))))
+            self.assertAlmostEqual(amplitude, np.vdot(psi, phi), places=9)
+
+    def test_cylinder_diagonal_is_the_norm(self):
+        # The explicit trivial-cobordism check: <psi|Z(W)|psi> = ||psi||^2.
+        dw = DijkgraafWitten(_torus_cylinder(), Cocycle.Trivial)
+        for i in range(self.prep.harmonicDimension()):
+            psi = self.harmonics[:, i]
+            prepared = list(self.prep.prepare(list(psi)))
+            self.assertAlmostEqual(dw.amplitude(prepared, prepared),
+                                   float(np.vdot(psi, psi).real), places=9)
+
+    def test_sign_cocycle_cylinder_agrees(self):
+        # The cup cube vanishes on the cylinder, so the Sign twist also returns
+        # the harmonic inner product.
+        dw = DijkgraafWitten(_torus_cylinder(), Cocycle.Sign)
+        psi = self._form([0.6 - 0.3j, 0.2 + 0.9j])
+        amplitude = dw.amplitude(list(self.prep.prepare(list(psi))),
+                                 list(self.prep.prepare(list(psi))))
+        self.assertAlmostEqual(amplitude, np.vdot(psi, psi), places=9)
+
+
+# --------------------------------------------------------------------------- #
+# Degenerate surface and guards.
+# --------------------------------------------------------------------------- #
+class TestEdgeCasesAndGuards(unittest.TestCase):
+
+    def test_sphere_has_trivial_boundary_space(self):
+        # b_1(S^2) = 0: the spectral qubit is a point and Z(S^2) is 1-dimensional.
+        prep = BoundaryStatePrep(_sphere2())
+        self.assertEqual(prep.harmonicDimension(), 0)
+        self.assertEqual(prep.boundaryDimension(), 1)
+        self.assertEqual(list(prep.generatorIndices()), [])
+        # prepare maps the (empty) harmonic data to the single trivial class.
+        state = prep.prepare([0.0] * prep.numEdges())
+        self.assertEqual(list(state), [0.0])
+        self.assertEqual(list(prep.readout([1.0])), [0.0] * prep.numEdges())
+
+    def test_prepare_rejects_wrong_form_length(self):
+        prep = BoundaryStatePrep(_torus())
+        with self.assertRaises((ValueError, RuntimeError)):
+            prep.prepare([1.0, 0.0])
+
+    def test_readout_rejects_wrong_state_length(self):
+        prep = BoundaryStatePrep(_torus())
+        with self.assertRaises((ValueError, RuntimeError)):
+            prep.readout([1.0, 0.0, 0.0])  # not 2^{b_1} = 4
+
+    def test_null_surface_raises(self):
+        with self.assertRaises((RuntimeError, TypeError)):
+            BoundaryStatePrep(None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

First step of the v0.4 DW–spectral bridge (epic #174). Adds **`cobordism::BoundaryStatePrep`**, making the spectral→DW boundary state preparation a **first-class, tested, invertible operation**. `DijkgraafWitten.amplitude()` already sandwiches the topological state sum between boundary states *prepared from* the Hodge harmonics, but that preparation was caller-side and implicit. This exposes it (and its readout) explicitly.

Two distinct objects on a closed surface Σ:

- **ker L₁(Σ)** — the Hodge harmonic 1-forms, the *spectral qubit*, dimension **`b₁`** (an orthonormal basis of 1-forms; `HodgeLaplacian` at `k=1`).
- **`Z(Σ) = ℂ[H¹(Σ;ℤ₂)]`** — the DW boundary Hilbert space, the flat-connection-class basis, dimension **`2^{b₁}`** (what `amplitude()`/`map()`/`boundaryVector()` consume).

## API

`tessera.cobordism.BoundaryStatePrep(sigma, tol=1e-9, metric=True)` — built over a closed surface Σ; computes & caches `ker L₁(Σ)` once via `HodgeLaplacian(k=1)` (reused, not reimplemented).

- `harmonicDimension()` → `b₁`; `boundaryDimension()` → `2^{b₁}`; `numEdges()` → `|C₁|`
- `harmonics()` → the orthonormal harmonic basis (flat `|C₁|×b₁`), for cross-checks
- `generatorIndices()` → `(2⁰, 2¹, …, 2^{b₁-1})`, the flat-connection classes carrying harmonic data
- `prepare(form)` : `ker L₁(Σ) → Z(Σ)`
- `readout(state)` : `Z(Σ) → ker L₁(Σ)` (the adjoint of `prepare`)

Bound in `src/cobordism/Bindings.cpp`. No free functions — everything is a method on the class, namespaced `tessera::cobordism`.

### Why a small new class rather than methods on `DijkgraafWitten`

`DijkgraafWitten` is built on the **bulk 3-manifold** `W` (its `computeBoundary()` throws unless `dim = 3`). The harmonics are intrinsic to the **boundary surface** Σ (a 2-manifold) and need only `b₁` + the harmonic basis — none of the bulk state-sum machinery. Forcing prep/readout onto `DijkgraafWitten` would mean passing Σ to every call or rebuilding Σ's `HodgeLaplacian` from a `∂W` sub-complex; a focused `BoundaryStatePrep(Σ)` that caches the basis is the cleaner, idiomatic split. It composes with `DijkgraafWitten.amplitude()` (see the cylinder test).

## The `b₁` vs `2^{b₁}` reconciliation

`H¹(Σ;ℤ₂) ≅ (ℤ₂)^{b₁}` has `b₁` distinguished **single-generator** classes (weight-one holonomy patterns). In the `gf2Span` ordering of `Z(Σ)` (mask `0…2^{b₁}-1`, basis vector `i` alone at mask `2^i`), those are exactly the amplitudes at indices `2⁰, 2¹, …, 2^{b₁-1}`.

`prepare` embeds the spectral qubit onto those generator slots: harmonic 1-form `i` (column `i` of `harmonics()`, ascending-eigenvalue order) carries its coordinate `c_i = ⟨h_i, form⟩` to the `Z(Σ)` amplitude at index `2^i`. **The trivial class (index 0) and every multi-generator class (non-power-of-two index) carry amplitude 0.** A prepared state thus occupies a `b₁`-dim coordinate subspace of the `2^{b₁}`-dim `Z(Σ)`.

Because the harmonic basis is orthonormal (the symmetric Hodge Laplacian's `SelfAdjointEigenSolver` eigenvectors):
- `prepare` is an **isometry**: `⟨prepare(ψ)|prepare(φ)⟩ = ⟨ψ|φ⟩` on `ker L₁`;
- `readout ∘ prepare = id` on `ker L₁`;
- hence on the trivial cylinder `Σ×[0,T]` (`Z(W)=id`), `amplitude(prepare(ψ), prepare(φ)) = ⟨ψ|φ⟩`.

## Tests (`tests/cobordism/test_boundary_state_prep_python.py`, anchored on T²: `b₁=2`, `Z(T²)=ℂ⁴`)

- **numpy/Hodge cross-check** of the harmonic basis for both metric and combinatorial weights: nullity `= b₁`, harmonics annihilated by an independently-assembled `L₁`, projector equality with the numpy kernel; basis ordering is reproducible.
- **Bases reconciliation:** `generatorIndices() == [1, 2]`; harmonic `i` lands exactly on index `2^i`; trivial/multi-generator classes stay empty.
- **Round-trip & isometry:** `readout(prepare(ψ)) = ψ` (basis + random complex combinations, metric & combinatorial); `⟨prepare(ψ)|prepare(φ)⟩ = ⟨ψ|φ⟩`; `prepare∘readout` projects onto the generator subspace.
- **Consistency with `amplitude()` + trivial cylinder:** a prepared state fed to `amplitude()` reproduces the direct `conj(ψ_A)·Z(W)·ψ_B` contraction; on the cylinder `amplitude(prepare(ψ), prepare(φ)) = ⟨ψ|φ⟩` (Trivial and Sign cocycles); the diagonal is the norm.
- **Edge cases/guards:** `S²` (`b₁=0` ⇒ `Z=ℂ¹`); wrong-length `prepare`/`readout` and null Σ raise.

## Test results (local — CI is build-only)

`poetry run python -m pytest tests/cobordism -q` → **355 passed, 1 skipped (pre-existing), 709 subtests passed**. The new file is 18 passed + 4 subtests. (No CUDA / `test_regge_solver` in this suite.)

Closes #175