### PR TITLE
cobordism: lift realizability synthesis to k=1 boundary harmonics on a 3-manifold-with-boundary

### DIFF
--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -97,12 +98,36 @@ using namespace ::tessera::spacetime;
 /// vertices); on a pure 1-complex every edge is interior (the free §4b regime).
 class EigenstateSynthesis {
   public:
-    /// Construct over a fixed triangulation. The vertex order (sorted id) and the
-    /// tunable edge order are captured now; edge weights/phases are read live on
-    /// each residual query. The held `shared_ptr` keeps the spacetime alive.
-    explicit EigenstateSynthesis(std::shared_ptr<Spacetime> st);
+    /// Construct over a fixed triangulation at cochain `degree` (\f$ k \f$). The
+    /// vertex order (sorted id) and the tunable edge order are captured now; edge
+    /// weights/phases are read live on each residual query. The held `shared_ptr`
+    /// keeps the spacetime alive.
+    ///
+    /// `degree = 0` (default) is the §4b graph-Laplacian regime: a `psi` is a
+    /// 0-cochain (vertex amplitudes, length \f$ |V| \f$) and `residual` scores it
+    /// as an **eigenvector** of \f$ L_0 = D - A \f$. `degree = 1` is the §5.2
+    /// regime for the DW bridge: a `psi` is a 1-cochain (edge amplitudes, length
+    /// \f$ |C_1| \f$ in the `HodgeLaplacian`/`ChainComplex` column order) and
+    /// `residual` scores it as a **harmonic** form (\f$ \ker L_1 \f$, the metric
+    /// Hodge Laplacian) — \f$ r = \lVert L_1\psi\rVert^2 \f$. At \f$ k\ge 1 \f$ the
+    /// real metric Laplacian is built from the simplex volumes
+    /// (`Simplex::volume`, live in the edge lengths), so the tunable **weights**
+    /// shape \f$ L_k \f$ while the U(1) **phases** do not enter it.
+    /// @throws std::runtime_error if `degree < 0`.
+    explicit EigenstateSynthesis(std::shared_ptr<Spacetime> st, int degree = 0);
 
-    /// Number of vertices \f$ N \f$ — the required length of any `psi`.
+    /// The cochain degree \f$ k \f$ this synthesizer scores at (0 = vertices /
+    /// eigenvector; 1 = edges / harmonic).
+    [[nodiscard]] int degree() const noexcept { return degree_; }
+
+    /// The required length of any `psi`: the number of \f$ k \f$-cells —
+    /// \f$ |V| \f$ at \f$ k = 0 \f$, \f$ |C_k| \f$ at \f$ k \ge 1 \f$ (the
+    /// `HodgeLaplacian` operator dimension at this degree).
+    [[nodiscard]] std::size_t dimension() const noexcept { return dimension_; }
+
+    /// Number of vertices \f$ N = |V| \f$ — the \f$ k = 0 \f$ `psi` length and the
+    /// vertex budget for the output-boundary support (`= dimension()` at
+    /// \f$ k = 0 \f$).
     [[nodiscard]] std::size_t order() const noexcept { return order_; }
 
     /// Number of tunable edges — the length of `weights()` / `phases()`.
@@ -188,6 +213,21 @@ class EigenstateSynthesis {
     [[nodiscard]] std::vector<std::pair<std::uint64_t, std::uint64_t>>
     interiorEdges() const;
 
+    /// The `psi`-component indices (in the operator / `dimension()` order) whose
+    /// \f$ k \f$-cell lies on \f$ \partial W \f$ — the **boundary support** a
+    /// target boundary state occupies. At \f$ k = 1 \f$ these are the boundary
+    /// edges of \f$ \partial W \f$ (a target harmonic 1-form is carried here); at
+    /// \f$ k = 0 \f$ the boundary vertices. The complement
+    /// (`interiorStateIndices()`) carries the free auxiliary amplitudes a
+    /// fixed-boundary fill solves for. Returned ascending.
+    [[nodiscard]] std::vector<std::size_t> boundaryStateIndices() const;
+
+    /// The `psi`-component indices (operator order) **not** on \f$ \partial W \f$
+    /// — the interior support (free auxiliary amplitudes); the complement of
+    /// `boundaryStateIndices()` in \f$ [0, \text{dimension}()) \f$. Returned
+    /// ascending.
+    [[nodiscard]] std::vector<std::size_t> interiorStateIndices() const;
+
     /// Cone a fresh interior vertex into a top cell via the boundary-fixed
     /// pre-geometric Pachner add (#112): a \f$ 1\!\to\!(d+1) \f$ stellar
     /// subdivision that leaves \f$ \partial W \f$ exactly fixed while enriching the
@@ -201,12 +241,15 @@ class EigenstateSynthesis {
 
   private:
     std::shared_ptr<Spacetime> st_;
-    // The k=0 Hermitian Laplacian operator over the same complex. laplacian(0)
-    // reassembles L = D - A from the live edges on each call, so perturbing the
-    // edges and re-querying is honest (the eigendecomposition cache is untouched
-    // by the matrix path).
+    int degree_{0};  // cochain degree k the residual scores at
+    // The Hodge Laplacian operator over the same complex. laplacian(degree_)
+    // reassembles L_k from the live edges (k=0: L = D - A; k>=1: the metric
+    // Hodge Laplacian from the live simplex volumes) on each call, so perturbing
+    // the edges and re-querying is honest (the eigendecomposition cache is
+    // untouched by the matrix path).
     HodgeLaplacian laplacian_;
-    std::size_t order_{0};  // N = |V|, the sorted-id vertex order
+    std::size_t order_{0};       // N = |V|, the sorted-id vertex order
+    std::size_t dimension_{0};   // psi length = |k-cells| at degree_
     // The tunable edges, in EdgeList order, restricted to those carrying weight
     // in L (both endpoints present, no self-loops). Raw pointers owned by the
     // EdgeList; valid for the complex's lifetime (kept alive via st_). Re-captured
@@ -219,14 +262,30 @@ class EigenstateSynthesis {
     std::vector<std::size_t> interiorEdgeIdx_{};
     std::vector<std::size_t> boundaryEdgeIdx_{};
     std::size_t interiorVertexCount_{0};  // vertices on no boundary face
+    // The ∂W edge key set ((min,max) endpoint ids), shared by classifyBoundary()
+    // (edge-parameter partition) and captureDegree() (psi-component partition).
+    std::set<std::pair<std::uint64_t, std::uint64_t>> boundaryEdgeKeys_{};
+
+    // The operator-order k-cells (degree_), the index space a psi lives over
+    // (ChainComplex column order); used to partition psi components into the
+    // boundary support and the free interior support.
+    std::vector<std::vector<std::uint64_t>> stateSimplices_{};
+    std::vector<std::size_t> boundaryStateIdx_{};  // psi components on ∂W
+    std::vector<std::size_t> interiorStateIdx_{};  // psi components off ∂W
 
     // (Re)build order_ and edges_ from the live vertex/edge lists. Called at
     // construction and after growInterior() mutates the complex.
     void capture();
 
     // (Re)build the interior/boundary edge partition (∂W = codim-1 faces in
-    // exactly one top cell) and interiorVertexCount_ from the live complex.
+    // exactly one top cell), boundaryEdgeKeys_, and interiorVertexCount_ from the
+    // live complex.
     void classifyBoundary();
+
+    // (Re)build dimension_, stateSimplices_, and the psi-component boundary /
+    // interior partition for degree_ from the live complex (after classifyBoundary
+    // has populated boundaryEdgeKeys_). Called at construction and after growth.
+    void captureDegree();
 };
 
 }  // namespace tessera::cobordism

--- a/include/cobordism/RealizabilityOracle.h
+++ b/include/cobordism/RealizabilityOracle.h
@@ -160,6 +160,25 @@ class RealizabilityOracle {
                                  int restarts = 64, int maxCones = 4,
                                  std::uint64_t seed = 0);
 
+    /// Decide whether a target **\f$ k=1 \f$ boundary harmonic** is realizable on
+    /// the bulk \f$ W \f$ (the DW bridge lift, #176): the spectral boundary qubit
+    /// is the harmonic 1-forms \f$ \ker L_1(\Sigma) \f$ of \f$ \Sigma=\partial W \f$,
+    /// and the question is whether `target` extends to a harmonic form of the
+    /// **bulk** \f$ \ker L_1(W) \f$ with \f$ \partial W \f$ pinned. `target` is the
+    /// 1-form on \f$ \partial W \f$'s edges — length the bulk's boundary-edge count,
+    /// ordered as `EigenstateSynthesis(W, 1).boundaryStateIndices()` (the boundary
+    /// edges in the canonical column order). Pins \f$ \partial W \f$, fills the
+    /// interior metric (interior edge weights) + free interior amplitudes to drive
+    /// the harmonic residual \f$ r=\lVert L_1\psi\rVert^2\to 0 \f$, and returns the
+    /// `Verdict` (realizable iff \f$ r<\epsilon \f$; otherwise the obstruction
+    /// floor). `state` is the realized bulk 1-form (length \f$ |C_1(W)| \f$);
+    /// `eigenvalue` is its Rayleigh quotient (\f$ \approx 0 \f$ when harmonic).
+    /// @throws std::invalid_argument if `target`'s length \f$ \neq \f$ the bulk's
+    ///   boundary-edge count.
+    [[nodiscard]] Verdict decideBoundaryHarmonic(
+        const std::vector<std::complex<double>> &target, double epsilon = 1e-10,
+        int restarts = 64, int maxCones = 4, std::uint64_t seed = 0);
+
   private:
     // §4b search box — identical to GeometrySynthesizer so the interior fill is
     // the same machinery applied to the interior: per-edge magnitudes in

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -341,23 +341,39 @@ exposes that fixed set). growInterior() cones a fresh interior vertex via the
 boundary-fixed pre-geometric Pachner add (#112), enriching the interior with dW
 untouched; interiorVertexCount / numInteriorEdges report the interior complexity
 reached. On a 1-complex there is no boundary — every edge is interior.)doc")
-      .def(py::init<std::shared_ptr<Spacetime>>(), py::arg("spacetime"),
-           "Build the synthesizer over a fixed triangulation.")
+      .def(py::init<std::shared_ptr<Spacetime>, int>(), py::arg("spacetime"),
+           py::arg("degree") = 0,
+           "Build the synthesizer over a fixed triangulation at cochain degree k "
+           "(0 = vertices / eigenvector of L = D - A, §4b; 1 = edges / harmonic "
+           "form ker L_1 via the metric Hodge Laplacian, §5.2 DW bridge). At "
+           "k>=1 the tunable weights shape the real metric L_k (the simplex "
+           "volumes, live in the edge lengths) while the phases do not enter it. "
+           "Raises if degree < 0.")
+      .def("degree", &EigenstateSynthesis::degree,
+           "The cochain degree k scored at (0 = vertices/eigenvector; 1 = "
+           "edges/harmonic).")
+      .def("dimension", &EigenstateSynthesis::dimension,
+           "The required length of any psi: |V| at k=0, |C_k| at k>=1 (the "
+           "HodgeLaplacian operator dimension at this degree).")
       .def("order", &EigenstateSynthesis::order,
-           "Number of vertices N — the required length of any psi.")
+           "Number of vertices N = |V| — the k=0 psi length and the vertex budget "
+           "for the output-boundary support (= dimension() at k=0).")
       .def("numEdges", &EigenstateSynthesis::numEdges,
            "Number of tunable edges — the length of weights() / phases().")
       .def("residual", &EigenstateSynthesis::residual, py::arg("psi"),
-           "Eigenvalue-agnostic residual r(psi) = ||(I - psi psi^dagger) L psi||^2 "
-           "against the current edge weights/phases (psi normalized internally). "
-           "r = 0 iff L psi || psi. Raises if len(psi) != order().")
+           "Residual against the current edge weights (psi normalized "
+           "internally), length dimension(). k=0: the eigenvalue-agnostic "
+           "eigenvector residual r = ||(I - psi psi^dagger) L psi||^2 (r = 0 iff "
+           "L psi || psi). k>=1: the harmonic residual r = ||L_k psi||^2 (r = 0 "
+           "iff psi in ker L_k). Raises if len(psi) != dimension().")
       .def("rayleigh", &EigenstateSynthesis::rayleigh, py::arg("psi"),
-           "Rayleigh quotient lambda = psi^dagger L psi / psi^dagger psi (real; L "
-           "Hermitian) — the realized eigenvalue when r = 0. Raises if "
-           "len(psi) != order().")
+           "Rayleigh quotient lambda = psi^dagger L_k psi / psi^dagger psi (real) "
+           "— the realized eigenvalue (~0 for a harmonic at k>=1). Raises if "
+           "len(psi) != dimension().")
       .def("apply", &EigenstateSynthesis::apply, py::arg("psi"),
-           "L psi against the current edge weights/phases (no normalization), for "
-           "direct L psi || psi cross-checks. Raises if len(psi) != order().")
+           "L_k psi against the current edge weights (no normalization), for "
+           "direct ker/eigenvector cross-checks. Raises if len(psi) != "
+           "dimension().")
       .def("weights", &EigenstateSynthesis::weights,
            "Edge magnitudes {w_ij} (squaredLength) in the stable edge order.")
       .def("phases", &EigenstateSynthesis::phases,
@@ -395,6 +411,14 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
       .def("interiorEdges", &EigenstateSynthesis::interiorEdges,
            "The interior tunable edges as sorted (min_id, max_id) endpoint tuples "
            "(the complement of boundaryEdges()).")
+      .def("boundaryStateIndices", &EigenstateSynthesis::boundaryStateIndices,
+           "The psi-component indices (operator / dimension() order) whose k-cell "
+           "lies on dW — the boundary support a target boundary state occupies "
+           "(k=1: the boundary edges; k=0: the boundary vertices). A target "
+           "boundary harmonic is ordered to match this (ascending) list.")
+      .def("interiorStateIndices", &EigenstateSynthesis::interiorStateIndices,
+           "The psi-component indices not on dW — the free interior support "
+           "(auxiliary amplitudes); the complement of boundaryStateIndices().")
       .def("growInterior", &EigenstateSynthesis::growInterior, py::arg("seed"),
            "Cone a fresh interior vertex into a top cell via the boundary-fixed "
            "pre-geometric Pachner add (#112): a 1->(d+1) stellar subdivision that "
@@ -536,13 +560,17 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
       .def_readonly("cones_applied", &RealizabilityOracle::Verdict::conesApplied,
                     "Boundary-fixed cones applied during the interior fill.")
       .def_readonly("state", &RealizabilityOracle::Verdict::state,
-                    "The witness state: the realized unit Laplacian eigenvector on "
-                    "W_AB (length = the bulk's vertex count); its first dA*dB "
-                    "components are the output-boundary block matching target. A "
-                    "genuine eigenstate iff realizable.")
+                    "The witness state: the realized unit eigenvector/harmonic on "
+                    "W_AB. decide() (k=0): a 0-cochain (length = vertex count) "
+                    "whose first dA*dB components are the output-boundary block "
+                    "matching target. decideBoundaryHarmonic() (k=1): a 1-form "
+                    "(length |C_1(W)|) whose dW boundary block matches target. A "
+                    "genuine eigenstate/harmonic iff realizable.")
       .def_readonly("target", &RealizabilityOracle::Verdict::target,
-                    "The bent target psi_U = vec(U)/||vec(U)|| (length dA*dB) the "
-                    "output boundary is matched against.")
+                    "The matched target: decide() the bent psi_U = "
+                    "vec(U)/||vec(U)|| (length dA*dB); decideBoundaryHarmonic() "
+                    "the target boundary harmonic (length the dW boundary-edge "
+                    "count).")
       .def_readonly("witness", &RealizabilityOracle::Verdict::witness,
                     "The realized bulk W_AB: the witness cobordism (realizable), or "
                     "the complex on which the residual floors (non-realizable).");
