### PR TITLE
fix(ci): install pybind11/blas/lapack in pages.yml so the docs deploy builds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,11 @@ jobs:
           python-version: "3.12"  # or match your project
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y doxygen
+        # The docs build compiles the C++ extension (`pip install ".[dev]"`), so it
+        # needs the same packages as build.yml: pybind11-dev for the
+        # find_package(pybind11) cmake config, plus liblapack/libblas for the
+        # quantum subsystem. Without them the build — and the whole deploy — fails.
+        run: sudo apt-get update && sudo apt-get install -y doxygen pybind11-dev liblapack-dev libblas-dev
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## What
The docs deploy (`pages.yml`) has been **failing on every run for 2+ days** (all runs since 2026-06-07 are `failure`), so the GitHub Pages site is stale and **no merged report has published** — #191, #194, and #203 (the k=1 correspondence re-test) are on `main` but absent from https://akellehe.github.io/tessera/.

## Root cause
`pages.yml` runs `pip install ".[dev]"`, which **compiles the C++ extension**, but its "Install system dependencies" step only installs `doxygen`. It's missing the packages `build.yml` (the passing build CI) installs:
- `pybind11-dev` — for `find_package(pybind11)` (the "pybind11 v2 regression trap" build.yml warns about),
- `liblapack-dev` / `libblas-dev` — for the quantum subsystem.

So the build dies at "Install dependencies" and `deploy` is skipped.

## Fix
Add `pybind11-dev liblapack-dev libblas-dev` to the system-deps step, matching build.yml.

## After merge
On merge to `main` the deploy re-runs and should publish the backlog. One thing to watch as a *possible* next failure (not addressed here): the workflow also runs `pytest tests/ -m "not slow"` before building docs — if that trips/times out on the runner, gating a docs deploy on it is worth revisiting separately.