### PR TITLE
feat(cobordism): free interior connectivity search in the realizability engine (beyond cone growth)

### DIFF
--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -32,7 +32,7 @@
 #include "cobordism/HodgeLaplacian.h"
 
 // === tessera subsystem ns fwd-decls ===
-namespace tessera::mesh { class Edge; }
+namespace tessera::mesh { class Edge; class Vertex; class Simplex; }
 namespace tessera::spacetime { class Spacetime; }
 namespace tessera::cobordism {
 using namespace ::tessera::spacetime;
@@ -236,6 +236,56 @@ class EigenstateSynthesis {
     /// 1-complex, top cells of \f$ <3 \f$ vertices), leaving the complex unchanged.
     bool growInterior(std::uint64_t seed);
 
+    // === Free interior connectivity (general growth primitive, #200) ===
+
+    /// Add a fresh interior vertex with an **arbitrary** specified set of incident
+    /// simplices — the cone-free generalization of `growInterior`. Each entry of
+    /// `incidentSimplices` is a set of **existing** vertex ids; the new vertex
+    /// together with that set forms one new simplex, whose 1-skeleton (every
+    /// pairwise edge) is materialized. So a singleton entry \f$ \{u\} \f$ wires the
+    /// new vertex to \f$ u \f$ by an edge, and the \f$ d \f$ facets of a top cell
+    /// reproduce that cell's cone connectivity — coning is one special case.
+    ///
+    /// The new vertex takes the largest id (it appends last in sorted-id order, so
+    /// the boundary-support \f$ \psi \f$ prefix is preserved). The move is **purely
+    /// additive** (nothing is removed) and validates **only** the two invariants
+    /// the experiment allows: (a) the result is a valid downward-closed abstract
+    /// simplicial complex (every pair within each new simplex carries an edge), and
+    /// (b) the pinned boundary \f$ \partial W \f$ is **bit-exact** untouched (same
+    /// edge set, same weights/phases). **No** manifold / pseudomanifold /
+    /// orientability / purity / topology constraint is imposed. Re-captures the
+    /// operator and the interior/boundary partition.
+    ///
+    /// Returns `false`, leaving the complex **unchanged** (rolled back), if a spec
+    /// is empty, references a missing vertex, repeats a vertex, or the attach would
+    /// perturb \f$ \partial W \f$. Because only the k=0 graph Laplacian's edges feed
+    /// `residual()`, wiring the interior vertex by edges (singleton specs) is always
+    /// boundary-safe: a new edge to a brand-new vertex creates no new top cell and
+    /// changes no facet count among the pinned boundary.
+    bool attachInteriorVertex(
+        const std::vector<std::vector<std::uint64_t>> &incidentSimplices);
+
+    /// Undo the most recent `attachInteriorVertex` (LIFO): remove the simplices
+    /// and edges it created and the interior vertex it added, restoring the
+    /// complex bit-exactly, and re-capture. Returns `false` if there is no attach
+    /// to undo. Lets a connectivity search try a candidate, score it, and roll
+    /// back to try the next.
+    bool detachLastInteriorVertex();
+
+    /// All vertex ids in the complex, sorted ascending — the candidate pool a
+    /// connectivity search wires a fresh interior vertex into.
+    [[nodiscard]] std::vector<std::uint64_t> vertexIds() const;
+
+    /// The boundary (\f$ \partial W \f$) vertex ids, sorted ascending — the
+    /// vertices on a codim-one face of exactly one top cell. A "boundary-star"
+    /// connectivity candidate wires the new vertex to these.
+    [[nodiscard]] std::vector<std::uint64_t> boundaryVertexIds() const;
+
+    /// The top cells as sorted vertex-id tuples (the \f$ d+1 \f$-vertex simplices).
+    /// The "cone-equivalent" connectivity candidate wires the new vertex to one of
+    /// these cells' vertices, reproducing `growInterior`'s 1-skeleton.
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> topCells() const;
+
   private:
     std::shared_ptr<Spacetime> st_;
     int k_{0};  // the Hodge degree of L_k that apply()/residual() score against
@@ -261,6 +311,24 @@ class EigenstateSynthesis {
     std::vector<std::size_t> interiorEdgeIdx_{};
     std::vector<std::size_t> boundaryEdgeIdx_{};
     std::size_t interiorVertexCount_{0};  // vertices on no boundary face
+    // Boundary (∂W) vertex ids, sorted ascending — persisted from
+    // classifyBoundary() for boundaryVertexIds().
+    std::vector<std::uint64_t> boundaryVertexIdsSorted_{};
+
+    // One attachInteriorVertex() record, for exact rollback (detach) and for the
+    // boundary-fixed connectivity search. Raw pointers owned by the Spacetime
+    // (stable-address storage), valid for its lifetime (kept alive via st_).
+    struct Attachment {
+      ::tessera::mesh::Vertex *vertex{nullptr};
+      std::vector<::tessera::mesh::Edge *> createdEdges{};
+      std::vector<::tessera::mesh::Simplex *> createdSimplices{};
+    };
+    std::vector<Attachment> attachments_{};
+
+    // Remove everything an attachment created (its simplices, then its freshly
+    // inserted edges, then its vertex) — the inverse of attachInteriorVertex's
+    // mesh mutation. Does not re-capture (callers do).
+    void rollbackAttachment(const Attachment &att);
 
     // (Re)build order_, cellOrdering_ and edges_ from the live complex (the
     // k-cell order at k_, plus the tunable edges). Called at construction and

--- a/include/cobordism/RealizabilityOracle.h
+++ b/include/cobordism/RealizabilityOracle.h
@@ -118,6 +118,20 @@ class Cochain;
 /// the returned `witness` is that realized \f$ W_{AB} \f$.
 class RealizabilityOracle {
   public:
+    /// How the interior fill grows when a pass cannot reach \f$ r<\epsilon \f$.
+    enum class GrowthMode {
+      /// The historical biased move: cone a fresh interior vertex into one top
+      /// cell (`EigenstateSynthesis::growInterior`), wiring it to exactly the
+      /// \f$ d+1 \f$ vertices of that cell.
+      Cone,
+      /// **Free interior connectivity** (#200): at each growth step search a
+      /// bounded set of candidate interior connectivities for the new vertex
+      /// (which existing vertices it wires to), score each by the residual it
+      /// reaches after the weight/phase optimization, and keep the best — so the
+      /// realized topology is what the residual selects, not a cone artifact.
+      FreeConnectivity
+    };
+
     /// The oracle's verdict on \f$ U \f$: the realizability decision, the
     /// residual (the obstruction floor when non-realizable), the witness state
     /// and bulk, and the interior complexity reached.
@@ -142,6 +156,19 @@ class RealizabilityOracle {
       /// Boundary-fixed cones applied during the fill (== `interiorVertexCount`
       /// for a single-top-cell seed; reported for the cone-and-retry trace).
       int conesApplied{0};
+      /// Interior tunable edges in the realized witness — the **emergent
+      /// connectivity** size. Cone growth adds exactly \f$ d+1 \f$ per vertex;
+      /// free-connectivity growth can differ (this is the headline observable).
+      std::size_t interiorEdgeCount{0};
+      /// Candidate interior connectivities **scored per growth step**
+      /// (`FreeConnectivity` only; 0 under `Cone`). The bounded breadth of the
+      /// connectivity search.
+      int connectivityCandidates{0};
+      /// The full per-step incidence space the candidates are pruned from:
+      /// \f$ 2^{N}-1 \f$ nonempty vertex subsets at the last growth step (`N` =
+      /// vertices then). `connectivityCandidates` \f$ \ll \f$ this documents the
+      /// cap — the search is bounded, not exhaustive, and logs what it skips.
+      std::size_t connectivitySpaceSize{0};
       /// The witness state: the realized full Laplacian eigenvector on
       /// \f$ W_{AB} \f$ (unit norm, length = the bulk's vertex count), whose
       /// first \f$ d_A d_B \f$ components are the output-boundary block matching
@@ -173,13 +200,21 @@ class RealizabilityOracle {
     /// @param maxCones boundary-fixed interior cones to try (0 ⇒ decide at the
     ///                 seed interior complexity — the bare obstruction floor).
     /// @param seed     RNG seed for the restart draws (reproducible).
+    /// @param mode      `Cone` (default) keeps the historical cone-only growth;
+    ///                  `FreeConnectivity` searches interior connectivity at each
+    ///                  growth step (the new vertex's incidence is a free variable).
+    /// @param connectivityCandidates  bounded number of candidate connectivities
+    ///                  scored per growth step under `FreeConnectivity` (ignored
+    ///                  under `Cone`). The candidate set is documented + logged.
     /// @throws std::invalid_argument if \f$ U \f$'s size \f$ \neq d_A d_B \f$, a
     ///   dimension is non-positive, or the bulk has fewer vertices than
     ///   \f$ d_A d_B \f$ (no room for the output-boundary support).
     [[nodiscard]] Verdict decide(const std::vector<std::complex<double>> &U,
                                  int dA, int dB, double epsilon = 1e-10,
                                  int restarts = 64, int maxCones = 4,
-                                 std::uint64_t seed = 0);
+                                 std::uint64_t seed = 0,
+                                 GrowthMode mode = GrowthMode::Cone,
+                                 int connectivityCandidates = 8);
 
     /// Decide whether a target **boundary harmonic** \f$ k \f$-form (\f$ k =
     /// \texttt{target.degree()} \f$, the \f$ k=1 \f$ DW setting) is realizable on
@@ -227,19 +262,58 @@ class RealizabilityOracle {
     // by sorted vertex-id tuple) carry the fixed target amplitudes; the remaining
     // (interior) k-cells carry free auxiliary amplitudes. Drives r(psi) -> 0 by
     // varying the interior edge weights (and, at k=0 only, phases) via `es` plus
-    // the auxiliary amplitudes; grows the interior (boundary-fixed Pachner add)
-    // and retries while unconverged and within `maxCones`, re-identifying the
-    // boundary/interior partition on the new k-cell order after each grow. Leaves
-    // `es`'s complex realized at the best parameters, writes the realized unit
-    // witness state to `witnessOut`, records the cones applied, and returns the
-    // best residual (the floor if it never converges). Reuses LevenbergMarquardt
-    // exactly as GeometrySynthesizer::runOptimizer does.
+    // the auxiliary amplitudes; grows the interior (`mode`: cone, or the bounded
+    // free-connectivity search) and retries while unconverged and within
+    // `maxCones`, re-identifying the boundary/interior partition on the new
+    // k-cell order after each grow. Leaves `es`'s complex realized at the best
+    // parameters, writes the realized unit witness state to `witnessOut`, records
+    // the cones applied and (free mode) the last step's candidate breadth into
+    // `candidatesOut` / `spaceSizeOut`, and returns the best residual (the floor
+    // if it never converges). Reuses LevenbergMarquardt exactly as
+    // GeometrySynthesizer::runOptimizer does.
     [[nodiscard]] double fillInterior(
         EigenstateSynthesis &es,
         const std::map<std::vector<std::uint64_t>, std::complex<double>>
             &pinnedByTuple,
         double epsilon, int restarts, int maxCones, std::uint64_t seed,
-        std::vector<std::complex<double>> &witnessOut, int &conesApplied) const;
+        GrowthMode mode, int connectivityCandidates,
+        std::vector<std::complex<double>> &witnessOut, int &conesApplied,
+        int &candidatesOut, std::size_t &spaceSizeOut) const;
+
+    // One fixed-complex optimization pass over the current `es`: the
+    // multi-restart bounded Levenberg–Marquardt on r(psi) for the target encoded
+    // by `pinnedByTuple`, seeded by `passSeed`. Leaves `es` realized at the best
+    // parameters, writes the realized unit witness to `witnessOut`, and returns
+    // the best residual. Extracted from the fill loop so the connectivity search
+    // can score a candidate complex with exactly the same machinery.
+    [[nodiscard]] double optimizePass(
+        EigenstateSynthesis &es,
+        const std::map<std::vector<std::uint64_t>, std::complex<double>>
+            &pinnedByTuple,
+        double epsilon, int restarts, std::uint64_t passSeed,
+        std::vector<std::complex<double>> &witnessOut) const;
+
+    // One free-connectivity growth step: generate a bounded set of candidate
+    // interior connectivities for a fresh interior vertex (which existing
+    // vertices it wires to), score each by `optimizePass` after attaching it,
+    // detach, and commit the best. Reports the candidate breadth scored vs. the
+    // full 2^N-1 incidence space (logged — no silent cap) into `candidatesOut` /
+    // `spaceSizeOut`. Returns true if a vertex was committed (falls back to the
+    // cone move if no candidate could attach).
+    [[nodiscard]] bool growBestConnectivity(
+        EigenstateSynthesis &es,
+        const std::map<std::vector<std::uint64_t>, std::complex<double>>
+            &pinnedByTuple,
+        double epsilon, int restarts, std::uint64_t seed, int nCandidates,
+        int &candidatesOut, std::size_t &spaceSizeOut) const;
+
+    // The bounded, documented candidate-connectivity generator: deterministic
+    // anchors (cone-equivalent — the d+1 vertices of a top cell; full-star — all
+    // vertices; boundary-star — all boundary vertices) plus reproducible random
+    // vertex subsets, deduplicated and capped at `nCandidates`. Each candidate is
+    // the set of existing vertices the new interior vertex wires to by an edge.
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> connectivityCandidates(
+        const EigenstateSynthesis &es, int nCandidates, std::uint64_t seed) const;
 };
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -421,7 +421,35 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "vertex order and interior/boundary partition, so order() grows by one "
            "(extend psi on the new apex, appended last in sorted-id order) and "
            "numInteriorEdges() grows. Returns False if no top cell can be "
-           "subdivided (e.g. a 1-complex), leaving the complex unchanged.");
+           "subdivided (e.g. a 1-complex), leaving the complex unchanged.")
+      // ----- Free interior connectivity (general growth primitive, #200) -----
+      .def("attachInteriorVertex", &EigenstateSynthesis::attachInteriorVertex,
+           py::arg("incident_simplices"),
+           "Add a fresh interior vertex with an arbitrary specified set of "
+           "incident simplices — the cone-free generalization of growInterior. "
+           "incident_simplices is a list of vertex-id lists; the new vertex + each "
+           "such set forms one new simplex (its full 1-skeleton is materialized), "
+           "so a singleton [u] wires the new vertex to u by an edge and the d "
+           "facets of a top cell reproduce coning. The new vertex takes the "
+           "largest id. Validates ONLY (a) a valid downward-closed complex and "
+           "(b) the pinned boundary dW bit-exact; no manifold/topology constraint. "
+           "Returns False, leaving the complex unchanged, on an invalid spec "
+           "(missing/repeated vertex, empty) or any perturbation of dW.")
+      .def("detachLastInteriorVertex",
+           &EigenstateSynthesis::detachLastInteriorVertex,
+           "Undo the most recent attachInteriorVertex (LIFO): remove its created "
+           "simplices/edges and the interior vertex, restoring the complex bit-"
+           "exactly, and re-capture. Returns False if there is no attach to undo. "
+           "Lets a search try a candidate connectivity, score it, and roll back.")
+      .def("vertexIds", &EigenstateSynthesis::vertexIds,
+           "All vertex ids, sorted — the candidate pool a connectivity search "
+           "wires a fresh interior vertex into.")
+      .def("boundaryVertexIds", &EigenstateSynthesis::boundaryVertexIds,
+           "The boundary (dW) vertex ids, sorted — the vertices on a codim-one "
+           "face of exactly one top cell (a 'boundary-star' candidate).")
+      .def("topCells", &EigenstateSynthesis::topCells,
+           "The top cells as sorted vertex-id tuples (the d+1-vertex simplices); "
+           "wiring the new vertex to one reproduces growInterior's 1-skeleton.");
 
   // ----- §4b cone-and-retry synthesis loop → geo(ψ) (#134) -----
   py::class_<GeometrySynthesizer> gs(m, "GeometrySynthesizer",
@@ -531,6 +559,17 @@ auxiliary amplitudes the fill solves for. The caller assembles the bulk and pins
 its boundary edges (Spacetime is built/pinned outside the synthesis classes);
 decide() realizes the held bulk in place and returns it as the witness.)doc");
 
+  py::enum_<RealizabilityOracle::GrowthMode>(ro, "GrowthMode",
+      "How the interior fill grows when a pass cannot reach r < epsilon.")
+      .value("CONE", RealizabilityOracle::GrowthMode::Cone,
+             "Cone a fresh interior vertex into one top cell (the historical "
+             "biased move, wiring it to exactly the d+1 cell vertices).")
+      .value("FREE_CONNECTIVITY",
+             RealizabilityOracle::GrowthMode::FreeConnectivity,
+             "Free interior connectivity (#200): search a bounded set of candidate "
+             "interior connectivities for the new vertex at each growth step and "
+             "keep the one reaching the lowest residual — topology is emergent.");
+
   py::class_<RealizabilityOracle::Verdict>(ro, "Verdict",
       "The oracle's verdict on U: the realizability decision, the residual (the "
       "obstruction floor when non-realizable), the realized witness state and "
@@ -554,6 +593,20 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
                     "complexity, the §4b (|V|,|E|) analogue under fixed ends).")
       .def_readonly("cones_applied", &RealizabilityOracle::Verdict::conesApplied,
                     "Boundary-fixed cones applied during the interior fill.")
+      .def_readonly("interior_edge_count",
+                    &RealizabilityOracle::Verdict::interiorEdgeCount,
+                    "Interior tunable edges in the realized witness — the emergent "
+                    "connectivity size. Cone growth adds exactly d+1 per vertex; "
+                    "free-connectivity growth can differ (the headline observable).")
+      .def_readonly("connectivity_candidates",
+                    &RealizabilityOracle::Verdict::connectivityCandidates,
+                    "Candidate interior connectivities scored per growth step "
+                    "(FREE_CONNECTIVITY only; 0 under CONE).")
+      .def_readonly("connectivity_space_size",
+                    &RealizabilityOracle::Verdict::connectivitySpaceSize,
+                    "Full per-step incidence space (2^N - 1 nonempty vertex "
+                    "subsets) the candidates are pruned from at the last growth "
+                    "step — connectivity_candidates << this documents the bound.")
       .def_readonly("state", &RealizabilityOracle::Verdict::state,
                     "The witness state: the realized unit Laplacian eigenvector on "
                     "W_AB (length = the bulk's vertex count); its first dA*dB "
@@ -574,14 +627,19 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
       .def("decide", &RealizabilityOracle::decide, py::arg("U"), py::arg("dA"),
            py::arg("dB"), py::arg("epsilon") = 1e-10, py::arg("restarts") = 64,
            py::arg("max_cones") = 4, py::arg("seed") = 0,
+           py::arg("growth_mode") = RealizabilityOracle::GrowthMode::Cone,
+           py::arg("connectivity_candidates") = 8,
            "Decide whether the dA x dB operator U (flat row-major) is realizable "
            "as a bulk cobordism: bend it to vec(U), fill the pinned-boundary "
            "interior to drive the §4b residual to zero (multi-restart "
            "Levenberg-Marquardt over the interior weights/phases + auxiliary "
            "amplitudes, growing the interior up to max_cones times), and return "
-           "the Verdict. Realizes the held bulk in place. Raises if U.size() != "
-           "dA*dB, a dimension is non-positive, or the bulk has fewer vertices "
-           "than dA*dB.")
+           "the Verdict. growth_mode=CONE (default) keeps the historical cone-only "
+           "growth; growth_mode=FREE_CONNECTIVITY searches connectivity_candidates "
+           "interior connectivities per growth step and keeps the best by residual "
+           "(the new vertex's incidence is a free variable; topology is emergent). "
+           "Realizes the held bulk in place. Raises if U.size() != dA*dB, a "
+           "dimension is non-positive, or the bulk has fewer vertices than dA*dB.")
       .def("decideHarmonic", &RealizabilityOracle::decideHarmonic,
            py::arg("target"), py::arg("epsilon") = 1e-10, py::arg("restarts") = 64,
            py::arg("max_cones") = 4, py::arg("seed") = 0,

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -28,6 +28,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -35,6 +36,7 @@
 #include "cobordism/ChainComplex.h"
 #include "mesh/Edge.h"
 #include "mesh/EdgeList.h"
+#include "mesh/Fingerprint.h"
 #include "mesh/Simplex.h"
 #include "mesh/Vertex.h"
 #include "mesh/VertexList.h"
@@ -102,6 +104,7 @@ void EigenstateSynthesis::capture() {
 void EigenstateSynthesis::classifyBoundary() {
   interiorEdgeIdx_.clear();
   boundaryEdgeIdx_.clear();
+  boundaryVertexIdsSorted_.clear();
   interiorVertexCount_ = 0;
   if (!st_) return;
 
@@ -167,6 +170,12 @@ void EigenstateSynthesis::classifyBoundary() {
     if (boundaryVertexIds.find(v->getId()) == boundaryVertexIds.end())
       ++interiorVertexCount_;
   }
+
+  // Persist the boundary vertex set (sorted) for boundaryVertexIds() — the
+  // candidate pool a "boundary-star" connectivity search wires into.
+  boundaryVertexIdsSorted_.assign(boundaryVertexIds.begin(),
+                                  boundaryVertexIds.end());
+  std::sort(boundaryVertexIdsSorted_.begin(), boundaryVertexIdsSorted_.end());
 }
 
 std::vector<cd> EigenstateSynthesis::apply(const std::vector<cd> &psi) const {
@@ -349,6 +358,184 @@ bool EigenstateSynthesis::growInterior(std::uint64_t seed) {
   capture();
   classifyBoundary();
   return true;
+}
+
+// === Free interior connectivity (general growth primitive, #200) ===
+
+void EigenstateSynthesis::rollbackAttachment(const Attachment &att) {
+  // Remove in dependency order: simplices reference edges/vertices, edges
+  // reference vertices. removeVertex also drops any edge still incident to the
+  // vertex, so removing the created edges first (some — among the spec's own
+  // vertices — are not incident to the new vertex) leaves only the vertex.
+  for (auto *s : att.createdSimplices)
+    if (s != nullptr) st_->removeSimplex(s);
+  for (auto *e : att.createdEdges)
+    if (e != nullptr) st_->removeEdge(e);
+  if (att.vertex != nullptr) st_->removeVertex(att.vertex);
+}
+
+bool EigenstateSynthesis::attachInteriorVertex(
+    const std::vector<std::vector<std::uint64_t>> &incidentSimplices) {
+  if (!st_) return false;
+  if (incidentSimplices.empty()) return false;  // would isolate the new vertex
+
+  // The spec may reference only existing vertices. Build id -> Vertex* and the
+  // current max id in one pass.
+  std::unordered_map<std::uint64_t, ::tessera::mesh::Vertex *> idToVert;
+  std::uint64_t maxId = 0;
+  bool anyVert = false;
+  for (const auto v : st_->getVertexList()->toVector()) {
+    if (v == nullptr) continue;
+    idToVert.emplace(v->getId(), v);
+    maxId = anyVert ? std::max(maxId, v->getId()) : v->getId();
+    anyVert = true;
+  }
+  if (!anyVert) return false;
+  for (const auto &spec : incidentSimplices) {
+    if (spec.empty()) return false;  // a face needs >= 1 existing vertex
+    // spec ∪ {new vertex} is one simplex; the Fingerprint caps a simplex at kMax
+    // vertices (createSimplex would otherwise throw mid-mutation).
+    if (spec.size() + 1 > ::tessera::mesh::kMax) return false;
+    std::unordered_set<std::uint64_t> seen;
+    for (const std::uint64_t id : spec) {
+      if (idToVert.find(id) == idToVert.end()) return false;  // dangling ref
+      if (!seen.insert(id).second) return false;              // duplicate
+    }
+  }
+
+  // Snapshot the pinned boundary (id-pair -> (w, theta)) for the bit-exact check.
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::pair<double, double>>
+      boundaryBefore;
+  for (const auto i : boundaryEdgeIdx_) {
+    const std::uint64_t a = edges_[i]->getSource()->getId();
+    const std::uint64_t b = edges_[i]->getTarget()->getId();
+    boundaryBefore[{std::min(a, b), std::max(a, b)}] = {
+        edges_[i]->getSquaredLength(), edges_[i]->getPhase()};
+  }
+
+  // Fresh interior vertex with the largest id (sorts last; preserves the
+  // boundary-support psi prefix). Mirror GeometrySynthesizer::coneInVertex's
+  // maxId+1 idiom rather than the vertexIdCounter, which can be stale relative
+  // to explicitly-id'd fixture vertices.
+  Attachment att;
+  ::tessera::mesh::Vertex *vnew = st_->createVertex(maxId + 1);
+  att.vertex = vnew;
+
+  // Create one simplex per spec; createSimplexTracked materializes the simplex's
+  // full 1-skeleton (every pairwise edge) and reports the freshly inserted edges
+  // so detach can undo exactly.
+  for (const auto &spec : incidentSimplices) {
+    ::tessera::mesh::VertexPtrs verts;
+    verts.reserve(spec.size() + 1);
+    for (const std::uint64_t id : spec) verts.push_back(idToVert[id]);
+    verts.push_back(vnew);
+    const auto res = st_->createSimplexTracked(verts);
+    if (res.created && res.simplex != nullptr)
+      att.createdSimplices.push_back(res.simplex);
+    for (const auto e : res.newEdges)
+      if (e != nullptr) att.createdEdges.push_back(e);
+  }
+
+  // Re-capture so the operator / partition track the grown complex.
+  laplacian_ = HodgeLaplacian(st_);
+  capture();
+  classifyBoundary();
+
+  // Validate the ONLY two invariants the experiment allows.
+  // (a) Valid downward-closed complex: every pair within each new simplex carries
+  //     an edge (createSimplexTracked guarantees this — assert it as a real gate).
+  std::set<std::pair<std::uint64_t, std::uint64_t>> edgeKeys;
+  for (const auto e : edges_) {
+    const std::uint64_t a = e->getSource()->getId();
+    const std::uint64_t b = e->getTarget()->getId();
+    edgeKeys.insert({std::min(a, b), std::max(a, b)});
+  }
+  bool valid = true;
+  for (const auto &spec : incidentSimplices) {
+    std::vector<std::uint64_t> ids(spec.begin(), spec.end());
+    ids.push_back(vnew->getId());
+    for (std::size_t i = 0; valid && i + 1 < ids.size(); ++i)
+      for (std::size_t j = i + 1; valid && j < ids.size(); ++j) {
+        const std::pair<std::uint64_t, std::uint64_t> key{
+            std::min(ids[i], ids[j]), std::max(ids[i], ids[j])};
+        if (edgeKeys.find(key) == edgeKeys.end()) valid = false;
+      }
+  }
+  // (b) Pinned boundary dW bit-exact: same edge set, same weights/phases.
+  if (valid) {
+    std::size_t matched = 0;
+    for (const auto i : boundaryEdgeIdx_) {
+      const std::uint64_t a = edges_[i]->getSource()->getId();
+      const std::uint64_t b = edges_[i]->getTarget()->getId();
+      const auto it =
+          boundaryBefore.find({std::min(a, b), std::max(a, b)});
+      if (it == boundaryBefore.end() ||
+          it->second.first != edges_[i]->getSquaredLength() ||
+          it->second.second != edges_[i]->getPhase()) {
+        valid = false;
+        break;
+      }
+      ++matched;
+    }
+    if (matched != boundaryBefore.size()) valid = false;  // a boundary edge vanished
+  }
+
+  if (!valid) {
+    rollbackAttachment(att);
+    laplacian_ = HodgeLaplacian(st_);
+    capture();
+    classifyBoundary();
+    return false;
+  }
+  attachments_.push_back(std::move(att));
+  return true;
+}
+
+bool EigenstateSynthesis::detachLastInteriorVertex() {
+  if (!st_ || attachments_.empty()) return false;
+  const Attachment att = std::move(attachments_.back());
+  attachments_.pop_back();
+  rollbackAttachment(att);
+  laplacian_ = HodgeLaplacian(st_);
+  capture();
+  classifyBoundary();
+  return true;
+}
+
+std::vector<std::uint64_t> EigenstateSynthesis::vertexIds() const {
+  std::vector<std::uint64_t> ids;
+  if (!st_) return ids;
+  for (const auto v : st_->getVertexList()->toVector())
+    if (v != nullptr) ids.push_back(v->getId());
+  std::sort(ids.begin(), ids.end());
+  ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+  return ids;
+}
+
+std::vector<std::uint64_t> EigenstateSynthesis::boundaryVertexIds() const {
+  return boundaryVertexIdsSorted_;
+}
+
+std::vector<std::vector<std::uint64_t>> EigenstateSynthesis::topCells() const {
+  std::vector<std::vector<std::uint64_t>> cells;
+  if (!st_) return cells;
+  const int d = st_->getMetric()->getSignature()->getDimensions();
+  const std::size_t topVerts = (d >= 0) ? static_cast<std::size_t>(d) + 1 : 0;
+  if (topVerts == 0) return cells;
+  for (const auto s : st_->getSimplices()) {
+    if (s == nullptr) continue;
+    if (s->size() != topVerts) continue;
+    std::vector<std::uint64_t> ids;
+    ids.reserve(topVerts);
+    for (const auto v : s->getVertices())
+      if (v != nullptr) ids.push_back(v->getId());
+    if (ids.size() != topVerts) continue;
+    std::sort(ids.begin(), ids.end());
+    cells.push_back(std::move(ids));
+  }
+  std::sort(cells.begin(), cells.end());
+  cells.erase(std::unique(cells.begin(), cells.end()), cells.end());
+  return cells;
 }
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/RealizabilityOracle.cpp
+++ b/src/cobordism/RealizabilityOracle.cpp
@@ -29,9 +29,11 @@
 #include <limits>
 #include <map>
 #include <random>
+#include <set>
 #include <stdexcept>
 #include <vector>
 
+#include "Logger.h"
 #include "cobordism/Cochain.h"
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/LevenbergMarquardt.h"
@@ -61,151 +63,273 @@ std::vector<cd> RealizabilityOracle::bend(const std::vector<cd> &U, int dA,
   return psi;
 }
 
-double RealizabilityOracle::fillInterior(
+double RealizabilityOracle::optimizePass(
     EigenstateSynthesis &es,
     const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
-    int restarts, int maxCones, std::uint64_t seed, std::vector<cd> &witnessOut,
-    int &conesApplied) const {
+    int restarts, std::uint64_t passSeed, std::vector<cd> &witnessOut) const {
   // The U(1) phases enter only the k=0 graph Laplacian; the metric Hodge L_k
   // (k>=1) is assembled from integer boundary maps and real volume weights, so
   // interior phases are not tuned there (they would be wasted search dimensions).
   const bool usePhases = (es.degree() == 0);
+  const std::size_t order = es.order();         // operator dim this pass
+  const std::size_t m = es.numInteriorEdges();  // free interior edge weights
+
+  // Re-identify, on the current k-cell order, which ψ components are pinned
+  // boundary cells (their sorted vertex-id tuple is a key of pinnedByTuple, the
+  // target form on ∂W) vs. free interior cells (auxiliary amplitudes). Growth
+  // changes the k-cell order, so this is rebuilt every pass.
+  const std::vector<std::vector<std::uint64_t>> &cells = es.cellSimplices();
+  std::vector<cd> pinnedValue(order, cd(0.0, 0.0));
+  std::vector<std::size_t> freeIdx;
+  for (std::size_t i = 0; i < order; ++i) {
+    const auto it = pinnedByTuple.find(cells[i]);
+    if (it != pinnedByTuple.end())
+      pinnedValue[i] = it->second;
+    else
+      freeIdx.push_back(i);
+  }
+  const std::size_t nAux = freeIdx.size();
+  const std::size_t nW = m;
+  const std::size_t nTheta = usePhases ? m : 0;
+  const std::size_t nParams = nW + nTheta + 2 * nAux;
+
+  // Assemble ψ from a parameter vector: the boundary cells hold the fixed
+  // target form; the auxiliary amplitudes (interior / coned-in cells) come from
+  // the tail of x (real, imag per free cell).
+  const auto buildPsi = [&pinnedValue, &freeIdx, nW, nTheta,
+                         nAux](const Eigen::VectorXd &x) -> std::vector<cd> {
+    std::vector<cd> psi = pinnedValue;
+    for (std::size_t k = 0; k < nAux; ++k) {
+      const auto re = static_cast<Eigen::Index>(nW + nTheta + 2 * k);
+      psi[freeIdx[k]] = cd(x[re], x[re + 1]);
+    }
+    return psi;
+  };
+
+  // Residual: write the interior weights (and phases at k=0) onto ∂W's
+  // complement (∂W itself is never touched), normalize the assembled ψ, and
+  // return the stacked g = L_kψ - λψ ([Re; Im], length 2·order) whose ‖g‖² is
+  // r(ψ) — the residual the Levenberg–Marquardt loop drives to zero.
+  const auto residual = [&es, &buildPsi, m, nW, usePhases,
+                         order](const Eigen::VectorXd &x) -> Eigen::VectorXd {
+    if (m > 0) {
+      std::vector<double> w(m);
+      for (std::size_t i = 0; i < m; ++i) w[i] = x[static_cast<Eigen::Index>(i)];
+      es.setInteriorWeights(w);
+      if (usePhases) {
+        std::vector<double> th(m);
+        for (std::size_t i = 0; i < m; ++i)
+          th[i] = x[static_cast<Eigen::Index>(nW + i)];
+        es.setInteriorPhases(th);
+      }
+    }
+    std::vector<cd> psi = buildPsi(x);
+    double nrm = 0.0;
+    for (const cd &z : psi) nrm += std::norm(z);
+    if (nrm > 0.0) {
+      const double inv = 1.0 / std::sqrt(nrm);
+      for (cd &z : psi) z *= inv;
+    }
+    const std::vector<cd> Lp = es.apply(psi);
+    cd lam(0.0, 0.0);
+    for (std::size_t i = 0; i < order; ++i) lam += std::conj(psi[i]) * Lp[i];
+    const double lambda = lam.real();
+    Eigen::VectorXd f(static_cast<Eigen::Index>(2 * order));
+    for (std::size_t i = 0; i < order; ++i) {
+      const cd g = Lp[i] - lambda * psi[i];
+      f[static_cast<Eigen::Index>(i)] = g.real();
+      f[static_cast<Eigen::Index>(order + i)] = g.imag();
+    }
+    return f;
+  };
+
+  // Clamp interior weights (and phases at k=0) into the §4b box and the
+  // auxiliary amplitudes into [-kAuxBound, kAuxBound].
+  const auto clamp = [nW, nTheta, nAux](const Eigen::VectorXd &x)
+      -> Eigen::VectorXd {
+    Eigen::VectorXd c = x;
+    for (std::size_t i = 0; i < nW; ++i) {
+      const auto wi = static_cast<Eigen::Index>(i);
+      c[wi] = std::min(std::max(c[wi], kWMin), kWMax);
+    }
+    for (std::size_t i = 0; i < nTheta; ++i) {
+      const auto ti = static_cast<Eigen::Index>(nW + i);
+      c[ti] = std::min(std::max(c[ti], -kThetaBound), kThetaBound);
+    }
+    for (std::size_t k = 0; k < 2 * nAux; ++k) {
+      const auto ai = static_cast<Eigen::Index>(nW + nTheta + k);
+      c[ai] = std::min(std::max(c[ai], -kAuxBound), kAuxBound);
+    }
+    return c;
+  };
+
+  // Sample a restart: w ∈ [kWMin, kWMax], θ ∈ [-π, π], aux ∈ [-1, 1]. Built
+  // once and captured (the single-rng draw convention GeometrySynthesizer uses).
+  std::uniform_real_distribution<double> wDist(kWMin, kWMax);
+  std::uniform_real_distribution<double> tDist(-kPi, kPi);
+  std::uniform_real_distribution<double> aDist(-1.0, 1.0);
+  const auto sample = [nW, nTheta, nAux, wDist, tDist,
+                       aDist](std::mt19937_64 &rng) mutable -> Eigen::VectorXd {
+    Eigen::VectorXd x0(static_cast<Eigen::Index>(nW + nTheta + 2 * nAux));
+    for (std::size_t i = 0; i < nW; ++i)
+      x0[static_cast<Eigen::Index>(i)] = wDist(rng);
+    for (std::size_t i = 0; i < nTheta; ++i)
+      x0[static_cast<Eigen::Index>(nW + i)] = tDist(rng);
+    for (std::size_t k = 0; k < 2 * nAux; ++k)
+      x0[static_cast<Eigen::Index>(nW + nTheta + k)] = aDist(rng);
+    return x0;
+  };
+
+  const LevenbergMarquardt lm(kMaxIterations, epsilon);
+  const LevenbergMarquardt::Result best =
+      lm.multiRestart(residual, clamp, sample, nParams, restarts, passSeed,
+                      epsilon);
+
+  // Leave the complex realized at the best parameters and read off the unit
+  // witness state there (multiRestart leaves `residual` evaluated last at
+  // best.parameters; re-evaluate so the witness ψ matches the live complex).
+  residual(best.parameters);
+  witnessOut = buildPsi(best.parameters);
+  double wn = 0.0;
+  for (const cd &z : witnessOut) wn += std::norm(z);
+  if (wn > 0.0) {
+    const double inv = 1.0 / std::sqrt(wn);
+    for (cd &z : witnessOut) z *= inv;
+  }
+  return best.cost;
+}
+
+std::vector<std::vector<std::uint64_t>>
+RealizabilityOracle::connectivityCandidates(const EigenstateSynthesis &es,
+                                            int nCandidates,
+                                            std::uint64_t seed) const {
+  const std::vector<std::uint64_t> verts = es.vertexIds();
+  const std::vector<std::uint64_t> bverts = es.boundaryVertexIds();
+  const std::vector<std::vector<std::uint64_t>> cells = es.topCells();
+
+  std::set<std::vector<std::uint64_t>> seen;
+  std::vector<std::vector<std::uint64_t>> out;
+  const auto add = [&](std::vector<std::uint64_t> s) {
+    std::sort(s.begin(), s.end());
+    s.erase(std::unique(s.begin(), s.end()), s.end());
+    if (s.empty()) return;
+    if (static_cast<int>(out.size()) >= std::max(nCandidates, 1)) return;
+    if (seen.insert(s).second) out.push_back(std::move(s));
+  };
+
+  // Deterministic anchors, highest priority first:
+  //  (0) cone-equivalent — the d+1 vertices of a top cell (so free-connectivity
+  //      includes the cone move's 1-skeleton and is never worse than it),
+  //  (1) full-star — wire to every existing vertex (maximal connectivity),
+  //  (2) boundary-star — wire to every pinned-boundary vertex.
+  if (!cells.empty())
+    add(cells.front());
+  else
+    add(verts);
+  add(verts);
+  if (!bverts.empty()) add(bverts);
+
+  // Reproducible random vertex subsets (each vertex w.p. 1/2; never empty) fill
+  // the remaining budget, so connectivity is genuinely searched, not fixed.
+  std::mt19937_64 rng(seed);
+  std::uniform_int_distribution<int> coin(0, 1);
+  const int guardMax = 200 * std::max(nCandidates, 1);
+  for (int guard = 0;
+       static_cast<int>(out.size()) < std::max(nCandidates, 1) && guard < guardMax;
+       ++guard) {
+    std::vector<std::uint64_t> s;
+    for (const std::uint64_t u : verts)
+      if (coin(rng) == 1) s.push_back(u);
+    if (s.empty() && !verts.empty())
+      s.push_back(verts[static_cast<std::size_t>(rng() % verts.size())]);
+    add(std::move(s));
+  }
+  return out;
+}
+
+bool RealizabilityOracle::growBestConnectivity(
+    EigenstateSynthesis &es,
+    const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
+    int restarts, std::uint64_t seed, int nCandidates, int &candidatesOut,
+    std::size_t &spaceSizeOut) const {
+  const std::vector<std::uint64_t> verts = es.vertexIds();
+  const std::size_t N = verts.size();
+  if (N == 0) return false;
+
+  // The full per-step incidence space the candidates are pruned from: nonempty
+  // subsets of the existing vertices the new interior vertex may wire to.
+  spaceSizeOut = (N < 63) ? ((std::size_t{1} << N) - 1)
+                          : std::numeric_limits<std::size_t>::max();
+
+  const std::vector<std::vector<std::uint64_t>> candidates =
+      connectivityCandidates(es, nCandidates, seed);
+  candidatesOut = static_cast<int>(candidates.size());
+
+  // Log what is pruned — no silent cap (quiet unless TESSERA_VERBOSE). The same
+  // counts are surfaced in the Verdict for programmatic inspection.
+  CLOG(INFO_LEVEL, "free-connectivity grow: scoring ", candidates.size(),
+       " of ", spaceSizeOut, " incidence patterns over ", N, " vertices");
+
+  double bestR = std::numeric_limits<double>::infinity();
+  std::vector<std::uint64_t> bestSubset;
+  std::vector<cd> tmpWitness;
+  for (std::size_t c = 0; c < candidates.size(); ++c) {
+    // Singleton specs: one 1-simplex {v_new, u} per chosen vertex u — the only
+    // structure the k=0 graph Laplacian sees, and provably boundary-safe (a new
+    // edge to a brand-new vertex creates no new top cell, so ∂W is untouched).
+    std::vector<std::vector<std::uint64_t>> specs;
+    specs.reserve(candidates[c].size());
+    for (const std::uint64_t u : candidates[c]) specs.push_back({u});
+    if (!es.attachInteriorVertex(specs)) continue;  // skip if it would touch ∂W
+    const double r =
+        optimizePass(es, pinnedByTuple, epsilon, restarts,
+                     seed + 1 + static_cast<std::uint64_t>(c), tmpWitness);
+    if (r < bestR) {
+      bestR = r;
+      bestSubset = candidates[c];
+    }
+    es.detachLastInteriorVertex();
+  }
+
+  // Fall back to the cone move if nothing could attach (keeps growth progressing).
+  if (bestSubset.empty()) return es.growInterior(seed);
+
+  std::vector<std::vector<std::uint64_t>> bestSpecs;
+  bestSpecs.reserve(bestSubset.size());
+  for (const std::uint64_t u : bestSubset) bestSpecs.push_back({u});
+  return es.attachInteriorVertex(bestSpecs);
+}
+
+double RealizabilityOracle::fillInterior(
+    EigenstateSynthesis &es,
+    const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
+    int restarts, int maxCones, std::uint64_t seed, GrowthMode mode,
+    int connectivityCandidates, std::vector<cd> &witnessOut, int &conesApplied,
+    int &candidatesOut, std::size_t &spaceSizeOut) const {
   double bestR = std::numeric_limits<double>::infinity();
   conesApplied = 0;
+  candidatesOut = 0;
+  spaceSizeOut = 0;
 
   for (int cone = 0;; ++cone) {
-    const std::size_t order = es.order();         // operator dim this pass
-    const std::size_t m = es.numInteriorEdges();  // free interior edge weights
-
-    // Re-identify, on the current k-cell order, which ψ components are pinned
-    // boundary cells (their sorted vertex-id tuple is a key of pinnedByTuple, the
-    // target form on ∂W) vs. free interior cells (auxiliary amplitudes). Growth
-    // changes the k-cell order, so this is rebuilt every pass.
-    const std::vector<std::vector<std::uint64_t>> &cells = es.cellSimplices();
-    std::vector<cd> pinnedValue(order, cd(0.0, 0.0));
-    std::vector<std::size_t> freeIdx;
-    for (std::size_t i = 0; i < order; ++i) {
-      const auto it = pinnedByTuple.find(cells[i]);
-      if (it != pinnedByTuple.end())
-        pinnedValue[i] = it->second;
-      else
-        freeIdx.push_back(i);
-    }
-    const std::size_t nAux = freeIdx.size();
-    const std::size_t nW = m;
-    const std::size_t nTheta = usePhases ? m : 0;
-    const std::size_t nParams = nW + nTheta + 2 * nAux;
-
-    // Assemble ψ from a parameter vector: the boundary cells hold the fixed
-    // target form; the auxiliary amplitudes (interior / coned-in cells) come from
-    // the tail of x (real, imag per free cell).
-    const auto buildPsi = [&pinnedValue, &freeIdx, nW, nTheta,
-                           nAux](const Eigen::VectorXd &x) -> std::vector<cd> {
-      std::vector<cd> psi = pinnedValue;
-      for (std::size_t k = 0; k < nAux; ++k) {
-        const auto re = static_cast<Eigen::Index>(nW + nTheta + 2 * k);
-        psi[freeIdx[k]] = cd(x[re], x[re + 1]);
-      }
-      return psi;
-    };
-
-    // Residual: write the interior weights (and phases at k=0) onto ∂W's
-    // complement (∂W itself is never touched), normalize the assembled ψ, and
-    // return the stacked g = L_kψ - λψ ([Re; Im], length 2·order) whose ‖g‖² is
-    // r(ψ) — the residual the Levenberg–Marquardt loop drives to zero.
-    const auto residual = [&es, &buildPsi, m, nW, usePhases,
-                           order](const Eigen::VectorXd &x) -> Eigen::VectorXd {
-      if (m > 0) {
-        std::vector<double> w(m);
-        for (std::size_t i = 0; i < m; ++i) w[i] = x[static_cast<Eigen::Index>(i)];
-        es.setInteriorWeights(w);
-        if (usePhases) {
-          std::vector<double> th(m);
-          for (std::size_t i = 0; i < m; ++i)
-            th[i] = x[static_cast<Eigen::Index>(nW + i)];
-          es.setInteriorPhases(th);
-        }
-      }
-      std::vector<cd> psi = buildPsi(x);
-      double nrm = 0.0;
-      for (const cd &z : psi) nrm += std::norm(z);
-      if (nrm > 0.0) {
-        const double inv = 1.0 / std::sqrt(nrm);
-        for (cd &z : psi) z *= inv;
-      }
-      const std::vector<cd> Lp = es.apply(psi);
-      cd lam(0.0, 0.0);
-      for (std::size_t i = 0; i < order; ++i) lam += std::conj(psi[i]) * Lp[i];
-      const double lambda = lam.real();
-      Eigen::VectorXd f(static_cast<Eigen::Index>(2 * order));
-      for (std::size_t i = 0; i < order; ++i) {
-        const cd g = Lp[i] - lambda * psi[i];
-        f[static_cast<Eigen::Index>(i)] = g.real();
-        f[static_cast<Eigen::Index>(order + i)] = g.imag();
-      }
-      return f;
-    };
-
-    // Clamp interior weights (and phases at k=0) into the §4b box and the
-    // auxiliary amplitudes into [-kAuxBound, kAuxBound].
-    const auto clamp = [nW, nTheta, nAux](const Eigen::VectorXd &x)
-        -> Eigen::VectorXd {
-      Eigen::VectorXd c = x;
-      for (std::size_t i = 0; i < nW; ++i) {
-        const auto wi = static_cast<Eigen::Index>(i);
-        c[wi] = std::min(std::max(c[wi], kWMin), kWMax);
-      }
-      for (std::size_t i = 0; i < nTheta; ++i) {
-        const auto ti = static_cast<Eigen::Index>(nW + i);
-        c[ti] = std::min(std::max(c[ti], -kThetaBound), kThetaBound);
-      }
-      for (std::size_t k = 0; k < 2 * nAux; ++k) {
-        const auto ai = static_cast<Eigen::Index>(nW + nTheta + k);
-        c[ai] = std::min(std::max(c[ai], -kAuxBound), kAuxBound);
-      }
-      return c;
-    };
-
-    // Sample a restart: w ∈ [kWMin, kWMax], θ ∈ [-π, π], aux ∈ [-1, 1]. Built
-    // once and captured (the single-rng draw convention GeometrySynthesizer uses).
-    std::uniform_real_distribution<double> wDist(kWMin, kWMax);
-    std::uniform_real_distribution<double> tDist(-kPi, kPi);
-    std::uniform_real_distribution<double> aDist(-1.0, 1.0);
-    const auto sample = [nW, nTheta, nAux, wDist, tDist,
-                         aDist](std::mt19937_64 &rng) mutable -> Eigen::VectorXd {
-      Eigen::VectorXd x0(static_cast<Eigen::Index>(nW + nTheta + 2 * nAux));
-      for (std::size_t i = 0; i < nW; ++i)
-        x0[static_cast<Eigen::Index>(i)] = wDist(rng);
-      for (std::size_t i = 0; i < nTheta; ++i)
-        x0[static_cast<Eigen::Index>(nW + i)] = tDist(rng);
-      for (std::size_t k = 0; k < 2 * nAux; ++k)
-        x0[static_cast<Eigen::Index>(nW + nTheta + k)] = aDist(rng);
-      return x0;
-    };
-
-    const LevenbergMarquardt lm(kMaxIterations, epsilon);
-    const LevenbergMarquardt::Result best =
-        lm.multiRestart(residual, clamp, sample, nParams, restarts,
-                        seed + static_cast<std::uint64_t>(cone), epsilon);
-
-    // Leave the complex realized at the best parameters and read off the unit
-    // witness state there (multiRestart leaves `residual` evaluated last at
-    // best.parameters; re-evaluate so the witness ψ matches the live complex).
-    residual(best.parameters);
-    witnessOut = buildPsi(best.parameters);
-    double wn = 0.0;
-    for (const cd &z : witnessOut) wn += std::norm(z);
-    if (wn > 0.0) {
-      const double inv = 1.0 / std::sqrt(wn);
-      for (cd &z : witnessOut) z *= inv;
-    }
-    bestR = best.cost;
+    // Optimize the current complex (seed + cone preserves the cone-path seed
+    // sequence exactly, so the historical decide() is byte-for-byte unchanged).
+    bestR = optimizePass(es, pinnedByTuple, epsilon, restarts,
+                         seed + static_cast<std::uint64_t>(cone), witnessOut);
 
     // Stop on convergence, an exhausted budget, or a complex that cannot grow
-    // (growInterior is the capacity/structure gate; it leaves ∂W byte-fixed).
+    // (growth is the capacity/structure gate; it leaves ∂W byte-fixed).
     if (bestR < epsilon) break;
     if (cone >= maxCones) break;
-    if (!es.growInterior(seed + 1000 + static_cast<std::uint64_t>(cone))) break;
+    bool grew;
+    if (mode == GrowthMode::FreeConnectivity)
+      grew = growBestConnectivity(
+          es, pinnedByTuple, epsilon, restarts,
+          seed + 1000 + static_cast<std::uint64_t>(cone), connectivityCandidates,
+          candidatesOut, spaceSizeOut);
+    else
+      grew = es.growInterior(seed + 1000 + static_cast<std::uint64_t>(cone));
+    if (!grew) break;
     ++conesApplied;
   }
   return bestR;
@@ -213,7 +337,8 @@ double RealizabilityOracle::fillInterior(
 
 RealizabilityOracle::Verdict RealizabilityOracle::decide(
     const std::vector<cd> &U, int dA, int dB, double epsilon, int restarts,
-    int maxCones, std::uint64_t seed) {
+    int maxCones, std::uint64_t seed, GrowthMode mode,
+    int connectivityCandidates) {
   const std::vector<cd> target = bend(U, dA, dB);  // ψ_U, length dA·dB
 
   EigenstateSynthesis es(bulk_);  // k = 0: the vertex graph Laplacian
@@ -223,9 +348,9 @@ RealizabilityOracle::Verdict RealizabilityOracle::decide(
         "needs on its output-boundary support (dA*dB).");
 
   // The output-boundary support is the first dA·dB sorted-id vertices (the
-  // established k=0 embedding idiom): pin those vertex cells to ψ_U. The apex
-  // growInterior cones in has the largest id, so the first dA·dB tuples are
-  // preserved across growth.
+  // established k=0 embedding idiom): pin those vertex cells to ψ_U. The interior
+  // vertex grown in (cone or free-connectivity) has the largest id, so the first
+  // dA·dB tuples are preserved across growth.
   const std::vector<std::vector<std::uint64_t>> &cells = es.cellSimplices();
   std::map<std::vector<std::uint64_t>, cd> pinnedByTuple;
   for (std::size_t i = 0; i < target.size(); ++i)
@@ -234,12 +359,15 @@ RealizabilityOracle::Verdict RealizabilityOracle::decide(
   Verdict v;
   v.target = target;
   const double r = fillInterior(es, pinnedByTuple, epsilon, restarts, maxCones,
-                                seed, v.state, v.conesApplied);
+                                seed, mode, connectivityCandidates, v.state,
+                                v.conesApplied, v.connectivityCandidates,
+                                v.connectivitySpaceSize);
   v.residual = r;
   v.realizable = (r < epsilon);
   v.floor = v.realizable ? 0.0 : r;
   v.eigenvalue = es.rayleigh(v.state);
   v.interiorVertexCount = es.interiorVertexCount();
+  v.interiorEdgeCount = es.numInteriorEdges();
   v.witness = bulk_;
   return v;
 }
@@ -288,13 +416,21 @@ RealizabilityOracle::Verdict RealizabilityOracle::decideHarmonic(
 
   Verdict v;
   v.target = targetOut;
+  // The k>=1 harmonic path keeps cone growth: at k>=1 the metric L_k depends on
+  // the higher (volume-weighted) cells, so a 1-skeleton-only connectivity search
+  // would be inert — free connectivity is the k=0 graph-Laplacian story.
+  int candidatesOut = 0;
+  std::size_t spaceSizeOut = 0;
   const double r = fillInterior(es, pinnedByTuple, epsilon, restarts, maxCones,
-                                seed, v.state, v.conesApplied);
+                                seed, GrowthMode::Cone, /*connectivityCandidates=*/0,
+                                v.state, v.conesApplied, candidatesOut,
+                                spaceSizeOut);
   v.residual = r;
   v.realizable = (r < epsilon);
   v.floor = v.realizable ? 0.0 : r;
   v.eigenvalue = es.rayleigh(v.state);
   v.interiorVertexCount = es.interiorVertexCount();
+  v.interiorEdgeCount = es.numInteriorEdges();
   v.witness = bulk_;
   return v;
 }

--- a/tests/cobordism/test_free_connectivity_python.py
+++ b/tests/cobordism/test_free_connectivity_python.py
@@ -1,0 +1,418 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Free interior connectivity in the realizability engine (#200).
+
+`growInterior` only ever **cones** a fresh interior vertex into one top cell,
+wiring it to exactly the ``d+1`` vertices of that cell — a biased move. This
+suite covers the cone-free generalization: a purely-additive growth primitive
+``EigenstateSynthesis.attachInteriorVertex(incident_simplices)`` that adds an
+interior vertex with an **arbitrary** incidence (coning is one special case), its
+exact inverse ``detachLastInteriorVertex``, and the bounded connectivity-search
+layer on ``RealizabilityOracle.decide`` (``growth_mode=FREE_CONNECTIVITY``).
+
+The only invariant the primitive enforces is the one the experiment allows: the
+result is a valid downward-closed abstract simplicial complex, and the pinned
+boundary ``dW`` is **bit-exact** untouched. No manifold / pseudomanifold /
+purity / topology constraint is imposed — the realized topology is whatever the
+residual selects.
+
+Key fact the engine leans on: the ``k=0`` Hodge Laplacian ``L = D - A`` (the
+objective) is assembled **only from the 1-skeleton** (edge weights/phases), so
+"free interior connectivity" here is exactly "free interior graph connectivity"
+— which existing vertices a new interior vertex wires to.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures — the #147 bulk-synthesis idiom, reused verbatim from the oracle
+# suite: Signature(d) so the d-cells register as top simplices; built through
+# the topology so the vertex-id counter advances.
+# --------------------------------------------------------------------------- #
+def _spacetime(dim, topology):
+    sig = tessera.Signature(dim, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, topology)
+
+
+def _solid_triangle():
+    """Delta^2: triangle 0-1-2 whose boundary dW is the three sides (S^1)."""
+    st = _spacetime(2, tessera.SolidSimplex(2))
+    st.build()
+    return st
+
+
+def _bipyramid():
+    """Triangles 012 and 013 sharing interior edge 01; the four outer edges
+    02,12,03,13 are the pinned boundary dW (the smallest fixed-boundary complex
+    with exactly one interior parameter)."""
+    st = _solid_triangle()
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    st.createSimplex([v[0], v[1], v3])
+    return st
+
+
+def _pin_all(st, w=1.0, phase=0.0):
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(w)
+        e.setPhase(phase)
+
+
+def _edge_map(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _edge_keys(st):
+    return set(_edge_map(st).keys())
+
+
+def _vertex_ids(st):
+    return sorted(v.getId() for v in st.getVertexList().toVector())
+
+
+def _cvec(v):
+    return [complex(z) for z in v]
+
+
+def _vec(U):
+    return np.asarray(U, dtype=complex).reshape(-1)
+
+
+# --------------------------------------------------------------------------- #
+class AttachInteriorVertexTest(unittest.TestCase):
+    """The general growth primitive: arbitrary incidence, validity + boundary
+    are the only gates, coning is a special case."""
+
+    def test_attach_edges_grows_order_and_interior_connectivity(self):
+        st = _bipyramid()
+        _pin_all(st)
+        es = cob.EigenstateSynthesis(st)
+
+        order0 = es.order()
+        ninterior0 = es.numInteriorEdges()
+        nboundary0 = es.numBoundaryEdges()
+        verts0 = set(es.vertexIds())
+
+        # Wire a fresh interior vertex to two existing vertices by edges
+        # (singleton specs -> 1-simplices). A purely additive, boundary-safe move.
+        self.assertTrue(es.attachInteriorVertex([[0], [3]]))
+
+        # Order grew by exactly one; the new vertex has the largest id.
+        self.assertEqual(es.order(), order0 + 1)
+        new_ids = set(es.vertexIds()) - verts0
+        self.assertEqual(len(new_ids), 1)
+        self.assertEqual(max(new_ids), max(es.vertexIds()))
+        new_id = next(iter(new_ids))
+
+        # The two new edges are interior (free), boundary unchanged in count.
+        self.assertEqual(es.numInteriorEdges(), ninterior0 + 2)
+        self.assertEqual(es.numBoundaryEdges(), nboundary0)
+        interior = set(es.interiorEdges())
+        self.assertIn((0, new_id), interior)
+        self.assertIn((3, new_id), interior)
+
+    def test_attach_validates_downward_closure_of_a_higher_simplex(self):
+        # A single 3-vertex spec {1,2,3} cones the new vertex into a *triangle*
+        # spanning interior vertices: the new simplex {1,2,3,new} materializes its
+        # whole 1-skeleton, so every pair carries an edge (downward closed).
+        st = _bipyramid()
+        _pin_all(st)
+        # 2-3 is not an edge of the bipyramid; attaching {1,2,3,new} must create it
+        # (along with the new vertex's edges) to stay a valid complex.
+        self.assertNotIn((2, 3), _edge_keys(st))
+        es = cob.EigenstateSynthesis(st)
+        self.assertTrue(es.attachInteriorVertex([[1, 2, 3]]))
+        new_id = max(es.vertexIds())
+        keys = _edge_keys(st)
+        for a, b in [(1, 2), (1, 3), (2, 3),
+                     (1, new_id), (2, new_id), (3, new_id)]:
+            self.assertIn((min(a, b), max(a, b)), keys)
+
+    def test_invalid_specs_are_rejected_and_leave_complex_unchanged(self):
+        st = _bipyramid()
+        _pin_all(st)
+        es = cob.EigenstateSynthesis(st)
+        order0, edges0 = es.order(), _edge_keys(st)
+
+        for bad in (
+            [],            # empty incidence -> would isolate the new vertex
+            [[]],          # an empty face
+            [[99]],        # dangling vertex reference
+            [[0, 0]],      # repeated vertex within a face
+        ):
+            self.assertFalse(es.attachInteriorVertex(bad))
+            self.assertEqual(es.order(), order0)
+            self.assertEqual(_edge_keys(st), edges0)
+
+    def test_attach_that_would_perturb_boundary_is_rejected(self):
+        # Spec {0,2} forms the *triangle* {0,2,new}: edge 02 is a boundary facet
+        # of triangle 012, so the new triangle would give it a second coface and
+        # flip it interior — perturbing dW. The primitive must reject + roll back.
+        st = _bipyramid()
+        _pin_all(st)
+        es = cob.EigenstateSynthesis(st)
+        boundary0 = set(es.boundaryEdges())
+        order0, edges0 = es.order(), _edge_keys(st)
+        self.assertIn((0, 2), boundary0)
+
+        self.assertFalse(es.attachInteriorVertex([[0, 2]]))
+
+        # Bit-exact unchanged: order, edges, and the boundary partition.
+        self.assertEqual(es.order(), order0)
+        self.assertEqual(_edge_keys(st), edges0)
+        self.assertEqual(set(es.boundaryEdges()), boundary0)
+
+    def test_boundary_is_bit_exact_across_an_edge_attach(self):
+        st = _bipyramid()
+        _pin_all(st, w=1.0, phase=0.0)
+        es = cob.EigenstateSynthesis(st)
+        before = {k: (e.getSquaredLength(), e.getPhase())
+                  for k, e in _edge_map(st).items()
+                  if k in set(es.boundaryEdges())}
+
+        self.assertTrue(es.attachInteriorVertex([[0], [1], [2]]))
+
+        live = _edge_map(st)
+        for k, (w, ph) in before.items():
+            self.assertEqual((live[k].getSquaredLength(), live[k].getPhase()),
+                             (w, ph))
+        # The boundary edge *set* is preserved exactly.
+        self.assertEqual(set(es.boundaryEdges()), set(before.keys()))
+
+    def test_coning_is_a_special_case_of_the_general_attach(self):
+        # Wiring the new vertex to the d+1 = 3 vertices of a top cell reproduces
+        # growInterior's 1-skeleton (the new vertex joined to that cell's
+        # vertices) — cone connectivity is a subset of what attach can express.
+        st = _bipyramid()
+        _pin_all(st)
+        es = cob.EigenstateSynthesis(st)
+        cell = es.topCells()[0]                       # e.g. [0,1,2]
+        self.assertEqual(len(cell), 3)
+        self.assertTrue(es.attachInteriorVertex([[c] for c in cell]))
+        new_id = max(es.vertexIds())
+        interior = set(es.interiorEdges())
+        for c in cell:
+            self.assertIn((min(c, new_id), max(c, new_id)), interior)
+
+
+class DetachInteriorVertexTest(unittest.TestCase):
+    """detachLastInteriorVertex is the exact inverse of attachInteriorVertex."""
+
+    def test_attach_then_detach_round_trips_the_complex(self):
+        st = _bipyramid()
+        _pin_all(st, w=1.0, phase=0.0)
+        es = cob.EigenstateSynthesis(st)
+
+        order0 = es.order()
+        edges0 = _edge_keys(st)
+        verts0 = _vertex_ids(st)
+        weights0 = {k: (e.getSquaredLength(), e.getPhase())
+                    for k, e in _edge_map(st).items()}
+        boundary0 = set(es.boundaryEdges())
+
+        # A rich attach (an interior triangle that even creates a new edge 2-3).
+        self.assertTrue(es.attachInteriorVertex([[1, 2, 3], [0]]))
+        self.assertGreater(es.order(), order0)
+        self.assertNotEqual(_edge_keys(st), edges0)
+
+        # Detach restores everything bit-exactly.
+        self.assertTrue(es.detachLastInteriorVertex())
+        self.assertEqual(es.order(), order0)
+        self.assertEqual(_vertex_ids(st), verts0)
+        self.assertEqual(_edge_keys(st), edges0)
+        self.assertEqual(set(es.boundaryEdges()), boundary0)
+        live = _edge_map(st)
+        for k, (w, ph) in weights0.items():
+            self.assertEqual((live[k].getSquaredLength(), live[k].getPhase()),
+                             (w, ph))
+
+    def test_detach_with_nothing_to_undo_returns_false(self):
+        st = _bipyramid()
+        _pin_all(st)
+        es = cob.EigenstateSynthesis(st)
+        self.assertFalse(es.detachLastInteriorVertex())
+
+    def test_detach_is_lifo_over_repeated_attaches(self):
+        st = _bipyramid()
+        _pin_all(st)
+        es = cob.EigenstateSynthesis(st)
+        base = es.order()
+        self.assertTrue(es.attachInteriorVertex([[0], [1]]))
+        self.assertTrue(es.attachInteriorVertex([[2], [3]]))
+        self.assertEqual(es.order(), base + 2)
+        self.assertTrue(es.detachLastInteriorVertex())
+        self.assertEqual(es.order(), base + 1)
+        self.assertTrue(es.detachLastInteriorVertex())
+        self.assertEqual(es.order(), base)
+        self.assertFalse(es.detachLastInteriorVertex())
+
+
+# --------------------------------------------------------------------------- #
+def _fan():
+    """Triangles 012, 013, 014 sharing the interior edge 01 — a fan whose three
+    boundary 'leaves' 2,3,4 each sit in exactly one top cell. The cone move wires
+    a fresh vertex to one top cell's 3 vertices, so it can reach at most ONE leaf
+    and always misses the other two: a genuine connectivity bottleneck the
+    free-connectivity search can step around."""
+    st = _solid_triangle()
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    st.createSimplex([v[0], v[1], v3])
+    v4 = st.createVertex(4)
+    st.createSimplex([v[0], v[1], v4])
+    return st
+
+
+class ConeVsFreeConnectivityTest(unittest.TestCase):
+    """Cone-only vs free-connectivity growth on the same target, reported
+    honestly. The cone baseline is ``decide(FREE_CONNECTIVITY,
+    connectivity_candidates=1)`` — exactly the cone-equivalent candidate (the
+    d+1 vertices of one top cell), grown by the same boundary-fixed attach as the
+    free search, so the two arms differ ONLY in the connectivity breadth searched.
+    (``growth_mode=CONE`` is the Pachner cone ``growInterior``; on hand-built
+    explicit-id fixtures it reissues a stale vertex id, which the additive attach's
+    max-id allocation avoids — so candidates=1 is the faithful, robust cone arm.)"""
+
+    # U whose boundary amplitudes on the three fan leaves 2,3,4 are distinct: a
+    # cone vertex reaching only one leaf forces two rigid boundary rows to demand
+    # inconsistent eigenvalues -> a residual floor; a free vertex coupling the
+    # leaves reconciles them.
+    U_FAN = [[1.0, 1.0, 2.0, 3.0, 5.0]]   # 1 x 5; vec on vertices 0,1,2,3,4
+
+    def test_free_connectivity_realizes_a_target_cone_growth_floors_on(self):
+        FREE = cob.RealizabilityOracle.GrowthMode.FREE_CONNECTIVITY
+
+        st = _fan()
+        _pin_all(st)
+        cone = cob.RealizabilityOracle(st).decide(
+            _cvec(_vec(self.U_FAN)), 1, 5, epsilon=1e-10, restarts=64,
+            max_cones=1, seed=0, growth_mode=FREE, connectivity_candidates=1)
+
+        st = _fan()
+        _pin_all(st)
+        free = cob.RealizabilityOracle(st).decide(
+            _cvec(_vec(self.U_FAN)), 1, 5, epsilon=1e-10, restarts=64,
+            max_cones=1, seed=0, growth_mode=FREE, connectivity_candidates=8)
+
+        # Cone connectivity floors away from zero — certified non-realizable.
+        self.assertFalse(cone.realizable)
+        self.assertGreater(cone.residual, 1e-4)
+
+        # Free connectivity realizes the SAME target with a single interior vertex.
+        self.assertTrue(free.realizable)
+        self.assertLess(free.residual, 1e-9)
+        self.assertEqual(free.interior_vertex_count, 1)
+
+        # The headline: removing the cone bias drops the residual by many orders.
+        self.assertLess(free.residual, cone.residual / 1e4)
+
+        # The realized connectivity is genuinely emergent (not a cone star): the
+        # grown vertex couples boundary leaves directly rather than the hub.
+        es = cob.EigenstateSynthesis(free.witness)
+        self.assertLess(es.residual(_cvec(free.state)), 1e-9)
+        new_id = max(es.vertexIds())
+        nbrs = {a if b == new_id else b
+                for (a, b) in es.interiorEdges() if new_id in (a, b)}
+        # It reaches at least two of the fan leaves {2,3,4} — impossible for a
+        # single cone (one top cell holds only one leaf).
+        self.assertGreaterEqual(len(nbrs & {2, 3, 4}), 2)
+
+    def test_cone_growth_is_already_sufficient_on_the_bipyramid(self):
+        # Honest counterpoint: on the existing bipyramid fixture a single missed
+        # boundary vertex only *fixes* the eigenvalue (the rest of the interior
+        # adapts), so cone connectivity already realizes U=[[1,2],[3,4]] — free
+        # connectivity is not needed here. Both reported, neither hidden.
+        FREE = cob.RealizabilityOracle.GrowthMode.FREE_CONNECTIVITY
+        U = [[1.0, 2.0], [3.0, 4.0]]
+
+        st = _bipyramid()
+        _pin_all(st)
+        cone = cob.RealizabilityOracle(st).decide(
+            _cvec(_vec(U)), 2, 2, epsilon=1e-10, restarts=48, max_cones=1,
+            seed=0, growth_mode=FREE, connectivity_candidates=1)
+
+        st = _bipyramid()
+        _pin_all(st)
+        free = cob.RealizabilityOracle(st).decide(
+            _cvec(_vec(U)), 2, 2, epsilon=1e-10, restarts=48, max_cones=1,
+            seed=0, growth_mode=FREE, connectivity_candidates=8)
+
+        self.assertTrue(cone.realizable)
+        self.assertTrue(free.realizable)
+        # Free is never worse than cone (it includes the cone candidate).
+        self.assertLessEqual(free.residual, max(cone.residual, 1e-9) * 10)
+
+    def test_connectivity_search_is_bounded_and_logged(self):
+        # No silent cap: the Verdict surfaces exactly how many candidates were
+        # scored vs the full 2^N-1 incidence space they were pruned from.
+        FREE = cob.RealizabilityOracle.GrowthMode.FREE_CONNECTIVITY
+        st = _fan()
+        _pin_all(st)
+        v = cob.RealizabilityOracle(st).decide(
+            _cvec(_vec(self.U_FAN)), 1, 5, epsilon=1e-10, restarts=32,
+            max_cones=1, seed=0, growth_mode=FREE, connectivity_candidates=8)
+
+        # 5 vertices at the (single) growth step -> 2^5 - 1 = 31 incidence patterns.
+        self.assertEqual(v.connectivity_space_size, 31)
+        self.assertGreaterEqual(v.connectivity_candidates, 3)   # >= the 3 anchors
+        self.assertLessEqual(v.connectivity_candidates, 8)
+        self.assertLess(v.connectivity_candidates, v.connectivity_space_size)
+
+        # Cone mode does not search connectivity (reports 0 candidates).
+        st = _fan()
+        _pin_all(st)
+        c = cob.RealizabilityOracle(st).decide(
+            _cvec(_vec(self.U_FAN)), 1, 5, epsilon=1e-10, restarts=8,
+            max_cones=0, seed=0)                       # default growth_mode=CONE
+        self.assertEqual(c.connectivity_candidates, 0)
+
+    def test_decide_free_connectivity_is_deterministic(self):
+        FREE = cob.RealizabilityOracle.GrowthMode.FREE_CONNECTIVITY
+        out = []
+        for _ in range(2):
+            st = _fan()
+            _pin_all(st)
+            out.append(cob.RealizabilityOracle(st).decide(
+                _cvec(_vec(self.U_FAN)), 1, 5, epsilon=1e-10, restarts=48,
+                max_cones=1, seed=3, growth_mode=FREE, connectivity_candidates=8))
+        self.assertEqual(out[0].residual, out[1].residual)
+        self.assertEqual(out[0].realizable, out[1].realizable)
+        np.testing.assert_array_equal(np.asarray(out[0].state),
+                                      np.asarray(out[1].state))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The residual-minimization synthesis engine (`EigenstateSynthesis` / `RealizabilityOracle`) grew the interior **only by coning** a fresh vertex into a top cell (`growInterior`) — a biased move that wires every new interior vertex to exactly the `d+1` vertices of one top cell. This PR makes interior **connectivity a free variable**:

- **`EigenstateSynthesis::attachInteriorVertex(incident-simplices)`** — a purely-additive growth primitive that adds an interior vertex with an arbitrary specified set of incident simplices (coning is one special case), plus its exact inverse `detachLastInteriorVertex`. It validates **only** the two invariants the experiment allows: a valid downward-closed abstract simplicial complex, and the pinned boundary `dW` staying **bit-exact**. No manifold / pseudomanifold / purity / topology constraint is imposed — topology is emergent.
- **A bounded, logged connectivity-search layer** on `RealizabilityOracle::decide` (`growth_mode=FREE_CONNECTIVITY`): at each growth step it scores candidate interior connectivities (cone-equivalent + full-star + boundary-star anchors, then reproducible random vertex subsets) by the residual each reaches after the existing weight/phase optimization, and commits the best. The Verdict surfaces `connectivity_candidates` scored vs the full `2^N-1` incidence space (no silent cap) and `interior_edge_count` (emergent connectivity size).

Key architectural fact: the k=0 Hodge Laplacian `L = D - A` (the objective) is assembled **only from the 1-skeleton**, so higher simplices are spectrally invisible to `residual()` — "free interior connectivity" here is exactly free interior graph connectivity (which existing vertices a new interior vertex wires to). The cone path is preserved byte-for-byte (`growth_mode=CONE` default; existing seeds untouched).

## Results (cone-only vs free-connectivity, same target)

- **Clean win** — 3-triangle *fan* (012, 013, 014 sharing interior edge 01; boundary leaves 2,3,4 with distinct target amplitudes), `U=[[1,1,2,3,5]]`: cone-equivalent growth **floors** at `r~3.1e-3` and stays non-realizable even at 3 cone vertices (it keeps wiring to one cell, never reaching two of the leaves); **free connectivity realizes** the same target at `r~4.5e-12` with a *single* interior vertex coupling boundary leaves directly — a genuinely non-cone emergent topology. Seed-independent.
- **Honest counterpoint** — bipyramid, `U=[[1,2],[3,4]]`: a single missed boundary vertex only *fixes* the eigenvalue (the rest of the interior adapts), so cone growth is already sufficient there; free connectivity is not needed. Reported, not hidden.

## Test plan
- [x] `attachInteriorVertex` adds an interior vertex with arbitrary incidence; validates downward-closure + boundary-untouched; rolls back on violation.
- [x] Coning is reproducible as a special case of the general attach (cone connectivity is a subset of free).
- [x] `detachLastInteriorVertex` exactly restores the prior complex (LIFO round-trip).
- [x] Boundary `dW` is bit-exact across the free-connectivity search.
- [x] Connectivity search is bounded + logs what it prunes (candidates `<< 2^N-1`).
- [x] Cone-only vs free-connectivity comparison on a reused oracle fixture: residual, vertices grown, emergent connectivity reported.
- [x] `pytest tests/cobordism` green locally (10-CPU cap, worktree venv): **485 passed, 1 skipped, 719 subtests**.

## Note / finding
`growth_mode=CONE` (the Pachner `growInterior`) reissues `vertexIdCounter` for the new apex; on hand-built fixtures that use the explicit-id `createVertex(id)` (which doesn't advance the counter, e.g. the bipyramid) it collides with an existing id and corrupts the complex on growth. The additive `attachInteriorVertex` allocates `maxId+1` and avoids this, so the comparison uses `connectivity_candidates=1` (the cone-equivalent candidate via the robust attach) as the faithful, fair cone arm. The latent `AddMove` id-allocation issue is pre-existing and out of scope here.

Closes #200.
