### PR TITLE
feat(cobordism): non-identity DW boundary maps via finite-order twisted cylinders

### DIFF
--- a/include/cobordism/Cobordism.h
+++ b/include/cobordism/Cobordism.h
@@ -130,6 +130,61 @@ class Cobordism {
     ///   two isomorphic components; `std::runtime_error` if the identification
     ///   collapses a top simplex (collar too thin).
     [[nodiscard]] static std::shared_ptr<Spacetime> selfGlue(const Spacetime &W);
+
+    /// # Twisted cylinder (a non-identity DW boundary map)
+    ///
+    /// The \f$ \varphi \f$-twisted product cobordism \f$ \Sigma\times[0,T] :
+    /// \Sigma \to \Sigma \f$, whose two boundary copies of the surface
+    /// \f$ \Sigma \f$ are threaded through a finite-order *simplicial
+    /// automorphism* \f$ \varphi \f$ of the triangulated \f$ \Sigma \f$. The
+    /// ordinary product cylinder — the one `glue`/`selfGlue` produce, identified
+    /// by the order-preserving (identity) isomorphism — has DW map the identity
+    /// on \f$ Z(\Sigma) \f$; that identity identification is the single home of
+    /// the "\f$ \to I \f$" collapse. Putting \f$ \varphi \f$ there instead makes
+    /// the interior monodromy from the bottom boundary to the top boundary equal
+    /// \f$ \varphi \f$, so `DijkgraafWitten::map()` returns the permutation
+    /// \f$ \varphi \f$ induces on the holonomy classes
+    /// \f$ Z(\Sigma)=\mathbb{C}[H^1(\Sigma;\mathbb{Z}_2)] \f$. For the
+    /// coordinate-swap \f$ \varphi:(x,y)\mapsto(y,x) \f$ of a square-product
+    /// torus \f$ T^2=S^1\times S^1 \f$ this transposes the holonomy classes
+    /// \f$ [a]\leftrightarrow[b] \f$ while fixing \f$ [0] \f$ and \f$ [a{+}b] \f$
+    /// — a non-identity \f$ 4\times4 \f$ permutation (\f$ \varphi\bmod 2 \f$ is
+    /// the modular \f$ S=\bigl(\begin{smallmatrix}0&1\\1&0\end{smallmatrix}\bigr)
+    /// \f$).
+    ///
+    /// Construction: three stacked copies of \f$ \Sigma \f$ (levels 0,1,2 at
+    /// vertex ids \f$ x,\;|V|{+}x,\;2|V|{+}x \f$). The level-0\f$ \to \f$1 prism
+    /// is the ordinary Eilenberg–Zilber product \f$ \Sigma\times[0,1] \f$ (the
+    /// same staircase `SimplicialProduct` uses); the level-1\f$ \to \f$2 prism is
+    /// the same product but its lower face is glued to the shared seam through
+    /// \f$ \varphi \f$ (the level-1 vertex of \f$ \varphi(x) \f$ carries the seam
+    /// id of \f$ x \f$). Because \f$ \varphi \f$ is a simplicial automorphism the
+    /// two prisms induce the *same* triangulation on the seam, so it closes up;
+    /// the seam (level 1) is interior, and \f$ \partial W \f$ is the two
+    /// \f$ \Sigma \f$ copies at levels 0 and 2 (\f$ \geq 3 \f$ layers, so no top
+    /// simplex touches both boundaries). The result is a fresh pre-geometric
+    /// `Spacetime` ready for `DijkgraafWitten::map()`.
+    ///
+    /// \f$ \varphi \f$ of order \f$ n \f$ gives a DW map of order \f$ n \f$
+    /// (`map`\f$ {}^n=I \f$), and composing twists composes the permutations —
+    /// the functoriality of the DW functor. Only the finite-order modular
+    /// elements (orders 2,3,4,6) are realizable this way: the Dehn twist
+    /// \f$ T=\bigl(\begin{smallmatrix}1&1\\0&1\end{smallmatrix}\bigr) \f$ is
+    /// infinite-order, hence *not* a finite-order simplicial automorphism of any
+    /// fixed triangulation — which is exactly why a fixed-triangulation cobordism
+    /// could only ever realize the identity until now.
+    ///
+    /// @param sigma a closed triangulated surface \f$ \Sigma \f$ whose vertices
+    ///   are exactly \f$ 0..|V|-1 \f$ (as the product-torus fixtures produce).
+    /// @param phi a vertex permutation (`phi[x]` is the image of vertex
+    ///   \f$ x \f$) that is a simplicial automorphism of \f$ \Sigma \f$ — both
+    ///   validated.
+    /// @throws std::invalid_argument if \f$ \Sigma \f$ is not a 2-dimensional
+    ///   triangulation with vertices \f$ 0..|V|-1 \f$, or `phi` is not a length-
+    ///   \f$ |V| \f$ permutation, or `phi` is not a simplicial automorphism of
+    ///   \f$ \Sigma \f$ (some top triangle's image is not a triangle).
+    [[nodiscard]] static std::shared_ptr<Spacetime> twistedCylinder(
+        const Spacetime &sigma, const std::vector<std::uint64_t> &phi);
 };
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -711,7 +711,24 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
                   "top simplex touches both (>= 3 layers in the glued "
                   "direction). Returns the closed manifold as a new Spacetime. "
                   "Raises unless dW has exactly two isomorphic components, or if "
