### PR TITLE
cobordism: lift realizability synthesis to k=1 boundary harmonics on a 3-manifold-with-boundary

### DIFF
--- a/examples/cobordism/visualize_realizability.py
+++ b/examples/cobordism/visualize_realizability.py
@@ -240,7 +240,10 @@ def _amp_rgba(z, max_mag, *, alpha=0.97, floor=0.42):
         return (0.55, 0.55, 0.58, alpha)
     hue = (np.angle(z) % (2.0 * np.pi)) / (2.0 * np.pi)
     val = floor + (1.0 - floor) * frac
-    return (*mcolors.hsv_to_rgb([hue, 0.85, val]), alpha)
+    # Clamp the rounding overshoot at val == 1 (hsv_to_rgb can return e.g.
+    # 1.0 + 2e-16, which matplotlib >= 3.10 rejects as out of the [0, 1] range).
+    rgb = np.clip(mcolors.hsv_to_rgb([hue, 0.85, val]), 0.0, 1.0)
+    return (*rgb, alpha)
 
 
 def _amp_size(z, max_mag, *, lo=45.0, hi=320.0):

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -39,11 +39,26 @@ using namespace ::tessera::spacetime;
 
 /// # EigenstateSynthesis
 ///
-/// The §4b inverse eigenvector problem on a **fixed** complex: given a target
-/// state \f$ \psi \f$, score how close the complex's current Hermitian edge
-/// weights make \f$ \psi \f$ to being an eigenvector of the \f$ k=0 \f$ Hodge
-/// Laplacian \f$ L = D - A \f$ (the magnitude convention, via
-/// `HodgeLaplacian`), and read/write those weights so a search can perturb them.
+/// The §4b inverse eigenvector problem on a **fixed** complex, degree-parameterized
+/// by `int k`: given a target state \f$ \psi \f$, score how close the complex's
+/// current Hermitian edge weights make \f$ \psi \f$ to being an eigenvector of the
+/// degree-\f$ k \f$ Hodge Laplacian \f$ L_k \f$ (via `HodgeLaplacian`), and
+/// read/write those weights so a search can perturb them.
+///
+/// At \f$ k = 0 \f$ \f$ L_0 = D - A \f$ is the U(1)-weighted graph Laplacian (the
+/// magnitude convention) and \f$ \psi \f$ is a vertex vector (length \f$ |V| \f$,
+/// sorted-id order). At \f$ k \geq 1 \f$ \f$ L_k \f$ is the **metric Hodge
+/// Laplacian** on \f$ k \f$-cochains and \f$ \psi \f$ is a \f$ k \f$-form (length
+/// \f$ |C_k| \f$, the canonical `ChainComplex` \f$ k \f$-cell order); the tunable
+/// parameters stay the **edge** squared-lengths (`Edge::setSquaredLength`), which
+/// feed the per-simplex volume weights \f$ W_k \f$ of \f$ L_k \f$ through
+/// `Simplex::volume` (the U(1) phases enter only the \f$ k = 0 \f$ operator). This
+/// lifts the §5.0 fixed-boundary interior fill from the \f$ k = 0 \f$ 2-complex
+/// setting to the \f$ k = 1 \f$ boundary harmonic of a 3-manifold-with-boundary
+/// (#176): a 3-manifold \f$ W \f$ whose \f$ \ker L_1(\partial W) \f$ is matched by
+/// pinning \f$ \partial W \f$ and filling the interior. `cellSimplices()` gives the
+/// sorted vertex-id tuple of each \f$ \psi \f$ component, so a caller can pin the
+/// boundary \f$ k \f$-cells to a target form and leave the interior free.
 ///
 /// The search itself (non-convex, multi-restart, e.g. `scipy.optimize.minimize`
 /// L-BFGS-B over the flat \f$ \{w_{ij}\}\cup\{\theta_{ij}\} \f$ vector) drives
