### PR TITLE
refactor(cobordism): Eigen-backed value objects for HodgeLaplacian outputs

### DIFF
--- a/examples/cobordism/topological_correspondence.py
+++ b/examples/cobordism/topological_correspondence.py
@@ -307,9 +307,10 @@ def _boundary_states_from_harmonics():
     """Two Z(T²) states (length 2^{b₁}=4) seeded by the ker L₁(T²) harmonics —
     the b₁ = 2 qubit, distinct from the 2^{b₁} = 4 flat-connection count."""
     torus = _build(_torus_topology())
-    harmonics = np.asarray(cob.HodgeLaplacian(torus).harmonics(1, 1e-9, True))
-    num_edges = cob.ChainComplex.fromSpacetime(torus).numSimplices(1)
-    cols = harmonics.reshape(num_edges, -1) if harmonics.size else harmonics
+    harmonics = cob.HodgeLaplacian(torus).harmonics(1, 1e-9, True)
+    # columns = the harmonic 1-form Cochains over the edge ordering.
+    cols = (np.column_stack([np.asarray(h.coeffs()) for h in harmonics])
+            if harmonics else np.zeros((0, 0), dtype=complex))
     psi_a = np.zeros(4, dtype=complex)
     psi_b = np.zeros(4, dtype=complex)
     seed_a = cols[:, 0]