-                  "the identification collapses a top simplex.");
+                  "the identification collapses a top simplex.")
+      .def_static("twistedCylinder", &Cobordism::twistedCylinder,
+                  py::arg("sigma"), py::arg("phi"),
+                  "Build the phi-twisted product cobordism Sigma x [0,T] : "
+                  "Sigma -> Sigma whose two boundary copies of the surface Sigma "
+                  "are threaded through a finite-order simplicial automorphism "
+                  "phi (phi[x] = image of vertex x; Sigma's vertices must be "
+                  "0..|V|-1). The ordinary product cylinder (phi = identity) has "
+                  "DW map the identity; a phi acting non-trivially on "
+                  "H^1(Sigma; Z_2) makes DijkgraafWitten.map() the corresponding "
+                  "non-identity permutation of the holonomy classes Z(Sigma) — "
+                  "e.g. the coordinate swap (x,y)->(y,x) of a square-product "
+                  "torus transposes [a]<->[b]. Three stacked Sigma levels (ids "
+                  "x, |V|+x, 2|V|+x) with the twist carried only by the seam "
+                  "(level 1) identification; returns the new Spacetime, ready for "
+                  "DijkgraafWitten.map(). Raises if Sigma is not a 2D "
+                  "triangulation with vertices 0..|V|-1, or phi is not a length-"
+                  "|V| permutation / not a simplicial automorphism of Sigma.");
 
   // ----- Capability T3 (#108): Dijkgraaf-Witten Z_2 state sum -----
   py::enum_<Cocycle>(m, "Cocycle",

--- a/src/cobordism/Cobordism.cpp
+++ b/src/cobordism/Cobordism.cpp
@@ -474,4 +474,88 @@ std::shared_ptr<Spacetime> Cobordism::selfGlue(const Spacetime &W) {
   return buildSpacetime(numVertices, merged);
 }
 
+std::shared_ptr<Spacetime> Cobordism::twistedCylinder(
+    const Spacetime &sigma, const std::vector<std::uint64_t> &phi) {
+  // Σ's top cells must be triangles (a 2-dimensional surface).
+  const SimplexList triangles = topSimplices(sigma);
+  if (triangles.empty())
+    throw std::invalid_argument(
+        "Cobordism::twistedCylinder: Σ must be a non-empty triangulation");
+  for (const std::vector<std::uint64_t> &triangle : triangles)
+    if (triangle.size() != 3)
+      throw std::invalid_argument(
+          "Cobordism::twistedCylinder: Σ must be a 2-dimensional surface (its "
+          "top cells must be triangles)");
+
+  // The vertices must be exactly 0..n-1: φ is supplied as a flat per-id vector
+  // and the level offsets below assume a dense [0, n) id range (the
+  // product-torus fixtures number their vertices this way).
+  std::set<std::uint64_t> vertexSet;
+  for (const std::vector<std::uint64_t> &triangle : triangles)
+    for (std::uint64_t v : triangle) vertexSet.insert(v);
+  const std::uint64_t n = static_cast<std::uint64_t>(vertexSet.size());
+  if (vertexSet.empty() || *vertexSet.rbegin() != n - 1)
+    throw std::invalid_argument(
+        "Cobordism::twistedCylinder: Σ's vertices must be exactly 0..|V|-1");
+
+  // φ must be a length-n permutation of 0..n-1 ...
+  if (static_cast<std::uint64_t>(phi.size()) != n)
+    throw std::invalid_argument(
+        "Cobordism::twistedCylinder: phi must have one entry per Σ vertex "
+        "(length |V|)");
+  const std::set<std::uint64_t> phiImage(phi.begin(), phi.end());
+  if (static_cast<std::uint64_t>(phiImage.size()) != n ||
+      *phiImage.rbegin() != n - 1)
+    throw std::invalid_argument(
+        "Cobordism::twistedCylinder: phi must be a permutation of 0..|V|-1");
+  // ... and a simplicial automorphism: every top triangle's φ-image is a
+  // triangle (this is what makes the two prisms induce one shared seam, and what
+  // limits the realizable maps to the finite-order modular elements).
+  const std::set<std::vector<std::uint64_t>> triangleSet(triangles.begin(),
+                                                         triangles.end());
+  for (const std::vector<std::uint64_t> &triangle : triangles) {
+    std::vector<std::uint64_t> image{phi[triangle[0]], phi[triangle[1]],
+                                     phi[triangle[2]]};
+    std::sort(image.begin(), image.end());
+    if (!triangleSet.count(image))
+      throw std::invalid_argument(
+          "Cobordism::twistedCylinder: phi is not a simplicial automorphism of "
+          "Σ (a top triangle's image is not a triangle)");
+  }
+
+  // Three stacked copies of Σ: level ℓ vertex x at id ℓ·n + x. Each triangle
+  // (a < b < c) spans a prism (a 2-simplex × [0,1]) cut into the three
+  // Eilenberg–Zilber tetrahedra {β(a),β(b),β(c),τ(c)}, {β(a),β(b),τ(b),τ(c)},
+  // {β(a),τ(a),τ(b),τ(c)} for a lower-face map β and an upper-face map τ — the
+  // same staircase SimplicialProduct lays down for Σ×[0,1], the diagonal fixed
+  // by Σ's vertex order so adjacent prisms (and the seam) glue consistently.
+  auto addPrism = [](SimplexList &tops, const std::vector<std::uint64_t> &tri,
+                     auto beta, auto tau) {
+    const std::uint64_t a = tri[0], b = tri[1], c = tri[2];
+    auto push = [&tops](std::vector<std::uint64_t> tet) {
+      std::sort(tet.begin(), tet.end());
+      tops.push_back(std::move(tet));
+    };
+    push({beta(a), beta(b), beta(c), tau(c)});
+    push({beta(a), beta(b), tau(b), tau(c)});
+    push({beta(a), tau(a), tau(b), tau(c)});
+  };
+
+  const auto level0 = [](std::uint64_t x) { return x; };
+  const auto level1 = [n](std::uint64_t x) { return n + x; };
+  const auto level2 = [n](std::uint64_t x) { return 2 * n + x; };
+  // The seam (level 1) read through φ: the level-1 copy of vertex φ(x) carries
+  // x's slot, so the monodromy from the bottom boundary (level 0) up to the top
+  // boundary (level 2) is exactly φ — the whole twist lives in this one map.
+  const auto seam = [n, &phi](std::uint64_t x) { return n + phi[x]; };
+
+  SimplexList tops;
+  tops.reserve(triangles.size() * 6);
+  for (const std::vector<std::uint64_t> &triangle : triangles) {
+    addPrism(tops, triangle, level0, level1);  // bottom prism Σ×[0,1] (identity)
+    addPrism(tops, triangle, seam, level2);    // top prism Σ×[1,2] (φ-threaded)
+  }
+  return buildSpacetime(static_cast<std::size_t>(3 * n), tops);
+}
+
 }  // namespace tessera::cobordism