@@ -562,7 +590,22 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
            "amplitudes, growing the interior up to max_cones times), and return "
            "the Verdict. Realizes the held bulk in place. Raises if U.size() != "
            "dA*dB, a dimension is non-positive, or the bulk has fewer vertices "
-           "than dA*dB.");
+           "than dA*dB.")
+      .def("decideBoundaryHarmonic",
+           &RealizabilityOracle::decideBoundaryHarmonic, py::arg("target"),
+           py::arg("epsilon") = 1e-10, py::arg("restarts") = 64,
+           py::arg("max_cones") = 4, py::arg("seed") = 0,
+           "Decide whether a target k=1 boundary harmonic extends to a harmonic "
+           "form of the bulk ker L_1(W) with dW pinned (the DW bridge lift, "
+           "#176). target is the 1-form on dW's edges, length the bulk's "
+           "boundary-edge count, ordered as "
+           "EigenstateSynthesis(W, 1).boundaryStateIndices(). Pins dW, fills the "
+           "interior metric (interior edge weights) + free interior amplitudes to "
+           "drive the harmonic residual r = ||L_1 psi||^2 -> 0, and returns the "
+           "Verdict (realizable iff r < epsilon; else the obstruction floor). "
+           "state is the realized bulk 1-form (length |C_1(W)|); eigenvalue is its "
+           "Rayleigh quotient (~0 when harmonic). Raises if len(target) != the "
+           "boundary-edge count.");
 
   // Exact integer / GF(2) / inertia primitives (also exposed for direct
   // testing). Matrices are passed flat row-major with explicit dims.

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -32,6 +32,7 @@
 #include <utility>
 #include <vector>
 