--- a/include/cobordism/Cochain.h
+++ b/include/cobordism/Cochain.h
@@ -1,0 +1,107 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_COCHAIN_H
+#define TESSERA_COBORDISM_COCHAIN_H
+
+#include <Eigen/Core>
+
+#include <complex>
+#include <cstdint>
+#include <vector>
+
+namespace tessera::cobordism {
+
+/// # Cochain
+///
+/// A \f$ k \f$-cochain value object: an Eigen-backed vector of complex
+/// amplitudes (`Eigen::VectorXcd`) together with the degree \f$ k \f$ and the
+/// \f$ k \f$-simplex ordering it is indexed over, so its indices are meaningful
+/// (not bare). The ordering is the same `HodgeLaplacian` / `ChainComplex` column
+/// order: component \f$ i \f$ is the amplitude on the \f$ i \f$-th \f$ k \f$-cell,
+/// each cell recorded as its sorted vertex-id tuple (`simplices()[i]`). For
+/// \f$ k = 0 \f$ each tuple is a single vertex id (the sorted-id vertex order).
+///
+/// Eigen-backed and iTensor-free — the cobordism/Hodge layer stays purely dense
+/// linear algebra (consistent with `quantum::ChoiJamiolkowski`'s "Eigen only, no
+/// ITensor, no MPS"). The Hermitian inner product follows the numpy convention
+/// \f$ \langle a, b\rangle = \sum_i \overline{a_i}\,b_i = \texttt{np.vdot(a, b)} \f$
+/// (conjugate-linear in the first argument).
+class Cochain {
+  public:
+    /// The empty 0-cochain (degree 0, no cells).
+    Cochain() = default;
+
+    /// A degree-`degree` cochain over `simplices` (sorted vertex-id tuples, in
+    /// the indexing order) carrying `coeffs`. @throws std::invalid_argument if
+    /// `simplices.size() != coeffs.size()`.
+    Cochain(int degree, std::vector<std::vector<std::uint64_t>> simplices,
+            Eigen::VectorXcd coeffs);
+
+    /// The cochain degree \f$ k \f$.
+    [[nodiscard]] int degree() const noexcept { return degree_; }
+
+    /// The number of \f$ k \f$-cells (= `coeffs().size()` = `simplices().size()`).
+    [[nodiscard]] std::size_t size() const noexcept {
+      return static_cast<std::size_t>(coeffs_.size());
+    }
+
+    /// The amplitude vector, Eigen-backed; pybind exposes it as a 1-D complex
+    /// `numpy.ndarray`.
+    [[nodiscard]] const Eigen::VectorXcd &coeffs() const noexcept { return coeffs_; }
+
+    /// The \f$ k \f$-simplex ordering: `simplices()[i]` is the sorted vertex-id
+    /// tuple of the cell carrying `coeffs()[i]`.
+    [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &simplices()
+        const noexcept {
+      return simplices_;
+    }
+
+    /// Amplitude on the \f$ i \f$-th \f$ k \f$-cell (by index).
+    /// @throws std::out_of_range if `index >= size()`.
+    [[nodiscard]] std::complex<double> amplitude(std::size_t index) const;
+
+    /// Amplitude on the \f$ k \f$-cell identified by its sorted vertex-id tuple
+    /// (e.g. `{vertexId}` at \f$ k = 0 \f$). @throws std::out_of_range if the
+    /// simplex is not in this cochain's ordering.
+    [[nodiscard]] std::complex<double> amplitudeFor(
+        const std::vector<std::uint64_t> &simplex) const;
+
+    /// The Hermitian inner product \f$ \langle \text{this}, \text{other}\rangle
+    /// = \sum_i \overline{\text{this}_i}\,\text{other}_i \f$ (= `np.vdot`).
+    /// @throws std::invalid_argument if the degrees or orderings differ.
+    [[nodiscard]] std::complex<double> innerProduct(const Cochain &other) const;
+
+    /// The Euclidean norm \f$ \sqrt{\sum_i |c_i|^2} \f$.
+    [[nodiscard]] double norm() const;
+
+    /// A copy scaled to unit norm; the cochain itself if its norm is ~0.
+    [[nodiscard]] Cochain normalized() const;
+
+  private:
+    int degree_{0};
+    std::vector<std::vector<std::uint64_t>> simplices_{};
+    Eigen::VectorXcd coeffs_{};
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_COCHAIN_H

--- a/include/cobordism/HodgeLaplacian.h
+++ b/include/cobordism/HodgeLaplacian.h
@@ -28,6 +28,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "cobordism/Cochain.h"
+#include "cobordism/Spectrum.h"
+
 // === tessera subsystem ns fwd-decls ===
 namespace tessera::spacetime { class Spacetime; }
 namespace tessera::cobordism {
@@ -153,33 +156,51 @@ class HodgeLaplacian {
     /// (Frobenius). ~0 for the Hermitian \f$ L \f$.
     [[nodiscard]] double unitarityResidual(double t = 1.0) const;
 
-    /// Eigenvalues of \f$ L_k \f$ (real, ascending). For \f$ k \geq 1 \f$,
-    /// `metric` selects volume vs. unit weights (ignored at \f$ k = 0 \f$).
+    /// The eigendecomposition of \f$ L_k \f$ as a `Spectrum` (real ascending
+    /// eigenvalues + eigenvectors as `Cochain`s; `Spectrum::isHermitian()` is
+    /// true). The self-adjoint \f$ k = 0 \f$ graph Laplacian and the symmetric
+    /// metric Hodge Laplacian (\f$ k \geq 1 \f$). For \f$ k \geq 1 \f$, `metric`
+    /// selects volume vs. unit weights (ignored at \f$ k = 0 \f$). The eigenvectors
+    /// are indexed over the sorted-id vertex order (\f$ k = 0 \f$) or the canonical
+    /// `ChainComplex` \f$ k \f$-simplex column order (\f$ k \geq 1 \f$).
+    /// @throws std::runtime_error for \f$ k < 0 \f$. Empty above the top dimension.
+    [[nodiscard]] Spectrum spectrum(int k = 0, bool metric = true) const;
+
+    /// Eigenvalues of \f$ L_k \f$ (real, ascending), a flat view consistent with
+    /// `spectrum(k, metric)`. For \f$ k \geq 1 \f$, `metric` selects volume vs.
+    /// unit weights (ignored at \f$ k = 0 \f$).
     /// @throws std::runtime_error for \f$ k < 0 \f$. Empty above the top dimension.
     [[nodiscard]] std::vector<double> eigenvalues(int k = 0, bool metric = true) const;
 
     /// Eigenvectors of \f$ L_k \f$ as a flat row-major \f$ M\times M \f$ array
     /// (\f$ M = N \f$ for \f$ k = 0 \f$, else \f$ |C_k| \f$); column \f$ j \f$
     /// (entries at indices \f$ iM + j \f$) is the eigenvector for the
-    /// \f$ j \f$-th ascending eigenvalue. For \f$ k \geq 1 \f$, `metric` selects
+    /// \f$ j \f$-th ascending eigenvalue — a flat view consistent with the
+    /// `Cochain`s of `spectrum(k, metric)`. For \f$ k \geq 1 \f$, `metric` selects
     /// volume vs. unit weights (ignored at \f$ k = 0 \f$).
     /// @throws std::runtime_error for \f$ k < 0 \f$. Empty above the top dimension.
     [[nodiscard]] std::vector<std::complex<double>> eigenvectors(int k = 0,
                                                                bool metric = true) const;
 
     /// Harmonic representatives: the eigenvectors with \f$ |\lambda| < \text{tol} \f$
-    /// (a basis for \f$ \ker L_k \cong H_k \f$), as a flat row-major
-    /// \f$ M\times H \f$ array whose \f$ H \f$ columns are the harmonics (so
-    /// \f$ H = \f$ size/\f$ M \f$, the harmonic dimension \f$ = b_k \f$). For
-    /// \f$ k \geq 1 \f$, `metric` selects volume vs. unit weights (ignored at
-    /// \f$ k = 0 \f$).
-    /// @throws std::runtime_error for \f$ k < 0 \f$. Empty above the top dimension.
-    [[nodiscard]] std::vector<std::complex<double>> harmonics(int k = 0,
-                                                              double tol = 1e-9,
-                                                              bool metric = true) const;
+    /// (a basis for \f$ \ker L_k \cong H_k \f$, so the count is the harmonic
+    /// dimension \f$ = b_k \f$), as `Cochain`s over the \f$ k \f$-simplex ordering.
+    /// For \f$ k \geq 1 \f$, `metric` selects volume vs. unit weights (ignored at
+    /// \f$ k = 0 \f$). @throws std::runtime_error for \f$ k < 0 \f$. Empty above the
+    /// top dimension.
+    [[nodiscard]] std::vector<Cochain> harmonics(int k = 0, double tol = 1e-9,
+                                                 bool metric = true) const;
 
     /// === Lorentzian (signed-weight) d'Alembertian, \f$ k \geq 1 \f$ (§5.6) ===
     ///
+    /// The eigendecomposition of the signed-weight \f$ L_k \f$ (the
+    /// non-self-adjoint d'Alembertian) as a `Spectrum` (`isHermitian() == false`):
+    /// complex eigenvalues sorted ascending by \f$ (\mathrm{Re},\mathrm{Im}) \f$,
+    /// paired with eigenvectors as `Cochain`s. `metric = false` falls back to unit
+    /// weights (the real, nonnegative combinatorial spectrum). @throws
+    /// std::runtime_error for \f$ k < 0 \f$. Empty above the top dimension.
+    [[nodiscard]] Spectrum lorentzianSpectrum(int k, bool metric = true) const;
+
     /// Eigenvalues of the signed-weight \f$ L_k \f$ (the non-self-adjoint
     /// d'Alembertian), as **complex** numbers sorted ascending by
     /// \f$ (\mathrm{Re},\mathrm{Im}) \f$ — they may be negative or come in complex
@@ -200,11 +221,12 @@ class HodgeLaplacian {
         int k, bool metric = true) const;
 
     /// Near-kernel ("harmonic") representatives of the d'Alembertian: the
-    /// eigenvectors with \f$ |\lambda| < \text{tol} \f$, as a flat row-major
-    /// \f$ M\times H \f$ complex array (\f$ H \f$ columns). For an all-spacelike
-    /// complex \f$ H = b_k \f$; with genuine timelike cells the count can differ
-    /// (the pseudo-Hodge decomposition). @throws std::runtime_error for \f$ k < 0 \f$.
-    [[nodiscard]] std::vector<std::complex<double>> lorentzianHarmonics(
+    /// eigenvectors with \f$ |\lambda| < \text{tol} \f$, as `Cochain`s. For an
+    /// all-spacelike complex the count is \f$ b_k \f$; with genuine timelike cells
+    /// it can differ (the pseudo-Hodge decomposition). The matching indefinite
+    /// \f$ W \f$-norms come from `lorentzianNullNorms(k, tol, metric)` (same order).
+    /// @throws std::runtime_error for \f$ k < 0 \f$.
+    [[nodiscard]] std::vector<Cochain> lorentzianHarmonics(
         int k, double tol = 1e-9, bool metric = true) const;
 
     /// The indefinite norms \f$ \langle h,h\rangle_W = \sum_i W_{k,i}|h_i|^2 \f$
@@ -255,6 +277,23 @@ class HodgeLaplacian {
 
     // Throw for k < 0 (no negative-degree chains).
     static void requireNonNegativeDegree(int k);
+
+    // The sorted vertex-id tuples a degree-k Cochain is indexed over.
+    // `useVertexSet` returns the full sorted-id vertex order (the Hermitian k=0
+    // basis, length N); otherwise the canonical ChainComplex k-simplex column
+    // order (the metric / Lorentzian basis, length |C_k|).
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> cochainOrdering(
+        int k, bool useVertexSet) const;
+
+    // Assemble a Spectrum from flat eigenvalues/eigenvectors. `evecsFlat` is
+    // row-major dim*dim with entry [i*dim + j] = component i of eigenvector j
+    // (column j); `ordering` indexes the components; `hermitian` flags the
+    // real-ascending regime.
+    static Spectrum makeSpectrum(
+        int degree, std::vector<std::vector<std::uint64_t>> ordering,
+        const std::vector<std::complex<double>> &evals,
+        const std::vector<std::complex<double>> &evecsFlat, int dim,
+        bool hermitian);
 
     // Build/fetch the cached symmetric spectrum of L_k^sym (k >= 1). Key folds in
     // `metric` so the metric and combinatorial spectra are cached separately.

--- a/include/cobordism/Spectrum.h
+++ b/include/cobordism/Spectrum.h
@@ -1,0 +1,108 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TESSERA_COBORDISM_SPECTRUM_H
+#define TESSERA_COBORDISM_SPECTRUM_H
+
+#include <Eigen/Core>
+
+#include <complex>
+#include <cstddef>
+#include <vector>
+
+#include "cobordism/Cochain.h"
+
+namespace tessera::cobordism {
+
+/// # Spectrum
+///
+/// The eigendecomposition of a Hodge Laplacian \f$ L_k \f$ as a value object:
+/// the eigenvalues paired with their eigenvectors-as-`Cochain`s, in matching
+/// order. Replaces the old `(flat evals, flat M\times M evecs)` pair so the
+/// eigenvector indexing carries its degree and \f$ k \f$-simplex ordering.
+///
+/// ## Representation (covers both regimes)
+///
+/// Eigenvalues are stored as a single complex vector (`Eigen::VectorXcd`),
+/// the cleanest representation that covers BOTH cases uniformly:
+///
+///  - **Hermitian / metric** (`isHermitian() == true`): the self-adjoint
+///    \f$ k = 0 \f$ graph Laplacian and the symmetric metric Hodge Laplacian
+///    (\f$ k \geq 1 \f$). The eigenvalues are mathematically real (their stored
+///    imaginary parts are zero) and **ascending**.
+///  - **Lorentzian** (`isHermitian() == false`): the signed-weight, generally
+///    non-self-adjoint d'Alembertian. The eigenvalues may be negative or come in
+///    complex-conjugate pairs, sorted ascending by \f$ (\mathrm{Re},\mathrm{Im}) \f$.
+///
+/// `eigenvalues()[i]` is the eigenvalue of `eigenvectors()[i]`. `harmonics(tol)`
+/// is the kernel subset \f$ \{v : |\lambda_v| < \text{tol}\} = \ker L_k \f$ as
+/// `Cochain`s (a basis for \f$ H_k \f$ in the Hermitian case; the small-\f$ |\lambda| \f$
+/// near-kernel pseudo-Hodge subset in the Lorentzian case).
+class Spectrum {
+  public:
+    /// The empty spectrum (no modes).
+    Spectrum() = default;
+
+    /// `eigenvalues[i]` pairs with `eigenvectors[i]`; `hermitian` records whether
+    /// the eigenvalues are guaranteed real & ascending (the metric/self-adjoint
+    /// regime) vs. the indefinite Lorentzian regime. @throws std::invalid_argument
+    /// if the eigenvalue and eigenvector counts differ.
+    Spectrum(Eigen::VectorXcd eigenvalues, std::vector<Cochain> eigenvectors,
+             bool hermitian);
+
+    /// The eigenvalues; pybind exposes them as a 1-D complex `numpy.ndarray`.
+    /// Ascending real values (imag 0) in the Hermitian regime; sorted by
+    /// \f$ (\mathrm{Re},\mathrm{Im}) \f$ in the Lorentzian regime.
+    [[nodiscard]] const Eigen::VectorXcd &eigenvalues() const noexcept {
+      return eigenvalues_;
+    }
+
+    /// The eigenvectors, one `Cochain` per eigenvalue, in matching order.
+    [[nodiscard]] const std::vector<Cochain> &eigenvectors() const noexcept {
+      return eigenvectors_;
+    }
+
+    /// The harmonic subset: the eigenvectors whose eigenvalue has
+    /// \f$ |\lambda| < \text{tol} \f$ (a basis for \f$ \ker L_k \f$), as `Cochain`s.
+    [[nodiscard]] std::vector<Cochain> harmonics(double tol = 1e-9) const;
+
+    /// The number of modes (eigenvalues = eigenvectors).
+    [[nodiscard]] std::size_t size() const noexcept { return eigenvectors_.size(); }
+
+    /// Whether the eigenvalues are guaranteed real & ascending (the
+    /// metric/self-adjoint regime) rather than the indefinite Lorentzian one.
+    [[nodiscard]] bool isHermitian() const noexcept { return hermitian_; }
+
+    /// The \f$ i \f$-th eigenvalue. @throws std::out_of_range if `i >= size()`.
+    [[nodiscard]] std::complex<double> eigenvalue(std::size_t i) const;
+
+    /// The \f$ i \f$-th eigenvector. @throws std::out_of_range if `i >= size()`.
+    [[nodiscard]] const Cochain &operator[](std::size_t i) const;
+
+  private:
+    Eigen::VectorXcd eigenvalues_{};
+    std::vector<Cochain> eigenvectors_{};
+    bool hermitian_{true};
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_SPECTRUM_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -25,6 +25,8 @@
 // _tessera's sources (see CMakeLists.txt, TESSERA_PYBIND_SOURCES).
 
 #include <pybind11/complex.h>
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -32,6 +34,7 @@
 #include "cobordism/BoundaryStatePrep.h"
 #include "cobordism/ChainComplex.h"
 #include "cobordism/Characteristic.h"
+#include "cobordism/Cochain.h"
 #include "cobordism/Cobordism.h"
 #include "cobordism/CombinatorialDimension.h"
 #include "cobordism/DijkgraafWitten.h"
@@ -39,6 +42,7 @@
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
 #include "cobordism/RealizabilityOracle.h"
+#include "cobordism/Spectrum.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
 
 namespace py = pybind11;
@@ -118,6 +122,70 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
            "monomial (e.g. 'w4', 'w2^2'); empty for the empty complex. Raises "
            "if a class needs a deferred higher Steenrod cup-i product (#65).");
 
+  // ----- Eigen-backed value objects for the Hodge spectrum (#183) -----
+  py::class_<Cochain>(m, "Cochain",
+      R"doc(A k-cochain: complex amplitudes over a k-simplex ordering.
+
+An Eigen-backed vector of complex amplitudes together with the degree k and the
+k-simplex ordering it indexes (the same HodgeLaplacian / ChainComplex column
+order), so its indices are meaningful. simplices()[i] is the sorted vertex-id
+tuple of the cell carrying coeffs()[i]; at k=0 each tuple is a single vertex id
+(the sorted-id vertex order). Eigen-backed and iTensor-free. The inner product is
+Hermitian, np.vdot convention: <a, b> = sum conj(a_i) b_i.)doc")
+      .def("degree", &Cochain::degree, "The cochain degree k.")
+      .def("size", &Cochain::size,
+           "Number of k-cells (= len(coeffs()) = len(simplices())).")
+      .def("__len__", &Cochain::size)
+      .def("coeffs", &Cochain::coeffs,
+           "The complex amplitudes as a 1-D numpy.ndarray (Eigen-backed).")
+      .def("simplices", &Cochain::simplices,
+           "The k-simplex ordering: simplices()[i] is the sorted vertex-id tuple "
+           "of the cell carrying coeffs()[i].")
+      .def("amplitude", &Cochain::amplitude, py::arg("index"),
+           "Amplitude on the index-th k-cell. Raises IndexError if out of range.")
+      .def("__getitem__", &Cochain::amplitude)
+      .def("amplitudeFor", &Cochain::amplitudeFor, py::arg("simplex"),
+           "Amplitude on the k-cell identified by its sorted vertex-id tuple "
+           "(e.g. (vertexId,) at k=0). Raises IndexError if absent.")
+      .def("innerProduct", &Cochain::innerProduct, py::arg("other"),
+           "The Hermitian inner product <self, other> = sum conj(self_i) other_i "
+           "(= np.vdot). Raises if the degrees or orderings differ.")
+      .def("norm", &Cochain::norm, "The Euclidean norm sqrt(sum |c_i|^2).")
+      .def("normalized", &Cochain::normalized,
+           "A copy scaled to unit norm (the cochain itself if its norm is ~0).");
+
+  py::class_<Spectrum>(m, "Spectrum",
+      R"doc(The eigendecomposition of a Hodge Laplacian L_k as a value object.
+
+Eigenvalues paired with their eigenvectors-as-Cochains, in matching order
+(eigenvalues()[i] is the eigenvalue of eigenvectors()[i]). Eigenvalues are stored
+complex to cover both regimes uniformly: in the Hermitian/metric case
+(isHermitian() == True) they are real (imag 0) and ascending; in the Lorentzian
+(signed-weight d'Alembertian) case they may be negative or complex-conjugate
+pairs, sorted by (Re, Im). harmonics(tol) is the kernel subset |lambda| < tol =
+ker L_k as Cochains. Supports len() and indexing (spectrum[i] is the i-th
+eigenvector Cochain).)doc")
+      .def("eigenvalues", &Spectrum::eigenvalues,
+           "The eigenvalues as a 1-D complex numpy.ndarray (ascending real, "
+           "imag 0, in the Hermitian regime; sorted by (Re, Im) in the Lorentzian "
+           "one).")
+      .def("eigenvectors", &Spectrum::eigenvectors,
+           "The eigenvectors as a list of Cochains, one per eigenvalue.")
+      .def("harmonics", &Spectrum::harmonics, py::arg("tol") = 1e-9,
+           "The harmonic subset: eigenvectors with |lambda| < tol (a basis for "
+           "ker L_k), as a list of Cochains.")
+      .def("size", &Spectrum::size, "The number of modes.")
+      .def("__len__", &Spectrum::size)
+      .def("isHermitian", &Spectrum::isHermitian,
+           "Whether the eigenvalues are guaranteed real and ascending (the "
+           "metric/self-adjoint regime) vs. the indefinite Lorentzian one.")
+      .def("eigenvalue", &Spectrum::eigenvalue, py::arg("i"),
+           "The i-th eigenvalue. Raises IndexError if out of range.")
+      .def("__getitem__",
+           [](const Spectrum &s, std::size_t i) -> const Cochain & { return s[i]; },
+           py::return_value_policy::reference_internal,
+           "The i-th eigenvector Cochain. Raises IndexError if out of range.");
+
   // ----- Hodge Laplacian: k=0 Hermitian graph (#90), k>=1 metric Hodge (#104) -----
   py::class_<HodgeLaplacian>(m, "HodgeLaplacian",
       R"doc(Hodge Laplacian on a Spacetime, degree-parameterized by int k.
@@ -177,24 +245,38 @@ Euclidean spectrum/kernel.)doc")
            py::arg("t") = 1.0,
            "Residual ||U U^dagger - I|| of U = e^{-iLt} formed from the "
            "eigendecomposition (~0 for the Hermitian L).")
+      .def("spectrum", &HodgeLaplacian::spectrum, py::arg("k") = 0,
+           py::arg("metric") = true,
+           "The eigendecomposition of L_k as a Spectrum (real ascending "
+           "eigenvalues + eigenvectors as Cochains; isHermitian()==True). metric "
+           "selects volume vs. unit weights for k>=1 (ignored at k=0). Raises for "
+           "k<0; empty above the top dimension.")
       .def("eigenvalues", &HodgeLaplacian::eigenvalues, py::arg("k") = 0,
            py::arg("metric") = true,
-           "Eigenvalues of L_k (real, ascending). metric selects volume vs. unit "
-           "weights for k>=1 (ignored at k=0). Raises for k<0; empty above the "
-           "top dimension.")
+           "Eigenvalues of L_k (real, ascending), a flat view consistent with "
+           "spectrum(k, metric). metric selects volume vs. unit weights for k>=1 "
+           "(ignored at k=0). Raises for k<0; empty above the top dimension.")
       .def("eigenvectors", &HodgeLaplacian::eigenvectors, py::arg("k") = 0,
            py::arg("metric") = true,
            "Eigenvectors of L_k as a flat row-major M*M complex array (column j "
-           "is the eigenvector for the j-th ascending eigenvalue). metric selects "
+           "is the eigenvector for the j-th ascending eigenvalue), a flat view "
+           "consistent with spectrum(k, metric).eigenvectors(). metric selects "
            "volume vs. unit weights for k>=1. Raises for k<0; empty above the top "
            "dimension.")
       .def("harmonics", &HodgeLaplacian::harmonics, py::arg("k") = 0,
            py::arg("tol") = 1e-9, py::arg("metric") = true,
-           "Harmonic representatives (eigenvectors with |lambda| < tol) as a flat "
-           "row-major M*H complex array whose H columns span ker L_k ~= H_k "
-           "(H = b_k). metric selects volume vs. unit weights for k>=1. Raises "
-           "for k<0; empty above the top dimension.")
+           "Harmonic representatives (eigenvectors with |lambda| < tol) as a list "
+           "of Cochains spanning ker L_k ~= H_k (the count is b_k). metric selects "
+           "volume vs. unit weights for k>=1. Raises for k<0; empty above the top "
+           "dimension.")
       // ----- Lorentzian (signed-weight) d'Alembertian (#105, spec §5.6) -----
+      .def("lorentzianSpectrum", &HodgeLaplacian::lorentzianSpectrum,
+           py::arg("k"), py::arg("metric") = true,
+           "The eigendecomposition of the signed-weight d'Alembertian L_k as a "
+           "Spectrum (isHermitian()==False): complex eigenvalues sorted by "
+           "(Re, Im) + eigenvectors as Cochains. metric=False falls back to unit "
+           "weights (the real combinatorial spectrum). Raises for k<0; empty "
+           "above the top dimension.")
       .def("lorentzianEigenvalues", &HodgeLaplacian::lorentzianEigenvalues,
            py::arg("k"), py::arg("metric") = true,
            "Eigenvalues of the signed-weight d'Alembertian L_k (k>=1) as complex "
@@ -209,9 +291,9 @@ Euclidean spectrum/kernel.)doc")
       .def("lorentzianHarmonics", &HodgeLaplacian::lorentzianHarmonics,
            py::arg("k"), py::arg("tol") = 1e-9, py::arg("metric") = true,
            "Near-kernel ('harmonic') representatives of the d'Alembertian "
-           "(eigenvectors with |lambda| < tol) as a flat row-major M*H complex "
-           "array. H = b_k on an all-spacelike complex; with timelike cells the "
-           "count can differ (pseudo-Hodge decomposition).")
+           "(eigenvectors with |lambda| < tol) as a list of Cochains. The count "
+           "is b_k on an all-spacelike complex; with timelike cells it can differ "
+           "(pseudo-Hodge decomposition). Matching W-norms: lorentzianNullNorms.")
       .def("lorentzianNullNorms", &HodgeLaplacian::lorentzianNullNorms,
            py::arg("k"), py::arg("tol") = 1e-9, py::arg("metric") = true,
            "Indefinite W-norms <h,h>_W = sum_i W_{k,i} |h_i|^2 of the near-kernel "

--- a/src/cobordism/BoundaryStatePrep.cpp
+++ b/src/cobordism/BoundaryStatePrep.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 
 #include "cobordism/ChainComplex.h"
+#include "cobordism/Cochain.h"
 #include "cobordism/HodgeLaplacian.h"
 #include "spacetime/Spacetime.h"
 
@@ -37,19 +38,26 @@ BoundaryStatePrep::BoundaryStatePrep(std::shared_ptr<Spacetime> sigma,
   if (sigma_ == nullptr)
     throw std::runtime_error("BoundaryStatePrep: the surface Sigma is null");
 
-  // |C_1(Sigma)| fixes the harmonic-form length and lets us recover b_1 from the
-  // flat harmonics array (size = |C_1| * b_1).
+  // |C_1(Sigma)| fixes the harmonic-form length (the row count of the flat
+  // |C_1| x b_1 harmonic basis assembled below).
   numEdges_ = static_cast<int>(ChainComplex::fromSpacetime(*sigma_).numSimplices(1));
 
   // ker L_1(Sigma) via the k=1 Hodge Laplacian — reused, not reimplemented. The
-  // columns are W_k-orthonormal (the symmetric SelfAdjointEigenSolver basis), so
-  // the standard inner product on them is the identity and `prepare` is an
-  // isometry for either weight choice.
-  harmonics_ = HodgeLaplacian(sigma_).harmonics(1, tol, metric);
-  if (numEdges_ > 0)
-    b1_ = static_cast<int>(harmonics_.size()) / numEdges_;
-  else
-    b1_ = 0;  // no edges ⇒ no 1-forms (e.g. a point/empty complex)
+  // basis Cochains are W_k-orthonormal (the symmetric SelfAdjointEigenSolver
+  // eigenvectors), so the standard inner product on them is the identity and
+  // `prepare` is an isometry for either weight choice. Flatten the b_1 harmonic
+  // Cochains into the column-major |C_1| x b_1 layout (element (edge e, harmonic
+  // i) at e*b_1 + i) the prepare/readout math below indexes.
+  const std::vector<Cochain> basis =
+      HodgeLaplacian(sigma_).harmonics(1, tol, metric);
+  b1_ = static_cast<int>(basis.size());  // one Cochain per ker L_1 basis vector
+  harmonics_.assign(
+      static_cast<std::size_t>(numEdges_) * static_cast<std::size_t>(b1_),
+      {0.0, 0.0});
+  for (int i = 0; i < b1_; ++i)
+    for (int e = 0; e < numEdges_; ++e)
+      harmonics_[static_cast<std::size_t>(e) * b1_ + i] =
+          basis[static_cast<std::size_t>(i)].amplitude(static_cast<std::size_t>(e));
 
   // Z(Sigma) = C[H^1(Sigma; Z_2)] has dimension 2^{b_1}; cap at the same nullity
   // the gf2Span materialization refuses, so boundaryDimension() cannot overflow

--- a/src/cobordism/Cochain.cpp
+++ b/src/cobordism/Cochain.cpp
@@ -1,0 +1,78 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/Cochain.h"
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace tessera::cobordism {
+
+Cochain::Cochain(int degree, std::vector<std::vector<std::uint64_t>> simplices,
+                 Eigen::VectorXcd coeffs)
+    : degree_(degree), simplices_(std::move(simplices)), coeffs_(std::move(coeffs)) {
+  if (simplices_.size() != static_cast<std::size_t>(coeffs_.size()))
+    throw std::invalid_argument(
+        "Cochain: ordering has " + std::to_string(simplices_.size()) +
+        " simplices but coeffs has " + std::to_string(coeffs_.size()) +
+        " amplitudes");
+}
+
+std::complex<double> Cochain::amplitude(std::size_t index) const {
+  if (index >= size())
+    throw std::out_of_range("Cochain::amplitude: index " +
+                            std::to_string(index) + " out of range (size " +
+                            std::to_string(size()) + ")");
+  return coeffs_[static_cast<Eigen::Index>(index)];
+}
+
+std::complex<double> Cochain::amplitudeFor(
+    const std::vector<std::uint64_t> &simplex) const {
+  for (std::size_t i = 0; i < simplices_.size(); ++i)
+    if (simplices_[i] == simplex)
+      return coeffs_[static_cast<Eigen::Index>(i)];
+  throw std::out_of_range(
+      "Cochain::amplitudeFor: simplex is not in this cochain's ordering");
+}
+
+std::complex<double> Cochain::innerProduct(const Cochain &other) const {
+  if (degree_ != other.degree_)
+    throw std::invalid_argument(
+        "Cochain::innerProduct: degree mismatch (" + std::to_string(degree_) +
+        " vs " + std::to_string(other.degree_) + ")");
+  if (simplices_ != other.simplices_)
+    throw std::invalid_argument(
+        "Cochain::innerProduct: the two cochains are indexed over different "
+        "k-simplex orderings");
+  // Hermitian, conjugate-linear in the first argument: <a, b> = sum conj(a_i) b_i.
+  return coeffs_.dot(other.coeffs_);
+}
+
+double Cochain::norm() const { return coeffs_.norm(); }
+
+Cochain Cochain::normalized() const {
+  const double n = norm();
+  if (n <= 0.0) return *this;
+  return Cochain(degree_, simplices_, Eigen::VectorXcd(coeffs_ / n));
+}
+
+}  // namespace tessera::cobordism

--- a/src/cobordism/HodgeLaplacian.cpp
+++ b/src/cobordism/HodgeLaplacian.cpp
@@ -34,6 +34,8 @@
 #include <vector>
 
 #include "cobordism/ChainComplex.h"
+#include "cobordism/Cochain.h"
+#include "cobordism/Spectrum.h"
 #include "mesh/Edge.h"
 #include "mesh/EdgeList.h"
 #include "mesh/Simplex.h"
@@ -234,6 +236,48 @@ void HodgeLaplacian::requireNonNegativeDegree(int k) {
     throw std::runtime_error(
         "HodgeLaplacian: degree k must be non-negative; requested k=" +
         std::to_string(k));
+}
+
+std::vector<std::vector<std::uint64_t>> HodgeLaplacian::cochainOrdering(
+    int k, bool useVertexSet) const {
+  std::vector<std::vector<std::uint64_t>> ord;
+  if (k < 0 || !st_) return ord;
+  if (useVertexSet && k == 0) {
+    // The Hermitian k=0 operator is indexed over the full sorted-id vertex set
+    // (it reads every vertex, including any lone vertices ChainComplex omits).
+    ord.reserve(ids_.size());
+    for (const std::uint64_t id : ids_) ord.push_back({id});
+    return ord;
+  }
+  // The metric (k>=1) and signed-weight (any k) operators are assembled from the
+  // ChainComplex boundary maps, so the eigenvector components are indexed in the
+  // canonical ChainComplex k-simplex column order — exactly kSimplexVertices(k),
+  // whose count always matches the operator dimension numSimplices(k).
+  return ChainComplex::fromSpacetime(*st_).kSimplexVertices(k);
+}
+
+Spectrum HodgeLaplacian::makeSpectrum(
+    int degree, std::vector<std::vector<std::uint64_t>> ordering,
+    const std::vector<cd> &evals, const std::vector<cd> &evecsFlat, int dim,
+    bool hermitian) {
+  if (dim <= 0) return Spectrum();
+  if (ordering.size() != static_cast<std::size_t>(dim))
+    throw std::runtime_error(
+        "HodgeLaplacian::makeSpectrum: k-simplex ordering size " +
+        std::to_string(ordering.size()) + " != operator dimension " +
+        std::to_string(dim));
+  Eigen::VectorXcd eigenvalues(dim);
+  for (int j = 0; j < dim; ++j)
+    eigenvalues[j] = evals[static_cast<std::size_t>(j)];
+  std::vector<Cochain> eigenvectors;
+  eigenvectors.reserve(static_cast<std::size_t>(dim));
+  for (int j = 0; j < dim; ++j) {
+    Eigen::VectorXcd col(dim);
+    for (int i = 0; i < dim; ++i)
+      col[i] = evecsFlat[static_cast<std::size_t>(i) * dim + j];
+    eigenvectors.emplace_back(degree, ordering, std::move(col));
+  }
+  return Spectrum(std::move(eigenvalues), std::move(eigenvectors), hermitian);
 }
 
 void HodgeLaplacian::assemble(std::vector<cd> &A, std::vector<double> &D) const {
@@ -459,6 +503,22 @@ double HodgeLaplacian::unitarityResidual(double t) const {
   return resid.norm();
 }
 
+Spectrum HodgeLaplacian::spectrum(int k, bool metric) const {
+  requireNonNegativeDegree(k);
+  if (k == 0) {
+    ensureDecomposition();
+    std::vector<cd> evalsC(evals_.size());
+    for (std::size_t i = 0; i < evals_.size(); ++i) evalsC[i] = cd(evals_[i], 0.0);
+    return makeSpectrum(0, cochainOrdering(0, /*useVertexSet=*/true), evalsC,
+                        evecs_, static_cast<int>(order_), /*hermitian=*/true);
+  }
+  const MetricSpectrum &sp = ensureMetricSpectrum(k, metric);
+  std::vector<cd> evalsC(sp.evals.size());
+  for (std::size_t i = 0; i < sp.evals.size(); ++i) evalsC[i] = cd(sp.evals[i], 0.0);
+  return makeSpectrum(k, cochainOrdering(k, /*useVertexSet=*/true), evalsC,
+                      sp.evecs, sp.dim, /*hermitian=*/true);
+}
+
 std::vector<double> HodgeLaplacian::eigenvalues(int k, bool metric) const {
   requireNonNegativeDegree(k);
   if (k == 0) {
@@ -477,37 +537,18 @@ std::vector<cd> HodgeLaplacian::eigenvectors(int k, bool metric) const {
   return ensureMetricSpectrum(k, metric).evecs;
 }
 
-std::vector<cd> HodgeLaplacian::harmonics(int k, double tol, bool metric) const {
+std::vector<Cochain> HodgeLaplacian::harmonics(int k, double tol,
+                                               bool metric) const {
+  // ker L_k as Cochains: the eigenvectors with (near-)zero eigenvalue, a basis
+  // for H_k (the count is b_k). requireNonNegativeDegree runs inside spectrum().
+  return spectrum(k, metric).harmonics(tol);
+}
+
+Spectrum HodgeLaplacian::lorentzianSpectrum(int k, bool metric) const {
   requireNonNegativeDegree(k);
-
-  // The harmonic dimension is b_k: the columns with (near-)zero eigenvalue span
-  // ker L_k. Bind to whichever cached spectrum applies, then share the selection.
-  const std::vector<double> *evals = nullptr;
-  const std::vector<cd> *evecs = nullptr;
-  std::size_t N = 0;
-  if (k == 0) {
-    ensureDecomposition();
-    evals = &evals_;
-    evecs = &evecs_;
-    N = order_;
-  } else {
-    const MetricSpectrum &sp = ensureMetricSpectrum(k, metric);
-    evals = &sp.evals;
-    evecs = &sp.evecs;
-    N = static_cast<std::size_t>(sp.dim);
-  }
-  if (N == 0) return {};
-
-  std::vector<std::size_t> cols;
-  for (std::size_t j = 0; j < N; ++j)
-    if (std::abs((*evals)[j]) < tol) cols.push_back(j);
-
-  const std::size_t M = cols.size();
-  std::vector<cd> H(N * M, cd(0.0, 0.0));
-  for (std::size_t i = 0; i < N; ++i)
-    for (std::size_t jj = 0; jj < M; ++jj)
-      H[i * M + jj] = (*evecs)[i * N + cols[jj]];
-  return H;
+  const LorentzianSpectrum &sp = ensureLorentzianSpectrum(k, metric);
+  return makeSpectrum(k, cochainOrdering(k, /*useVertexSet=*/false), sp.evals,
+                      sp.evecs, sp.dim, /*hermitian=*/false);
 }
 
 std::vector<cd> HodgeLaplacian::lorentzianEigenvalues(int k, bool metric) const {
@@ -520,23 +561,11 @@ std::vector<cd> HodgeLaplacian::lorentzianEigenvectors(int k, bool metric) const
   return ensureLorentzianSpectrum(k, metric).evecs;
 }
 
-std::vector<cd> HodgeLaplacian::lorentzianHarmonics(int k, double tol,
-                                                    bool metric) const {
-  requireNonNegativeDegree(k);
-  const LorentzianSpectrum &sp = ensureLorentzianSpectrum(k, metric);
-  const std::size_t N = static_cast<std::size_t>(sp.dim);
-  if (N == 0) return {};
-
-  std::vector<std::size_t> cols;
-  for (std::size_t j = 0; j < N; ++j)
-    if (std::abs(sp.evals[j]) < tol) cols.push_back(j);
-
-  const std::size_t H = cols.size();
-  std::vector<cd> out(N * H, cd(0.0, 0.0));
-  for (std::size_t i = 0; i < N; ++i)
-    for (std::size_t jj = 0; jj < H; ++jj)
-      out[i * H + jj] = sp.evecs[i * N + cols[jj]];
-  return out;
+std::vector<Cochain> HodgeLaplacian::lorentzianHarmonics(int k, double tol,
+                                                         bool metric) const {
+  // The near-kernel (pseudo-Hodge) representatives as Cochains; the matching
+  // indefinite W-norms come from lorentzianNullNorms (same order).
+  return lorentzianSpectrum(k, metric).harmonics(tol);
 }
 
 std::vector<double> HodgeLaplacian::lorentzianNullNorms(int k, double tol,

--- a/src/cobordism/Spectrum.cpp
+++ b/src/cobordism/Spectrum.cpp
@@ -1,0 +1,65 @@
+// MIT License
+// Copyright (c) 2025 Andrew Kelleher
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cobordism/Spectrum.h"
+
+#include <complex>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace tessera::cobordism {
+
+Spectrum::Spectrum(Eigen::VectorXcd eigenvalues,
+                   std::vector<Cochain> eigenvectors, bool hermitian)
+    : eigenvalues_(std::move(eigenvalues)),
+      eigenvectors_(std::move(eigenvectors)),
+      hermitian_(hermitian) {
+  if (static_cast<std::size_t>(eigenvalues_.size()) != eigenvectors_.size())
+    throw std::invalid_argument(
+        "Spectrum: " + std::to_string(eigenvalues_.size()) + " eigenvalues but " +
+        std::to_string(eigenvectors_.size()) + " eigenvectors");
+}
+
+std::vector<Cochain> Spectrum::harmonics(double tol) const {
+  std::vector<Cochain> out;
+  for (std::size_t i = 0; i < eigenvectors_.size(); ++i)
+    if (std::abs(eigenvalues_[static_cast<Eigen::Index>(i)]) < tol)
+      out.push_back(eigenvectors_[i]);
+  return out;
+}
+
+std::complex<double> Spectrum::eigenvalue(std::size_t i) const {
+  if (i >= size())
+    throw std::out_of_range("Spectrum::eigenvalue: index " + std::to_string(i) +
+                            " out of range (size " + std::to_string(size()) + ")");
+  return eigenvalues_[static_cast<Eigen::Index>(i)];
+}
+
+const Cochain &Spectrum::operator[](std::size_t i) const {
+  if (i >= size())
+    throw std::out_of_range("Spectrum::operator[]: index " + std::to_string(i) +
+                            " out of range (size " + std::to_string(size()) + ")");
+  return eigenvectors_[i];
+}
+
+}  // namespace tessera::cobordism

--- a/src/observables/Spectral.cpp
+++ b/src/observables/Spectral.cpp
@@ -40,11 +40,9 @@ double SpectralGap::compute(const std::shared_ptr<Spacetime> &spacetime) {
 
 double HarmonicDimension::compute(const std::shared_ptr<Spacetime> &spacetime) {
   if (spacetime == nullptr) return 0.0;
-  const ::tessera::cobordism::HodgeLaplacian hodge(spacetime);
-  const std::size_t order = hodge.eigenvalues().size();  // N = |V|
-  if (order == 0) return 0.0;
-  // harmonics() is a flat N*M array whose M columns span ker L_0; M = dim ker.
-  return static_cast<double>(hodge.harmonics().size() / order);
+  // harmonics() is one Cochain per basis vector of ker L_0, so dim ker = its count.
+  return static_cast<double>(
+      ::tessera::cobordism::HodgeLaplacian(spacetime).harmonics().size());
 }
 
 }  // namespace tessera::observables

--- a/tests/cobordism/test_cochain_python.py
+++ b/tests/cobordism/test_cochain_python.py
@@ -1,0 +1,321 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Eigen-backed value objects for the Hodge spectrum (#183).
+
+Exercises ``cobordism.Cochain`` and ``cobordism.Spectrum`` — the value objects
+``HodgeLaplacian.spectrum`` / ``harmonics`` now return — against numpy oracles,
+and anchors the harmonic basis on the triangle (S¹, b₀ = b₁ = 1) and the torus
+T² (b = [1, 2, 1]), matching the values the existing Hodge tests pin.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders (shared with the Hodge Laplacian tests)
+# --------------------------------------------------------------------------- #
+def _build_topology(topology):
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, topology)
+    st.build()
+    return st
+
+
+def _set_uniform(st, squared_length=1.0, phase=0.0):
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(squared_length)
+        e.setPhase(phase)
+    return st
+
+
+def _triangle(phase=0.0):
+    """S¹ = boundary of a 2-simplex (3 vertices, 3 edges), unit edges."""
+    st = _build_topology(tessera.SimplexBoundarySphere(1))
+    _set_uniform(st, 1.0, 0.0)
+    if phase:
+        st.getEdgeList().toVector()[0].setPhase(phase)
+    return st
+
+
+def _torus():
+    """T² = S¹ × S¹ via SimplicialProduct + CDT (b = [1, 2, 1]), unit edges."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    topology = tessera.SimplicialProduct(tessera.SimplexBoundarySphere(1),
+                                         tessera.SimplexBoundarySphere(1))
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0, tessera.PREFERRED,
+                           topology)
+    st.build()
+    return _set_uniform(st, 1.0, 0.0)
+
+
+def _from_simplices(num_vertices, simplices):
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    verts = [st.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        st.createSimplex([verts[i] for i in simplex])
+    return st
+
+
+def _triangle_one_timelike(alpha):
+    """The 3-cycle 0-1-2-0 with edge (1,2) timelike (l² = -alpha²)."""
+    st = _set_uniform(_from_simplices(3, [(0, 1), (1, 2), (2, 0)]), 1.0, 0.0)
+    for e in st.getEdgeList().toVector():
+        if {e.getSource().getId(), e.getTarget().getId()} == {1, 2}:
+            e.setSquaredLength(-(alpha ** 2))
+    return st
+
+
+# --------------------------------------------------------------------------- #
+# Cochain
+# --------------------------------------------------------------------------- #
+class TestCochain(unittest.TestCase):
+
+    def test_degree_size_and_ordering_at_k0(self):
+        # A k=0 Cochain is indexed over the sorted-id vertex order: each entry of
+        # simplices() is a single-vertex tuple.
+        h = cob.HodgeLaplacian(_triangle()).harmonics()[0]
+        self.assertEqual(h.degree(), 0)
+        self.assertEqual(h.size(), 3)
+        self.assertEqual(len(h), 3)
+        self.assertEqual(h.simplices(), [[0], [1], [2]])
+
+    def test_coeffs_is_a_complex_numpy_array(self):
+        h = cob.HodgeLaplacian(_triangle()).harmonics()[0]
+        c = h.coeffs()
+        self.assertIsInstance(c, np.ndarray)
+        self.assertEqual(c.dtype, np.dtype("complex128"))
+        self.assertEqual(c.shape, (3,))
+
+    def test_amplitude_by_index_and_by_simplex_id(self):
+        h = cob.HodgeLaplacian(_triangle()).harmonics()[0]
+        coeffs = np.asarray(h.coeffs())
+        for i, simplex in enumerate(h.simplices()):
+            self.assertEqual(h.amplitude(i), coeffs[i])     # by index
+            self.assertEqual(h[i], coeffs[i])               # __getitem__
+            self.assertEqual(h.amplitudeFor(simplex), coeffs[i])  # by simplex id
+
+    def test_amplitude_out_of_range_raises(self):
+        h = cob.HodgeLaplacian(_triangle()).harmonics()[0]
+        with self.assertRaises(IndexError):
+            h.amplitude(99)
+        with self.assertRaises(IndexError):
+            h.amplitudeFor([12345])  # no such vertex in the ordering
+
+    def test_inner_product_matches_numpy_vdot(self):
+        # <a, b> = sum conj(a_i) b_i = np.vdot(a, b), across the full eigenbasis.
+        evecs = cob.HodgeLaplacian(_triangle()).spectrum().eigenvectors()
+        for a in evecs:
+            for b in evecs:
+                ca, cb = np.asarray(a.coeffs()), np.asarray(b.coeffs())
+                self.assertAlmostEqual(a.innerProduct(b), complex(np.vdot(ca, cb)),
+                                       places=12)
+
+    def test_eigenbasis_is_orthonormal(self):
+        # The SelfAdjointEigenSolver basis: <v_i, v_j> = delta_ij.
+        evecs = cob.HodgeLaplacian(_triangle()).spectrum().eigenvectors()
+        for i, a in enumerate(evecs):
+            for j, b in enumerate(evecs):
+                self.assertAlmostEqual(a.innerProduct(b), 1.0 if i == j else 0.0,
+                                       places=10)
+
+    def test_norm_matches_numpy(self):
+        for v in cob.HodgeLaplacian(_torus()).spectrum(1).eigenvectors():
+            self.assertAlmostEqual(v.norm(),
+                                   float(np.linalg.norm(np.asarray(v.coeffs()))),
+                                   places=12)
+
+    def test_normalized_has_unit_norm_and_preserves_ordering(self):
+        # Scale a harmonic up, renormalize, and check unit norm + same ordering.
+        h = cob.HodgeLaplacian(_triangle()).harmonics()[0]
+        hn = h.normalized()
+        self.assertAlmostEqual(hn.norm(), 1.0, places=12)
+        self.assertEqual(hn.degree(), h.degree())
+        self.assertEqual(hn.simplices(), h.simplices())
+        # direction preserved (parallel to the original)
+        overlap = abs(complex(np.vdot(np.asarray(hn.coeffs()),
+                                      np.asarray(h.coeffs()))))
+        self.assertAlmostEqual(overlap, h.norm(), places=10)
+
+    def test_inner_product_degree_mismatch_raises(self):
+        hl = cob.HodgeLaplacian(_triangle())
+        v0 = hl.spectrum(0).eigenvectors()[0]   # degree 0
+        v1 = hl.spectrum(1).eigenvectors()[0]   # degree 1
+        with self.assertRaises(ValueError):
+            v0.innerProduct(v1)
+
+
+# --------------------------------------------------------------------------- #
+# Spectrum
+# --------------------------------------------------------------------------- #
+class TestSpectrum(unittest.TestCase):
+
+    def test_size_len_and_indexing(self):
+        sp = cob.HodgeLaplacian(_triangle()).spectrum()
+        self.assertEqual(sp.size(), 3)
+        self.assertEqual(len(sp), 3)
+        self.assertEqual(len(sp.eigenvectors()), 3)
+        self.assertEqual(sp.eigenvalues().shape, (3,))
+        for i in range(len(sp)):
+            self.assertEqual(sp[i].degree(), 0)
+            self.assertEqual(sp.eigenvalue(i), sp.eigenvalues()[i])
+
+    def test_index_out_of_range_raises(self):
+        sp = cob.HodgeLaplacian(_triangle()).spectrum()
+        with self.assertRaises(IndexError):
+            _ = sp[99]
+        with self.assertRaises(IndexError):
+            sp.eigenvalue(99)
+
+    def test_hermitian_eigenvalues_are_real_and_ascending(self):
+        sp = cob.HodgeLaplacian(_triangle()).spectrum()
+        self.assertTrue(sp.isHermitian())
+        evals = sp.eigenvalues()
+        self.assertEqual(evals.dtype, np.dtype("complex128"))
+        np.testing.assert_allclose(evals.imag, 0.0, atol=1e-12)
+        np.testing.assert_allclose(np.sort(evals.real), [0.0, 3.0, 3.0], atol=1e-12)
+        self.assertTrue(np.all(np.diff(evals.real) >= -1e-12))  # ascending
+
+    def test_eigenvalues_match_flat_accessor(self):
+        for build, k in ((_triangle, 0), (_torus, 1), (_torus, 2)):
+            with self.subTest(k=k):
+                hl = cob.HodgeLaplacian(build())
+                np.testing.assert_allclose(hl.spectrum(k).eigenvalues().real,
+                                           np.array(hl.eigenvalues(k)), atol=1e-12)
+
+    def test_eigenvectors_match_flat_accessor_columns(self):
+        # spectrum().eigenvectors()[j].coeffs() == column j of the flat eigenvectors().
+        hl = cob.HodgeLaplacian(_torus())
+        n1 = cob.ChainComplex.fromSpacetime(_torus()).numSimplices(1)
+        flat = np.array(hl.eigenvectors(1), dtype=complex).reshape(n1, n1)
+        for j, v in enumerate(hl.spectrum(1).eigenvectors()):
+            np.testing.assert_allclose(np.asarray(v.coeffs()), flat[:, j], atol=1e-12)
+
+    def test_harmonics_is_the_zero_eigenvalue_subset(self):
+        sp = cob.HodgeLaplacian(_triangle()).spectrum()
+        harm = sp.harmonics()
+        expected = [v for v, lam in zip(sp.eigenvectors(), sp.eigenvalues())
+                    if abs(lam) < 1e-9]
+        self.assertEqual(len(harm), len(expected))
+        for got, want in zip(harm, expected):
+            np.testing.assert_allclose(np.asarray(got.coeffs()),
+                                       np.asarray(want.coeffs()), atol=1e-12)
+
+    def test_harmonics_matches_hodge_laplacian_harmonics(self):
+        hl = cob.HodgeLaplacian(_torus())
+        a = hl.spectrum(1).harmonics()
+        b = hl.harmonics(1)
+        self.assertEqual(len(a), len(b))
+        for x, y in zip(a, b):
+            np.testing.assert_allclose(np.asarray(x.coeffs()),
+                                       np.asarray(y.coeffs()), atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Harmonic anchors: triangle (S¹) and torus (T²)
+# --------------------------------------------------------------------------- #
+class TestHarmonicAnchors(unittest.TestCase):
+
+    def test_triangle_zero_mode_is_the_uniform_0_cochain(self):
+        # b₀ = 1: a single harmonic, the constant 0-cochain (equal magnitudes).
+        harm = cob.HodgeLaplacian(_triangle()).harmonics()
+        self.assertEqual(len(harm), 1)
+        h = harm[0]
+        self.assertEqual(h.degree(), 0)
+        c = np.abs(np.asarray(h.coeffs()))
+        np.testing.assert_allclose(c, np.full(3, c[0]), atol=1e-9)
+
+    def test_triangle_one_cycle_harmonic(self):
+        # S¹ has b₁ = 1: one harmonic 1-cochain over the 3 edges.
+        harm = cob.HodgeLaplacian(_triangle()).harmonics(1)
+        self.assertEqual(len(harm), 1)
+        self.assertEqual(harm[0].degree(), 1)
+        self.assertEqual(harm[0].size(), 3)
+        for simplex in harm[0].simplices():
+            self.assertEqual(len(simplex), 2)  # an edge = two vertex ids
+
+    def test_flux_lifts_the_zero_mode(self):
+        # Any U(1) flux removes the k=0 harmonic (magnetic frustration).
+        self.assertEqual(len(cob.HodgeLaplacian(_triangle(math.pi)).harmonics()), 0)
+
+    def test_torus_first_homology_is_the_qubit(self):
+        # T²: dim ker L_1 = b₁ = 2 — the qubit. Each harmonic is a 1-cochain.
+        torus = _torus()
+        harm = cob.HodgeLaplacian(torus).harmonics(1)
+        self.assertEqual(len(harm), 2)
+        n1 = cob.ChainComplex.fromSpacetime(torus).numSimplices(1)
+        for h in harm:
+            self.assertEqual(h.degree(), 1)
+            self.assertEqual(h.size(), n1)
+
+    def test_torus_fundamental_class_harmonic(self):
+        # b₂ = 1: a single harmonic 2-cochain over the triangles.
+        torus = _torus()
+        harm = cob.HodgeLaplacian(torus).harmonics(2)
+        self.assertEqual(len(harm), 1)
+        self.assertEqual(harm[0].degree(), 2)
+        self.assertEqual(harm[0].size(),
+                         cob.ChainComplex.fromSpacetime(torus).numSimplices(2))
+
+
+# --------------------------------------------------------------------------- #
+# Lorentzian spectrum: complex eigenvalues, harmonics as Cochains
+# --------------------------------------------------------------------------- #
+class TestLorentzianSpectrum(unittest.TestCase):
+
+    def test_is_not_hermitian_and_eigenvalues_are_complex_typed(self):
+        sp = cob.HodgeLaplacian(_triangle_one_timelike(1.0)).lorentzianSpectrum(1)
+        self.assertFalse(sp.isHermitian())
+        self.assertEqual(sp.eigenvalues().dtype, np.dtype("complex128"))
+        # closed form {0, 3, 1 - 2/alpha} with alpha=1 -> {0, 3, -1}: indefinite.
+        np.testing.assert_allclose(np.sort(sp.eigenvalues().real), [-1.0, 0.0, 3.0],
+                                   atol=1e-7)
+
+    def test_lorentzian_harmonic_is_the_unit_cycle(self):
+        # The near-kernel mode is the 1-cycle: |h_i|² = 1/3 on every edge.
+        harm = cob.HodgeLaplacian(_triangle_one_timelike(1.3)).lorentzianHarmonics(1)
+        self.assertEqual(len(harm), 1)
+        self.assertEqual(harm[0].degree(), 1)
+        np.testing.assert_allclose(np.abs(np.asarray(harm[0].coeffs())) ** 2,
+                                   np.full(3, 1.0 / 3.0), atol=1e-7)
+
+    def test_all_spacelike_lorentzian_matches_hermitian_kernel(self):
+        # All-spacelike: the signed path reproduces the Euclidean harmonic count.
+        st = _set_uniform(_from_simplices(3, [(0, 1), (1, 2), (2, 0)]), 1.0, 0.0)
+        hl = cob.HodgeLaplacian(st)
+        self.assertEqual(len(hl.lorentzianHarmonics(1)), len(hl.harmonics(1)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_dijkgraaf_witten_boundary_python.py
+++ b/tests/cobordism/test_dijkgraaf_witten_boundary_python.py
@@ -310,19 +310,19 @@ class TestCylinderReproducesInnerProduct(unittest.TestCase):
         # harmonic count, deliberately distinct from the 2^{b₁} = 4 flat ℤ₂
         # connections that index Z(T²) (spec §5.2).
         torus = _build(_torus_topology())
-        harmonics = np.asarray(
-            cobordism.HodgeLaplacian(torus).harmonics(1)).reshape(-1)
+        harmonics = cobordism.HodgeLaplacian(torus).harmonics(1)
         num_edges = cobordism.ChainComplex.fromSpacetime(torus).numSimplices(1)
-        self.assertEqual(harmonics.size % num_edges, 0)
-        self.assertEqual(harmonics.size // num_edges, 2)
+        self.assertEqual(len(harmonics), 2)  # b₁ = 2 harmonic 1-forms (Cochains)
+        self.assertTrue(all(h.degree() == 1 and h.size() == num_edges
+                            for h in harmonics))
 
     def _boundary_states_from_harmonics(self):
         """Two Z(T²) states (length 2^{b₁}=4) seeded by the ker L₁ harmonics."""
         torus = _build(_torus_topology())
-        harmonics = np.asarray(
-            cobordism.HodgeLaplacian(torus).harmonics(1, 1e-9, True))
-        num_edges = cobordism.ChainComplex.fromSpacetime(torus).numSimplices(1)
-        cols = harmonics.reshape(num_edges, -1) if harmonics.size else harmonics
+        harmonics = cobordism.HodgeLaplacian(torus).harmonics(1, 1e-9, True)
+        # columns = the harmonic 1-form Cochains over the edge ordering.
+        cols = (np.column_stack([np.asarray(h.coeffs()) for h in harmonics])
+                if harmonics else np.zeros((0, 0), dtype=complex))
         # Map the two real harmonic 1-forms to two distinct unit vectors in the
         # 4-dim flat-connection Hilbert space Z(T²) (the precise embedding is
         # immaterial for T1: Z(W)=id makes the amplitude the inner product).

--- a/tests/cobordism/test_hodge_laplacian_lorentzian_python.py
+++ b/tests/cobordism/test_hodge_laplacian_lorentzian_python.py
@@ -311,9 +311,11 @@ class TestLorentzianDAlembertian(unittest.TestCase):
 
     def test_harmonic_is_the_cycle_with_unit_magnitude_support(self):
         # The kernel mode is the 1-cycle: |h_i|^2 = 1/3 on every edge.
-        h = np.array(cob.HodgeLaplacian(_triangle_one_timelike(1.3))
-                     .lorentzianHarmonics(1, 1e-9), dtype=complex)
-        self.assertEqual(h.size, 3)  # one harmonic (H=1), three edges
+        harmonics = (cob.HodgeLaplacian(_triangle_one_timelike(1.3))
+                     .lorentzianHarmonics(1, 1e-9))
+        self.assertEqual(len(harmonics), 1)  # one harmonic, a degree-1 Cochain
+        h = np.asarray(harmonics[0].coeffs())
+        self.assertEqual(h.size, 3)  # three edges
         np.testing.assert_allclose(np.abs(h) ** 2, np.full(3, 1.0 / 3.0), atol=1e-7)
 
 
@@ -380,12 +382,9 @@ class TestLorentzianBothTerms(unittest.TestCase):
         eigs = _lor_eigs(st, 1)
         self.assertTrue(_is_not_psd(eigs))                  # not PSD
         # near-kernel modes are well-defined and their null-norms line up 1:1
-        h = np.array(cob.HodgeLaplacian(st).lorentzianHarmonics(1, TOL),
-                     dtype=complex)
+        harmonics = cob.HodgeLaplacian(st).lorentzianHarmonics(1, TOL)
         norms = _null_norms(st, 1, tol=TOL)
-        n_edges = _nk(st, 1)
-        n_harm = 0 if n_edges == 0 else h.size // n_edges
-        self.assertEqual(n_harm, len(norms))
+        self.assertEqual(len(harmonics), len(norms))
 
     def test_filled_square_euclidean_limit_recovers_betti(self):
         # alpha -> spacelike (all positive) recovers ker dim = b_1 with no nulls.

--- a/tests/cobordism/test_hodge_laplacian_python.py
+++ b/tests/cobordism/test_hodge_laplacian_python.py
@@ -230,10 +230,9 @@ def _kernel_dim_from_eigenvalues(st, k, metric=True, tol=1e-7):
 
 
 def _harmonic_dim(st, k, metric=True, tol=1e-9):
-    nk = cob.ChainComplex.fromSpacetime(st).numSimplices(k)
-    if nk == 0:
-        return 0
-    return len(cob.HodgeLaplacian(st).harmonics(k, tol, metric)) // nk
+    # harmonics() is one Cochain per basis vector of ker L_k, so its length is
+    # the harmonic dimension (= b_k) directly.
+    return len(cob.HodgeLaplacian(st).harmonics(k, tol, metric))
 
 
 # --------------------------------------------------------------------------- #
@@ -371,17 +370,20 @@ class TestFluxSpectrum(unittest.TestCase):
     def test_flux_lifts_the_zero_mode(self):
         # No flux: one harmonic (the constant 0-cochain, b0 = 1). Any flux lifts
         # it, so the harmonic dimension of L0 drops to 0.
-        n = 3
         hl0 = cob.HodgeLaplacian(_triangle())
-        self.assertEqual(len(hl0.harmonics()) // n, 1)
+        self.assertEqual(len(hl0.harmonics()), 1)
         hlpi = cob.HodgeLaplacian(self._triangle_with_flux(math.pi))
         self.assertEqual(len(hlpi.harmonics()), 0)
 
     def test_zero_mode_is_uniform(self):
         # The Φ=0 harmonic is the uniform vector (equal magnitudes on every vertex).
         n = 3
-        vec = np.array(cob.HodgeLaplacian(_triangle()).harmonics(), dtype=complex)
-        self.assertEqual(vec.size, n)  # one harmonic (M=1), length N
+        harmonics = cob.HodgeLaplacian(_triangle()).harmonics()
+        self.assertEqual(len(harmonics), 1)  # one harmonic, a degree-0 Cochain
+        h = harmonics[0]
+        self.assertEqual(h.degree(), 0)
+        vec = np.asarray(h.coeffs())
+        self.assertEqual(vec.size, n)  # length N over the vertex ordering
         np.testing.assert_allclose(np.abs(vec), np.full(n, abs(vec[0])), atol=1e-9)
 
 

--- a/tests/cobordism/test_hodge_spectral_hardening_python.py
+++ b/tests/cobordism/test_hodge_spectral_hardening_python.py
@@ -255,7 +255,8 @@ def _kernel_dim(hl, k, metric=True, tol=TOL_KER):
 def _harmonic_dim(hl, nk, k, metric=True, tol=TOL_KER):
     if nk == 0:
         return 0
-    return len(hl.harmonics(k, tol, metric)) // nk
+    # harmonics() is one Cochain per ker L_k basis vector => its length is b_k.
+    return len(hl.harmonics(k, tol, metric))
 
 
 # --------------------------------------------------------------------------- #
@@ -502,12 +503,12 @@ class TestFluxSpectrum(unittest.TestCase):
         hl = cob.HodgeLaplacian(self._triangle_total_flux(2.0 * PI))
         np.testing.assert_allclose(sorted(hl.eigenvalues()), [0.0, 3.0, 3.0],
                                    atol=1e-10)
-        self.assertEqual(len(hl.harmonics()) // 3, 1)
+        self.assertEqual(len(hl.harmonics()), 1)
 
     def test_harmonic_dimension_tracks_flux(self):
         # Zero (or full-quantum) flux: one harmonic; any intermediate flux: none.
         self.assertEqual(len(cob.HodgeLaplacian(
-            self._triangle_total_flux(0.0)).harmonics()) // 3, 1)
+            self._triangle_total_flux(0.0)).harmonics()), 1)
         for phi in (0.3, 1.0, PI / 2, 2.0):
             with self.subTest(phi=phi):
                 self.assertEqual(len(cob.HodgeLaplacian(
@@ -593,8 +594,10 @@ class TestLorentzianNullNormCrossing(unittest.TestCase):
         # The kernel mode is the 1-cycle: |h_i|² = 1/3 on every edge, for any α.
         for alpha in (0.7, 1.3, 2.4):
             with self.subTest(alpha=alpha):
-                h = np.array(cob.HodgeLaplacian(_triangle_one_timelike(alpha))
-                             .lorentzianHarmonics(1, 1e-9), dtype=complex)
+                harmonics = (cob.HodgeLaplacian(_triangle_one_timelike(alpha))
+                             .lorentzianHarmonics(1, 1e-9))
+                self.assertEqual(len(harmonics), 1)
+                h = np.asarray(harmonics[0].coeffs())
                 self.assertEqual(h.size, 3)
                 np.testing.assert_allclose(np.abs(h) ** 2, np.full(3, 1.0 / 3.0),
                                            atol=1e-7)

--- a/tests/cobordism/test_spectral_observables_python.py
+++ b/tests/cobordism/test_spectral_observables_python.py
@@ -142,9 +142,9 @@ class TestHarmonicDimension(unittest.TestCase):
     def test_matches_operator_harmonic_count(self):
         st = _triangle()
         hl = cob.HodgeLaplacian(st)
-        n = len(hl.eigenvalues())
+        # harmonics() is one Cochain per ker L_0 basis vector => len == dim ker.
         self.assertEqual(obs.HarmonicDimension().compute(st),
-                         float(len(hl.harmonics()) // n))
+                         float(len(hl.harmonics())))
 
     def test_empty_spacetime_returns_zero(self):
         self.assertEqual(obs.HarmonicDimension().compute(tessera.Spacetime()), 0.0)


### PR DESCRIPTION
## What

Replaces `HodgeLaplacian`'s flat `std::vector<std::complex<double>>` eigen outputs — whose shape/indexing lived only in comments — with **Eigen-backed value objects** that encapsulate the degree, the k-simplex ordering, and the operations. Eigen-only, **no iTensor** (keeps the Hodge layer iTensor-free, consistent with `ChoiJamiolkowski`).

### New value objects (`tessera.cobordism`)

- **`Cochain`** (`include/cobordism/Cochain.{h}`, `src/cobordism/Cochain.cpp`) — a k-cochain: `Eigen::VectorXcd` amplitudes + degree + the sorted vertex-id ordering it indexes (k=0 → single-vertex tuples; k≥1 → ChainComplex column order). API: `degree()`, `size()`/`__len__`, `coeffs()` (→ `np.ndarray`), `simplices()`, `amplitude(i)`/`__getitem__`, `amplitudeFor(simplex)`, `innerProduct(other)` (Hermitian, `np.vdot`; asserts matching degree+ordering), `norm()`, `normalized()`.
- **`Spectrum`** (`include/cobordism/Spectrum.{h}`, `src/cobordism/Spectrum.cpp`) — the `L_k` eigendecomposition: eigenvalues + eigenvectors-as-`Cochain`s. Eigenvalues are stored **complex** to cover both regimes uniformly, with an `isHermitian()` flag: `True` ⇒ real, ascending (the metric/self-adjoint case); `False` ⇒ possibly complex, sorted by (Re, Im) (the Lorentzian d'Alembertian). API: `eigenvalues()` (→ `np.ndarray`), `eigenvectors()` (→ `list[Cochain]`), `harmonics(tol=1e-9)` (the |λ|<tol kernel subset), `size()`/`__len__`, `eigenvalue(i)`, `__getitem__` (→ i-th eigenvector Cochain), `isHermitian()`.

### HodgeLaplacian API migration

- `harmonics(k)` / `lorentzianHarmonics(k)` → **`std::vector<Cochain>`** (breaking).
- new `spectrum(k)` / `lorentzianSpectrum(k)` → **`Spectrum`**.
- `eigenvalues(k)` / `eigenvectors(k)` / `lorentzian{Eigenvalues,Eigenvectors,NullNorms}` kept as **thin flat views** (delegating to the same caches) so the Python API stays usable.
- `adjacency()` / `laplacian()` / `degree()` / `weights()` unchanged (out of scope).
- The k-simplex ordering uses `ChainComplex::kSimplexVertices(k)` (guaranteed to match the operator dimension `numSimplices(k)`), fixing a latent count mismatch the private `orderedFaces` helper had on the filled-square fixture.
- pybind bindings expose `Cochain`/`Spectrum` with numpy interop (`pybind11/eigen.h` + `numpy.h`; `coeffs`/`eigenvalues` → ndarray, `__len__`/`__getitem__`).

## Consumers migrated

- C++: `observables::HarmonicDimension` (`src/observables/Spectral.cpp`), and `cobordism::BoundaryStatePrep` (PR #180, which merged to `main` mid-flight — its internal `harmonics(1)` consumption now flattens the `Cochain` basis).
- Python tests/examples: `test_hodge_laplacian_python`, `test_hodge_spectral_hardening_python`, `test_spectral_observables_python`, `test_hodge_laplacian_lorentzian_python`, `test_dijkgraaf_witten_boundary_python`, and `examples/cobordism/topological_correspondence.py`.
- New: `tests/cobordism/test_cochain_python.py` (Cochain/Spectrum numpy cross-checks of `coeffs`/`innerProduct`/`harmonics`; harmonic anchors on the triangle S¹ {0,3,3}, b₀=b₁=1, and T² b=[1,2,1]; Lorentzian complex-spectrum + |h|²=1/3 cycle).

## Validation

`pytest tests/cobordism tests/quantum -q` → **630 passed, 1 skipped, 779 subtests passed** (local; CI is build-only).

Closes #183