--- a/tests/cobordism/test_twisted_cylinder_python.py
+++ b/tests/cobordism/test_twisted_cylinder_python.py
@@ -1,0 +1,431 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Non-identity DW boundary maps via finite-order twisted cylinders (#192).
+
+The realizable Dijkgraaf–Witten 2-boundary map image had collapsed to a single
+point, ``{I₄}``: the only buildable ``T²→T²`` cobordism was the trivial product
+cylinder (``→`` identity). ``Cobordism.twistedCylinder(Σ, φ)`` breaks that
+degeneracy by identifying the two boundary copies of the surface ``Σ`` through a
+finite-order **simplicial automorphism** ``φ`` instead of the order-preserving
+identity. The interior monodromy from the bottom boundary to the top boundary is
+then ``φ``, so ``DijkgraafWitten.map()`` returns the permutation ``φ`` induces on
+the holonomy classes ``Z(Σ) = ℂ[H¹(Σ; ℤ₂)]``.
+
+On the symmetric square-product torus ``T² = S¹×S¹`` (``SimplicialProduct(∂Δ²,
+∂Δ²)``, 9 vertices) the coordinate-swap ``φ: (x,y) ↦ (y,x)`` (``φ mod 2`` is the
+modular ``S = [[0,1],[1,0]]``) transposes the holonomy classes ``[a]↔[b]`` while
+fixing ``[0]`` and ``[a+b]`` — the non-identity ``4×4`` permutation
+
+    [[1 0 0 0]
+     [0 0 1 0]
+     [0 1 0 0]
+     [0 0 0 1]]
+
+asserted here against an independent numpy GF(2) holonomy oracle. The realizable
+image is now ``{I₄} ∪ {this swap}`` — strictly larger than a point.
+
+Functoriality: ``φ`` of order ``n`` ⇒ a DW map of order ``n`` (the swap is an
+involution, ``map² = I₄``), and composing twists composes the permutations
+(``twistedCylinder(φ∘φ) = map(φ)²``).
+
+The Dehn twist ``T = [[1,1],[0,1]]`` is *not* realizable this way — it is
+infinite-order, hence not a finite-order simplicial automorphism of any fixed
+triangulation. That is exactly why the map image was stuck at ``{I₄}``: only the
+finite-order modular elements (orders 2, 3, 4, 6) are simplicially realizable.
+"""
+
+import unittest
+
+import numpy as np
+
+import tessera
+
+cobordism = tessera.cobordism
+DijkgraafWitten = cobordism.DijkgraafWitten
+Cocycle = cobordism.Cocycle
+Cobordism = cobordism.Cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures.
+# --------------------------------------------------------------------------- #
+def _build(topology):
+    signature = tessera.Signature(topology.dimension(), tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, topology)
+    spacetime.build()
+    return spacetime
+
+
+def _circle():
+    # S¹ = ∂Δ², the minimal triangle-boundary circle (3 vertices).
+    return tessera.SimplexBoundarySphere(1)
+
+
+def _torus_topology():
+    # T² = S¹ × S¹ via the simplicial (Eilenberg–Zilber) product: 9 vertices,
+    # productId(u, v) = 3·u + v, and the coordinate swap (u, v) ↦ (v, u) is a
+    # simplicial automorphism (the staircase is swap-symmetric).
+    return tessera.SimplicialProduct(_circle(), _circle())
+
+
+def _torus():
+    return _build(_torus_topology())
+
+
+# The two factors of T² = S¹×S¹ each have 3 vertices, so productId(u, v) = 3u+v.
+# The coordinate swap φ(u, v) = (v, u) reads 3u+v ↦ 3v+u; it fixes the diagonal
+# (0, 4, 8) and pairs (1,3), (2,6), (5,7).
+_SWAP = [v * 3 + u for u in range(3) for v in range(3)]
+_IDENTITY = list(range(9))
+
+
+def _top_triangles(spacetime):
+    """Top-cell (triangle) vertex-id tuples of a built surface, sorted."""
+    by_size = {}
+    for simplex in spacetime.getSimplices():
+        cell = tuple(sorted(vertex.getId() for vertex in simplex.getVertices()))
+        by_size.setdefault(len(cell), []).append(cell)
+    return sorted(by_size[max(by_size)])
+
+
+# --------------------------------------------------------------------------- #
+# Independent numpy GF(2) holonomy oracle for the induced permutation.
+#
+# Reimplements, in pure numpy, the same per-component class indexing
+# DijkgraafWitten.computeBoundary uses — H¹(Σ) = Z¹/B¹ representatives ordered by
+# gf2Span(reps) — and reads off the permutation φ induces by pulling each class
+# back along φ. Convention-matched to the C++ so the *exact* matrix can be
+# asserted, but computed through a fully separate code path.
+# --------------------------------------------------------------------------- #
+def _gf2_nullspace(matrix, cols):
+    if matrix.size == 0:
+        return [np.eye(cols, dtype=np.int64)[i] for i in range(cols)]
+    a = (np.asarray(matrix, dtype=np.int64) & 1).copy()
+    rows, _ = a.shape
+    pivots, r = [], 0
+    for col in range(cols):
+        if r >= rows:
+            break
+        piv = next((i for i in range(r, rows) if a[i, col] & 1), None)
+        if piv is None:
+            continue
+        a[[r, piv]] = a[[piv, r]]
+        for i in range(rows):
+            if i != r and (a[i, col] & 1):
+                a[i] ^= a[r]
+        pivots.append(col)
+        r += 1
+    is_pivot = [c in pivots for c in range(cols)]
+    basis = []
+    for free in range(cols):
+        if is_pivot[free]:
+            continue
+        x = np.zeros(cols, dtype=np.int64)
+        x[free] = 1
+        for t, pc in enumerate(pivots):
+            x[pc] = a[t, free] & 1
+        basis.append(x)
+    return basis
+
+
+def _gf2_span(basis, cols):
+    out = []
+    for mask in range(1 << len(basis)):
+        x = np.zeros(cols, dtype=np.int64)
+        for b in range(len(basis)):
+            if (mask >> b) & 1:
+                x ^= basis[b]
+        out.append(x)
+    return out
+
+
+def _gf2_residue(vector, span_rows):
+    v = (np.asarray(vector, dtype=np.int64) & 1).copy()
+    for row in span_rows:
+        piv = int(np.argmax(row)) if row.any() else -1
+        if piv >= 0 and (v[piv] & 1):
+            v ^= row
+    return v & 1
+
+
+def _gf2_echelon(generators, cols):
+    rows = []
+    for gen in generators:
+        v = _gf2_residue(gen, rows)
+        if v.any():
+            rows.append(v)
+            rows.sort(key=lambda row: int(np.argmax(row)))
+    return rows
+
+
+def _cohomology_reps(cocycles, coboundaries, cols):
+    span_rows = _gf2_echelon(coboundaries, cols)
+    reps = []
+    for z in cocycles:
+        if _gf2_residue(z, span_rows).any():
+            reps.append(np.asarray(z, dtype=np.int64) & 1)
+            span_rows = _gf2_echelon(
+                list(span_rows) + [np.asarray(z, dtype=np.int64) & 1], cols)
+    return reps
+
+
+def _holonomy_permutation(triangles, phi):
+    """The permutation φ induces on Z(Σ), in computeBoundary's class order.
+
+    Returns (sigma, b1): sigma[c] is the class index that holonomy class c maps
+    to under φ (a connection's class is its gf2Span(reps) index), and b1 is the
+    first Betti number of Σ (so 2**b1 = dim Z(Σ)).
+    """
+    edges = sorted({pair for tri in triangles
+                    for pair in ((tri[0], tri[1]), (tri[0], tri[2]),
+                                 (tri[1], tri[2]))})
+    edge_index = {e: i for i, e in enumerate(edges)}
+    n_edges = len(edges)
+    verts = sorted({v for tri in triangles for v in tri})
+
+    # d₁ (triangles × edges) incidence; Z¹ = ker d₁, B¹ = im d₀ (vertex stars).
+    d1 = np.zeros((len(triangles), n_edges), dtype=np.int64)
+    for t, tri in enumerate(triangles):
+        for pair in ((tri[0], tri[1]), (tri[0], tri[2]), (tri[1], tri[2])):
+            d1[t, edge_index[pair]] = 1
+    cocycles = _gf2_nullspace(d1, n_edges)
+    coboundaries = [np.array([1 if v in e else 0 for e in edges], dtype=np.int64)
+                    for v in verts]
+    reps = _cohomology_reps(cocycles, coboundaries, n_edges)
+    classes = _gf2_span(reps, n_edges)
+    cob_rows = _gf2_echelon(coboundaries, n_edges)
+    class_of_residue = {tuple(_gf2_residue(c, cob_rows)): i
+                        for i, c in enumerate(classes)}
+
+    # φ pulls a connection (edge-cochain) back: (φ* g)[e] = g[sorted(φ e)].
+    def pullback(g):
+        out = np.zeros(n_edges, dtype=np.int64)
+        for e, i in edge_index.items():
+            out[i] = g[edge_index[tuple(sorted((phi[e[0]], phi[e[1]])))]]
+        return out
+
+    sigma = {c: class_of_residue[tuple(_gf2_residue(pullback(cls), cob_rows))]
+             for c, cls in enumerate(classes)}
+    return sigma, len(reps)
+
+
+def _oracle_matrix(triangles, phi):
+    """The expected DW map: the top boundary class is φ* of the bottom's."""
+    sigma, b1 = _holonomy_permutation(triangles, phi)
+    dim = 1 << b1
+    matrix = np.zeros((dim, dim))
+    for bottom, top in sigma.items():
+        matrix[bottom][top] = 1.0
+    return matrix
+
+
+def _map(phi, cocycle=Cocycle.Trivial):
+    """The DW map of the φ-twisted T² cylinder, as a numpy array."""
+    return np.asarray(DijkgraafWitten(
+        Cobordism.twistedCylinder(_torus(), phi), cocycle).map())
+
+
+# --------------------------------------------------------------------------- #
+# The headline: the swap gives a verified non-identity permutation.
+# --------------------------------------------------------------------------- #
+class TestSwapIsNonIdentityPermutation(unittest.TestCase):
+
+    EXPECTED = np.array([[1, 0, 0, 0],
+                         [0, 0, 1, 0],
+                         [0, 1, 0, 0],
+                         [0, 0, 0, 1]], dtype=float)
+
+    def test_map_is_not_the_identity(self):
+        # The whole point of #192: the realizable image is no longer {I₄}.
+        matrix = _map(_SWAP)
+        self.assertEqual(matrix.shape, (4, 4))
+        self.assertFalse(np.allclose(matrix, np.eye(4)),
+                         "the twisted cylinder must NOT be the identity")
+
+    def test_map_equals_the_expected_swap_permutation(self):
+        # Fixes the trivial class [0] (index 0) and [a+b] (index 3); transposes
+        # [a]↔[b] (indices 1, 2) — φ mod 2 = S = [[0,1],[1,0]].
+        np.testing.assert_allclose(_map(_SWAP), self.EXPECTED, atol=1e-9)
+
+    def test_map_matches_independent_numpy_oracle(self):
+        oracle = _oracle_matrix(_top_triangles(_torus()), _SWAP)
+        np.testing.assert_allclose(_map(_SWAP), oracle, atol=1e-9)
+        np.testing.assert_allclose(oracle, self.EXPECTED, atol=1e-9)
+
+    def test_map_is_unitary(self):
+        matrix = _map(_SWAP)
+        np.testing.assert_allclose(matrix.conj().T @ matrix, np.eye(4), atol=1e-9)
+
+    def test_map_is_a_genuine_zero_one_permutation(self):
+        matrix = _map(_SWAP).real
+        # Entries are 0/1, with exactly one 1 per row and per column.
+        self.assertTrue(np.all(np.isclose(matrix, 0) | np.isclose(matrix, 1)))
+        np.testing.assert_array_equal(np.round(matrix.sum(axis=0)).astype(int),
+                                      np.ones(4, dtype=int))
+        np.testing.assert_array_equal(np.round(matrix.sum(axis=1)).astype(int),
+                                      np.ones(4, dtype=int))
+
+    def test_map_fixes_the_trivial_holonomy_class(self):
+        # The trivial connection (index 0) is φ-invariant for any φ.
+        self.assertAlmostEqual(_map(_SWAP)[0, 0], 1.0, places=9)
+
+    def test_map_is_a_single_transposition(self):
+        # The swap fixes two classes ([0], [a+b]) and exchanges the other two
+        # ([a]↔[b]): an involution with exactly one 2-cycle.
+        matrix = _map(_SWAP).real
+        np.testing.assert_allclose(matrix @ matrix, np.eye(4), atol=1e-9)  # P²=I
+        fixed = int(np.round(np.trace(matrix)))
+        self.assertEqual(fixed, 2, "a transposition fixes exactly two classes")
+        off_diagonal_ones = int(np.round(matrix.sum() - np.trace(matrix)))
+        self.assertEqual(off_diagonal_ones, 2, "exactly one 2-cycle")
+
+    def test_sign_cocycle_gives_the_same_permutation(self):
+        # The mod-2 cup cube vanishes on the cylinder, so the Sign twist agrees.
+        np.testing.assert_allclose(_map(_SWAP, Cocycle.Sign), self.EXPECTED,
+                                   atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# The trivial twist (φ = identity) recovers the product cylinder → I₄.
+# --------------------------------------------------------------------------- #
+class TestTrivialTwistIsIdentity(unittest.TestCase):
+
+    def test_identity_phi_is_the_identity_map(self):
+        np.testing.assert_allclose(_map(_IDENTITY), np.eye(4), atol=1e-9)
+
+    def test_identity_phi_matches_the_product_cylinder(self):
+        # Cross-check against the independently-built product cylinder
+        # T²×[0,T] = SimplicialProduct(T², interval), which #109 pins to I₄.
+        interval = tessera.SolidSimplex(1)
+        product = _build(tessera.SimplicialProduct(_torus_topology(), interval))
+        product_map = np.asarray(
+            DijkgraafWitten(product, Cocycle.Trivial).map())
+        np.testing.assert_allclose(_map(_IDENTITY), product_map, atol=1e-9)
+
+    def test_identity_phi_matches_oracle(self):
+        oracle = _oracle_matrix(_top_triangles(_torus()), _IDENTITY)
+        np.testing.assert_allclose(oracle, np.eye(4), atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# Functoriality of the DW functor.
+# --------------------------------------------------------------------------- #
+class TestFunctoriality(unittest.TestCase):
+
+    def test_order_of_map_equals_order_of_phi(self):
+        # φ (the swap) has order 2, so the DW map has order 2: map² = I₄, and
+        # map ≠ I₄ (so the order is exactly 2, not 1).
+        matrix = _map(_SWAP)
+        self.assertFalse(np.allclose(matrix, np.eye(4)))
+        np.testing.assert_allclose(matrix @ matrix, np.eye(4), atol=1e-9)
+
+    def test_composing_twists_composes_permutations(self):
+        # twistedCylinder(φ∘φ) realizes the composite permutation map(φ)·map(φ);
+        # for the order-2 swap φ∘φ = id, so this is I₄ — the identity cylinder.
+        swap_squared = [_SWAP[_SWAP[i]] for i in range(9)]
+        self.assertEqual(swap_squared, _IDENTITY)
+        composed = _map(swap_squared)
+        np.testing.assert_allclose(composed, _map(_SWAP) @ _map(_SWAP), atol=1e-9)
+        np.testing.assert_allclose(composed, np.eye(4), atol=1e-9)
+
+    def test_realizable_image_is_strictly_larger_than_a_point(self):
+        # The realizable image now contains {I₄, swap} — at least two distinct
+        # unitaries, where before #192 it was the single point {I₄}.
+        image = [_map(_IDENTITY), _map(_SWAP)]
+        distinct = []
+        for matrix in image:
+            if not any(np.allclose(matrix, seen, atol=1e-9) for seen in distinct):
+                distinct.append(matrix)
+        self.assertGreaterEqual(len(distinct), 2)
+
+
+# --------------------------------------------------------------------------- #
+# Boundary / b₁ cross-checks against the existing machinery.
+# --------------------------------------------------------------------------- #
+class TestBoundaryCrossChecks(unittest.TestCase):
+
+    def test_boundary_dimensions_are_two_tori(self):
+        # ∂W = T² ⊔ T², each Z(T²) of dimension 2^{b₁(T²)} = 4.
+        dims = DijkgraafWitten(Cobordism.twistedCylinder(_torus(), _SWAP),
+                               Cocycle.Trivial).boundaryDimensions()
+        self.assertEqual(list(dims), [4, 4])
+
+    def test_is_a_genuine_cobordism_from_torus_to_torus(self):
+        torus = _torus()
+        twisted = Cobordism.twistedCylinder(torus, _SWAP)
+        result = Cobordism.verify(twisted, torus, torus)
+        self.assertTrue(result.ok, result.detail)
+
+    def test_bulk_is_a_torus_times_interval(self):
+        # W ≃ T²×I (φ is a homeomorphism), so b = (1, 2, 1, 0): the b₁ = 2 bulk
+        # is what 2^{b₁} = 4 holonomy classes per boundary rests on.
+        chain = cobordism.ChainComplex.fromSpacetime(
+            Cobordism.twistedCylinder(_torus(), _SWAP))
+        self.assertEqual(chain.bettiNumbers(), [1, 2, 1, 0])
+
+    def test_boundary_has_two_torus_components(self):
+        twisted = Cobordism.twistedCylinder(_torus(), _SWAP)
+        faces = Cobordism.boundaryFaces(twisted)
+        components = Cobordism.connectedComponents([list(f) for f in faces])
+        self.assertEqual(len(components), 2)
+        for component in components:  # each a closed T² (χ = 0)
+            verts = {v for tri in component for v in tri}
+            edges = {tuple(sorted(pair)) for tri in component
+                     for pair in ((tri[0], tri[1]), (tri[0], tri[2]),
+                                  (tri[1], tri[2]))}
+            self.assertEqual(len(verts) - len(edges) + len(component), 0)
+
+
+# --------------------------------------------------------------------------- #
+# Input validation.
+# --------------------------------------------------------------------------- #
+class TestGuards(unittest.TestCase):
+
+    def test_phi_must_have_one_entry_per_vertex(self):
+        with self.assertRaises((ValueError, RuntimeError)):
+            Cobordism.twistedCylinder(_torus(), _SWAP[:-1])
+
+    def test_phi_must_be_a_permutation(self):
+        not_a_permutation = list(_SWAP)
+        not_a_permutation[0] = not_a_permutation[1]  # 1 repeated, 0 missing
+        with self.assertRaises((ValueError, RuntimeError)):
+            Cobordism.twistedCylinder(_torus(), not_a_permutation)
+
+    def test_phi_must_be_a_simplicial_automorphism(self):
+        # A bare transposition of two non-equivalent vertices is a permutation
+        # but not a simplicial automorphism of the torus.
+        not_an_automorphism = list(_IDENTITY)
+        not_an_automorphism[0], not_an_automorphism[1] = 1, 0
+        with self.assertRaises((ValueError, RuntimeError)):
+            Cobordism.twistedCylinder(_torus(), not_an_automorphism)
+
+    def test_sigma_must_be_a_surface(self):
+        # A circle (1-manifold) has no triangles, so it is rejected.
+        circle = _build(_circle())
+        with self.assertRaises((ValueError, RuntimeError)):
+            Cobordism.twistedCylinder(circle, [0, 1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_twisted_cylinder_python.py
+++ b/tests/cobordism/test_twisted_cylinder_python.py
@@ -47,6 +47,12 @@ Functoriality: ``φ`` of order ``n`` ⇒ a DW map of order ``n`` (the swap is an
 involution, ``map² = I₄``), and composing twists composes the permutations
 (``twistedCylinder(φ∘φ) = map(φ)²``).
 
+The order-3 stretch lands on the minimal 7-vertex (Möbius) torus, whose
+multiplier automorphism ``i ↦ 2i`` (mod 7) is an order-3 rotation that 3-cycles
+the three non-trivial holonomy classes (``map³ = I₄``, ``map² ≠ I₄``). The swap
+and this 3-cycle together generate the full ``S₃ ≅ SL(2, ℤ₂)`` of holonomy-class
+permutations — the realizable monodromy image, end to end.
+
 The Dehn twist ``T = [[1,1],[0,1]]`` is *not* realizable this way — it is
 infinite-order, hence not a finite-order simplicial automorphism of any fixed
 triangulation. That is exactly why the map image was stuck at ``{I₄}``: only the
@@ -98,6 +104,33 @@ def _torus():
 # (0, 4, 8) and pairs (1,3), (2,6), (5,7).
 _SWAP = [v * 3 + u for u in range(3) for v in range(3)]
 _IDENTITY = list(range(9))
+
+
+# The minimal 7-vertex triangulation of T² (the Möbius torus): the two ℤ₇-orbits
+# of {0,1,3} and {0,2,3} under i ↦ i+1 (14 triangles, 21 edges, every vertex pair
+# an edge). Its multiplier automorphisms i ↦ m·i (m a unit mod 7) act on
+# H¹(T²;ℤ₂): i ↦ 2i has order 3 (2³ ≡ 1 mod 7) and is an order-3 rotation that
+# 3-cycles the three non-trivial holonomy classes — the order-3 element the 3×3
+# product torus (which realizes only the order-2 swap) cannot carry.
+_SEVEN_VERTEX_TRIANGLES = sorted({
+    tuple(sorted(((i) % 7, (i + step) % 7, (i + 3) % 7)))
+    for i in range(7) for step in (1, 2)})
+
+
+def _seven_vertex_torus():
+    signature = tessera.Signature(2, tessera.Lorentzian)
+    metric = tessera.Metric(True, signature)
+    spacetime = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                                  tessera.PREFERRED, None)
+    vertices = [spacetime.createVertex(i) for i in range(7)]
+    for triangle in _SEVEN_VERTEX_TRIANGLES:
+        spacetime.createSimplex([vertices[i] for i in triangle])
+    return spacetime
+
+
+def _multiplier(m, n):
+    """The multiplier automorphism i ↦ m·i (mod n)."""
+    return [(m * i) % n for i in range(n)]
 
 
 def _top_triangles(spacetime):
@@ -240,10 +273,21 @@ def _oracle_matrix(triangles, phi):
     return matrix
 
 
-def _map(phi, cocycle=Cocycle.Trivial):
-    """The DW map of the φ-twisted T² cylinder, as a numpy array."""
+def _twisted_map(surface, phi, cocycle=Cocycle.Trivial):
+    """The DW map of the φ-twisted cylinder over a surface, as a numpy array."""
     return np.asarray(DijkgraafWitten(
-        Cobordism.twistedCylinder(_torus(), phi), cocycle).map())
+        Cobordism.twistedCylinder(surface, phi), cocycle).map())
+
+
+def _map(phi, cocycle=Cocycle.Trivial):
+    """The DW map of the φ-twisted T² (3×3 product torus) cylinder."""
+    return _twisted_map(_torus(), phi, cocycle)
+
+
+def _permutation_from_matrix(matrix):
+    """A 0/1 permutation matrix as a {row: column} dict."""
+    rounded = np.round(np.asarray(matrix).real).astype(int)
+    return {r: int(np.argmax(rounded[r])) for r in range(rounded.shape[0])}
 
 
 # --------------------------------------------------------------------------- #
@@ -425,6 +469,83 @@ class TestGuards(unittest.TestCase):
         circle = _build(_circle())
         with self.assertRaises((ValueError, RuntimeError)):
             Cobordism.twistedCylinder(circle, [0, 1, 2])
+
+
+class TestOrderThreeRotation(unittest.TestCase):
+    """The stretch goal: an order-3 rotation 3-cycles the holonomy classes."""
+
+    ROTATION = _multiplier(2, 7)  # i ↦ 2i, order 3 (2³ ≡ 1 mod 7)
+
+    def test_seven_vertex_torus_is_a_torus(self):
+        # b = (1, 2, 1): a genuine T², so Z(T²) is again 4-dimensional.
+        chain = cobordism.ChainComplex.fromSpacetime(_seven_vertex_torus())
+        self.assertEqual(chain.bettiNumbers(), [1, 2, 1])
+
+    def test_rotation_map_is_an_order_three_three_cycle(self):
+        matrix = _twisted_map(_seven_vertex_torus(), self.ROTATION).real
+        self.assertFalse(np.allclose(matrix, np.eye(4)))  # ≠ I₄
+        # Order exactly 3: map³ = I₄ but map² ≠ I₄ and map ≠ I₄.
+        np.testing.assert_allclose(np.linalg.matrix_power(matrix, 3),
+                                   np.eye(4), atol=1e-9)
+        self.assertFalse(np.allclose(matrix @ matrix, np.eye(4)))
+        # Fixes the trivial class [0]; the three non-trivial classes form a
+        # single 3-cycle (none fixed).
+        self.assertAlmostEqual(matrix[0, 0], 1.0, places=9)
+        perm = _permutation_from_matrix(matrix)
+        self.assertEqual(perm[0], 0)
+        self.assertEqual(sorted(perm[i] for i in (1, 2, 3)), [1, 2, 3])
+        self.assertTrue(all(perm[i] != i for i in (1, 2, 3)))
+
+    def test_rotation_map_matches_independent_numpy_oracle(self):
+        oracle = _oracle_matrix(_SEVEN_VERTEX_TRIANGLES, self.ROTATION)
+        np.testing.assert_allclose(
+            _twisted_map(_seven_vertex_torus(), self.ROTATION), oracle, atol=1e-9)
+
+    def test_rotation_map_is_a_unitary_permutation(self):
+        matrix = _twisted_map(_seven_vertex_torus(), self.ROTATION)
+        np.testing.assert_allclose(matrix.conj().T @ matrix, np.eye(4), atol=1e-9)
+        real = matrix.real
+        self.assertTrue(np.all(np.isclose(real, 0) | np.isclose(real, 1)))
+
+    def test_translation_acts_trivially(self):
+        # i ↦ i+1 is a simplicial automorphism but isotopic to the identity, so
+        # it acts trivially on H¹ → DW map = I₄ (a negative control: not every
+        # automorphism twists the map).
+        translation = [(i + 1) % 7 for i in range(7)]
+        np.testing.assert_allclose(
+            _twisted_map(_seven_vertex_torus(), translation), np.eye(4),
+            atol=1e-9)
+
+
+class TestSwapAndRotationGenerateS3(unittest.TestCase):
+    """swap (order 2) + 3-cycle (order 3) generate S₃ ≅ SL(2, ℤ₂)."""
+
+    def test_generate_the_full_symmetric_group_on_nontrivial_classes(self):
+        # Read both permutations straight off the realized DW maps (the swap from
+        # the 3×3 product torus, the 3-cycle from the 7-vertex torus).
+        swap = _permutation_from_matrix(_map(_SWAP))
+        rotation = _permutation_from_matrix(
+            _twisted_map(_seven_vertex_torus(), _multiplier(2, 7)))
+        # Both fix the trivial class [0] and permute {[a], [b], [a+b]}.
+        self.assertEqual((swap[0], rotation[0]), (0, 0))
+
+        def compose(f, g):
+            return {i: f[g[i]] for i in range(4)}
+
+        identity = {i: i for i in range(4)}
+        group = {tuple(sorted(identity.items()))}
+        frontier = [identity]
+        while frontier:
+            element = frontier.pop()
+            for generator in (swap, rotation):
+                product = compose(generator, element)
+                key = tuple(sorted(product.items()))
+                if key not in group:
+                    group.add(key)
+                    frontier.append(product)
+        # The realizable monodromy permutations are all of S₃ (order 6) on the
+        # three non-trivial holonomy classes — the full SL(2, ℤ₂).
+        self.assertEqual(len(group), 6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The post-#191 realizability sweep showed the realizable Dijkgraaf–Witten 2-boundary **map image was a single point, `{I₄}`**: the only buildable `T²→T²` cobordism was the trivial product cylinder (`→` identity), so "DW-representable" collapsed to "`U = I₄`" and the realizability-trend question was degenerate. This breaks the degeneracy.

`Cobordism::twistedCylinder(sigma, phi)` builds the **φ-twisted product cobordism** `Σ×[0,T] : Σ → Σ` whose two boundary copies of the surface `Σ` are identified through a finite-order **simplicial automorphism** `φ`. The ordinary product cylinder that `glue`/`selfGlue` produce always uses the order-preserving (identity) identification — the single home of the `→ I₄` collapse. Threading `φ` through the seam instead makes the interior monodromy from the bottom boundary to the top boundary equal `φ`, so `DijkgraafWitten::map()` returns the permutation `φ` induces on the holonomy classes `Z(Σ) = ℂ[H¹(Σ;ℤ₂)]`.

**Construction** (reuses the Eilenberg–Zilber prism + `buildSpacetime`/glue machinery — no parallel stack): three stacked copies of `Σ` (levels 0,1,2 at vertex ids `x`, `|V|+x`, `2|V|+x`). The level-0→1 prism is the ordinary product `Σ×[0,1]`; the level-1→2 prism is the same product with its lower face glued to the shared seam through `φ` (the level-1 copy of `φ(x)` carries `x`'s seam slot). Because `φ` is a simplicial automorphism the two prisms induce the *same* triangulation on the seam, so it closes up; the seam (level 1) is interior and `∂W` is the two `Σ` copies at levels 0 and 2 (≥ 3 layers, so no top simplex touches both boundaries).

**Realized maps.**

- **Swap (order 2).** On the symmetric square-product torus `T² = S¹×S¹` (`SimplicialProduct(∂Δ², ∂Δ²)`, 9 vertices) the coordinate-swap `φ:(x,y)↦(y,x)` (`φ mod 2 = S = [[0,1],[1,0]]`) gives the non-identity `4×4` permutation `[[1,0,0,0],[0,0,1,0],[0,1,0,0],[0,0,0,1]]` — it fixes `[0]` (index 0) and `[a+b]` (index 3) and transposes `[a]↔[b]` (indices 1,2). Unitary, a genuine 0/1 permutation, an involution (`map² = I₄`).
- **3-cycle (order 3, stretch).** On the minimal 7-vertex (Möbius) torus the multiplier automorphism `i↦2i (mod 7)` is an order-3 rotation whose map is an exact 3-cycle of the three non-trivial classes (`map³ = I₄`, `map² ≠ I₄`).
- **S₃.** The swap and the 3-cycle together generate the full `S₃ ≅ SL(2,ℤ₂)` of holonomy-class permutations (verified by group closure). The realizable image is now all of `S₃` (≥ 2 distinct unitaries beyond the point `{I₄}`).

Each map is asserted against an **independent numpy GF(2) holonomy oracle** that reimplements the class-indexing convention through a separate code path. The translation `i↦i+1` is a negative control (acts trivially → `I₄`).

**Why the Dehn twist is out.** `T = [[1,1],[0,1]]` is infinite-order, so it is *not* a finite-order simplicial automorphism of any fixed triangulation — which is exactly why the map image was stuck at `{I₄}`. Only the finite-order modular elements (orders 2,3,4,6) are simplicially realizable; this is stated in the code/docs, not forced.

Closes #192.

## Test plan

- [x] `twistedCylinder(identity)` map `== I₄` (cross-check vs the trivial product cylinder).
- [x] `twistedCylinder(swap)` map is the exact non-identity `4×4` permutation, asserted against an independent numpy GF(2) holonomy oracle (and `≠ I₄` — the headline).
- [x] map is unitary and a genuine 0/1 permutation in the holonomy basis; fixes the trivial class.
- [x] Functoriality: `φ` of order `n` ⇒ DW map of order `n` (`map² = I₄` for the swap, `map³ = I₄` for the rotation); composing twists composes the permutations.
- [x] Order-3 stretch on the 7-vertex torus (3-cycle), and swap + 3-cycle generate `S₃ ≅ SL(2,ℤ₂)`.
- [x] `b₁` / holonomy-class cross-checks (`boundaryDimensions == [4,4]`, `betti == [1,2,1,0]`, genuine `T²→T²` cobordism, two `T²` boundary components).
- [x] Validation guards (non-permutation `phi`, non-automorphism `phi`, non-surface `Σ`, wrong-length `phi`).
- [x] Full `pytest tests/cobordism` green locally, capped to 10 CPUs: **439 passed, 1 skipped, 719 subtests passed** (28 new in `test_twisted_cylinder_python.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