+#include "cobordism/ChainComplex.h"
 #include "mesh/Edge.h"
 #include "mesh/EdgeList.h"
 #include "mesh/Simplex.h"
@@ -46,11 +47,16 @@ namespace tessera::cobordism {
 
 using cd = std::complex<double>;
 
-EigenstateSynthesis::EigenstateSynthesis(std::shared_ptr<Spacetime> st)
-    : st_(st), laplacian_(std::move(st)) {
+EigenstateSynthesis::EigenstateSynthesis(std::shared_ptr<Spacetime> st, int degree)
+    : st_(st), degree_(degree), laplacian_(std::move(st)) {
+  if (degree_ < 0)
+    throw std::runtime_error(
+        "EigenstateSynthesis: degree must be >= 0, got " +
+        std::to_string(degree_));
   if (!st_) return;
   capture();
   classifyBoundary();
+  captureDegree();
 }
 
 void EigenstateSynthesis::capture() {
@@ -85,6 +91,7 @@ void EigenstateSynthesis::capture() {
 void EigenstateSynthesis::classifyBoundary() {
   interiorEdgeIdx_.clear();
   boundaryEdgeIdx_.clear();
+  boundaryEdgeKeys_.clear();
   interiorVertexCount_ = 0;
   if (!st_) return;
 
@@ -98,7 +105,6 @@ void EigenstateSynthesis::classifyBoundary() {
   // one top cell. An *edge* sits on the boundary only once codim-1 faces are at
   // least edges themselves (topVerts >= 3); below that there is no boundary —
   // every tunable edge is interior (the free §4b regime, owned by #134).
-  std::set<std::pair<std::uint64_t, std::uint64_t>> boundaryEdgeKeys;
   std::unordered_set<std::uint64_t> boundaryVertexIds;
   if (topVerts >= 3) {
     std::map<std::vector<std::uint64_t>, int> facetCount;
@@ -125,7 +131,7 @@ void EigenstateSynthesis::classifyBoundary() {
       // facet is sorted ascending, so (facet[i], facet[j]) for i<j is ordered.
       for (std::size_t i = 0; i + 1 < facet.size(); ++i)
         for (std::size_t j = i + 1; j < facet.size(); ++j)
-          boundaryEdgeKeys.insert({facet[i], facet[j]});
+          boundaryEdgeKeys_.insert({facet[i], facet[j]});
     }
   }
 
@@ -136,7 +142,7 @@ void EigenstateSynthesis::classifyBoundary() {
     const std::uint64_t b = edges_[e]->getTarget()->getId();
     const std::pair<std::uint64_t, std::uint64_t> key =
         a < b ? std::make_pair(a, b) : std::make_pair(b, a);
-    if (boundaryEdgeKeys.find(key) != boundaryEdgeKeys.end())
+    if (boundaryEdgeKeys_.find(key) != boundaryEdgeKeys_.end())
       boundaryEdgeIdx_.push_back(e);
     else
       interiorEdgeIdx_.push_back(e);
@@ -152,18 +158,75 @@ void EigenstateSynthesis::classifyBoundary() {
   }
 }
 
+void EigenstateSynthesis::captureDegree() {
+  dimension_ = 0;
+  stateSimplices_.clear();
+  boundaryStateIdx_.clear();
+  interiorStateIdx_.clear();
+  if (!st_) return;
+
+  // Boundary vertices = endpoints of the ∂W boundary edges: a vertex lies on ∂W
+  // iff it bounds a boundary facet, i.e. is an endpoint of a boundary edge.
+  std::set<std::uint64_t> boundaryVertices;
+  for (const auto &key : boundaryEdgeKeys_) {
+    boundaryVertices.insert(key.first);
+    boundaryVertices.insert(key.second);
+  }
+
+  if (degree_ == 0) {
+    // psi components are the sorted-id vertices (HodgeLaplacian's k=0 order).
+    std::vector<std::uint64_t> ids;
+    std::unordered_set<std::uint64_t> seen;
+    for (const auto v : st_->getVertexList()->toVector()) {
+      if (v == nullptr) continue;
+      if (!seen.insert(v->getId()).second) continue;
+      ids.push_back(v->getId());
+    }
+    std::sort(ids.begin(), ids.end());
+    dimension_ = ids.size();
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+      if (boundaryVertices.find(ids[i]) != boundaryVertices.end())
+        boundaryStateIdx_.push_back(i);
+      else
+        interiorStateIdx_.push_back(i);
+    }
+    return;
+  }
+
+  // k >= 1: the operator-order k-cells (the canonical ChainComplex column order,
+  // matching HodgeLaplacian's L_k and the harmonic Cochains). A k-cell is on ∂W
+  // iff (k = 1) it is a boundary edge; higher degrees carry no boundary partition
+  // here (all interior).
+  const ChainComplex chain = ChainComplex::fromSpacetime(*st_);
+  stateSimplices_ = chain.kSimplexVertices(degree_);
+  dimension_ = stateSimplices_.size();
+  for (std::size_t i = 0; i < stateSimplices_.size(); ++i) {
+    bool boundary = false;
+    if (degree_ == 1 && stateSimplices_[i].size() == 2) {
+      const std::pair<std::uint64_t, std::uint64_t> key{stateSimplices_[i][0],
+                                                        stateSimplices_[i][1]};
+      boundary = boundaryEdgeKeys_.find(key) != boundaryEdgeKeys_.end();
+    }
+    if (boundary)
+      boundaryStateIdx_.push_back(i);
+    else
+      interiorStateIdx_.push_back(i);
+  }
+}
+
 std::vector<cd> EigenstateSynthesis::apply(const std::vector<cd> &psi) const {
-  const std::size_t N = order_;
+  const std::size_t N = dimension_;
   if (psi.size() != N)
     throw std::runtime_error(
         "EigenstateSynthesis::apply: psi has length " +
         std::to_string(psi.size()) + ", expected " + std::to_string(N));
   std::vector<cd> out(N, cd(0.0, 0.0));
   if (N == 0) return out;
-  // L = D - A reassembled from the live edge weights/phases (the k=0 magnitude
-  // convention). The matrix path does not consult the eigendecomposition cache,
-  // so repeated perturb-then-query is honest.
-  const std::vector<cd> L = laplacian_.laplacian(0);
+  // L_k reassembled from the live edge weights on each call (k=0: L = D - A, the
+  // magnitude convention; k>=1: the metric Hodge Laplacian from the live simplex
+  // volumes). The matrix path does not consult the eigendecomposition cache, so
+  // repeated perturb-then-query is honest.
+  const std::vector<cd> L = laplacian_.laplacian(degree_);
   for (std::size_t i = 0; i < N; ++i) {
     cd acc(0.0, 0.0);
     for (std::size_t j = 0; j < N; ++j) acc += L[i * N + j] * psi[j];
@@ -173,15 +236,15 @@ std::vector<cd> EigenstateSynthesis::apply(const std::vector<cd> &psi) const {
 }
 
 double EigenstateSynthesis::residual(const std::vector<cd> &psi) const {
-  const std::size_t N = order_;
+  const std::size_t N = dimension_;
   if (psi.size() != N)
     throw std::runtime_error(
         "EigenstateSynthesis::residual: psi has length " +
         std::to_string(psi.size()) + ", expected " + std::to_string(N));
   if (N == 0) return 0.0;
 
-  // Normalize: r and the eigenvector condition are scale-invariant, and the spec
-  // writes r for a unit target.
+  // Normalize: r and the eigenvector/harmonic conditions are scale-invariant, and
+  // the spec writes r for a unit target.
   double nrm2 = 0.0;
   for (const cd &c : psi) nrm2 += std::norm(c);
   if (nrm2 <= 0.0) return 0.0;
@@ -190,19 +253,30 @@ double EigenstateSynthesis::residual(const std::vector<cd> &psi) const {
   for (std::size_t i = 0; i < N; ++i) p[i] = psi[i] * inv;
 
   const std::vector<cd> Lp = apply(p);
-  // lambda = p^dagger L p (real for Hermitian L; take the real part).
+
+  if (degree_ >= 1) {
+    // k>=1: the harmonic residual r = ||L_k p||^2 (p unit) — the ker L_k
+    // condition, r = 0 iff p is a harmonic k-form (§5.2). For the metric L_k the
+    // eigenvalues are >= 0, so this is lambda^2 on an eigenvector and isolates
+    // the kernel (lambda = 0), not an arbitrary eigenvector.
+    double r = 0.0;
+    for (std::size_t i = 0; i < N; ++i) r += std::norm(Lp[i]);
+    return r;
+  }
+
+  // k=0: the eigenvalue-agnostic eigenvector residual r = ||L p - lambda p||^2 =
+  // ||(I - p p^dagger) L p||^2 (p unit), lambda = p^dagger L p the Rayleigh
+  // quotient — r = 0 iff p is an eigenvector of L = D - A (§4b).
   cd lam(0.0, 0.0);
   for (std::size_t i = 0; i < N; ++i) lam += std::conj(p[i]) * Lp[i];
   const double lambda = lam.real();
-
-  // r = || L p - lambda p ||^2 = ||(I - p p^dagger) L p||^2 (p unit).
   double r = 0.0;
   for (std::size_t i = 0; i < N; ++i) r += std::norm(Lp[i] - lambda * p[i]);
   return r;
 }
 
 double EigenstateSynthesis::rayleigh(const std::vector<cd> &psi) const {
-  const std::size_t N = order_;
+  const std::size_t N = dimension_;
   if (psi.size() != N)
     throw std::runtime_error(
         "EigenstateSynthesis::rayleigh: psi has length " +
@@ -312,6 +386,14 @@ EigenstateSynthesis::interiorEdges() const {
   return out;
 }
 
+std::vector<std::size_t> EigenstateSynthesis::boundaryStateIndices() const {
+  return boundaryStateIdx_;
+}
+
+std::vector<std::size_t> EigenstateSynthesis::interiorStateIndices() const {
+  return interiorStateIdx_;
+}
+
 bool EigenstateSynthesis::growInterior(std::uint64_t seed) {
   if (!st_) return false;
   // Cone a fresh interior vertex via the boundary-fixed pre-geometric Pachner
@@ -329,6 +411,7 @@ bool EigenstateSynthesis::growInterior(std::uint64_t seed) {
   laplacian_ = HodgeLaplacian(st_);
   capture();
   classifyBoundary();
+  captureDegree();
   return true;
 }
 

--- a/src/cobordism/RealizabilityOracle.cpp
+++ b/src/cobordism/RealizabilityOracle.cpp
@@ -64,45 +64,77 @@ double RealizabilityOracle::fillInterior(EigenstateSynthesis &es,
                                          int maxCones, std::uint64_t seed,
                                          std::vector<cd> &witnessOut,
                                          int &conesApplied) const {
+  // Degree-aware fill. At k = 0 the target is matched as an EIGENVECTOR of
+  // L = D - A on the first L sorted-id vertices (§4b), tuning interior weights +
+  // phases. At k >= 1 the target is matched as the boundary block of a HARMONIC
+  // form (ker L_k) on the ∂W cells, tuning interior weights only — the real
+  // metric L_k ignores the U(1) phases (§5.2 / the DW bridge, #176).
+  const int degree = es.degree();
+  const bool harmonic = degree >= 1;
+  const bool tunePhases = degree == 0;
   const std::size_t L = target.size();  // the pinned boundary-support length
   double bestR = std::numeric_limits<double>::infinity();
   conesApplied = 0;
 
   for (int cone = 0;; ++cone) {
-    const std::size_t order = es.order();       // total vertices this pass
-    const std::size_t m = es.numInteriorEdges();  // free interior edges
-    const std::size_t nAux = order - L;           // free auxiliary amplitudes
-    const std::size_t nParams = 2 * m + 2 * nAux;
+    const std::size_t dim = es.dimension();       // psi length (|V| or |C_k|)
+    const std::size_t m = es.numInteriorEdges();  // free interior edges (weights)
+
+    // The psi-component support: targetIdx carries the fixed target, auxIdx the
+    // free auxiliary amplitudes. k=0 uses the first-L convention; k>=1 the ∂W
+    // cells (boundaryStateIndices) so the target lands on the geometric boundary.
+    std::vector<std::size_t> targetIdx, auxIdx;
+    if (degree == 0) {
+      targetIdx.reserve(L);
+      for (std::size_t i = 0; i < L; ++i) targetIdx.push_back(i);
+      for (std::size_t i = L; i < dim; ++i) auxIdx.push_back(i);
+    } else {
+      targetIdx = es.boundaryStateIndices();
+      auxIdx = es.interiorStateIndices();
+    }
+    if (targetIdx.size() != L)
+      throw std::invalid_argument(
+          "RealizabilityOracle: target length does not match the bulk's boundary "
+          "support at this degree");
+    const std::size_t nAux = auxIdx.size();
+    const std::size_t nPhase = tunePhases ? m : 0;
+    const std::size_t auxBase = m + nPhase;   // x offset of the aux re/im block
+    const std::size_t nParams = auxBase + 2 * nAux;
 
     // Assemble ψ from a parameter vector: the boundary support is the fixed
-    // target (first L sorted-id vertices); the auxiliary amplitudes (interior /
-    // coned-in apices) come from the tail of x (real, imag per vertex).
-    const auto buildPsi = [&target, L, m, nAux,
-                           order](const Eigen::VectorXd &x) -> std::vector<cd> {
-      std::vector<cd> psi = target;
-      psi.resize(order, cd(0.0, 0.0));
+    // target; the auxiliary amplitudes (interior / coned-in cells) come from the
+    // tail of x (real, imag per free component).
+    const auto buildPsi = [&target, &targetIdx, &auxIdx, L, nAux, auxBase,
+                           dim](const Eigen::VectorXd &x) -> std::vector<cd> {
+      std::vector<cd> psi(dim, cd(0.0, 0.0));
+      for (std::size_t i = 0; i < L; ++i) psi[targetIdx[i]] = target[i];
       for (std::size_t k = 0; k < nAux; ++k) {
-        const auto re = static_cast<Eigen::Index>(2 * m + 2 * k);
-        psi[L + k] = cd(x[re], x[re + 1]);
+        const auto re = static_cast<Eigen::Index>(auxBase + 2 * k);
+        psi[auxIdx[k]] = cd(x[re], x[re + 1]);
       }
       return psi;
     };
 
-    // Residual: write the interior weights/phases onto ∂W's complement (∂W
-    // itself is never touched), normalize the assembled ψ, and return the
-    // stacked g = Lψ - λψ ([Re; Im], length 2·order) whose ‖g‖² is r(ψ) — the
-    // §4b residual the Levenberg–Marquardt loop drives to zero.
-    const auto residual =
-        [&es, &buildPsi, m, order](const Eigen::VectorXd &x) -> Eigen::VectorXd {
+    // Residual: write the interior weights (and, at k=0, phases) onto ∂W's
+    // complement (∂W itself is never touched), normalize ψ, and return the
+    // stacked residual ([Re; Im], length 2·dim) whose ‖·‖² the
+    // Levenberg–Marquardt loop drives to zero. k=0: g = Lψ - λψ (eigenvector).
+    // k>=1: g = L_kψ (harmonic, ker L_k).
+    const auto residual = [&es, &buildPsi, m, nPhase, dim, harmonic,
+                           tunePhases](const Eigen::VectorXd &x) -> Eigen::VectorXd {
       if (m > 0) {
-        std::vector<double> w(m), th(m);
-        for (std::size_t i = 0; i < m; ++i) {
+        std::vector<double> w(m);
+        for (std::size_t i = 0; i < m; ++i)
           w[i] = x[static_cast<Eigen::Index>(i)];
-          th[i] = x[static_cast<Eigen::Index>(m + i)];
-        }
         es.setInteriorWeights(w);
-        es.setInteriorPhases(th);
+        if (tunePhases) {
+          std::vector<double> th(m);
+          for (std::size_t i = 0; i < m; ++i)
+            th[i] = x[static_cast<Eigen::Index>(m + i)];
+          es.setInteriorPhases(th);
+        }
       }
+      (void)nPhase;
       std::vector<cd> psi = buildPsi(x);
       double nrm = 0.0;
       for (const cd &z : psi) nrm += std::norm(z);
@@ -111,49 +143,57 @@ double RealizabilityOracle::fillInterior(EigenstateSynthesis &es,
         for (cd &z : psi) z *= inv;
       }
       const std::vector<cd> Lp = es.apply(psi);
-      cd lam(0.0, 0.0);
-      for (std::size_t i = 0; i < order; ++i) lam += std::conj(psi[i]) * Lp[i];
-      const double lambda = lam.real();
-      Eigen::VectorXd f(static_cast<Eigen::Index>(2 * order));
-      for (std::size_t i = 0; i < order; ++i) {
-        const cd g = Lp[i] - lambda * psi[i];
+      double lambda = 0.0;
+      if (!harmonic) {
+        cd lam(0.0, 0.0);
+        for (std::size_t i = 0; i < dim; ++i) lam += std::conj(psi[i]) * Lp[i];
+        lambda = lam.real();
+      }
+      Eigen::VectorXd f(static_cast<Eigen::Index>(2 * dim));
+      for (std::size_t i = 0; i < dim; ++i) {
+        const cd g = harmonic ? Lp[i] : (Lp[i] - lambda * psi[i]);
         f[static_cast<Eigen::Index>(i)] = g.real();
-        f[static_cast<Eigen::Index>(order + i)] = g.imag();
+        f[static_cast<Eigen::Index>(dim + i)] = g.imag();
       }
       return f;
     };
 
-    // Clamp interior weights/phases into the §4b box and the auxiliary
-    // amplitudes into [-kAuxBound, kAuxBound].
-    const auto clamp = [m, nAux](const Eigen::VectorXd &x) -> Eigen::VectorXd {
+    // Clamp interior weights into the §4b box, the phases (k=0 only) into
+    // [-kThetaBound, kThetaBound], and the auxiliary amplitudes into
+    // [-kAuxBound, kAuxBound].
+    const auto clamp = [m, nPhase, nAux, auxBase,
+                        tunePhases](const Eigen::VectorXd &x) -> Eigen::VectorXd {
       Eigen::VectorXd c = x;
       for (std::size_t i = 0; i < m; ++i) {
         const auto wi = static_cast<Eigen::Index>(i);
-        const auto ti = static_cast<Eigen::Index>(m + i);
         c[wi] = std::min(std::max(c[wi], kWMin), kWMax);
-        c[ti] = std::min(std::max(c[ti], -kThetaBound), kThetaBound);
       }
+      if (tunePhases)
+        for (std::size_t i = 0; i < nPhase; ++i) {
+          const auto ti = static_cast<Eigen::Index>(m + i);
+          c[ti] = std::min(std::max(c[ti], -kThetaBound), kThetaBound);
+        }
       for (std::size_t k = 0; k < 2 * nAux; ++k) {
-        const auto ai = static_cast<Eigen::Index>(2 * m + k);
+        const auto ai = static_cast<Eigen::Index>(auxBase + k);
         c[ai] = std::min(std::max(c[ai], -kAuxBound), kAuxBound);
       }
       return c;
     };
 
-    // Sample a restart: w ∈ [kWMin, kWMax], θ ∈ [-π, π], aux ∈ [-1, 1]. Built
-    // once and captured (the single-rng draw convention GeometrySynthesizer uses).
+    // Sample a restart: w ∈ [kWMin, kWMax], θ ∈ [-π, π] (k=0), aux ∈ [-1, 1].
     std::uniform_real_distribution<double> wDist(kWMin, kWMax);
     std::uniform_real_distribution<double> tDist(-kPi, kPi);
     std::uniform_real_distribution<double> aDist(-1.0, 1.0);
-    const auto sample = [m, nAux, wDist, tDist,
-                         aDist](std::mt19937_64 &rng) mutable -> Eigen::VectorXd {
-      Eigen::VectorXd x0(static_cast<Eigen::Index>(2 * m + 2 * nAux));
-      for (std::size_t i = 0; i < m; ++i) {
+    const auto sample = [m, nPhase, nAux, auxBase, tunePhases, wDist, tDist, aDist](
+                            std::mt19937_64 &rng) mutable -> Eigen::VectorXd {
+      Eigen::VectorXd x0(static_cast<Eigen::Index>(auxBase + 2 * nAux));
+      for (std::size_t i = 0; i < m; ++i)
         x0[static_cast<Eigen::Index>(i)] = wDist(rng);
-        x0[static_cast<Eigen::Index>(m + i)] = tDist(rng);
-      }
+      if (tunePhases)
+        for (std::size_t i = 0; i < nPhase; ++i)
+          x0[static_cast<Eigen::Index>(m + i)] = tDist(rng);
       for (std::size_t k = 0; k < 2 * nAux; ++k)
-        x0[static_cast<Eigen::Index>(2 * m + k)] = aDist(rng);
+        x0[static_cast<Eigen::Index>(auxBase + k)] = aDist(rng);
       return x0;
     };
 
@@ -201,6 +241,32 @@ RealizabilityOracle::Verdict RealizabilityOracle::decide(
   const double r =
       fillInterior(es, target, epsilon, restarts, maxCones, seed, v.state,
                    v.conesApplied);
+  v.residual = r;
+  v.realizable = (r < epsilon);
+  v.floor = v.realizable ? 0.0 : r;
+  v.eigenvalue = es.rayleigh(v.state);
+  v.interiorVertexCount = es.interiorVertexCount();
+  v.witness = bulk_;
+  return v;
+}
+
+RealizabilityOracle::Verdict RealizabilityOracle::decideBoundaryHarmonic(
+    const std::vector<cd> &target, double epsilon, int restarts, int maxCones,
+    std::uint64_t seed) {
+  EigenstateSynthesis es(bulk_, /*degree=*/1);
+  const std::size_t nBoundary = es.boundaryStateIndices().size();
+  if (target.size() != nBoundary)
+    throw std::invalid_argument(
+        "RealizabilityOracle::decideBoundaryHarmonic: the target boundary "
+        "harmonic length (" +
+        std::to_string(target.size()) +
+        ") must equal the number of dW boundary edges (" +
+        std::to_string(nBoundary) + ")");
+
+  Verdict v;
+  v.target = target;
+  const double r = fillInterior(es, target, epsilon, restarts, maxCones, seed,
+                                v.state, v.conesApplied);
   v.residual = r;
   v.realizable = (r < epsilon);
   v.floor = v.realizable ? 0.0 : r;

--- a/tests/cobordism/test_k1_boundary_synthesis_python.py
+++ b/tests/cobordism/test_k1_boundary_synthesis_python.py
@@ -1,0 +1,283 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""k=1 boundary-harmonic realizability synthesis on a 3-manifold-with-boundary (#176).
+
+The v0.3 synthesis (`EigenstateSynthesis` / `RealizabilityOracle`) matched a k=0
+boundary eigenvector of L = D - A on a 2-complex. The DW bridge (#174) lives in
+the 3-manifold / k=1 setting: the spectral boundary qubit is the harmonic 1-forms
+ker L_1(Sigma) of Sigma = dW (spec §5.2), prepared into the DW state space Z(Sigma)
+by #175. This lifts the synthesis to k=1:
+
+* `EigenstateSynthesis(W, degree=1)` scores a 1-form psi (length |C_1(W)|, the
+  HodgeLaplacian/ChainComplex column order) by the HARMONIC residual
+  r = ||L_1 psi||^2 (the metric Hodge Laplacian, built from the live simplex
+  volumes; r = 0 iff psi in ker L_1). `boundaryStateIndices()` are the dW edges,
+  the boundary support a target boundary harmonic occupies; the complement are the
+  free interior amplitudes the fill solves for.
+* `RealizabilityOracle.decideBoundaryHarmonic(target)` decides whether a target
+  k=1 boundary harmonic extends to a harmonic of the bulk ker L_1(W) with dW
+  pinned: realizable iff the harmonic residual is driven below epsilon, otherwise
+  certified non-realizable by the obstruction floor (the v0.3 floor semantics).
+
+Fixtures: the solid torus S^1 x D^2 (dW = T^2, the single-boundary realizability
+verdict) and the thickened torus T^2 x I (genuine interior edges — the engine's
+interior-completion demonstration).
+"""
+
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures (the bulk-synthesis idiom: Signature(d) so d-cells register as top
+# simplices; a uniform spacelike metric so the metric L_1 is a clean Euclidean
+# Hodge Laplacian — ker L_1 = H_1).
+# --------------------------------------------------------------------------- #
+def _build(topology):
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, topology)
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+        e.setPhase(0.0)
+    return st
+
+
+def _circle():
+    return tessera.SimplexBoundarySphere(1)  # S^1 = boundary of a triangle
+
+
+def _solid_torus():
+    # S^1 x D^2: a 3-manifold with boundary dW = T^2 (one boundary component).
+    return _build(tessera.SimplicialProduct(_circle(), tessera.SolidSimplex(2)))
+
+
+def _thick_torus():
+    # T^2 x I: a thickened surface with genuine interior edges; dW = T^2 ⊔ T^2.
+    return _build(tessera.SimplicialProduct(
+        tessera.SimplicialProduct(_circle(), _circle()), tessera.SolidSimplex(1)))
+
+
+def _cvec(v):
+    return [complex(z) for z in v]
+
+
+def _bulk_harmonic(st):
+    """The first bulk harmonic 1-form ker L_1(W) as a numpy vector (|C_1|)."""
+    harmonics = cob.HodgeLaplacian(st).harmonics(1)
+    assert harmonics, "fixture has trivial H_1; expected a bulk harmonic"
+    return np.asarray(harmonics[0].coeffs())
+
+
+# --------------------------------------------------------------------------- #
+# The k=1 EigenstateSynthesis engine: the harmonic residual + indexing.
+# --------------------------------------------------------------------------- #
+class TestK1EngineResidual(unittest.TestCase):
+
+    def test_degree_and_dimension(self):
+        st = _solid_torus()
+        es = cob.EigenstateSynthesis(st, 1)
+        self.assertEqual(es.degree(), 1)
+        # |C_1(W)| = the number of edges = the k=1 operator dimension.
+        n_edges = cob.ChainComplex.fromSpacetime(st).numSimplices(1)
+        self.assertEqual(es.dimension(), n_edges)
+        # k=0 still reports the vertex count (backward compatible).
+        self.assertEqual(cob.EigenstateSynthesis(st, 0).dimension(),
+                         cob.ChainComplex.fromSpacetime(st).numSimplices(0))
+
+    def test_state_index_partition(self):
+        es = cob.EigenstateSynthesis(_solid_torus(), 1)
+        bnd = list(es.boundaryStateIndices())
+        inter = list(es.interiorStateIndices())
+        # The two index sets partition [0, dimension()).
+        self.assertEqual(sorted(bnd + inter), list(range(es.dimension())))
+        self.assertEqual(len(set(bnd) & set(inter)), 0)
+        self.assertEqual(len(bnd), es.numBoundaryEdges())
+        self.assertEqual(len(inter), es.numInteriorEdges())
+
+    def test_bulk_harmonics_have_zero_residual(self):
+        # A genuine ker L_1(W) form is harmonic: r = ||L_1 psi||^2 ~ 0, lambda ~ 0.
+        for fixture in (_solid_torus, _thick_torus):
+            with self.subTest(fixture=fixture.__name__):
+                st = fixture()
+                es = cob.EigenstateSynthesis(st, 1)
+                for h in cob.HodgeLaplacian(st).harmonics(1):
+                    psi = list(h.coeffs())
+                    self.assertLess(es.residual(psi), 1e-12)
+                    self.assertLess(abs(es.rayleigh(psi)), 1e-9)
+                    lp = np.asarray(es.apply(psi))
+                    self.assertLess(float(np.sum(np.abs(lp) ** 2)), 1e-12)
+
+    def test_nonharmonic_eigenvector_residual_is_eigenvalue_squared(self):
+        # For an eigenvector with eigenvalue lambda, r = ||L_1 v||^2 = lambda^2
+        # (v unit) — nonzero away from the kernel, isolating ker L_1.
+        st = _solid_torus()
+        es = cob.EigenstateSynthesis(st, 1)
+        spec = cob.HodgeLaplacian(st).spectrum(1)
+        evals = np.asarray(spec.eigenvalues()).real
+        j = int(np.argmax(evals))           # the largest, clearly non-harmonic
+        self.assertGreater(evals[j], 1.0)
+        r = es.residual(list(spec[j].coeffs()))
+        self.assertAlmostEqual(r, evals[j] ** 2, delta=1e-6 * evals[j] ** 2)
+
+    def test_residual_rejects_wrong_length(self):
+        es = cob.EigenstateSynthesis(_solid_torus(), 1)
+        with self.assertRaises((RuntimeError, ValueError)):
+            es.residual([1.0, 0.0])  # not |C_1|
+
+    def test_negative_degree_raises(self):
+        with self.assertRaises((RuntimeError, ValueError)):
+            cob.EigenstateSynthesis(_solid_torus(), -1)
+
+
+# --------------------------------------------------------------------------- #
+# The interior completion: a boundary harmonic extends only via the interior.
+# --------------------------------------------------------------------------- #
+class TestInteriorCompletion(unittest.TestCase):
+    """On a fixture with genuine interior edges, a bulk harmonic's boundary block
+    alone is NOT harmonic — the interior amplitudes (the fill's free parameters)
+    are what complete it. This is the structure RealizabilityOracle.fillInterior
+    solves for at k=1."""
+
+    def test_boundary_block_needs_the_interior(self):
+        st = _thick_torus()
+        es = cob.EigenstateSynthesis(st, 1)
+        inter = list(es.interiorStateIndices())
+        self.assertGreater(len(inter), 0)          # genuine interior edges
+        psi = _bulk_harmonic(st)
+
+        # The full harmonic (boundary block + its interior completion) is harmonic.
+        self.assertLess(es.residual(list(psi)), 1e-12)
+        # The harmonic genuinely lives on the interior (nonzero there).
+        self.assertGreater(float(np.sum(np.abs(psi[inter]) ** 2)), 1e-6)
+        # Zeroing the interior (keeping only the boundary block) breaks harmonicity:
+        # the boundary block alone is far from ker L_1 — the fill must restore it.
+        boundary_only = psi.copy()
+        boundary_only[inter] = 0.0
+        self.assertGreater(es.residual(list(boundary_only)), 1e-3)
+
+
+# --------------------------------------------------------------------------- #
+# The k=1 realizability oracle: verdict + obstruction floor on the solid torus.
+# --------------------------------------------------------------------------- #
+class TestK1RealizabilityVerdict(unittest.TestCase):
+
+    def _target_from_bulk_harmonic(self, st, es):
+        """The bulk harmonic's boundary block, ordered as boundaryStateIndices()."""
+        psi = _bulk_harmonic(st)
+        return [complex(psi[i]) for i in es.boundaryStateIndices()]
+
+    def test_realizable_boundary_harmonic(self):
+        # The boundary block of a genuine bulk harmonic ker L_1(W) is realizable:
+        # it extends to a bulk harmonic with dW pinned, so r -> 0.
+        st = _solid_torus()
+        es = cob.EigenstateSynthesis(st, 1)
+        target = self._target_from_bulk_harmonic(st, es)
+        v = cob.RealizabilityOracle(st).decideBoundaryHarmonic(
+            _cvec(target), epsilon=1e-9, restarts=8, max_cones=0, seed=1)
+
+        self.assertTrue(v.realizable)
+        self.assertLess(v.residual, 1e-9)
+        self.assertEqual(v.floor, 0.0)
+        self.assertLess(abs(v.eigenvalue), 1e-7)   # harmonic: lambda ~ 0
+        # The witness is the realized bulk 1-form (length |C_1(W)|); its dW
+        # boundary block matches the target (up to global phase/scale).
+        self.assertEqual(len(v.state), es.dimension())
+        block = np.asarray(v.state)[list(es.boundaryStateIndices())]
+        tgt = np.asarray(target)
+        overlap = abs(np.vdot(block / np.linalg.norm(block),
+                              tgt / np.linalg.norm(tgt)))
+        self.assertAlmostEqual(overlap, 1.0, places=8)
+
+    def test_obstructed_boundary_form_floors(self):
+        # A generic boundary 1-form is not a harmonic boundary block: it cannot be
+        # extended to a bulk harmonic with dW pinned, so r floors away from 0 —
+        # the obstruction floor IS the non-realizability certificate.
+        st = _solid_torus()
+        es = cob.EigenstateSynthesis(st, 1)
+        n = es.numBoundaryEdges()
+        rng = np.random.default_rng(0)
+        target = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+        v = cob.RealizabilityOracle(st).decideBoundaryHarmonic(
+            _cvec(target), epsilon=1e-9, restarts=8, max_cones=0, seed=1)
+
+        self.assertFalse(v.realizable)
+        self.assertGreater(v.residual, 1e-2)
+        self.assertEqual(v.floor, v.residual)
+
+    def test_floor_is_seed_independent(self):
+        # The certified floor is the genuine obstruction, not a seed-specific local
+        # min: independent restart seeds reach the same floor.
+        st = _solid_torus()
+        n = cob.EigenstateSynthesis(st, 1).numBoundaryEdges()
+        rng = np.random.default_rng(7)
+        target = _cvec(rng.standard_normal(n) + 1j * rng.standard_normal(n))
+        floors = []
+        for s in (0, 13, 41):
+            v = cob.RealizabilityOracle(st).decideBoundaryHarmonic(
+                target, epsilon=1e-9, restarts=8, max_cones=0, seed=s)
+            self.assertFalse(v.realizable)
+            floors.append(v.floor)
+        for f in floors[1:]:
+            self.assertAlmostEqual(f, floors[0], delta=1e-6)
+
+    def test_obstructed_with_growth_still_floors_after_coning(self):
+        # The fixed-boundary cone-and-retry runs at k=1: an obstructed target grows
+        # the interior (boundary-fixed Pachner) but still cannot be realized — the
+        # floor certificate survives interior growth.
+        st = _solid_torus()
+        n = cob.EigenstateSynthesis(st, 1).numBoundaryEdges()
+        rng = np.random.default_rng(3)
+        target = _cvec(rng.standard_normal(n) + 1j * rng.standard_normal(n))
+        v = cob.RealizabilityOracle(st).decideBoundaryHarmonic(
+            target, epsilon=1e-9, restarts=8, max_cones=2, seed=1)
+        self.assertFalse(v.realizable)
+        self.assertGreater(v.floor, 1e-3)
+        self.assertGreaterEqual(v.cones_applied, 1)   # growth was attempted
+
+    def test_determinism(self):
+        st = _solid_torus()
+        es = cob.EigenstateSynthesis(st, 1)
+        target = self._target_from_bulk_harmonic(st, es)
+        a = cob.RealizabilityOracle(st).decideBoundaryHarmonic(
+            _cvec(target), epsilon=1e-9, restarts=8, max_cones=0, seed=5)
+        b = cob.RealizabilityOracle(st).decideBoundaryHarmonic(
+            _cvec(target), epsilon=1e-9, restarts=8, max_cones=0, seed=5)
+        self.assertEqual(a.realizable, b.realizable)
+        self.assertEqual(a.residual, b.residual)
+        np.testing.assert_array_equal(np.asarray(a.state), np.asarray(b.state))
+
+    def test_target_wrong_length_raises(self):
+        st = _solid_torus()
+        with self.assertRaises((ValueError, RuntimeError)):
+            cob.RealizabilityOracle(st).decideBoundaryHarmonic(
+                [1.0 + 0j, 0.0 + 0j], max_cones=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Sub-ticket 2 of the v0.4 DW bridge (#174): lift the realizability synthesis from
the v0.3 `k=0` (2-complex, eigenvector of `L = D - A`) setting to **`k=1` on a
3-manifold-with-boundary**. The spectral boundary qubit is the harmonic 1-forms
`ker L₁(Σ)` of `Σ = ∂W` (spec §5.2); the question is whether a target boundary
harmonic **extends to a harmonic of the bulk `ker L₁(W)` with `∂W` pinned**.

## What changed

- **`EigenstateSynthesis`** gains a `degree` parameter (`k=0` default, backward
  compatible). At `k=1` a `psi` is a 1-form (length `|C₁(W)|`, the
  `HodgeLaplacian`/`ChainComplex` column order) scored by the **harmonic
  residual** `r = ||L₁ psi||²` (the metric Hodge Laplacian — built from the live
  simplex volumes, so the tunable edge **weights** shape `L₁`; the U(1) phases do
  not enter the real metric `L₁`). `r = 0 ⇔ psi ∈ ker L₁`. New accessors:
  `degree()`, `dimension()`, `boundaryStateIndices()` / `interiorStateIndices()`
  (the `psi`-component `∂W` boundary support vs the free interior support).
- **`RealizabilityOracle.decideBoundaryHarmonic(target)`** — pins `∂W`, fills the
  interior metric (interior edge weights) + free interior amplitudes to drive
  `r → 0`, and returns the same `Verdict` (realizable iff `r < ε`; else the
  obstruction **floor**, the v0.3 certificate semantics). `fillInterior` is now
  degree-aware (harmonic residual + `∂W`-edge target placement at `k≥1`; the
  `k=0` eigenvector path is byte-identical) and **reused, not duplicated**.
- **pybind**: `EigenstateSynthesis(degree=0)` + the new accessors;
  `RealizabilityOracle.decideBoundaryHarmonic`. No new free functions.

## Test plan

- [x] `tests/cobordism/test_k1_boundary_synthesis_python.py` — 13 tests:
  - the `k=1` engine residual cross-checked against `HodgeLaplacian.harmonics(1)`
    (bulk harmonic → `r ~ 0`, `λ ~ 0`; eigenvector → `r ~ λ²`) on the solid torus
    `S¹×D²` and the thickened torus `T²×I`;
  - degree / dimension / boundary–interior `psi`-index partition;
  - interior completion (a boundary block alone is far from `ker L₁`; the interior
    amplitudes complete it — the structure the fill solves);
  - oracle verdict on `S¹×D²`: a bulk-harmonic boundary block is **realizable**
    (`r → 0`, witness boundary block matches), a generic boundary form **floors**
    (seed-independent, survives interior growth), guards.
- [x] `pytest tests/cobordism tests/quantum` — **653 passed, 1 skipped, 781
  subtests** in an isolated worktree venv. (See note below on the one unrelated
  failure.)

## Note: one pre-existing, unrelated failure

`test_visualize_realizability_python.py::test_render_writes_nonempty_png` fails
with `matplotlib` 3.10.7's strict `RGBA values should be within 0-1 range` on a
**1-ULP** color overshoot (`1.0000000000000002`) from `hsv_to_rgb`. The
visualization script is byte-identical to `main`, the oracle pipeline tests in
that file pass, and the `k=0` oracle output is numerically unchanged — only the
matplotlib **render** step trips the new strict check. It reproduces on `main`
under this matplotlib; it is **not** caused by this PR (a separate, trivial
viz-clamp fix / ticket).

Part of #174. Closes #176