@@ -97,13 +112,31 @@ using namespace ::tessera::spacetime;
 /// vertices); on a pure 1-complex every edge is interior (the free §4b regime).
 class EigenstateSynthesis {
   public:
-    /// Construct over a fixed triangulation. The vertex order (sorted id) and the
+    /// Construct over a fixed triangulation at degree `k` (default \f$ 0 \f$, the
+    /// vertex graph Laplacian). The \f$ k \f$-cell order (`cellSimplices()`) and the
     /// tunable edge order are captured now; edge weights/phases are read live on
     /// each residual query. The held `shared_ptr` keeps the spacetime alive.
-    explicit EigenstateSynthesis(std::shared_ptr<Spacetime> st);
+    /// @throws std::runtime_error if `k < 0`.
+    explicit EigenstateSynthesis(std::shared_ptr<Spacetime> st, int k = 0);
 
-    /// Number of vertices \f$ N \f$ — the required length of any `psi`.
+    /// The cochain degree \f$ k \f$ this synthesizer scores against (the
+    /// `HodgeLaplacian` degree of \f$ L_k \f$).
+    [[nodiscard]] int degree() const noexcept { return k_; }
+
+    /// The operator dimension \f$ N \f$ — the required length of any `psi`:
+    /// \f$ |V| \f$ at \f$ k = 0 \f$, else \f$ |C_k| \f$ (the number of
+    /// \f$ k \f$-cells).
     [[nodiscard]] std::size_t order() const noexcept { return order_; }
+
+    /// The sorted vertex-id tuple of each \f$ \psi \f$ component, in operator
+    /// order (length `order()`): a single-vertex tuple per component at
+    /// \f$ k = 0 \f$, else the \f$ k \f$-cell vertex tuples in the canonical
+    /// `ChainComplex` column order. Lets a caller identify which components are the
+    /// boundary \f$ k \f$-cells carrying a target form vs. the interior ones.
+    [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &cellSimplices()
+        const noexcept {
+      return cellOrdering_;
+    }
 
     /// Number of tunable edges — the length of `weights()` / `phases()`.
     [[nodiscard]] std::size_t numEdges() const noexcept { return edges_.size(); }
@@ -190,23 +223,32 @@ class EigenstateSynthesis {
 
     /// Cone a fresh interior vertex into a top cell via the boundary-fixed
     /// pre-geometric Pachner add (#112): a \f$ 1\!\to\!(d+1) \f$ stellar
-    /// subdivision that leaves \f$ \partial W \f$ exactly fixed while enriching the
-    /// interior. Re-captures the vertex order, tunable edges, and interior/boundary
-    /// partition, so `order()` grows by one (a `psi` must be extended on the new
-    /// apex, appended last in sorted-id order) and `numInteriorEdges()` grows. The
-    /// RNG `seed` makes the target-cell choice reproducible. Returns `false` if no
-    /// top cell can be subdivided (e.g. a 1-complex, top cells of \f$ <3 \f$
-    /// vertices), leaving the complex unchanged.
+    /// subdivision (valid in any dimension — \f$ 1\!\to\!4 \f$ on a tetrahedron in
+    /// 3D) that leaves \f$ \partial W \f$ exactly fixed while enriching the
+    /// interior. Re-captures the \f$ k \f$-cell order (`cellSimplices()`), tunable
+    /// edges, and interior/boundary partition, so `order()` and
+    /// `numInteriorEdges()` grow. At \f$ k = 0 \f$ the new apex is the largest id,
+    /// appended last, so existing `psi` indices are preserved; at \f$ k \geq 1 \f$
+    /// the new \f$ k \f$-cells interleave in the canonical order, so re-identify
+    /// the boundary/interior components via `cellSimplices()` (by sorted vertex-id
+    /// tuple) after each grow. The RNG `seed` makes the target-cell choice
+    /// reproducible. Returns `false` if no top cell can be subdivided (e.g. a
+    /// 1-complex, top cells of \f$ <3 \f$ vertices), leaving the complex unchanged.
     bool growInterior(std::uint64_t seed);
 
   private:
     std::shared_ptr<Spacetime> st_;
-    // The k=0 Hermitian Laplacian operator over the same complex. laplacian(0)
-    // reassembles L = D - A from the live edges on each call, so perturbing the
-    // edges and re-querying is honest (the eigendecomposition cache is untouched
-    // by the matrix path).
+    int k_{0};  // the Hodge degree of L_k that apply()/residual() score against
+    // The Hodge Laplacian operator over the same complex. laplacian(k_)
+    // reassembles L_k from the live edges/volumes on each call, so perturbing the
+    // edge squared-lengths and re-querying is honest (the eigendecomposition
+    // cache is untouched by the matrix path).
     HodgeLaplacian laplacian_;
-    std::size_t order_{0};  // N = |V|, the sorted-id vertex order
+    std::size_t order_{0};  // N = operator dimension (|V| at k=0, else |C_k|)
+    // The sorted vertex-id tuple of each psi component, in operator order: the
+    // sorted-id vertices at k=0, else the ChainComplex k-cell column order.
+    // Re-captured after growInterior() mutates the complex.
+    std::vector<std::vector<std::uint64_t>> cellOrdering_{};
     // The tunable edges, in EdgeList order, restricted to those carrying weight
     // in L (both endpoints present, no self-loops). Raw pointers owned by the
     // EdgeList; valid for the complex's lifetime (kept alive via st_). Re-captured
@@ -220,8 +262,9 @@ class EigenstateSynthesis {
     std::vector<std::size_t> boundaryEdgeIdx_{};
     std::size_t interiorVertexCount_{0};  // vertices on no boundary face
 
-    // (Re)build order_ and edges_ from the live vertex/edge lists. Called at
-    // construction and after growInterior() mutates the complex.
+    // (Re)build order_, cellOrdering_ and edges_ from the live complex (the
+    // k-cell order at k_, plus the tunable edges). Called at construction and
+    // after growInterior() mutates the complex.
     void capture();
 
     // (Re)build the interior/boundary edge partition (∂W = codim-1 faces in

--- a/include/cobordism/RealizabilityOracle.h
+++ b/include/cobordism/RealizabilityOracle.h
@@ -25,6 +25,7 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -34,6 +35,7 @@ namespace tessera::cobordism {
 using namespace ::tessera::spacetime;
 
 class EigenstateSynthesis;
+class Cochain;
 
 /// # RealizabilityOracle
 ///
@@ -54,6 +56,25 @@ class EigenstateSynthesis;
 /// the analogue of §4b's two-vertex floor \f$ w_{\min}^2(|c_0|^2-|c_1|^2)^2 \f$.
 /// The floor **is** the certificate: non-existence is certified by the residual
 /// floor, **not** by exhausting triangulations.
+///
+/// ## `k=1` boundary harmonics on a 3-manifold-with-boundary (#176)
+///
+/// `decideHarmonic` lifts the same pipeline from the reduced \f$ k=0 \f$ 2-complex
+/// to the DW-native \f$ k=1 \f$, 3-manifold setting. The target is a boundary
+/// **harmonic 1-form** in \f$ \ker L_1(\partial W) \f$ (a degree-1 `Cochain`,
+/// typically the readout of a `PreparedBoundaryState` — the bent \f$ U \f$
+/// expressed in the prepared DW boundary basis via `BoundaryStateSpace`). The
+/// bulk \f$ W \f$ is a 3-manifold-with-boundary (e.g. a solid torus, boundary
+/// \f$ T^2 \f$); its boundary surface \f$ \partial W \f$ is pinned byte-fixed and
+/// the interior is filled — interior edge squared-lengths (the metric content of
+/// \f$ L_1 \f$ via the simplex volumes) plus boundary-fixed Pachner growth
+/// (\f$ 1\!\to\!4 \f$ in 3D) — driving \f$ r = \lVert(I-\psi\psi^\dagger)L_1\psi
+/// \rVert^2 \to 0 \f$ so the bulk carries the target as a (near-)harmonic whose
+/// boundary restriction matches it. Realizable iff \f$ r<\epsilon \f$; otherwise
+/// the floor certifies non-realizability — exactly as at \f$ k=0 \f$. The boundary
+/// harmonic carried by the manifold (the restriction of \f$ \ker L_1(W) \f$, e.g.
+/// the solid torus's longitude) is realizable; a class that bounds in the bulk
+/// (the meridian) floors.
 ///
 /// ## Pure orchestration (no new math)
 ///
@@ -160,6 +181,26 @@ class RealizabilityOracle {
                                  int restarts = 64, int maxCones = 4,
                                  std::uint64_t seed = 0);
 
+    /// Decide whether a target **boundary harmonic** \f$ k \f$-form (\f$ k =
+    /// \texttt{target.degree()} \f$, the \f$ k=1 \f$ DW setting) is realizable on
+    /// the held 3-manifold bulk \f$ W \f$: pin the boundary surface
+    /// \f$ \partial W \f$ byte-fixed, fill the interior (interior edge
+    /// squared-lengths + boundary-fixed Pachner growth) to drive the \f$ k \f$-form
+    /// residual \f$ r=\lVert(I-\psi\psi^\dagger)L_k\psi\rVert^2\to 0 \f$, and return
+    /// the `Verdict`. `target` is a degree-\f$ k \f$ `Cochain` over \f$ \partial W \f$'s
+    /// \f$ k \f$-cells (the readout of a `PreparedBoundaryState`); it is matched to
+    /// the bulk's boundary \f$ k \f$-cells by sorted vertex-id tuple, the remaining
+    /// (interior) \f$ k \f$-cells carrying free auxiliary amplitudes. The witness
+    /// `state` is the realized \f$ L_k(W) \f$ (near-)eigenvector whose boundary
+    /// block matches `target`; realizable iff \f$ r<\epsilon \f$, else the floor
+    /// certifies non-realizability at the explored complexity.
+    /// @throws std::invalid_argument if `target` is empty, its degree is negative,
+    ///   or none of its \f$ k \f$-cells are boundary cells of the bulk (the surface
+    ///   does not match \f$ \partial W \f$).
+    [[nodiscard]] Verdict decideHarmonic(const Cochain &target,
+                                         double epsilon = 1e-10, int restarts = 64,
+                                         int maxCones = 4, std::uint64_t seed = 0);
+
   private:
     // §4b search box — identical to GeometrySynthesizer so the interior fill is
     // the same machinery applied to the interior: per-edge magnitudes in
@@ -181,19 +222,23 @@ class RealizabilityOracle {
     [[nodiscard]] static std::vector<std::complex<double>> bend(
         const std::vector<std::complex<double>> &U, int dA, int dB);
 
-    // The §4b cone-and-retry restricted to the interior: drive r(psi) -> 0 for
-    // the target on its first `target.size()` (boundary-support) components with
-    // the remaining (interior/auxiliary) components free, varying only the
-    // interior edge weights/phases via `es`; grow the interior (boundary-fixed
-    // Pachner add) and retry while unconverged and within `maxCones`. Leaves
+    // The §4b cone-and-retry restricted to the interior, degree-agnostic. The
+    // boundary k-cells (the keys of `pinnedByTuple`, matched to es.cellSimplices()
+    // by sorted vertex-id tuple) carry the fixed target amplitudes; the remaining
+    // (interior) k-cells carry free auxiliary amplitudes. Drives r(psi) -> 0 by
+    // varying the interior edge weights (and, at k=0 only, phases) via `es` plus
+    // the auxiliary amplitudes; grows the interior (boundary-fixed Pachner add)
+    // and retries while unconverged and within `maxCones`, re-identifying the
+    // boundary/interior partition on the new k-cell order after each grow. Leaves
     // `es`'s complex realized at the best parameters, writes the realized unit
     // witness state to `witnessOut`, records the cones applied, and returns the
     // best residual (the floor if it never converges). Reuses LevenbergMarquardt
     // exactly as GeometrySynthesizer::runOptimizer does.
     [[nodiscard]] double fillInterior(
         EigenstateSynthesis &es,
-        const std::vector<std::complex<double>> &target, double epsilon,
-        int restarts, int maxCones, std::uint64_t seed,
+        const std::map<std::vector<std::uint64_t>, std::complex<double>>
+            &pinnedByTuple,
+        double epsilon, int restarts, int maxCones, std::uint64_t seed,
         std::vector<std::complex<double>> &witnessOut, int &conesApplied) const;
 };
 

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -310,12 +310,19 @@ Euclidean spectrum/kernel.)doc")
 
   // ----- §4b eigenstate synthesis: residual + parameter access (#133) -----
   py::class_<EigenstateSynthesis>(m, "EigenstateSynthesis",
-      R"doc(§4b inverse eigenvector problem on a fixed complex.
+      R"doc(§4b inverse eigenvector problem on a fixed complex, degree-k.
 
 Scores how close the complex's current Hermitian edge weights make a target
-state psi to being an eigenvector of the k=0 Hodge Laplacian L = D - A (the
-magnitude convention, via HodgeLaplacian), and reads/writes those weights so a
-search can perturb them. The non-convex, multi-restart search itself (e.g.
+state psi to being an eigenvector of the degree-k Hodge Laplacian L_k (via
+HodgeLaplacian), and reads/writes those weights so a search can perturb them.
+At k=0 L_0 = D - A is the graph Laplacian (magnitude convention) and psi is a
+vertex vector (|V|, sorted-id order). At k>=1 L_k is the metric Hodge Laplacian
+on k-forms (|C_k|, ChainComplex k-cell order); the tunable parameters stay the
+edge squared-lengths, which feed the volume weights W_k of L_k via Simplex.volume
+(phases enter only k=0). cellSimplices() gives each psi component's vertex tuple,
+so a caller can pin the boundary k-cells to a target form (the #176 k=1
+3-manifold boundary-harmonic synthesis). The non-convex, multi-restart search
+itself (e.g.
 scipy.optimize.minimize L-BFGS-B over the flat {w_ij} + {theta_ij} vector) lives
 in the driver and calls residual() here; the cone-and-retry growth loop is a
 separate stage (this class is fixed-complex only).
@@ -341,10 +348,22 @@ exposes that fixed set). growInterior() cones a fresh interior vertex via the
 boundary-fixed pre-geometric Pachner add (#112), enriching the interior with dW
 untouched; interiorVertexCount / numInteriorEdges report the interior complexity
 reached. On a 1-complex there is no boundary — every edge is interior.)doc")
-      .def(py::init<std::shared_ptr<Spacetime>>(), py::arg("spacetime"),
-           "Build the synthesizer over a fixed triangulation.")
+      .def(py::init<std::shared_ptr<Spacetime>, int>(), py::arg("spacetime"),
+           py::arg("k") = 0,
+           "Build the synthesizer over a fixed triangulation at Hodge degree k "
+           "(default 0, the vertex graph Laplacian; k=1 is the metric Hodge "
+           "Laplacian on edge 1-forms for the 3-manifold boundary-harmonic "
+           "synthesis). Raises if k < 0.")
+      .def("degree", &EigenstateSynthesis::degree,
+           "The cochain degree k of L_k this synthesizer scores against.")
       .def("order", &EigenstateSynthesis::order,
-           "Number of vertices N — the required length of any psi.")
+           "Operator dimension N — the required length of any psi (|V| at k=0, "
+           "else |C_k|, the number of k-cells).")
+      .def("cellSimplices", &EigenstateSynthesis::cellSimplices,
+           "The sorted vertex-id tuple of each psi component, in operator order "
+           "(a single-vertex tuple per component at k=0, else the k-cell tuples "
+           "in canonical ChainComplex column order) — used to pin the boundary "
+           "k-cells to a target form and leave the interior free.")
       .def("numEdges", &EigenstateSynthesis::numEdges,
            "Number of tunable edges — the length of weights() / phases().")
       .def("residual", &EigenstateSynthesis::residual, py::arg("psi"),
@@ -562,7 +581,22 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
            "amplitudes, growing the interior up to max_cones times), and return "
            "the Verdict. Realizes the held bulk in place. Raises if U.size() != "
            "dA*dB, a dimension is non-positive, or the bulk has fewer vertices "
-           "than dA*dB.");
+           "than dA*dB.")
+      .def("decideHarmonic", &RealizabilityOracle::decideHarmonic,
+           py::arg("target"), py::arg("epsilon") = 1e-10, py::arg("restarts") = 64,
+           py::arg("max_cones") = 4, py::arg("seed") = 0,
+           "Decide whether a target boundary harmonic k-form (a degree-k Cochain, "
+           "k = target.degree(); the k=1 DW setting) is realizable on the held "
+           "3-manifold-with-boundary bulk W: pin the boundary surface dW byte-"
+           "fixed, fill the interior (interior edge squared-lengths + boundary-"
+           "fixed Pachner growth) to drive r = ||(I - psi psi^dagger) L_k psi||^2 "
+           "to 0, and return the Verdict. target is matched to the bulk's boundary "
+           "k-cells by sorted vertex-id tuple (the readout of a "
+           "PreparedBoundaryState); interior k-cells carry free auxiliary "
+           "amplitudes. Realizable iff r < epsilon, else the floor certifies non-"
+           "realizability at the explored complexity. Realizes the held bulk in "
+           "place. Raises if target is empty/negative-degree or none of its "
+           "k-cells are boundary cells of the bulk.");
 
   // Exact integer / GF(2) / inertia primitives (also exposed for direct
   // testing). Matrices are passed flat row-major with explicit dims.

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -32,6 +32,7 @@
 #include <utility>
 #include <vector>
 
+#include "cobordism/ChainComplex.h"
 #include "mesh/Edge.h"
 #include "mesh/EdgeList.h"
 #include "mesh/Simplex.h"
@@ -46,8 +47,12 @@ namespace tessera::cobordism {
 
 using cd = std::complex<double>;
 
-EigenstateSynthesis::EigenstateSynthesis(std::shared_ptr<Spacetime> st)
-    : st_(st), laplacian_(std::move(st)) {
+EigenstateSynthesis::EigenstateSynthesis(std::shared_ptr<Spacetime> st, int k)
+    : st_(st), k_(k), laplacian_(std::move(st)) {
+  if (k_ < 0)
+    throw std::runtime_error(
+        "EigenstateSynthesis: degree k must be non-negative; got k=" +
+        std::to_string(k_));
   if (!st_) return;
   capture();
   classifyBoundary();
@@ -56,14 +61,26 @@ EigenstateSynthesis::EigenstateSynthesis(std::shared_ptr<Spacetime> st)
 void EigenstateSynthesis::capture() {
   order_ = 0;
   edges_.clear();
+  cellOrdering_.clear();
   if (!st_) return;
 
-  // Stable vertex order (sorted id), matching HodgeLaplacian's k=0 indexing so a
-  // psi entry aligns with the operator's row/column for that vertex.
+  // The psi ordering: at k=0 the sorted-id vertex set (one component per vertex),
+  // matching HodgeLaplacian's k=0 indexing; at k>=1 the canonical ChainComplex
+  // k-cell column order, matching the metric L_k the operator assembles. order_
+  // is the operator dimension N either way.
   std::unordered_set<std::uint64_t> idset;
   for (const auto v : st_->getVertexList()->toVector())
     if (v != nullptr) idset.insert(v->getId());
-  order_ = idset.size();
+
+  if (k_ == 0) {
+    std::vector<std::uint64_t> ids(idset.begin(), idset.end());
+    std::sort(ids.begin(), ids.end());
+    cellOrdering_.reserve(ids.size());
+    for (const std::uint64_t id : ids) cellOrdering_.push_back({id});
+  } else {
+    cellOrdering_ = ChainComplex::fromSpacetime(*st_).kSimplexVertices(k_);
+  }
+  order_ = cellOrdering_.size();
 
   // Stable edge order: the tunable edges in EdgeList order — those that actually
   // carry weight in L = D - A (both endpoints present in the vertex set, not a
@@ -160,10 +177,12 @@ std::vector<cd> EigenstateSynthesis::apply(const std::vector<cd> &psi) const {
         std::to_string(psi.size()) + ", expected " + std::to_string(N));
   std::vector<cd> out(N, cd(0.0, 0.0));
   if (N == 0) return out;
-  // L = D - A reassembled from the live edge weights/phases (the k=0 magnitude
-  // convention). The matrix path does not consult the eigendecomposition cache,
-  // so repeated perturb-then-query is honest.
-  const std::vector<cd> L = laplacian_.laplacian(0);
+  // L_k reassembled from the live edges on each call: at k=0 the k=0 magnitude
+  // convention L = D - A; at k>=1 the symmetric metric Hodge Laplacian whose
+  // volume weights W_k are read live from the edge squared-lengths. The matrix
+  // path does not consult the eigendecomposition cache, so repeated
+  // perturb-then-query is honest.
+  const std::vector<cd> L = laplacian_.laplacian(k_);
   for (std::size_t i = 0; i < N; ++i) {
     cd acc(0.0, 0.0);
     for (std::size_t j = 0; j < N; ++j) acc += L[i * N + j] * psi[j];

--- a/src/cobordism/RealizabilityOracle.cpp
+++ b/src/cobordism/RealizabilityOracle.cpp
@@ -23,13 +23,16 @@
 
 #include <Eigen/Dense>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <map>
 #include <random>
 #include <stdexcept>
 #include <vector>
 
+#include "cobordism/Cochain.h"
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/LevenbergMarquardt.h"
 #include "quantum/ChoiJamiolkowski.h"
@@ -58,50 +61,70 @@ std::vector<cd> RealizabilityOracle::bend(const std::vector<cd> &U, int dA,
   return psi;
 }
 
-double RealizabilityOracle::fillInterior(EigenstateSynthesis &es,
-                                         const std::vector<cd> &target,
-                                         double epsilon, int restarts,
-                                         int maxCones, std::uint64_t seed,
-                                         std::vector<cd> &witnessOut,
-                                         int &conesApplied) const {
-  const std::size_t L = target.size();  // the pinned boundary-support length
+double RealizabilityOracle::fillInterior(
+    EigenstateSynthesis &es,
+    const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
+    int restarts, int maxCones, std::uint64_t seed, std::vector<cd> &witnessOut,
+    int &conesApplied) const {
+  // The U(1) phases enter only the k=0 graph Laplacian; the metric Hodge L_k
+  // (k>=1) is assembled from integer boundary maps and real volume weights, so
+  // interior phases are not tuned there (they would be wasted search dimensions).
+  const bool usePhases = (es.degree() == 0);
   double bestR = std::numeric_limits<double>::infinity();
   conesApplied = 0;
 
   for (int cone = 0;; ++cone) {
-    const std::size_t order = es.order();       // total vertices this pass
-    const std::size_t m = es.numInteriorEdges();  // free interior edges
-    const std::size_t nAux = order - L;           // free auxiliary amplitudes
-    const std::size_t nParams = 2 * m + 2 * nAux;
+    const std::size_t order = es.order();         // operator dim this pass
+    const std::size_t m = es.numInteriorEdges();  // free interior edge weights
 
-    // Assemble ψ from a parameter vector: the boundary support is the fixed
-    // target (first L sorted-id vertices); the auxiliary amplitudes (interior /
-    // coned-in apices) come from the tail of x (real, imag per vertex).
-    const auto buildPsi = [&target, L, m, nAux,
-                           order](const Eigen::VectorXd &x) -> std::vector<cd> {
-      std::vector<cd> psi = target;
-      psi.resize(order, cd(0.0, 0.0));
+    // Re-identify, on the current k-cell order, which ψ components are pinned
+    // boundary cells (their sorted vertex-id tuple is a key of pinnedByTuple, the
+    // target form on ∂W) vs. free interior cells (auxiliary amplitudes). Growth
+    // changes the k-cell order, so this is rebuilt every pass.
+    const std::vector<std::vector<std::uint64_t>> &cells = es.cellSimplices();
+    std::vector<cd> pinnedValue(order, cd(0.0, 0.0));
+    std::vector<std::size_t> freeIdx;
+    for (std::size_t i = 0; i < order; ++i) {
+      const auto it = pinnedByTuple.find(cells[i]);
+      if (it != pinnedByTuple.end())
+        pinnedValue[i] = it->second;
+      else
+        freeIdx.push_back(i);
+    }
+    const std::size_t nAux = freeIdx.size();
+    const std::size_t nW = m;
+    const std::size_t nTheta = usePhases ? m : 0;
+    const std::size_t nParams = nW + nTheta + 2 * nAux;
+
+    // Assemble ψ from a parameter vector: the boundary cells hold the fixed
+    // target form; the auxiliary amplitudes (interior / coned-in cells) come from
+    // the tail of x (real, imag per free cell).
+    const auto buildPsi = [&pinnedValue, &freeIdx, nW, nTheta,
+                           nAux](const Eigen::VectorXd &x) -> std::vector<cd> {
+      std::vector<cd> psi = pinnedValue;
       for (std::size_t k = 0; k < nAux; ++k) {
-        const auto re = static_cast<Eigen::Index>(2 * m + 2 * k);
-        psi[L + k] = cd(x[re], x[re + 1]);
+        const auto re = static_cast<Eigen::Index>(nW + nTheta + 2 * k);
+        psi[freeIdx[k]] = cd(x[re], x[re + 1]);
       }
       return psi;
     };
 
-    // Residual: write the interior weights/phases onto ∂W's complement (∂W
-    // itself is never touched), normalize the assembled ψ, and return the
-    // stacked g = Lψ - λψ ([Re; Im], length 2·order) whose ‖g‖² is r(ψ) — the
-    // §4b residual the Levenberg–Marquardt loop drives to zero.
-    const auto residual =
-        [&es, &buildPsi, m, order](const Eigen::VectorXd &x) -> Eigen::VectorXd {
+    // Residual: write the interior weights (and phases at k=0) onto ∂W's
+    // complement (∂W itself is never touched), normalize the assembled ψ, and
+    // return the stacked g = L_kψ - λψ ([Re; Im], length 2·order) whose ‖g‖² is
+    // r(ψ) — the residual the Levenberg–Marquardt loop drives to zero.
+    const auto residual = [&es, &buildPsi, m, nW, usePhases,
+                           order](const Eigen::VectorXd &x) -> Eigen::VectorXd {
       if (m > 0) {
-        std::vector<double> w(m), th(m);
-        for (std::size_t i = 0; i < m; ++i) {
-          w[i] = x[static_cast<Eigen::Index>(i)];
-          th[i] = x[static_cast<Eigen::Index>(m + i)];
-        }
+        std::vector<double> w(m);
+        for (std::size_t i = 0; i < m; ++i) w[i] = x[static_cast<Eigen::Index>(i)];
         es.setInteriorWeights(w);
-        es.setInteriorPhases(th);
+        if (usePhases) {
+          std::vector<double> th(m);
+          for (std::size_t i = 0; i < m; ++i)
+            th[i] = x[static_cast<Eigen::Index>(nW + i)];
+          es.setInteriorPhases(th);
+        }
       }
       std::vector<cd> psi = buildPsi(x);
       double nrm = 0.0;
@@ -123,18 +146,21 @@ double RealizabilityOracle::fillInterior(EigenstateSynthesis &es,
       return f;
     };
 
-    // Clamp interior weights/phases into the §4b box and the auxiliary
-    // amplitudes into [-kAuxBound, kAuxBound].
-    const auto clamp = [m, nAux](const Eigen::VectorXd &x) -> Eigen::VectorXd {
+    // Clamp interior weights (and phases at k=0) into the §4b box and the
+    // auxiliary amplitudes into [-kAuxBound, kAuxBound].
+    const auto clamp = [nW, nTheta, nAux](const Eigen::VectorXd &x)
+        -> Eigen::VectorXd {
       Eigen::VectorXd c = x;
-      for (std::size_t i = 0; i < m; ++i) {
+      for (std::size_t i = 0; i < nW; ++i) {
         const auto wi = static_cast<Eigen::Index>(i);
-        const auto ti = static_cast<Eigen::Index>(m + i);
         c[wi] = std::min(std::max(c[wi], kWMin), kWMax);
+      }
+      for (std::size_t i = 0; i < nTheta; ++i) {
+        const auto ti = static_cast<Eigen::Index>(nW + i);
         c[ti] = std::min(std::max(c[ti], -kThetaBound), kThetaBound);
       }
       for (std::size_t k = 0; k < 2 * nAux; ++k) {
-        const auto ai = static_cast<Eigen::Index>(2 * m + k);
+        const auto ai = static_cast<Eigen::Index>(nW + nTheta + k);
         c[ai] = std::min(std::max(c[ai], -kAuxBound), kAuxBound);
       }
       return c;
@@ -145,15 +171,15 @@ double RealizabilityOracle::fillInterior(EigenstateSynthesis &es,
     std::uniform_real_distribution<double> wDist(kWMin, kWMax);
     std::uniform_real_distribution<double> tDist(-kPi, kPi);
     std::uniform_real_distribution<double> aDist(-1.0, 1.0);
-    const auto sample = [m, nAux, wDist, tDist,
+    const auto sample = [nW, nTheta, nAux, wDist, tDist,
                          aDist](std::mt19937_64 &rng) mutable -> Eigen::VectorXd {
-      Eigen::VectorXd x0(static_cast<Eigen::Index>(2 * m + 2 * nAux));
-      for (std::size_t i = 0; i < m; ++i) {
+      Eigen::VectorXd x0(static_cast<Eigen::Index>(nW + nTheta + 2 * nAux));
+      for (std::size_t i = 0; i < nW; ++i)
         x0[static_cast<Eigen::Index>(i)] = wDist(rng);
-        x0[static_cast<Eigen::Index>(m + i)] = tDist(rng);
-      }
+      for (std::size_t i = 0; i < nTheta; ++i)
+        x0[static_cast<Eigen::Index>(nW + i)] = tDist(rng);
       for (std::size_t k = 0; k < 2 * nAux; ++k)
-        x0[static_cast<Eigen::Index>(2 * m + k)] = aDist(rng);
+        x0[static_cast<Eigen::Index>(nW + nTheta + k)] = aDist(rng);
       return x0;
     };
 
@@ -190,17 +216,80 @@ RealizabilityOracle::Verdict RealizabilityOracle::decide(
     int maxCones, std::uint64_t seed) {
   const std::vector<cd> target = bend(U, dA, dB);  // ψ_U, length dA·dB
 
-  EigenstateSynthesis es(bulk_);
+  EigenstateSynthesis es(bulk_);  // k = 0: the vertex graph Laplacian
   if (es.order() < target.size())
     throw std::invalid_argument(
         "RealizabilityOracle: the bulk has fewer vertices than the bent target "
         "needs on its output-boundary support (dA*dB).");
 
+  // The output-boundary support is the first dA·dB sorted-id vertices (the
+  // established k=0 embedding idiom): pin those vertex cells to ψ_U. The apex
+  // growInterior cones in has the largest id, so the first dA·dB tuples are
+  // preserved across growth.
+  const std::vector<std::vector<std::uint64_t>> &cells = es.cellSimplices();
+  std::map<std::vector<std::uint64_t>, cd> pinnedByTuple;
+  for (std::size_t i = 0; i < target.size(); ++i)
+    pinnedByTuple[cells[i]] = target[i];
+
   Verdict v;
   v.target = target;
-  const double r =
-      fillInterior(es, target, epsilon, restarts, maxCones, seed, v.state,
-                   v.conesApplied);
+  const double r = fillInterior(es, pinnedByTuple, epsilon, restarts, maxCones,
+                                seed, v.state, v.conesApplied);
+  v.residual = r;
+  v.realizable = (r < epsilon);
+  v.floor = v.realizable ? 0.0 : r;
+  v.eigenvalue = es.rayleigh(v.state);
+  v.interiorVertexCount = es.interiorVertexCount();
+  v.witness = bulk_;
+  return v;
+}
+
+RealizabilityOracle::Verdict RealizabilityOracle::decideHarmonic(
+    const Cochain &target, double epsilon, int restarts, int maxCones,
+    std::uint64_t seed) {
+  const int k = target.degree();
+  if (k < 0 || target.size() == 0)
+    throw std::invalid_argument(
+        "RealizabilityOracle::decideHarmonic: the target must be a non-empty "
+        "k-form (degree >= 0).");
+
+  EigenstateSynthesis es(bulk_, k);
+
+  // Pin the boundary k-cells to the target form, matched to the bulk's k-cell
+  // order by sorted vertex-id tuple. Normalize the target so its boundary block
+  // has unit norm (comparable to the auxiliary-amplitude box); the residual is
+  // scale-invariant either way. Record the normalized boundary values in the
+  // verdict's `target` for traceability.
+  const Eigen::VectorXcd &coeffs = target.coeffs();
+  double tnrm = 0.0;
+  for (Eigen::Index i = 0; i < coeffs.size(); ++i) tnrm += std::norm(coeffs[i]);
+  const double inv = (tnrm > 0.0) ? 1.0 / std::sqrt(tnrm) : 1.0;
+
+  std::map<std::vector<std::uint64_t>, cd> pinnedByTuple;
+  std::vector<cd> targetOut;
+  targetOut.reserve(target.simplices().size());
+  for (std::size_t i = 0; i < target.simplices().size(); ++i) {
+    std::vector<std::uint64_t> key = target.simplices()[i];
+    std::sort(key.begin(), key.end());
+    const cd value = coeffs[static_cast<Eigen::Index>(i)] * inv;
+    pinnedByTuple[key] = value;
+    targetOut.push_back(value);
+  }
+
+  // The surface must actually be ∂W: at least one target k-cell has to land on a
+  // boundary cell of the bulk (else the form is over a mismatched complex).
+  bool anyMatch = false;
+  for (const std::vector<std::uint64_t> &cell : es.cellSimplices())
+    if (pinnedByTuple.find(cell) != pinnedByTuple.end()) { anyMatch = true; break; }
+  if (!anyMatch)
+    throw std::invalid_argument(
+        "RealizabilityOracle::decideHarmonic: none of the target form's k-cells "
+        "are cells of the bulk — the surface does not match the bulk boundary.");
+
+  Verdict v;
+  v.target = targetOut;
+  const double r = fillInterior(es, pinnedByTuple, epsilon, restarts, maxCones,
+                                seed, v.state, v.conesApplied);
   v.residual = r;
   v.realizable = (r < epsilon);
   v.floor = v.realizable ? 0.0 : r;

--- a/tests/cobordism/test_k1_boundary_harmonic_synthesis_python.py
+++ b/tests/cobordism/test_k1_boundary_harmonic_synthesis_python.py
@@ -1,0 +1,416 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""§5.0 realizability synthesis lifted to k=1 boundary harmonics on a
+3-manifold-with-boundary (#176, the v0.4 bridge sub-ticket 2 of #174).
+
+The v0.3 `RealizabilityOracle`/`EigenstateSynthesis` synthesize a k=0 boundary
+eigenvector on a 2-complex. The DW bridge lives in the 3-manifold / k=1 setting:
+the spectral boundary qubit is the harmonic 1-forms ker L_1(Sigma) (dim b_1).
+`EigenstateSynthesis(W, k=1)` scores a target edge 1-form against the metric Hodge
+Laplacian L_1(W); `RealizabilityOracle.decideHarmonic` pins the boundary surface
+dW byte-fixed and fills the interior (interior edge squared-lengths -> the simplex
+volumes -> W_k of L_1, plus boundary-fixed 1->4 Pachner growth in 3D), driving
+r = ||(I - psi psi^dagger) L_1 psi||^2 to 0.
+
+Fixture: the **solid torus** W = D^2 x S^1 = SolidSimplex(2) x S^1 (a 3-manifold
+with boundary T^2; b_1(W) = 1) whose boundary surface Sigma = T^2 = S^1 x S^1
+(b_1 = 2, the natural qubit). The two share the product vertex-id scheme, so
+dW == Sigma edge-for-edge.
+
+Acceptance (#176), the topological dichotomy of H_1(Sigma) -> H_1(W):
+
+  * **Realizable** — the boundary harmonic the manifold *carries*: the restriction
+    of the bulk harmonic ker L_1(W) (the solid torus's longitude / core circle),
+    expressed in the prepared DW basis via BoundaryStateSpace. decideHarmonic
+    drives r -> 0 with the boundary pinned byte-fixed; the witness is a genuine
+    L_1(W) harmonic (lambda ~ 0) whose boundary block matches the target.
+  * **Obstructed** — the meridian (the boundary cycle that bounds a disk in W, so
+    it dies in H_1(W)): the residual floors away from 0, a certified obstruction
+    cross-checked against an independent numpy Hodge oracle.
+  * **Growth** — the boundary-fixed 1->4 Pachner add runs in 3D (dW byte-fixed),
+    and the interior fill genuinely cones + re-optimizes, driving a floored
+    target's residual down.
+
+numpy/Hodge cross-checks throughout: the C++ L_1 apply, the harmonic basis, and
+the residual floor are all reproduced from an independent numpy assembly.
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures (the cobordism idiom: Signature(d) so the d-cells register as top
+# simplices; built through the topology so the vertex-id counter advances).
+# --------------------------------------------------------------------------- #
+def _build(topology):
+    sig = tessera.Signature(topology.dimension(), tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, topology)
+    st.build()
+    return st
+
+
+def _circle():
+    return tessera.SimplexBoundarySphere(1)  # S^1 = boundary of a triangle
+
+
+def _solid_torus():
+    """W = D^2 x S^1 = SolidSimplex(2) x S^1: a 3-manifold with boundary T^2."""
+    return _build(tessera.SimplicialProduct(tessera.SolidSimplex(2), _circle()))
+
+
+def _torus():
+    """Sigma = T^2 = S^1 x S^1, the boundary surface (b_1 = 2)."""
+    return _build(tessera.SimplicialProduct(_circle(), _circle()))
+
+
+def _pin_uniform(st, w=1.0, phase=0.0):
+    """Pin every edge to a fixed Hermitian value; decideHarmonic's fill only
+    rewrites interior edges, so this fixes dW (and Sigma)."""
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(w)
+        e.setPhase(phase)
+
+
+def _pinned_solid_torus():
+    """A fresh solid torus with every edge pinned uniform — the synthesis bulk."""
+    W = _solid_torus()
+    _pin_uniform(W)
+    return W
+
+
+# --------------------------------------------------------------------------- #
+# numpy Hodge oracle for L_1 (symmetric metric Laplacian) + helpers.
+# --------------------------------------------------------------------------- #
+def _numpy_L1(st):
+    """L_1^sym = B_1^T B_1 + B_2 B_2^T, B_k = W_{k-1}^{1/2} d_k W_k^{-1/2}, in the
+    canonical ChainComplex k=1 cell order (matches HodgeLaplacian.laplacian(1))."""
+    chain = cob.ChainComplex.fromSpacetime(st)
+    nv, ne, nt = (chain.numSimplices(0), chain.numSimplices(1),
+                  chain.numSimplices(2))
+    d1 = np.asarray(chain.boundaryMatrix(1), float).reshape(nv, ne)
+    d2 = np.asarray(chain.boundaryMatrix(2), float).reshape(ne, nt)
+    hodge = cob.HodgeLaplacian(st)
+    w1 = np.asarray(hodge.weights(1), float)
+    w2 = np.asarray(hodge.weights(2), float)
+    b1 = d1 * (1.0 / np.sqrt(w1))[None, :]          # W_0 = I
+    b2 = np.sqrt(w1)[:, None] * d2 * (1.0 / np.sqrt(w2))[None, :]
+    return b1.T @ b1 + b2 @ b2.T
+
+
+def _residual_agnostic(L, psi):
+    psi = np.asarray(psi, dtype=complex)
+    psi = psi / np.linalg.norm(psi)
+    Lp = L @ psi
+    lam = np.vdot(psi, Lp).real
+    return float(np.vdot(Lp - lam * psi, Lp - lam * psi).real)
+
+
+def _boundary_edges(W):
+    """Edges of W on dW (in some boundary triangle), as sorted id pairs."""
+    bnd = set()
+    for facet in cob.Cobordism.boundaryFaces(W):
+        for e in itertools.combinations(sorted(facet), 2):
+            bnd.add(e)
+    return bnd
+
+
+def _cvec(v):
+    return [complex(z) for z in v]
+
+
+def _Cochain(simplices, coeffs):
+    return cob.Cochain(1, simplices, np.asarray(coeffs, dtype=complex))
+
+
+def _embed_on_W(form, cells):
+    """Map a degree-1 Cochain over Sigma's edges onto W's k=1 cell order."""
+    index = {tuple(c): i for i, c in enumerate(cells)}
+    out = np.zeros(len(cells), dtype=complex)
+    for c, s in zip(np.asarray(form.coeffs()), form.simplices()):
+        out[index[tuple(s)]] = c
+    return out
+
+
+def _longitude_and_meridian(W, space):
+    """The two distinguished boundary harmonics of the solid torus:
+
+      * longitude = the restriction of the bulk harmonic ker L_1(W) to Sigma,
+        expressed in the prepared DW basis (the cycle that survives in H_1(W));
+      * meridian  = its orthogonal complement in ker L_1(Sigma) (the cycle that
+        bounds a disk in W, dying in H_1(W)).
+    """
+    sig_simpl = space.harmonics()[0].simplices()
+    bulk_h = cob.HodgeLaplacian(W).harmonics(1)[0]   # b_1(W) = 1
+    restriction = _Cochain(
+        sig_simpl,
+        [complex(bulk_h.amplitudeFor(list(e))) for e in sig_simpl])
+    prepared = space.prepare(restriction)
+    longitude = prepared.readout()
+    coords = np.array([complex(prepared.generatorAmplitude(i)) for i in range(2)])
+    coords = coords / np.linalg.norm(coords)
+    harmonics = np.column_stack([np.asarray(h.coeffs()) for h in space.harmonics()])
+    meridian = _Cochain(sig_simpl, harmonics @ np.array([coords[1], -coords[0]]))
+    return longitude, meridian
+
+
+# --------------------------------------------------------------------------- #
+class SolidTorusFixtureTest(unittest.TestCase):
+    """The 3-manifold-with-boundary fixture and its boundary surface."""
+
+    def test_solid_torus_is_three_manifold_with_torus_boundary(self):
+        W = _solid_torus()
+        chain = cob.ChainComplex.fromSpacetime(W)
+        self.assertEqual(chain.dimension(), 3)                 # tetrahedra
+        self.assertEqual(chain.bettiNumbers(), [1, 1, 0, 0])   # solid torus
+        # dW is a single T^2 component: chi(dW) = 0, all triangles in one tet.
+        facets = cob.Cobordism.boundaryFaces(W)
+        self.assertTrue(all(len(f) == 3 for f in facets))
+
+    def test_boundary_matches_standalone_torus(self):
+        # dW edge-for-edge equals the standalone Sigma = T^2 (shared product
+        # vertex-id scheme), so a boundary harmonic of Sigma lands on dW.
+        self.assertEqual(_boundary_edges(_solid_torus()),
+                         set(tuple(e) for e in cob.ChainComplex.fromSpacetime(
+                             _torus()).kSimplexVertices(1)))
+
+    def test_boundary_qubit_is_b1_two(self):
+        space = cob.BoundaryStateSpace(_torus())
+        self.assertEqual(space.harmonicDimension(), 2)         # b_1(T^2) = 2
+        self.assertEqual(space.boundaryDimension(), 4)         # Z(T^2) = C^4
+
+
+# --------------------------------------------------------------------------- #
+class K1EngineTest(unittest.TestCase):
+    """EigenstateSynthesis at k=1: the metric Hodge L_1 residual core, with a
+    numpy cross-check, and the 3D boundary-fixed Pachner growth."""
+
+    def test_degree_order_and_cells(self):
+        W = _solid_torus()
+        _pin_uniform(W)
+        es = cob.EigenstateSynthesis(W, 1)
+        self.assertEqual(es.degree(), 1)
+        # psi is an edge 1-form: order() = |C_1(W)| = 27, and every edge is a
+        # boundary edge of the minimal solid torus (0 interior edges at the seed).
+        self.assertEqual(es.order(), 27)
+        self.assertEqual(len(es.cellSimplices()), 27)
+        self.assertEqual(es.numInteriorEdges(), 0)
+        self.assertEqual(es.numBoundaryEdges(), 27)
+        self.assertTrue(all(len(c) == 2 for c in es.cellSimplices()))  # edges
+
+    def test_apply_and_residual_match_numpy_hodge(self):
+        # L_1(W) apply and the eigenvalue-agnostic residual reproduce an
+        # independent numpy assembly of the symmetric metric Hodge Laplacian.
+        W = _solid_torus()
+        _pin_uniform(W)
+        es = cob.EigenstateSynthesis(W, 1)
+        L1 = _numpy_L1(W)
+        rng = np.random.default_rng(176)
+        psi = rng.standard_normal(27) + 1j * rng.standard_normal(27)
+        np.testing.assert_allclose(np.asarray(es.apply(_cvec(psi))), L1 @ psi,
+                                   atol=1e-8)
+        self.assertAlmostEqual(es.residual(_cvec(psi)),
+                               _residual_agnostic(L1, psi), places=8)
+
+    def test_bulk_harmonic_has_zero_residual(self):
+        # ker L_1(W) is the exact zero mode: r ~ 0 and Rayleigh lambda ~ 0.
+        W = _solid_torus()
+        _pin_uniform(W)
+        es = cob.EigenstateSynthesis(W, 1)
+        h = np.asarray(cob.HodgeLaplacian(W).harmonics(1)[0].coeffs())
+        # The harmonic Cochain is in the same k=1 order as the engine.
+        self.assertLess(es.residual(_cvec(h)), 1e-15)
+        self.assertAlmostEqual(es.rayleigh(_cvec(h)), 0.0, places=9)
+
+    def test_boundary_fixed_pachner_growth_is_3d(self):
+        # growInterior is the 1->4 stellar add on a tetrahedron: +1 interior
+        # vertex, +4 interior edges, dW byte-fixed, degree unchanged.
+        W = _solid_torus()
+        _pin_uniform(W)
+        es = cob.EigenstateSynthesis(W, 1)
+        boundary_before = set(tuple(t) for t in es.boundaryEdges())
+        self.assertEqual(len(boundary_before), 27)
+        self.assertTrue(es.growInterior(7))
+        self.assertEqual(es.degree(), 1)
+        self.assertEqual(es.interiorVertexCount(), 1)
+        self.assertEqual(es.numInteriorEdges(), 4)             # apex -> 4 verts
+        self.assertEqual(es.order(), 31)                       # |C_1| grew by 4
+        # dW is byte-fixed: the boundary edge set is unchanged.
+        self.assertEqual(set(tuple(t) for t in es.boundaryEdges()),
+                         boundary_before)
+
+
+# --------------------------------------------------------------------------- #
+class RealizableTest(unittest.TestCase):
+    """The boundary harmonic the solid torus carries (the longitude) is realized:
+    r -> 0, the witness is a genuine L_1(W) harmonic, dW byte-fixed."""
+
+    def test_longitude_is_realizable(self):
+        W = _solid_torus()
+        _pin_uniform(W)
+        space = cob.BoundaryStateSpace(_torus())
+        longitude, _ = _longitude_and_meridian(W, space)
+
+        # The target is a genuine boundary harmonic (the readout of a prepared
+        # DW boundary state), annihilated by L_1(Sigma).
+        L1_sigma = _numpy_L1(_torus())
+        np.testing.assert_allclose(
+            L1_sigma @ np.asarray(longitude.coeffs()), 0.0, atol=1e-7)
+
+        boundary_before = {(min(a, b), max(a, b)):
+                           (e.getSquaredLength(), e.getPhase())
+                           for e in W.getEdgeList().toVector()
+                           for a, b in [(e.getSource().getId(),
+                                         e.getTarget().getId())]}
+
+        oracle = cob.RealizabilityOracle(W)
+        v = oracle.decideHarmonic(longitude, epsilon=1e-9, restarts=8,
+                                  max_cones=0, seed=1)
+
+        # Realizable, r driven below the threshold, floor 0, no growth needed
+        # (the manifold already carries it at the seed metric).
+        self.assertTrue(v.realizable)
+        self.assertLess(v.residual, 1e-9)
+        self.assertEqual(v.floor, 0.0)
+        self.assertEqual(v.interior_vertex_count, 0)
+
+        # The witness is a genuine harmonic: lambda ~ 0 and L_1(W) psi ~ 0.
+        state = np.asarray(v.state)
+        self.assertEqual(state.shape, (27,))
+        self.assertAlmostEqual(v.eigenvalue, 0.0, places=7)
+        L1_W = _numpy_L1(W)
+        np.testing.assert_allclose(L1_W @ state, 0.0, atol=1e-6)
+
+        # The witness's boundary block matches the target (all 27 cells are
+        # boundary cells): proportional to the embedded target form.
+        target_on_W = _embed_on_W(longitude, [tuple(c)
+                                              for c in cob.EigenstateSynthesis(
+                                                  W, 1).cellSimplices()])
+        overlap = abs(np.vdot(state / np.linalg.norm(state),
+                              target_on_W / np.linalg.norm(target_on_W)))
+        self.assertAlmostEqual(overlap, 1.0, places=7)
+
+        # dW was pinned byte-identical (the fill never touched the boundary).
+        live = {(min(a, b), max(a, b)): (e.getSquaredLength(), e.getPhase())
+                for e in W.getEdgeList().toVector()
+                for a, b in [(e.getSource().getId(), e.getTarget().getId())]}
+        self.assertEqual(live, boundary_before)
+
+    def test_realizable_is_deterministic(self):
+        results = []
+        for _ in range(2):
+            W = _solid_torus()
+            _pin_uniform(W)
+            longitude, _ = _longitude_and_meridian(W, cob.BoundaryStateSpace(
+                _torus()))
+            v = cob.RealizabilityOracle(W).decideHarmonic(
+                longitude, epsilon=1e-9, restarts=8, max_cones=0, seed=5)
+            results.append(v)
+        self.assertEqual(results[0].realizable, results[1].realizable)
+        self.assertEqual(results[0].residual, results[1].residual)
+        np.testing.assert_array_equal(np.asarray(results[0].state),
+                                      np.asarray(results[1].state))
+
+
+# --------------------------------------------------------------------------- #
+class ObstructedTest(unittest.TestCase):
+    """The meridian (a cycle that bounds in W) is certified non-realizable by a
+    residual floor bounded away from 0, cross-checked against numpy."""
+
+    def test_meridian_floors_and_is_certified_non_realizable(self):
+        W = _solid_torus()
+        _pin_uniform(W)
+        space = cob.BoundaryStateSpace(_torus())
+        _, meridian = _longitude_and_meridian(W, space)
+
+        oracle = cob.RealizabilityOracle(W)
+        v = oracle.decideHarmonic(meridian, epsilon=1e-9, restarts=8,
+                                  max_cones=0, seed=0)
+
+        self.assertFalse(v.realizable)
+        self.assertGreater(v.residual, 1e-2)            # bounded away from 0
+        self.assertEqual(v.floor, v.residual)
+        self.assertEqual(v.interior_vertex_count, 0)
+
+        # Independent numpy oracle: at the seed there are no interior cells, so
+        # the floor is exactly r(meridian) on L_1(W) (the global min over an
+        # empty parameter set), to which the certified floor must agree.
+        cells = [tuple(c) for c in cob.EigenstateSynthesis(W, 1).cellSimplices()]
+        mer_on_W = _embed_on_W(meridian, cells)
+        self.assertAlmostEqual(v.floor, _residual_agnostic(_numpy_L1(W), mer_on_W),
+                               delta=1e-6)
+
+    def test_raw_boundary_harmonics_also_floor(self):
+        # The bare ker L_1(Sigma) basis 1-forms are not the carried harmonic
+        # either; each floors against the pinned solid-torus boundary.
+        W = _solid_torus()
+        _pin_uniform(W)
+        space = cob.BoundaryStateSpace(_torus())
+        for i in range(space.harmonicDimension()):
+            v = cob.RealizabilityOracle(W).decideHarmonic(
+                space.harmonics()[i], epsilon=1e-9, restarts=4, max_cones=0,
+                seed=i)
+            self.assertFalse(v.realizable)
+            self.assertGreater(v.floor, 1e-2)
+
+
+# --------------------------------------------------------------------------- #
+class GrowthFillTest(unittest.TestCase):
+    """The interior fill genuinely cones (boundary-fixed 1->4 Pachner) and
+    re-optimizes in 3D, driving a floored target's residual down while keeping
+    dW byte-fixed."""
+
+    def test_growth_reduces_a_floored_residual(self):
+        W = _solid_torus()
+        _pin_uniform(W)
+        space = cob.BoundaryStateSpace(_torus())
+        _, meridian = _longitude_and_meridian(W, space)
+
+        seed_floor = cob.RealizabilityOracle(_pinned_solid_torus()).decideHarmonic(
+            meridian, epsilon=1e-9, restarts=4, max_cones=0, seed=2).floor
+
+        boundary_before = set(_boundary_edges(W))
+        v = cob.RealizabilityOracle(W).decideHarmonic(
+            meridian, epsilon=1e-9, restarts=4, max_cones=1, seed=2)
+
+        # The fill coned in an interior vertex (boundary-fixed 1->4 Pachner) and
+        # re-optimized: the witness grew and the residual dropped well below the
+        # bare-seed floor (genuine LM + interior fill work in 3D).
+        self.assertGreaterEqual(v.cones_applied, 1)
+        self.assertEqual(v.interior_vertex_count, v.cones_applied)
+        self.assertEqual(len(v.state), 27 + 4 * v.cones_applied)
+        self.assertLess(v.residual, seed_floor)
+
+        # dW is byte-fixed through the growth: the boundary edge set is unchanged.
+        self.assertEqual(set(_boundary_edges(W)), boundary_before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Lifts the v0.3 realizability synthesis from the reduced `k=0` 2-complex setting to the DW-native **`k=1`, 3-manifold-with-boundary** setting (the v0.4 bridge sub-ticket 2 of #174).

## What this builds

**`EigenstateSynthesis` is now degree-parameterized (`int k`, default 0).**
- `apply()`/`residual()`/`rayleigh()` score a target against the degree-`k` Hodge Laplacian `L_k` (k=1 = the metric Hodge Laplacian on edge 1-forms); `order()` = `|C_k|` and `psi` is indexed over the canonical `ChainComplex` k-cell order, exposed by the new `cellSimplices()` / `degree()`.
- The tunable geometry stays the **edge squared-lengths**, which drive the per-simplex volume weights `W_k` of `L_k` through `Simplex::volume` (U(1) phases enter only the k=0 operator).
- `growInterior` is the boundary-fixed `1→4` stellar Pachner add — valid in 3D (each cone adds 1 interior vertex + 4 interior edges, `∂W` byte-fixed).

**`RealizabilityOracle::decideHarmonic(target Cochain)`** carries over the #138 realizable/floor-certificate verdict to k=1: pin the boundary surface `∂W` byte-fixed, fill the interior (interior edge weights + boundary-fixed Pachner growth), and drive `r = ||(I − ψψ†) L₁ ψ||² → 0`. The target (a `ker L₁(Σ)` harmonic 1-form, e.g. the readout of a `PreparedBoundaryState` via `BoundaryStateSpace`) is matched to the bulk's boundary k-cells by sorted vertex-id tuple; interior k-cells carry free auxiliary amplitudes. `fillInterior` was refactored to a degree-agnostic, tuple-keyed boundary/interior partition rebuilt per growth pass — the existing **k=0 `decide()` path is behavior-preserved** (identical parameter layout and RNG draws).

## Fixture

The **solid torus** `W = D² × S¹ = SolidSimplex(2) × S¹` — a 3-manifold with boundary `T²` (`b₁(W)=1`, `b₁(∂W)=b₁(T²)=2`, the natural qubit). It shares the product vertex-id scheme with the standalone `T² = S¹ × S¹`, so `∂W` equals that `T²` edge-for-edge (a boundary harmonic of `Σ` lands on `∂W`). (`Toroid` is *not* usable here — it is a closed manifold `T^{d-1}×S¹` with no boundary surface to pin.)

## Acceptance results — the `H₁(Σ) → H₁(W)` dichotomy

- **Realizable**: the boundary harmonic the manifold *carries* — the **longitude**, the restriction of `ker L₁(W)` (which lies exactly in `span(ker L₁(Σ))`, rel-resid `1e-15`) — is realized with **residual ≈ 9.5e-29** and Rayleigh **λ ≈ 2.2e-16** (a genuine harmonic), boundary pinned byte-fixed, witness boundary block ∝ target.
- **Obstructed**: the **meridian** (the boundary cycle that bounds a disk in `W`, dying in `H₁(W)`) is certified non-realizable by a residual **floor ≈ 15.26**, cross-checked against an independent numpy Hodge oracle (15.2567).
- **Growth**: the boundary-fixed `1→4` Pachner add runs in 3D and the interior fill genuinely cones + re-optimizes (meridian: floor 15.26 → 1.69 after one cone), `∂W` byte-fixed throughout.

## Tests / validation

- New `tests/cobordism/test_k1_boundary_harmonic_synthesis_python.py` — **12 cases** with numpy/Hodge cross-checks of the `L₁` apply, the harmonic basis, the realizable/obstructed verdicts, the floor, and the 3D growth.
- `pytest tests/cobordism tests/quantum -q`: **653 passed, 1 skipped, 779 subtests** (local, the only gate — CI is build-only).
- Also fixes a pre-existing `visualize_realizability` example crash under matplotlib ≥ 3.10 (RGBA rounding overshoot at the max-magnitude vertex), which the full-suite gate surfaced.
- Docs: `sphinx-build -E` → 0 warnings.

Closes #176
