### PR TITLE
feat(cobordism): emergent-bulk realizability — grow from the bare boundary, let the obstruction fall out

### DIFF
--- a/docs/source/quantum-experiments/cobordism-correspondence-retest-k1-report.md
+++ b/docs/source/quantum-experiments/cobordism-correspondence-retest-k1-report.md
@@ -1,366 +1,282 @@
-# Cobordism experiment — re-testing the correspondence at k=1: results
+# Cobordism experiment — emergent-bulk realizability at k=1: surgery makes b₁ an output
 
-> What happens when the **free-interior-connectivity** realizability engine (#201)
-> is turned on the three State–Operation–Cobordism hypotheses at the Hodge-qubit
-> degree ($k=1$, harmonic 1-forms). The engine first had to be extended to $k=1$
-> (the search now proposes 2-simplex/triangle attachments, since $L_1$ reads the
-> 2-cells through $\partial_2$); then H1/H2/H3 are re-run on the solid-torus bulk
-> and the realizable set is compared across three engines — free-connectivity,
-> cone-only, and the discrete Dijkgraaf–Witten $S_3$ shadow. Companion to the
-> runnable capstone `examples/cobordism/correspondence_retest_k1.py` and the
-> diagram generator `examples/cobordism/visualize_correspondence_retest_k1.py`;
-> mirrors the realizability report (`cobordism-realizability-report.md`) and the
-> realizable-image report (`cobordism-realizable-image-report.md`); grounds in the
+> What happens when, at the Hodge-qubit degree $k=1$, you stop **pinning** the
+> bulk topology and let it emerge? The earlier re-test assembled the bulk as a
+> solid torus *before* asking which boundary harmonics it carries — so
+> "longitude realizes / meridian floors" was just the chosen filling's $H_1$ read
+> back out, a property of the **input**, not an output. This report corrects that:
+> fix only the boundary, grow the interior with a **topology-changing surgery
+> move** (a boundary-fixed interior-cell *remove*, #196), and read $b_1$ **off the
+> witness**. The headline is sharp and now genuinely emergent — $b_1$ moves on its
+> own, the matched two-boundary meridian realizes **iff** the grown filling has
+> $b_1=1$, and a sign-flipped control floors on *every* filling. Companion to the
+> runnable example `examples/cobordism/emergent_bulk_realizability.py` and the
+> diagram generator `examples/cobordism/visualize_emergent_bulk.py`; grounds in the
 > charter `cobordism.md` §4b, §5.0.
 
 ## Verdict
 
-**The three hypotheses hold at $k=1$ — and the headline is an honest reversal of
-the $k=0$ result.** With **free connectivity == cone, to ~30 digits, on every
-target**, the realizable set is exactly the **carried homology class**: the
-**longitude** of the solid torus (the cycle that survives in $H_1(W)$) is
-realizable ($r\approx 9.5\times10^{-29}$); the **meridian** (which bounds a disk
-and dies in $H_1(W)$) and the raw $\ker L_1(T^2)$ basis **floor**
-($r\approx 15.3,\ 1.88,\ 16.7$). Free connectivity does **not** enlarge the
-realizable set — the **opposite** of the $k=0$ fan win (#201). The capstone runs
-clean, deterministic, and `exit 0`:
+**At $k=1$ the realizability obstruction does NOT have to be installed by a
+hand-picked filling — it falls out of the topology the search grows.** With the
+boundary-fixed surgery move-set the bulk's first Betti number $b_1$ is a pure
+**output**, and two distinct obstructions separate cleanly:
 
-```
-State-Operation-Cobordism re-test at k=1 (the Hodge qubit) with the free-connectivity engine
+- **A topological one (does the handle exist?).** The matched two-boundary meridian
+  **floors on the disk filling** ($b_1=0$: it bounds) and **realizes as a bulk
+  harmonic on the annulus filling** ($b_1=1$: the cobordism carries it),
+  $r\approx7\times10^{-8}$, eigenvalue $\to 0$. The surgery search, handed only the
+  disk seed, **opens the handle on its own** ($b_1:0\to1$) and the floored meridian
+  realizes.
+- **A cohomological one (do the periods match?).** Flip the sign of *one* of the two
+  boundary meridians (the cobordism conjugation $\mathrm{geo}(\psi_A)\sqcup
+  \mathrm{conj}(\mathrm{geo}(\psi_B))$) and the target **floors on every filling,
+  even after surgery opens the handle** — opposite periods are not the restriction
+  of any closed form, so no bulk topology can carry them.
 
-  discrete-DW S_3 shadow: <swap, 3-cycle> closes to 6 maps on Z(T^2)=C^4 (the GL(2,Z_2) holonomy permutations)
+The example runs clean, deterministic at the seed verdict, and `exit 0`.
 
-  H1  realizable set on the boundary qubit (free-k1 vs cone; the DW shadow realizes operations, not states):
-      target                         free    r (free)   cone    r (cone) tri_cand  agree
-      ----------------------------------------------------------------------------------
-      longitude (carried)             YES   9.493e-29    YES   9.493e-29        0    yes
-      meridian (bounds a disk)         no   1.526e+01     no   1.526e+01        8    yes
-      ker L_1 basis #0                 no   1.879e+00     no   1.879e+00        8    yes
-      ker L_1 basis #1                 no   1.672e+01     no   1.672e+01        8    yes
+![emergent-bulk composite: the disk floors, the annulus realizes, surgery opens the handle](https://github.com/akellehe/tessera/releases/download/issue-attachments/emergent_bulk_composite.png)
 
-  H2  dW = the two states, held bit-exact through growth: PASS  (Pachner growth applied: True; every boundary edge byte-identical)
+## The methodological fix
 
-  H3  Z(W_AB) = <psi_A|U|psi_B> on the realized longitude: PASS
-      witness is an L_1(W) harmonic (lambda=2.24e-16 ~ 0), its boundary block reproduces the target form (overlap=1.000000); the Choi transition-amplitude identity holds (True).
+The earlier $k=1$ re-test built the bulk as `SimplicialProduct(SolidSimplex(2),
+S^1)` — the solid torus $W=D^2\times S^1$ — *before* asking which boundary
+harmonics it carries. But $H_1(W)=\mathbb{Z}\langle\text{longitude}\rangle$ is
+*built into that choice*: the longitude survives $H_1(\partial W)\to H_1(W)$, the
+meridian bounds the disk and dies. "Longitude realizes, meridian floors" was the
+chosen filling's homology read back out; the topology was an **input**.
 
-  Verdict: SUPPORTED -- at k=1 the free engine realizes EXACTLY the carried harmonics that
-  cone growth does; additive free connectivity does not enlarge the realizable set, and
-  H2/H3 hold on the realized longitude.
-```
+The fix demotes the bulk topology from input to output. Nothing is hardcoded as a
+torus / solid torus / disk / cone. The bulk is built **generically from a face
+list** — an octahedron (a triangulated $S^2$) with faces deleted — and the
+realizability engine is given a **topology-changing** move it never had before: a
+boundary-fixed interior-cell **remove** (`EigenstateSynthesis::removeInteriorCell`,
+exposed as `RealizabilityOracle.GrowthMode.SURGERY`). Removing an interior top cell
+opens a hole/handle while the pinned boundary $\partial W$ stays **bit-exact**, so
+$b_1$ **moves**. The realizability test is the physical one (`harmonic=True`): a
+boundary class realizes iff it is *carried* as a bulk harmonic, i.e. it is the
+restriction of a closed-and-coclosed 1-form on $W$ — equivalently it lies in
+$\mathrm{image}\big(H^1(W)\to H^1(\partial W)\big)$.
 
-## Setup: the $k=1$ Hodge qubit on a solid-torus bulk
+## Setup: the octahedron surface family and the two-boundary meridian
 
-The bulk is the **solid torus** $W = D^2\times S^1$ — a 3-manifold with boundary
-$\partial W = T^2$, assembled as `SimplicialProduct(SolidSimplex(2), S^1)` and
-pinned Hermitian (all boundary edges weight $1$, phase $0$). Its degree-1 homology
-is $H_1(W)=\mathbb{Z}$, generated by the **longitude** (the $S^1$ direction the
-disk is swept along).
+The whole story runs at $k=1$ on a **surface** bulk $W$ (top cells = triangles),
+the faithful low-dimensional analogue of the 3-manifold meridian/longitude setting.
+The octahedron has eight triangular faces; deleting antipodal faces opens boundary
+circles:
 
-The **boundary qubit** is $\ker L_1(T^2)$, the harmonic 1-forms on the boundary
-torus. Because $b_1(T^2)=2$, this is a 2-dimensional space — a *qubit* — with two
-distinguished cycles:
+- **delete one face** $\Rightarrow$ a **disk** ($b_1=0$): the one circle bounds, and
+  the antipodal triangle $\{3,4,5\}$ is still **filled**, so the second meridian
+  bounds it too;
+- **delete the two antipodal faces** $\Rightarrow$ an **annulus** ($b_1=1$): the two
+  boundary circles are homologous, each surviving in $H_1$ — the cobordism between
+  them.
 
-- the **longitude**, the cycle the solid torus *carries*: it is the boundary
-  restriction of the bulk harmonic $h\in\ker L_1(W)$ (which is 1-dimensional,
-  $b_1(W)=1$), so it survives the inclusion $H_1(T^2)\to H_1(W)$;
-- the **meridian**, the cycle that **bounds a disk** $D^2\times\{pt\}$ inside $W$
-  and therefore **dies** in $H_1(W)$ — it is in the kernel of $H_1(T^2)\to H_1(W)$.
+Drawn as a Schlegel diagram (hole A $=\{0,1,2\}$ the outer triangle, hole B
+$=\{3,4,5\}$ the inner triangle, six band cells between), the disk is a fully
+**filled** triangle and the annulus is that triangle with the inner cell **punched
+out** (a ring):
 
-A target boundary harmonic $U$ (a degree-1 `Cochain`) is **realizable** iff the
-pinned-boundary interior fill can drive the $k=1$ residual
-$r=\lVert(I-\psi\psi^\dagger)\,L_1\psi\rVert^2$ to $0$ — exactly the §5.0 spectral
-test of the realizability report, now at $k=1$ on a 3-manifold-with-boundary
-instead of $k=0$ on a wheel. The engine pins $\partial W$ byte-for-byte and fills
-the interior (interior edge squared-lengths, plus boundary-fixed growth).
+![the two boundary meridians geo(psi_A) || geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/emergent_bulk_boundary.png)
 
-### Extending the free search to $k=1$ (the prerequisite)
+The **target** is the meridian carried on *both* boundary circles, read off the
+annulus's own $H_1$ generator (`HodgeLaplacian(annulus).harmonics(1)[0]`) restricted
+to the two cycles, built two ways:
 
-#201's free-connectivity search proposed only **edge** (1-simplex) candidates —
-correct at $k=0$, where $L_0=D-A$ reads just the 1-skeleton. At $k=1$,
-$L_1=\partial_1^\top\partial_1+\partial_2\partial_2^\top$ reads the **2-simplices**
-through $\partial_2$, so the search was extended to also propose **triangle**
-(2-simplex) attachments, surfaced as `Verdict.triangle_candidates` (bounded and
-logged, never silently capped), with `decideHarmonic` gaining
-`growth_mode`/`connectivity_candidates`. The triangles *are* proposed at every
-growth step (`tri_cand=8` on every floored target below) — and the finding is that
-they are **provably inert** under the pinned boundary.
+| target | construction | period $p_A$ | period $p_B$ | $p_A/p_B$ |
+|---|---|---|---|---|
+| **matched** | the harmonic's restriction (equal periods) | $-1.095$ | $-1.095$ | $+1$ |
+| **flipped** | negate circle B's period (the conjugation) | $-1.095$ | $+1.095$ | $-1$ |
 
-## H1 — the realizable set: free vs cone vs the DW $S_3$ shadow
+A closed 1-form on the annulus has **equal** periods on its two homologous boundary
+circles (the flow is conserved through the tube), so the matched target is the
+restriction of a genuine harmonic and the flipped one cannot be — the sign flip is
+a deliberate negative control.
 
-The seed-complex verdict (`max_cones=0`, so the residual is exact and bit-exact
-reproducible across runs):
+## E1 — the 2×2: realizable iff $b_1=1$ **and** the periods match
 
-| target | free | $r$ (free) | cone | $r$ (cone) | `tri_cand` | agree |
-|---|---|---|---|---|---|---|
-| **longitude** (carried) | **YES** | $9.493\times10^{-29}$ | **YES** | $9.493\times10^{-29}$ | $0$ | yes |
-| meridian (bounds a disk) | no | $1.526\times10^{1}$ | no | $1.526\times10^{1}$ | $8$ | yes |
-| $\ker L_1$ basis #0 | no | $1.879\times10^{0}$ | no | $1.879\times10^{0}$ | $8$ | yes |
-| $\ker L_1$ basis #1 | no | $1.672\times10^{1}$ | no | $1.672\times10^{1}$ | $8$ | yes |
+Both targets against both validity-only fillings, seed verdict (`max_cones=0`, so
+the residual is exact and bit-exact reproducible across runs):
 
-Two facts read straight off the table:
+| target | filling | $b_1$ | realizable | residual $r$ | eigenvalue $\lambda$ |
+|---|---|---|---|---|---|
+| **matched** | disk | $0$ | no | $4.52\times10^{-1}$ | $4.81\times10^{-1}$ |
+| **matched** | **annulus** | $1$ | **YES** | $6.90\times10^{-8}$ | $6.32\times10^{-9}$ |
+| flipped | disk | $0$ | no | $9.92\times10^{-1}$ | $9.25\times10^{-1}$ |
+| flipped | annulus | $1$ | no | $2.03\times10^{-1}$ | $4.51\times10^{-1}$ |
 
-1. **Free $\equiv$ cone, bit-for-bit, on every target.** The free residual equals
-   the cone residual to the last digit (`agree=yes` in every row). The triangle
-   candidates are enumerated and logged (`tri_cand=8`), then found inert; the free
-   search falls back to the stellar (cone) Pachner move. Free connectivity buys
-   **nothing** at $k=1$.
-2. **The realizable set is the topological image $H_1(\Sigma)\to H_1(W)$.** Exactly
-   one target realizes — the **longitude**, the generator of $H_1(W)$ — and it
-   realizes to $r\sim10^{-29}$. The meridian (which dies in $H_1(W)$) and the two
-   raw basis harmonics floor far above $\epsilon$. *Realizable $\iff$ the boundary
-   class is the carried homology class.*
+Read straight off the table:
 
-The **residual floor tracks the homology map.** The basis-#0 floor ($1.88$) sits
-well below basis-#1 ($16.7$) and the meridian ($15.3$) because basis-#0 has the
-larger overlap with the carried longitude (qubit $(-0.993,\,0.116)$ in the
-generator frame) — the spectral obstruction is a continuous measure of *how far*
-the requested boundary class lies from the image of $H_1(\Sigma)\to H_1(W)$, zero
-exactly on the image.
+1. **MATCHED realizes only on the annulus.** Same boundary, same target — the
+   *disk* filling ($b_1=0$) floors it ($r\approx0.45$) and the *annulus* ($b_1=1$)
+   realizes it to $r\sim10^{-8}$ with eigenvalue $\to0$ (carried as a harmonic).
+   The verdict flips with the filling's $b_1$.
+2. **FLIPPED floors on both.** Even on the annulus, where the topology is right, the
+   sign-flipped meridian floors ($r\approx0.20$, $\lambda\approx0.45\neq0$): opposite
+   periods are not the restriction of any closed form. The realizable set is exactly
+   $\mathrm{image}\big(H^1(W)\to H^1(\partial W)\big)$ — for the disk that image is
+   $\{p=0\}$ (any nonzero meridian floors), for the annulus it is the diagonal
+   $\{p_A=p_B\}$ (matched realizes, flipped does not).
 
-### The discrete-DW $S_3$ shadow (for contrast)
+![disk filling (b1=0): the matched meridian floors](https://github.com/akellehe/tessera/releases/download/issue-attachments/emergent_bulk_disk.png)
+![annulus filling (b1=1): the matched meridian realizes as a harmonic](https://github.com/akellehe/tessera/releases/download/issue-attachments/emergent_bulk_annulus.png)
 
-For contrast, the **discrete** Dijkgraaf–Witten state-sum realizes a different kind
-of thing: it realizes **operations** on $Z(T^2)=\mathbb{C}^4$, not boundary states.
-Rebuilt from `Cobordism.twistedCylinder` (#194), the two generators
-$\langle\,\mathrm{DW(swap)},\mathrm{DW(3\text{-}cycle)}\,\rangle$ close to a group
-of exactly **6** maps — the $GL(2,\mathbb{Z}_2)=S_3$ holonomy permutations (the
-realizable-image report). The two notions of "realizable" answer different
-questions: the spectral engine asks which boundary *state* a fixed bulk carries
-(the carried homology class); the state-sum asks which *operation* the topological
-theory induces (the holonomy automorphisms).
+The disk panel is a fully filled triangle (the inner cell $\{3,4,5\}$ is present, so
+circle B bounds it); the annulus panel is the same triangle with the inner cell
+punched out — a ring — and its edges are colored by the realized **carried harmonic
+1-form** (the `Verdict.state`), the meridian the cobordism carries.
 
-## Per-hypothesis verdicts
+The sign-flip is a clean negative control: the **same** annulus ($b_1=1$), only
+circle B's period negated, floors exactly where the matched meridian realizes — the
+cohomological obstruction made visible side by side (matched left, flipped right):
 
-**H1 ✅ — $W_{AB}=\mathrm{geo}(U)$ is a cobordism iff $U$ is the carried class.**
-The longitude is realized with its solid-torus witness ($r\to0$); the meridian and
-the raw basis floor. Free $\equiv$ cone on every target; neither realizes what the
-discrete theory cannot. The realizable set is precisely the image of
-$H_1(\Sigma)\to H_1(W)$.
+![matched vs flipped on the same annulus — the period sign decides realizability](https://github.com/akellehe/tessera/releases/download/issue-attachments/emergent_bulk_flipped.png)
 
-**H2 ✅ — $\partial W$ stays the two states, held bit-exact through growth.** The
-boundary edges of $\partial W=T^2$ are byte-identical before and after the whole
-(Pachner) growth — the interior fill rewrites only interior edges, and the
-boundary-fixed guard rejects any move that would touch $\partial W$. (`PASS`, with
-a Pachner cone genuinely applied during the meridian growth.)
+## E2 — surgery moves $b_1$ on its own (the obstruction is emergent)
 
-**H3 ✅ — $Z(W_{AB})=\langle\psi_A|U|\psi_B\rangle$ on the realized witness.** The
-realized longitude witness is a genuine $L_1(W)$ harmonic
-($\lambda=2.24\times10^{-16}\approx0$) whose boundary block reproduces the target
-form (overlap $=1.000000$); and the Choi–Jamiołkowski transition-amplitude identity
-$\langle\psi_A|U|\psi_B\rangle=\langle\mathrm{vec}(U_T)|\mathrm{vec}(U)\rangle$ holds
-independently (the bulk-independent algebraic anchor reused from the v0.3 report).
+From the **disk seed** ($b_1=0$, the meridian floored) the SURGERY search scores
+every interior-top-cell removal by the harmonic residual it reaches and commits the
+best improving one. There is exactly one interior top cell — $\{3,4,5\}$ — and
+removing it opens the handle. Across seeds:
 
-## The diagrams
+| target | seed | removals | $b_1$ | realizable | residual $r$ |
+|---|---|---|---|---|---|
+| **matched** | 0 | 1 | $0\to1$ | **YES** | $4.76\times10^{-5}$ |
+| **matched** | 1 | 1 | $0\to1$ | **YES** | $1.06\times10^{-4}$ |
+| **matched** | 2 | 1 | $0\to1$ | **YES** | $5.31\times10^{-5}$ |
+| **matched** | 3 | 1 | $0\to1$ | **YES** | $3.48\times10^{-5}$ |
+| flipped | 0 | 1 | $0\to1$ | no | $2.25\times10^{-1}$ |
+| flipped | 1 | 1 | $0\to1$ | no | $2.20\times10^{-1}$ |
+| flipped | 2 | 1 | $0\to1$ | no | $2.21\times10^{-1}$ |
+| flipped | 3 | 1 | $0\to1$ | no | $2.19\times10^{-1}$ |
 
-For **every** operator/target the re-test exercises, four diagrams make the
-State–Operation–Cobordism story legible, all rendered through the project's
-existing layout/render infrastructure (`tessera.utils.plot`'s
-`layout_from_spacetime`/`render_frame`/`draw_edges`/`pca_align`, with the panel
-helpers reused from `visualize_realizability.py` — no hand-rolled plotter):
+$b_1$ moves $0\to1$ **on its own** for *both* targets (the opened handle always
+lowers the residual, so the removal is committed) — scored purely by the harmonic
+residual, with $\partial W$ held bit-exact. The grown $b_1$ is a pure **output**.
+But only the **matched** meridian then realizes; the **flipped** one still floors on
+the opened handle. Surgery delivers the *topology*; the leftover period mismatch is
+the *cohomological* obstruction no filling can fix. The before/after — the red
+interior cell $\{3,4,5\}$ punched out to a white hole, $b_1:0\to1$:
 
-1. **`geo(ψ_A)`** — the geometric image of the boundary state the operator asks the
-   bulk to carry (the target harmonic in its $\ker L_1(T^2)$ qubit coordinates),
-   synthesized by `GeometrySynthesizer` (#134): the minimal complex whose $k=0$
-   Hodge-Laplacian has $\psi_A$ as an eigenvector. Vertices colored by
-   $|\text{amplitude}|$, phase $\to$ hue.
-2. **`geo(ψ_B)`** — the same for $\psi_B$. For the four boundary-harmonic targets,
-   $\psi_B$ is the **homology class the solid torus actually carries** (the
-   longitude, the generator of $H_1(W)$) — the invariant the re-test compares
-   against, so this panel is the same carried class across those four rows; for the
-   H3 case it is the genuine right boundary state $\psi_B=(0.6,0.8)$.
-3. **The candidate operator cobordism `W`** — the grown solid-torus complex the
-   free-connectivity engine builds for that target (`decideHarmonic`'s `witness`).
-   The boundary $\partial W=T^2$ is drawn thick/solid, the filled interior
-   thin/dashed, and every edge is colored by the realized **$k=1$ harmonic 1-form**
-   (the `Verdict.state`). *To make the Pachner cone visible, the floored targets
-   are grown one step (`max_cones=1`) here, so a W-panel residual is the
-   post-cone value and differs from the exact seed-complex table above; the
-   verdict (realizable vs floored) is unchanged.*
-4. **Everything connected** — `geo(ψ_A) ⊔ W ⊔ geo(ψ_B)` assembled in one shared
-   layout. The realizability verdict reads off directly: **a target is realizable
-   iff `geo(ψ_A)` matches `geo(ψ_B)`** — iff the requested boundary harmonic *is*
-   the carried homology class.
+![surgery: disk -> annulus, b1 moves 0 -> 1 on its own](https://github.com/akellehe/tessera/releases/download/issue-attachments/emergent_bulk_surgery.png)
 
-(The diagram PNGs are reproducibility artifacts, **not** committed to the repo
-tree: they are generated to `/tmp/cobordism/` by the visualizer and uploaded to the
-[`issue-attachments`](https://github.com/akellehe/tessera/releases/tag/issue-attachments)
-release; the images below are referenced by their release URLs.)
+## E3 — only removal moves $b_1$; additive growth is frozen
 
-### Longitude (carried) — realizable, $r\approx9.5\times10^{-29}$
+The contrast that makes "surgery is the load-bearing move" precise. Without the
+remove move, $b_1$ cannot budge:
 
-`geo(ψ_A)` and `geo(ψ_B)` are the **same** carried-class qubit, so the two
-geometric images coincide and the assembled cobordism has *matching ends* — the
-visual signature of a realizable target. The witness is the bare 9-vertex
-solid torus (no growth: `cones=0`).
+| growth | $b_1$ | matched realizable | note |
+|---|---|---|---|
+| none (seed only, `max_cones=0`) | $0\to0$ | no ($r=4.5\times10^{-1}$) | the bare disk floor |
+| additive attach (`attachInteriorVertex`) | $0\to0$ | rejected | wiring a triangle in grows $\partial W$ |
 
-![longitude geo(psi_A)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_longitude_geoA.png)
-![longitude geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_longitude_geoB.png)
-![longitude operator cobordism W](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_longitude_W.png)
-![longitude assembled geo(psi_A) ⊔ W ⊔ geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_longitude_assembled.png)
+The additive `attachInteriorVertex` (the `FREE_CONNECTIVITY` atom) and the stellar
+Pachner subdivision (`growInterior`) are **topology-preserving** at $k\ge1$:
+a dangling additive cell is dropped by the downward-closure `ChainComplex`, and an
+additive top-cell attach introduces boundary edges the bit-exact $\partial W$ guard
+rejects. So no boundary-fixed *additive* move can move $b_1$ — the boundary-fixed
+**remove** is the one move that does.
 
-### Meridian (bounds a disk) — floored, $r\approx15.3$ (seed)
+## Headline finding: the obstruction is emergent, not installed
 
-The meridian qubit is **orthogonal** to the carried longitude, so `geo(ψ_A)`
-(meridian) and `geo(ψ_B)` (carried longitude) are **different** complexes — the
-assembled cobordism has *mismatched ends*, the signature of a floored target. The
-witness shows the one boundary-fixed move the engine has to fall back on: a stellar
-Pachner **cone** (10 vertices, the dangling apex wired by the dashed interior
-edges) — which still cannot match the meridian.
+Putting the pieces together, the emergent-bulk methodology — fix the boundary, grow
+with surgery, let the obstruction fall out — **works at $k=1$**, and it resolves the
+earlier "obstruction is installed by the filling" diagnosis:
 
-![meridian geo(psi_A)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_meridian_geoA.png)
-![meridian geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_meridian_geoB.png)
-![meridian operator cobordism W](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_meridian_W.png)
-![meridian assembled geo(psi_A) ⊔ W ⊔ geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_meridian_assembled.png)
+- The disk seed floors the matched meridian; the surgery search opens the handle
+  ($b_1:0\to1$) **on its own**, scored only by the residual, and the meridian
+  realizes (E2). The topology is selected by the spectral residual, not by the
+  experimenter.
+- Realizability is two conditions, and the experiment separates them: a
+  **topological** one ($b_1=1$, the handle exists — E1's disk/annulus split, E2's
+  surgery) and a **cohomological** one (matched periods — E1's matched/flipped
+  split, E2's flipped-still-floors). The sign-flipped meridian floors on *every*
+  filling, so the period obstruction is genuinely distinct from the topological one.
+- The move that moves $b_1$ is **removal**; the additive moves are frozen at $k\ge1$
+  (E3).
 
-### $\ker L_1$ basis #0 — floored, $r\approx1.88$ (seed)
-
-A raw generator of the boundary qubit. It has the larger overlap with the carried
-longitude (hence the smallest floor of the three non-realizable targets), but it is
-still not the carried class — `geo(ψ_A)` and `geo(ψ_B)` differ, and the witness
-floors after the cone.
-
-![basis0 geo(psi_A)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_basis0_geoA.png)
-![basis0 geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_basis0_geoB.png)
-![basis0 operator cobordism W](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_basis0_W.png)
-![basis0 assembled geo(psi_A) ⊔ W ⊔ geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_basis0_assembled.png)
-
-### $\ker L_1$ basis #1 — floored, $r\approx16.7$ (seed)
-
-The other raw generator, nearly orthogonal to the carried class — the largest floor
-in the battery. Same picture: mismatched geometric ends, a coned witness that
-floors.
-
-![basis1 geo(psi_A)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_basis1_geoA.png)
-![basis1 geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_basis1_geoB.png)
-![basis1 operator cobordism W](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_basis1_W.png)
-![basis1 assembled geo(psi_A) ⊔ W ⊔ geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_basis1_assembled.png)
-
-### H3 — the transition $(\psi_A,\psi_B,U=I)$ — the Choi anchor
-
-The genuine two-state transition: $\psi_A=(1,\,0.5i)$ and $\psi_B=(0.6,\,0.8)$ are
-distinct boundary states (note the imaginary amplitude rendering green via the
-phase $\to$ hue map), $U=I$, and `W` is the realized longitude cobordism the re-test
-reads $Z(W)$ off. This is the case where $\psi_A$ and $\psi_B$ are literally the two
-ends of the operation, not a state-vs-carried-class comparison.
-
-![h3 geo(psi_A)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_h3_geoA.png)
-![h3 geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_h3_geoB.png)
-![h3 operator cobordism W](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_h3_W.png)
-![h3 assembled geo(psi_A) ⊔ W ⊔ geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/retest_k1_h3_assembled.png)
-
-## Headline finding: free $\equiv$ cone at $k=1$ — the honest reversal
-
-At $k=0$ (#201), free interior connectivity was a genuine win: $L_0=D-A$ reads the
-1-skeleton, so a freely-wired interior edge (the "fan") changes the spectrum, and
-the free engine realized operations the cone could not. **At $k=1$ the result
-reverses, and the reason is structural.** `ChainComplex::fromSpacetime` builds only
-the **downward closure of the top cells**. Two consequences pin the engine:
-
-- An **additively attached dangling** edge or triangle is *dropped* from $L_k$ —
-  it is not in any top cell's closure — so it leaves the operator dimension and the
-  residual **bit-exact**. It is spectrally **inert**.
-- An additive **top-cell** attach (a new tetrahedron) is **boundary-locked**: it
-  introduces boundary edges incident to the new vertex, which the bit-exact
-  $\partial W$ guard rejects.
-
-So the only boundary-fixed move that *enriches* $L_k$ is the **stellar Pachner
-subdivision** (the cone). The free search dutifully enumerates and logs its edge +
-triangle candidates (`tri_cand=8` on every floored target), finds them provably
-inert, and falls back to the cone — hence **free $\equiv$ cone, to ~30 digits, on
-every target**. The 2-cell *is* spectrally real at $k=1$ (a filled vs hollow
-triangle shifts the $k=1$ residual while leaving $k=0$ bit-exact — checked in the
-tests); the *additive* engine simply cannot realize one under the pinned boundary.
-
-The consequence for the correspondence is clean and topological: **free
-connectivity does not enlarge the realizable set.** The realizable set at $k=1$ is
-exactly the **topological image** $H_1(\Sigma)\to H_1(W)$ — the carried longitude,
-nothing more — and the spectral residual is a continuous certificate of distance
-from that image. This is the opposite of the $k=0$ fan win, and it is reported as
-the finding (the issue's stop-condition asked for the precise wall, win or lose),
-not papered over.
+So the realizable set at $k=1$ is exactly $\mathrm{image}\big(H^1(W)\to
+H^1(\partial W)\big)$ for the $W$ the **search grows** — the earlier re-test's
+result, now produced as an *output* (with $b_1$ read off the witness) rather than
+installed by a pinned solid torus, and refined by the period-matching control.
 
 ## Method
 
-The capstone is pure orchestration of the merged, separately-tested classes — no
-new math in the example:
+The example is pure orchestration of the merged, separately-tested classes — no new
+math:
 
-1. **Build the boundary qubit and the two distinguished cycles.**
-   `BoundaryStateSpace(T^2)` gives the two $\ker L_1$ generators; the carried
-   **longitude** is the boundary restriction of `HodgeLaplacian(W).harmonics(1)[0]`
-   prepared onto the boundary state space, and the **meridian** is its orthogonal
-   complement in the qubit.
-2. **Decide each target, free vs cone.** `RealizabilityOracle(W).decideHarmonic`
-   with `growth_mode=FREE_CONNECTIVITY` (`connectivity_candidates=8`) and with
-   `growth_mode=CONE`, on a fresh pinned solid torus each time; record realizable /
-   residual / `triangle_candidates`, and assert the free and cone residuals agree.
-3. **Check H2 and H3 explicitly.** Snapshot $\partial W$ before/after a growing run
-   and assert every boundary edge is byte-identical; read the realized longitude
-   witness back as an $L_1(W)$ harmonic and assert its boundary overlap is $1$ and
-   $\lambda\approx0$; and cross-check the Choi transition-amplitude identity in two
-   independent code paths.
-4. **Rebuild the DW $S_3$ shadow.** Close
-   $\langle\,\mathrm{DW(swap)},\mathrm{DW(3\text{-}cycle)}\,\rangle$ from
-   `Cobordism.twistedCylinder` and certify it is the 6-element $GL(2,\mathbb{Z}_2)$.
+1. **Build the boundary and the meridian targets.** The octahedron-minus-faces disk
+   and annulus are built from a face list (`_surface`); the matched / flipped
+   meridians are the annulus's `HodgeLaplacian.harmonics(1)[0]` restricted to the
+   two boundary cycles, with circle B's period optionally negated.
+2. **E1 — the 2×2.** `RealizabilityOracle(W).decideHarmonic(growth_mode=SURGERY,
+   max_cones=0, harmonic=True)` on each (target, filling); record realizable /
+   residual / eigenvalue, and `ChainComplex.bettiNumbers` of each filling.
+3. **E2 — surgery emergence.** Re-run from the disk seed with `max_cones=3` across
+   seeds; read `Verdict.surgery_removals` and the witness $b_1$ before/after.
+4. **E3 — frozen without surgery.** Seed-only verdict, plus a direct
+   `EigenstateSynthesis.attachInteriorVertex` probe showing the additive move is
+   refused.
 
-The $k=1$ search extension, the inertness of the additive attach, and the activeness
-of the 2-cell at $k=1$ are re-derived independently in `tests/cobordism` (a separate
-code path from the example), which also checks the committed example self-verifies.
+The surgery primitive (remove / restore, $b_1$ moves, $\partial W$ bit-exact), the
+2×2, the surgery emergence, and the additive lock are re-derived independently in
+`tests/cobordism/test_emergent_bulk_python.py` (a separate code path from the
+example), which also checks the committed example self-verifies.
 
 ## Key findings
 
-1. **Free $\equiv$ cone at $k=1$.** The free residual equals the cone residual
-   bit-for-bit on every target; free interior connectivity does not enlarge the
-   realizable set. The opposite of the $k=0$ fan win (#201).
-2. **The realizable set is the topological image $H_1(\Sigma)\to H_1(W)$.** Exactly
-   the carried longitude is realizable ($r\sim10^{-29}$); the meridian (which dies
-   in $H_1(W)$) and the raw basis floor. *Realizable $\iff$ the boundary class is
-   the carried homology class.*
-3. **The spectral residual tracks the homology map.** The floor is a continuous
-   measure of distance from the image of $H_1(\Sigma)\to H_1(W)$ — smallest for the
-   basis harmonic with the largest overlap with the longitude, zero exactly on it.
-4. **The 2-cell is spectrally real but additively unrealizable.** A filled vs
-   hollow triangle shifts the $k=1$ residual (leaving $k=0$ bit-exact), so $L_1$
-   genuinely reads 2-cells; but a dangling additive 2-cell is dropped by the
-   downward-closure `ChainComplex` and a top-cell attach is boundary-locked, so the
-   only active boundary-fixed move is the stellar cone.
-5. **H1/H2/H3 hold; the DW $S_3$ shadow is the operation-realizing contrast.** The
-   correspondence stands at $k=1$; $\partial W$ is bit-exact through growth; the
-   realized witness reproduces the target form and the Choi identity; and the
-   discrete state-sum's $S_3=GL(2,\mathbb{Z}_2)$ image realizes *operations*, a
-   different question than the spectral *state* realizability.
+1. **$b_1$ is an output.** The surgery search opens the handle ($b_1:0\to1$) on its
+   own from the disk seed, scored only by the harmonic residual, with $\partial W$
+   bit-exact. Topology is read off the witness, not pinned.
+2. **The matched meridian realizes iff $b_1=1$.** It floors on the disk ($b_1=0$,
+   $r\approx0.45$) and realizes on the annulus ($b_1=1$, $r\approx7\times10^{-8}$,
+   $\lambda\to0$); the surgery-grown annulus realizes it too ($r\sim10^{-5}$).
+3. **The sign-flip floors everywhere.** Opposite periods ($p_A=-p_B$) are not the
+   restriction of any closed form, so the flipped meridian floors on the disk *and*
+   the annulus *and* the surgery-grown handle — a cohomological obstruction distinct
+   from the topological one.
+4. **Removal is the load-bearing move.** No boundary-fixed *additive* move (attach /
+   Pachner subdivision) moves $b_1$ at $k\ge1$; the boundary-fixed remove is the one
+   that does.
+5. **The realizable set is $\mathrm{image}(H^1(W)\to H^1(\partial W))$.** Read as a
+   continuous spectral certificate: zero on the image (carried), a positive floor
+   off it whose size tracks the distance from the image.
 
 ## Conventions
 
-- The bulk is `SimplicialProduct(SolidSimplex(2), S^1)` (the solid torus
-  $D^2\times S^1$), pinned Hermitian (all boundary edges weight $1$, phase $0$);
-  $\partial W=T^2$, $b_1(W)=1$, $b_1(T^2)=2$.
+- The bulk family is built **generically from a face list** (no `SimplicialProduct`,
+  no `Toroid`, no `SolidSimplex`): an octahedron (triangulated $S^2$); the disk is it
+  minus one face ($b_1=0$), the annulus minus two antipodal faces ($b_1=1$). All
+  edges pinned Hermitian (weight $1$, phase $0$).
 - The $k=1$ Laplacian is $L_1=\partial_1^\top\partial_1+\partial_2\partial_2^\top$;
-  the residual is $r=\lVert(I-\psi\psi^\dagger)L_1\psi\rVert^2$ and the eigenvalue is
-  the Rayleigh quotient $\lambda=\psi^\dagger L_1\psi$.
-- Realizable iff $r<\epsilon=10^{-9}$; a floored target sits far above it (the
-  certified obstruction floor). The H1 table uses `max_cones=0` so the residual is
-  exact and bit-exact reproducible; the W diagrams use `max_cones=1` to make the
-  Pachner cone visible (growth is non-deterministic — the #201 `AddMove` global
-  counter — but the floored verdict holds regardless).
-- $\psi_B$ in the diagrams is the **carried homology class** (the longitude) for
-  the four boundary-harmonic targets, and the genuine right state for the H3 case.
-- The DW maps are read **metric-free** (topology + cocycle only); the $S_3$ shadow
-  is the $GL(2,\mathbb{Z}_2)$ holonomy-permutation group on $Z(T^2)=\mathbb{C}^4$.
-- Seeded and reproducible; the 10-CPU cap is honored (thread env set at launch);
-  matplotlib uses the headless `Agg` backend.
+  with `harmonic=True` the residual is $r=\lVert L_1\psi\rVert^2$ (distance from
+  $\ker L_1=H_1(W)$) and the eigenvalue is the Rayleigh quotient
+  $\lambda=\psi^\dagger L_1\psi$.
+- Realizable iff $r<\texttt{REALIZE}=10^{-3}$; floored when $r>\texttt{CERT\_FLOOR}=
+  10^{-2}$ (the certified obstruction floor). The LM tolerance `DEEP_EPS`$=10^{-7}$
+  polishes below the verdict line; the verdict is read off the realized residual.
+- Topology is read **off the witness** as an output: `ChainComplex.bettiNumbers`.
+  The $E1$ seed verdict (`max_cones=0`) is exact and bit-exact reproducible; the
+  surgery removal count and $b_1:0\to1$ hold across seeds (the residuals vary in the
+  last digits with the seeded restart draws).
+- The diagrams use a fixed Schlegel layout so the only visible change between
+  fillings is which 2-cell is filled; every panel carries a large title and an
+  explicit legend. Seeded and reproducible; the 10-CPU cap is honored (thread env set
+  at launch); matplotlib uses the headless `Agg` backend.
 
 ## Reproduce
 
 ```
-pip install -e ".[dev]"
-python examples/cobordism/correspondence_retest_k1.py             # the verdict + H1 table
-python examples/cobordism/visualize_correspondence_retest_k1.py   # the 4 diagrams per operator
+pip install -e ".[dev]"        # default Release; the fast linker is auto-gated off Release (bfd links the LTO _tessera)
+python examples/cobordism/emergent_bulk_realizability.py   # the 2x2 + surgery tables
+python examples/cobordism/visualize_emergent_bulk.py       # the panels + composite
 python -m pytest tests/cobordism
 ```
 
-The raw comparison table and the diagram PNGs default to `/tmp/cobordism/` and are
-**not committed** — the two scripts are the committed artifacts. The diagrams are
-uploaded to the
+The raw table defaults to `/tmp/cobordism/emergent_bulk_realizability.json` and the
+diagram PNGs to `/tmp/cobordism/`, both **not committed** — the example, the
+visualizer, and this report are the committed artifacts. The diagrams are uploaded to
+the
 [`issue-attachments`](https://github.com/akellehe/tessera/releases/tag/issue-attachments)
 release and referenced above by their release URLs; attach the raw table to the
 issue/PR to pin a result.

--- a/examples/cobordism/emergent_bulk_realizability.py
+++ b/examples/cobordism/emergent_bulk_realizability.py
@@ -1,0 +1,432 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Emergent-bulk realizability: grow the bulk by surgery, let b_1 (and the
+obstruction) be a pure output.
+
+Two boundary circles, a meridian carried on both, and two validity-only fillings.
+Three things make this the genuine construction:
+
+  (a) **Two boundaries, and the period sign matters.** The boundary is
+      geo(psi_A) || geo(psi_B) -- TWO circles -- and the meridian is carried on
+      BOTH. We build the target two ways and test both:
+
+        * MATCHED -- equal periods on the two circles (p_A = p_B). This is the
+          boundary restriction of the annulus's own H_1 generator, so by Stokes
+          the swept meridian m x I closes up through the tube and the class
+          survives. It SHOULD be realizable on a filling that keeps both circles
+          in H_1.
+        * FLIPPED -- one circle's period negated (p_A = -p_B), the cobordism
+          conjugation geo(psi_A) || conj(geo(psi_B)). The two ends no longer agree,
+          so no closed 1-form on any filling restricts to it: it should FLOOR on
+          EVERY filling, even one with the handle open. The sign flip is the
+          negative control.
+
+  (b) **No pinned topology anywhere.** Nothing is hardcoded as a torus / solid
+      torus / disk / cone / SimplicialProduct-of-circles. The two boundary circles
+      are general valid 1-cycles; the bulk W starts from a minimal validity-only
+      seed and its topology -- in particular b_1(W) -- is whatever the surgery
+      search produces. The bulk topology is an OUTPUT.
+
+  (c) **Topology-changing moves (surgery).** Growth is NOT limited to coning /
+      Pachner subdivision (topology-PRESERVING, so b_1 is frozen at the seed -- the
+      negative result the earlier draft was stuck at). The move-set adds a
+      boundary-fixed REMOVE (``EigenstateSynthesis::removeInteriorCell`` /
+      ``RealizabilityOracle.GrowthMode.SURGERY``): detach an interior top cell (and
+      its now-orphaned faces) while holding the pinned boundary bit-exact. Removing
+      a cell OPENS a hole/handle, so b_1 MOVES. The realizability test is the
+      physical one (``harmonic=True``): a boundary class realizes iff it is
+      *carried* as a bulk harmonic, i.e. it lies in image(H_1(dW) -> H_1(W)).
+
+The whole story runs at the Hodge-qubit degree k=1 on a surface bulk W (top cells =
+triangles), the faithful low-dimensional analogue of the 3-manifold meridian/
+longitude setting. The bulk family is built generically from a face list (an
+octahedron = triangulated S^2):
+
+  * delete ONE face            -> a DISK   (b_1 = 0): the one circle bounds; the
+    antipodal triangle is still filled, so the other meridian bounds it too.
+  * delete the TWO antipodal faces -> an ANNULUS (b_1 = 1): the two circles are
+    homologous and each survives in H_1 -- the cobordism between them.
+
+What actually happens (all numbers reproduced below; exit 0 iff the claims hold):
+
+  E1 (the 2x2 -- the heart of (a)). Two targets x two fillings, seed verdict, no
+     growth:
+
+        filling \\ target     MATCHED (p_A=p_B)        FLIPPED (p_A=-p_B)
+        disk    (b_1=0)        floor                    floor
+        annulus (b_1=1)        REALIZE  (carried)       floor
+
+     The disk (b_1=0) carries no nontrivial harmonic, so BOTH meridians floor. The
+     annulus (b_1=1) carries the matched meridian (r -> 0, eigenvalue -> 0) but
+     NOT the flipped one: opposite periods are not the restriction of any closed
+     form, so the flip floors even where the topology is right. Realizable iff the
+     filling has b_1=1 AND the periods match.
+
+  E2 (surgery moves b_1 on its own, (c)). From the disk seed (b_1=0) the SURGERY
+     search commits one boundary-fixed removal on its own -- scored purely by the
+     harmonic residual -- opening the handle so b_1: 0 -> 1, for BOTH targets (the
+     opened handle always lowers the residual). But only the MATCHED meridian then
+     REALIZES; the FLIPPED one still FLOORS on the opened handle. So surgery
+     delivers the topology as a pure output, and the leftover obstruction is the
+     cohomological one (the period mismatch) that no filling can fix.
+
+  E3 (only removal moves b_1). With the budget but no remove move -- the additive
+     attach (FREE_CONNECTIVITY) and the Pachner subdivision are boundary-locked /
+     spectrally inert at k>=1 -- b_1 stays frozen at the seed and the matched
+     meridian never realizes. Removal is the load-bearing move.
+
+Headline: with the surgery move-set the topology obstruction does NOT have to be
+installed by a hand-picked filling -- b_1 falls out of the search. The matched
+two-boundary meridian, unrealizable on the disk, becomes realizable the moment the
+search opens the handle; the flipped meridian floors on every filling, so the
+period-matching obstruction is genuinely separate from the topological one.
+
+Run:  python examples/cobordism/emergent_bulk_realizability.py
+      (--help for options; the raw table defaults to /tmp/cobordism and is NOT
+      committed -- attach it to the issue/PR to pin a result.)
+"""
+
+from __future__ import annotations
+
+# Honor the 10-CPU cap before numpy / the C++ ext pull in a BLAS.
+import os
+
+for _var in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+             "BLIS_NUM_THREADS"):
+    os.environ.setdefault(_var, "10")
+
+import argparse  # noqa: E402
+import json  # noqa: E402
+
+import numpy as np  # noqa: E402
+
+import tessera  # noqa: E402
+
+cob = tessera.cobordism
+SURGERY = cob.RealizabilityOracle.GrowthMode.SURGERY
+
+# A boundary class realizes iff its harmonic residual ||L_1 psi||^2 can be driven
+# below REALIZE; it is certified obstructed when it floors above CERT_FLOOR. The
+# bounded Levenberg-Marquardt fill reaches ~1e-7 on a carried class and floors at
+# ~2e-1..1e0 otherwise -- orders of magnitude either side of these thresholds.
+# DEEP_EPS is the LM tolerance (well below REALIZE so the optimizer polishes deep
+# instead of stopping the instant it dips under the verdict line); the verdict
+# itself is read off the realized residual against REALIZE.
+DEEP_EPS = 1e-7
+REALIZE = 1e-3
+CERT_FLOOR = 1e-2
+RESTARTS = 64
+GROW_STEPS = 3
+
+
+# --------------------------------------------------------------------------- #
+# The octahedron surface family -- built generically from a face list, NOT from
+# any named topology (no SimplicialProduct, no Toroid, no SolidSimplex). The
+# octahedron is a triangulated S^2; deleting faces opens boundary circles:
+#   * delete one face          -> a DISK   (b_1 = 0): the one circle bounds.
+#   * delete two opposite faces -> an ANNULUS (b_1 = 1): the two circles are
+#     homologous, so each survives in H_1 -- the meridian that lives.
+# Hole A is the triangle {0,1,2}; the antipodal hole B is the triangle {3,4,5}.
+# Vertices 0,1,2 carry hole A; 3,4,5 carry hole B; every edge is in two faces.
+# --------------------------------------------------------------------------- #
+_OCTAHEDRON = [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 1, 4),
+               (5, 1, 2), (5, 2, 3), (5, 3, 4), (5, 1, 4)]
+HOLE_A = (0, 1, 2)        # boundary circle A (the meridian m_A lives here)
+HOLE_B = (3, 4, 5)        # antipodal boundary circle B (m_B)
+CYCLE_A = [(0, 1), (0, 2), (1, 2)]
+CYCLE_B = [(3, 4), (3, 5), (4, 5)]
+
+
+def _surface(faces, weight=1.0, phase=0.0):
+    """A pre-geometric 2-complex (top cells = triangles) from a face list, with all
+    edges pinned to a uniform Hermitian weight. No topology object is used."""
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {i: st.createVertex(i) for i in sorted({v for f in faces for v in f})}
+    for f in faces:
+        t = sorted(f)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]]])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(weight)
+        e.setPhase(phase)
+    return st
+
+
+def _delete(*faces):
+    drop = {tuple(sorted(f)) for f in faces}
+    return [f for f in _OCTAHEDRON if tuple(sorted(f)) not in drop]
+
+
+def _disk():
+    """Minimal validity-only seed: the octahedron minus hole A -- a disk filling of
+    boundary circle A. b_1 = 0 (the circle bounds; the antipodal triangle {3,4,5}
+    is still filled, so circle B bounds it). This is the bulk SEED, not a pinned
+    answer; surgery decides the real topology."""
+    return _surface(_delete(HOLE_A))
+
+
+def _annulus():
+    """The octahedron minus the two antipodal holes A and B -- the annulus/cylinder
+    cobordism between the two boundary circles. b_1 = 1 (each circle survives)."""
+    return _surface(_delete(HOLE_A, HOLE_B))
+
+
+def _betti(st):
+    return [int(b) for b in cob.ChainComplex.fromSpacetime(st).bettiNumbers()]
+
+
+# --------------------------------------------------------------------------- #
+# The two-boundary meridian target, matched or sign-flipped (the heart of (a)).
+# --------------------------------------------------------------------------- #
+def _periods(vals):
+    """The two boundary periods (oriented loop sums) of a 1-form given on
+    CYCLE_A + CYCLE_B: p_A around 0->1->2->0, p_B around 3->4->5->3."""
+    v = {e: c for e, c in zip(CYCLE_A + CYCLE_B, vals)}
+    p_a = v[(0, 1)] + v[(1, 2)] - v[(0, 2)]
+    p_b = v[(3, 4)] + v[(4, 5)] - v[(3, 5)]
+    return complex(p_a), complex(p_b)
+
+
+def _meridian_target(flip=False):
+    """The meridian carried on BOTH boundary circles, read off the annulus's own
+    harmonic 1-form (the generator of H_1) restricted to CYCLE_A + CYCLE_B.
+
+    MATCHED (flip=False) keeps the harmonic's equal periods (p_A = p_B) -- the
+    cobordism-consistent meridian. FLIPPED (flip=True) negates circle B, giving
+    opposite periods (p_A = -p_B) -- the cobordism conjugation geo(psi_A) ||
+    conj(geo(psi_B)), the negative control that no closed form can carry."""
+    h = cob.HodgeLaplacian(_annulus()).harmonics(1)[0]
+    edges = CYCLE_A + CYCLE_B
+    vals = [complex(h.amplitudeFor(list(e))) for e in edges]
+    if flip:
+        vals = vals[:3] + [-v for v in vals[3:]]   # negate circle B's period
+    return cob.Cochain(1, edges, np.asarray(vals, dtype=complex)), edges, vals
+
+
+def _decide(st, target, *, mode, max_cones, seed=1, restarts=RESTARTS):
+    """Harmonic realizability: drive ||L_1 psi||^2 -> 0 with the pinned boundary,
+    growing via `mode` up to `max_cones` steps. harmonic=True so realizable means
+    the meridian is CARRIED as a bulk harmonic (in image(H_1(dW) -> H_1(W)))."""
+    return cob.RealizabilityOracle(st).decideHarmonic(
+        target, epsilon=DEEP_EPS, restarts=restarts, max_cones=max_cones,
+        seed=seed, growth_mode=mode, connectivity_candidates=8, harmonic=True)
+
+
+# --------------------------------------------------------------------------- #
+# E1: the 2x2 -- the verdict tracks (filling b_1) AND (period match) (a + b).
+# --------------------------------------------------------------------------- #
+def two_by_two(targets):
+    """Both targets (matched, flipped) x both fillings (disk, annulus), seed
+    verdict (no growth) -> the 2x2 residual table the physics turns on."""
+    rows = []
+    for tname, (target, _edges, _vals) in targets.items():
+        for fname, fn in [("disk", _disk), ("annulus", _annulus)]:
+            st = fn()
+            b1 = _betti(st)[1]
+            v = _decide(st, target, mode=SURGERY, max_cones=0)
+            rows.append({"target": tname, "filling": fname, "filling_b1": b1,
+                         "realizable": bool(v.residual < REALIZE),
+                         "residual": float(v.residual),
+                         "eigenvalue": float(v.eigenvalue)})
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# E2: surgery moves b_1 on its own (c) -- the obstruction is emergent.
+# --------------------------------------------------------------------------- #
+def surgery_emergence(targets, seeds=(0, 1, 2, 3)):
+    """From the disk seed (b_1=0) the SURGERY search opens the handle on its own
+    (b_1: 0 -> 1) for BOTH targets. The matched meridian then REALIZES; the flipped
+    one still FLOORS on the opened handle -- the period mismatch is a separate,
+    cohomological obstruction surgery cannot fix."""
+    rows = []
+    for tname, (target, _edges, _vals) in targets.items():
+        for seed in seeds:
+            st = _disk()
+            before = _betti(st)[1]
+            v = _decide(st, target, mode=SURGERY, max_cones=GROW_STEPS, seed=seed)
+            rows.append({"target": tname, "seed": seed, "b1_before": before,
+                         "b1_after": _betti(st)[1],
+                         "removals": int(v.surgery_removals),
+                         "realizable": bool(v.residual < REALIZE),
+                         "residual": float(v.residual)})
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# E3: only removal moves b_1 -- additive growth leaves it frozen (the contrast).
+# --------------------------------------------------------------------------- #
+def frozen_without_surgery(target):
+    """Without the remove move b_1 is frozen at the seed and the matched meridian
+    floors:
+       * no growth at all (max_cones=0);
+       * additive attach (FREE_CONNECTIVITY) -- every additive candidate is
+         boundary-locked / spectrally inert at k>=1, so attachInteriorVertex is
+         rejected and b_1 cannot move."""
+    rows = []
+    st = _disk()
+    before = _betti(st)[1]
+    v0 = _decide(st, target, mode=SURGERY, max_cones=0)
+    rows.append({"growth": "none (seed only)", "b1_before": before,
+                 "b1_after": _betti(st)[1],
+                 "realizable": bool(v0.residual < REALIZE),
+                 "residual": float(v0.residual)})
+    # Additive attach: probe directly that it cannot move b_1 (it is rejected --
+    # wiring a triangle in introduces new dW edges the bit-exact guard refuses).
+    st = _disk()
+    es = cob.EigenstateSynthesis(st, 1)
+    attached = es.attachInteriorVertex([[3, 4]])  # a fresh triangle over edge {3,4}
+    rows.append({"growth": "additive attach", "b1_before": before,
+                 "b1_after": _betti(st)[1], "attach_accepted": bool(attached),
+                 "realizable": False, "residual": None})
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", default="/tmp/cobordism",
+                    help="dir for the raw table (default /tmp/cobordism; NOT committed).")
+    ap.add_argument("--no-write", action="store_true")
+    args = ap.parse_args()
+
+    print("Emergent-bulk realizability at k=1: grow the bulk by surgery, let b_1 "
+          "and the obstruction be outputs\n")
+
+    targets = {"matched": _meridian_target(flip=False),
+               "flipped": _meridian_target(flip=True)}
+    for tname, (_target, _edges, vals) in targets.items():
+        p_a, p_b = _periods(vals)
+        agree = abs(p_a - p_b) < abs(p_a) * 1e-6 + 1e-12
+        gloss = ("matched -> closes up through the tube" if agree
+                 else "opposite -> no closed form carries it")
+        print(f"  Target [{tname}] meridian on circle A {HOLE_A} || circle B "
+              f"{HOLE_B}:")
+        print(f"        m_A {[f'{v.real:+.2f}' for v in vals[:3]]}  "
+              f"m_B {[f'{v.real:+.2f}' for v in vals[3:]]}")
+        print(f"        periods p_A={p_a.real:+.3f}  p_B={p_b.real:+.3f}  "
+              f"(p_A/p_B={ (p_a / p_b).real:+.2f}: {gloss})")
+
+    ok = True
+
+    # ---- E1: the 2x2 -- the heart of the experiment ------------------------ #
+    e1 = two_by_two(targets)
+    print("\n  E1  the 2x2: two targets x two validity-only fillings (no growth):")
+    header = (f"      {'target':>8} {'filling':>9} {'b_1':>4} {'realizable':>11} "
+              f"{'residual':>11} {'eig':>11}")
+    print(header)
+    print("      " + "-" * (len(header) - 6))
+    for r in e1:
+        print(f"      {r['target']:>8} {r['filling']:>9} {r['filling_b1']:>4} "
+              f"{'YES' if r['realizable'] else 'floored':>11} "
+              f"{r['residual']:>11.2e} {r['eigenvalue']:>11.2e}")
+
+    def _row(t, f):
+        return next(r for r in e1 if r["target"] == t and r["filling"] == f)
+
+    print("        => MATCHED realizes ONLY on the annulus (b_1=1): the carried "
+          "meridian, eigenvalue -> 0. FLIPPED floors on BOTH: opposite periods are "
+          "not the restriction of any closed form. Realizable iff b_1=1 AND periods "
+          "match. The realizable set is image(H_1(dW) -> H_1(W)).")
+    ok &= _row("matched", "annulus")["realizable"]
+    ok &= not _row("matched", "disk")["realizable"]
+    ok &= _row("matched", "disk")["residual"] > CERT_FLOOR
+    ok &= not _row("flipped", "annulus")["realizable"]
+    ok &= _row("flipped", "annulus")["residual"] > CERT_FLOOR
+    ok &= not _row("flipped", "disk")["realizable"]
+    ok &= _row("flipped", "disk")["residual"] > CERT_FLOOR
+
+    # ---- E2: surgery moves b_1 on its own (the obstruction is emergent) ---- #
+    e2 = surgery_emergence(targets)
+    print("\n  E2  SURGERY search from the disk seed (b_1=0) -- the remove move "
+          "opens the handle on its own:")
+    header = (f"      {'target':>8} {'seed':>5} {'removals':>9} {'b_1':>9} "
+              f"{'realizable':>11} {'residual':>11}")
+    print(header)
+    print("      " + "-" * (len(header) - 6))
+    for r in e2:
+        print(f"      {r['target']:>8} {r['seed']:>5} {r['removals']:>9} "
+              f"{str(r['b1_before'])+'->'+str(r['b1_after']):>9} "
+              f"{'YES' if r['realizable'] else 'floored':>11} "
+              f"{r['residual']:>11.2e}")
+    print("        => b_1 moves 0 -> 1 on its own for BOTH targets, scored purely "
+          "by the harmonic residual. The MATCHED meridian then REALIZES; the "
+          "FLIPPED one still FLOORS on the opened handle. Surgery delivers the "
+          "topology as an output; the period mismatch is the separate obstruction "
+          "no filling can fix.")
+    e2_matched = [r for r in e2 if r["target"] == "matched"]
+    e2_flipped = [r for r in e2 if r["target"] == "flipped"]
+    ok &= all(r["b1_before"] == 0 and r["b1_after"] == 1 for r in e2)
+    ok &= all(r["removals"] >= 1 for r in e2)
+    ok &= all(r["realizable"] for r in e2_matched)
+    ok &= all(not r["realizable"] for r in e2_flipped)
+
+    # ---- E3: only removal moves b_1 -- additive growth is frozen ----------- #
+    e3 = frozen_without_surgery(targets["matched"][0])
+    print("\n  E3  without the remove move, b_1 is frozen and the matched meridian "
+          "floors:")
+    for r in e3:
+        extra = ("" if r["residual"] is None
+                 else f"  residual={r['residual']:.2e}")
+        acc = ("" if "attach_accepted" not in r
+               else f"  attach_accepted={r['attach_accepted']}")
+        print(f"        {r['growth']:20} b_1 {r['b1_before']}->{r['b1_after']}  "
+              f"realizable={r['realizable']}{acc}{extra}")
+    print("        => additive growth (attach / Pachner subdivision) is boundary-"
+          "locked / topology-PRESERVING at k>=1: b_1 cannot move, so the meridian "
+          "stays floored. Removal is the load-bearing move.")
+    ok &= all(r["b1_before"] == r["b1_after"] == 0 for r in e3)
+    ok &= not e3[1]["attach_accepted"]
+
+    # ---- raw table (PR artifact, not committed) --------------------------- #
+    if not args.no_write:
+        os.makedirs(args.out, exist_ok=True)
+        path = os.path.join(args.out, "emergent_bulk_realizability.json")
+        target_raw = {}
+        for tname, (_t, edges, vals) in targets.items():
+            p_a, p_b = _periods(vals)
+            target_raw[tname] = {
+                "edges": [list(e) for e in edges],
+                "values": [[v.real, v.imag] for v in vals],
+                "period_A": [p_a.real, p_a.imag],
+                "period_B": [p_b.real, p_b.imag]}
+        raw = {"degree": 1, "targets": target_raw, "E1_two_by_two": e1,
+               "E2_surgery_emergence": e2, "E3_frozen_without_surgery": e3}
+        with open(path, "w") as handle:
+            json.dump(raw, handle, indent=2)
+        print(f"\n  raw table (PR artifact, not committed): {path}")
+
+    print("\n  Verdict: " + (
+        "SUPPORTED -- the matched two-boundary meridian floors on the disk "
+        "(b_1=0) and realizes on the annulus (b_1=1); the SURGERY search moves "
+        "b_1 0 -> 1 on its own; and the sign-flipped meridian floors on EVERY "
+        "filling, so the period-matching obstruction is genuinely separate from "
+        "the topological one. The obstruction is emergent, not installed."
+        if ok else
+        "NOT SUPPORTED -- a claim failed; inspect the tables above."))
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/visualize_emergent_bulk.py
+++ b/examples/cobordism/visualize_emergent_bulk.py
@@ -1,0 +1,450 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Visualize emergent-bulk realizability: surgery makes b_1 a pure output (#207).
+
+Make the emergent-bulk story legible. The boundary is two meridian circles
+geo(psi_A) || geo(psi_B); the bulk is grown from a validity-only seed; surgery
+opens the handle so b_1 moves on its own, and the matched meridian realizes
+exactly where b_1=1.
+
+The octahedron (a triangulated S^2) is drawn as a Schlegel diagram on ONE fixed
+layout, so the topology of each filling reads at a glance:
+
+  * hole A = {0,1,2} is the OUTER triangle, hole B = {3,4,5} the INNER triangle,
+    with the six "band" 2-cells between them;
+  * a FILLED 2-cell is shaded; a removed face is an OPEN (white, dashed) hole --
+    a boundary circle dW.
+
+So the panels are immediate:
+
+  1. geo(psi_A) || geo(psi_B) -- the two bare boundary circles (outer A, inner B),
+     edges colored by the matched meridian 1-form (equal periods p_A = p_B).
+  2. disk filling (b_1=0)     -- only hole A is open; the inner triangle {3,4,5} is
+     FILLED (a disk), so circle B bounds it. The meridian FLOORS.
+  3. annulus filling (b_1=1)  -- BOTH triangles open: the six band cells form a
+     ring (an annulus). Edges colored by the realized carried harmonic 1-form. The
+     meridian REALIZES, eigenvalue -> 0.
+  4. surgery: disk -> annulus -- the boundary-fixed REMOVE of the interior top cell
+     {3,4,5} punches the inner triangle out: b_1 0 -> 1, dW held bit-exact.
+
+A fifth composite tiles 1-4. Every panel carries a large title and an explicit
+legend. Images go to /tmp/cobordism and are NOT committed (this script is the
+committed artifact; the PNGs are uploaded to the issue-attachments release and
+referenced from the docs report by URL). BLAS/OpenMP pools are capped at the box's
+shared budget.
+
+Run:  python examples/cobordism/visualize_emergent_bulk.py
+      (--help for options; writes the panels + composite into /tmp/cobordism)
+"""
+
+from __future__ import annotations
+
+# Cap BLAS / OpenMP threads at launch (shared box) before numpy / tessera import.
+import os
+
+for _v in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+           "BLIS_NUM_THREADS"):
+    os.environ.setdefault(_v, "10")
+
+import argparse  # noqa: E402
+import sys  # noqa: E402
+
+import numpy as np  # noqa: E402
+import matplotlib  # noqa: E402
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.lines import Line2D  # noqa: E402
+from matplotlib.patches import Patch, Polygon  # noqa: E402
+
+import tessera  # noqa: E402
+
+# Sibling example import: the fixtures + the decide() helper.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import emergent_bulk_realizability as E  # noqa: E402
+from visualize_realizability import _amp_rgba  # noqa: E402
+
+cob = tessera.cobordism
+
+HOLE_A = tuple(sorted(E.HOLE_A))    # {0,1,2} -- outer triangle
+HOLE_B = tuple(sorted(E.HOLE_B))    # {3,4,5} -- inner triangle
+
+# Fixed Schlegel layout: hole A is the big outer triangle, hole B the small inner
+# triangle, each inner vertex placed between the two outer vertices it bonds to
+# (3<->{0,2}, 4<->{0,1}, 5<->{1,2}), so the six band faces never cross.
+_R, _r = 1.0, 0.44
+POS = {
+    0: (_R * np.cos(np.radians(90)),  _R * np.sin(np.radians(90))),
+    1: (_R * np.cos(np.radians(210)), _R * np.sin(np.radians(210))),
+    2: (_R * np.cos(np.radians(330)), _R * np.sin(np.radians(330))),
+    3: (_r * np.cos(np.radians(30)),  _r * np.sin(np.radians(30))),
+    4: (_r * np.cos(np.radians(150)), _r * np.sin(np.radians(150))),
+    5: (_r * np.cos(np.radians(270)), _r * np.sin(np.radians(270))),
+}
+
+FACE_FILL = (0.78, 0.84, 0.92, 0.85)     # a filled 2-cell (light blue)
+SURGERY_FILL = (0.96, 0.78, 0.78, 0.95)  # the cell surgery removes (red wash)
+HOLE_EDGE = (0.45, 0.45, 0.50)           # open-hole dashed outline
+ZERO_EDGE = (0.72, 0.72, 0.76)           # decoupled (|amp| ~ 0) edge
+
+
+# =========================================================================
+# Topology + the 1-form on edges
+# =========================================================================
+
+def _faces(st):
+    out = set()
+    for v in st.getVertexList().toVector():
+        for s in v.getSimplices():
+            ids = tuple(sorted(x.getId() for x in s.getVertices()))
+            if len(ids) == 3:
+                out.add(ids)
+    return sorted(out)
+
+
+def _edges(st):
+    out = set()
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        if a != b:
+            out.add((min(a, b), max(a, b)))
+    return sorted(out)
+
+
+def _boundary_keys(st):
+    keys = set()
+    for face in st.getBoundary():
+        for i in range(len(face)):
+            for j in range(i + 1, len(face)):
+                keys.add((min(face[i], face[j]), max(face[i], face[j])))
+    return keys
+
+
+def _target_edge_amp(target):
+    out = {}
+    for cell, c in zip(target.simplices(), np.asarray(target.coeffs())):
+        ids = tuple(int(i) for i in cell)
+        if len(ids) == 2:
+            out[(min(ids), max(ids))] = complex(c)
+    return out
+
+
+def _witness_edge_amp(witness, state):
+    cells = [tuple(int(i) for i in c)
+             for c in cob.EigenstateSynthesis(witness, 1).cellSimplices()]
+    amp = np.asarray(state, dtype=complex)
+    out = {}
+    for i, c in enumerate(cells):
+        if len(c) == 2 and i < len(amp):
+            out[(min(c), max(c))] = amp[i]
+    return out
+
+
+# =========================================================================
+# 2D drawing on the fixed Schlegel layout
+# =========================================================================
+
+def _draw_complex(ax, st, edge_amp, *, max_mag, draw_faces=True, punch_holes=(),
+                  surgery_cell=None, only_edges=None, label_holes=True):
+    """Draw a filling on the Schlegel layout: shaded 2-cells, the inner hole(s)
+    punched white, the 1-form on edges (boundary thick, interior dashed), vertices.
+
+    hole A = {0,1,2} is the OUTER triangle (the unbounded Schlegel face) -- it is
+    never punched; its thick outer edges ARE the boundary circle A. Only inner
+    removed faces (hole B) are white-punched, so a disk reads as the fully filled
+    outer triangle and an annulus as that triangle with B punched out (a ring)."""
+    bkeys = _boundary_keys(st)
+    surg = tuple(sorted(surgery_cell)) if surgery_cell else None
+
+    # Filled 2-cells (shade); the surgery cell gets the red wash.
+    if draw_faces:
+        for f in _faces(st):
+            col = SURGERY_FILL if f == surg else FACE_FILL
+            ax.add_patch(Polygon([POS[v] for v in f], closed=True, facecolor=col,
+                                 edgecolor="none", zorder=1))
+
+    # Inner holes (removed bounded faces): white interior + dashed outline + label.
+    for h in punch_holes:
+        h = tuple(sorted(h))
+        ax.add_patch(Polygon([POS[v] for v in h], closed=True, facecolor="white",
+                             edgecolor=HOLE_EDGE, lw=1.6, ls=(0, (4, 3)),
+                             zorder=2))
+        if label_holes:
+            cx = np.mean([POS[v][0] for v in h])
+            cy = np.mean([POS[v][1] for v in h])
+            tag = "B" if h == HOLE_B else ("A" if h == HOLE_A else "?")
+            ax.text(cx, cy, f"hole {tag}\n(dW)", ha="center", va="center",
+                    fontsize=10.5, color=HOLE_EDGE, zorder=3, style="italic")
+
+    # Edges colored by the 1-form; boundary thick solid, interior thin dashed.
+    edges = only_edges if only_edges is not None else _edges(st)
+    for (u, v) in edges:
+        key = (min(u, v), max(u, v))
+        z = edge_amp.get(key, 0.0 + 0.0j)
+        col = ZERO_EDGE if abs(z) <= 1e-9 else _amp_rgba(z, max_mag)[:3]
+        is_bnd = key in bkeys
+        (x0, y0), (x1, y1) = POS[u], POS[v]
+        ax.plot([x0, x1], [y0, y1], color=col,
+                lw=5.0 if is_bnd else 1.8,
+                ls="solid" if is_bnd else (0, (5, 3)),
+                solid_capstyle="round", zorder=4)
+
+    # Vertices, labeled.
+    vids = sorted({v for e in _edges(st) for v in e})
+    for vid in vids:
+        x, y = POS[vid]
+        ax.plot([x], [y], "o", color=(0.18, 0.18, 0.22), ms=11, zorder=5)
+        ax.annotate(str(vid), (x, y), textcoords="offset points",
+                    xytext=(8, 6), fontsize=13, fontweight="bold",
+                    color=(0.1, 0.1, 0.1), zorder=6)
+
+    ax.set_aspect("equal")
+    ax.set_xlim(-1.35, 1.5)
+    ax.set_ylim(-1.3, 1.35)
+    ax.set_axis_off()
+
+
+# =========================================================================
+# Verdicts (seed) + the surgery-grown witness
+# =========================================================================
+
+def _verdict(fill_fn, target):
+    st = fill_fn()
+    return st, E._decide(st, target, mode=E.SURGERY, max_cones=0)
+
+
+def _surgery_grow(target, seed=0):
+    st = E._disk()
+    return st, E._decide(st, target, mode=E.SURGERY, max_cones=E.GROW_STEPS,
+                         seed=seed)
+
+
+# =========================================================================
+# Legends
+# =========================================================================
+
+def _form_legend(max_mag):
+    bright = _amp_rgba(complex(max_mag), max_mag)[:3]
+    return [
+        Line2D([0], [0], color=bright, lw=5, label="boundary circle dW (thick)"),
+        Line2D([0], [0], color=ZERO_EDGE, lw=1.8, ls=(0, (5, 3)),
+               label="interior edge (thin dashed)"),
+        Patch(facecolor=FACE_FILL, edgecolor="none", label="filled 2-cell"),
+        Patch(facecolor="white", edgecolor=HOLE_EDGE, ls="--",
+              label="open hole = boundary circle"),
+        Line2D([0], [0], marker="s", color="w", markerfacecolor=bright,
+               markersize=11, label="edge hue = 1-form phase, brightness = |amp|"),
+    ]
+
+
+def _save(fig, path, dpi):
+    fig.savefig(path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+
+
+# =========================================================================
+# Orchestration
+# =========================================================================
+
+def build(out_dir, *, dpi=130, layout_seed=42):
+    matched, _edges_t, mvals = E._meridian_target(flip=False)
+    p_a, p_b = E._periods(mvals)
+    tgt_amp = _target_edge_amp(matched)
+    tgt_max = max((abs(z) for z in tgt_amp.values()), default=1.0)
+
+    disk_st, disk_v = _verdict(E._disk, matched)
+    ann_st, ann_v = _verdict(E._annulus, matched)
+    grow_st, grow_v = _surgery_grow(matched, seed=layout_seed)
+    b1 = (E._betti(disk_st)[1], E._betti(ann_st)[1], E._betti(grow_st)[1])
+
+    ann_amp = _witness_edge_amp(ann_v.witness, ann_v.state)
+    ann_max = max((abs(z) for z in ann_amp.values()), default=1.0)
+    grow_amp = _witness_edge_amp(grow_v.witness, grow_v.state)
+    grow_max = max((abs(z) for z in grow_amp.values()), default=1.0)
+
+    paths = {}
+
+    # --- 1. geo(psi_A) || geo(psi_B): the two bare boundary circles only. ---
+    fig, ax = plt.subplots(figsize=(7.6, 8.2))
+    _draw_complex(ax, ann_st, tgt_amp, max_mag=tgt_max, draw_faces=False,
+                  only_edges=E.CYCLE_A + E.CYCLE_B, label_holes=False)
+    ax.text(*POS[0], "  circle A (m_A)", fontsize=12, fontweight="bold",
+            color=(0.78, 0.12, 0.12), va="bottom")
+    ax.text(0.0, -0.02, "circle B (m_B)", fontsize=11, fontweight="bold",
+            color=(0.12, 0.3, 0.78), ha="center")
+    ax.set_title("geo(psi_A)  ||  geo(psi_B):  the two boundary meridians\n"
+                 f"matched, equal periods  p_A = {p_a.real:+.2f},  "
+                 f"p_B = {p_b.real:+.2f}", fontsize=15, fontweight="bold",
+                 linespacing=1.3)
+    ax.legend(handles=[
+        Line2D([0], [0], color=_amp_rgba(complex(tgt_max), tgt_max)[:3], lw=5,
+               label="meridian 1-form on a boundary circle"),
+        Line2D([0], [0], marker="s", color="w",
+               markerfacecolor=_amp_rgba(complex(tgt_max), tgt_max)[:3],
+               markersize=11, label="hue = phase, brightness = |amplitude|")],
+        loc="lower center", ncol=1, fontsize=10, frameon=False,
+        bbox_to_anchor=(0.5, -0.13))
+    paths["boundary"] = os.path.join(out_dir, "emergent_bulk_boundary.png")
+    _save(fig, paths["boundary"], dpi)
+
+    # --- 2. disk filling (b_1=0): meridian floors. ---
+    fig, ax = plt.subplots(figsize=(7.6, 8.4))
+    _draw_complex(ax, disk_st, tgt_amp, max_mag=tgt_max)
+    ax.set_title("Disk filling   (b_1 = 0)\n"
+                 f"meridian FLOORS:  r = {disk_v.residual:.2e}   "
+                 f"(eigenvalue {disk_v.eigenvalue:.2e})",
+                 fontsize=15, fontweight="bold", linespacing=1.3)
+    ax.text(0.0, -1.22, "the inner triangle {3,4,5} is FILLED, so circle B bounds "
+            "it: the disk carries no nontrivial harmonic", ha="center",
+            fontsize=10.5, style="italic", color=(0.25, 0.25, 0.25))
+    ax.legend(handles=_form_legend(tgt_max), loc="lower center", ncol=2,
+              fontsize=9.5, frameon=False, bbox_to_anchor=(0.5, -0.20))
+    paths["disk"] = os.path.join(out_dir, "emergent_bulk_disk.png")
+    _save(fig, paths["disk"], dpi)
+
+    # --- 3. annulus filling (b_1=1): the carried harmonic; meridian realizes. ---
+    fig, ax = plt.subplots(figsize=(7.6, 8.4))
+    _draw_complex(ax, ann_st, ann_amp, max_mag=ann_max, punch_holes=(HOLE_B,))
+    ax.set_title("Annulus filling   (b_1 = 1)   --   the harmonic on the annulus\n"
+                 f"meridian REALIZES:  r = {ann_v.residual:.2e}   "
+                 f"(eigenvalue {ann_v.eigenvalue:.1e} ~ 0)",
+                 fontsize=15, fontweight="bold", linespacing=1.3)
+    ax.text(0.0, -1.22, "both triangles removed: the six band cells form a ring; "
+            "the cobordism carries the meridian as a bulk harmonic", ha="center",
+            fontsize=10.5, style="italic", color=(0.25, 0.25, 0.25))
+    ax.legend(handles=_form_legend(ann_max), loc="lower center", ncol=2,
+              fontsize=9.5, frameon=False, bbox_to_anchor=(0.5, -0.20))
+    paths["annulus"] = os.path.join(out_dir, "emergent_bulk_annulus.png")
+    _save(fig, paths["annulus"], dpi)
+
+    # --- 4. surgery: disk -> annulus (before / after). ---
+    fig, axes = plt.subplots(1, 2, figsize=(15.0, 8.0))
+    _draw_complex(axes[0], E._disk(), tgt_amp, max_mag=tgt_max,
+                  surgery_cell=HOLE_B)
+    axes[0].set_title("before: disk seed  (b_1 = 0)\n"
+                      "surgery will REMOVE interior cell {3,4,5} (red)",
+                      fontsize=13.5, fontweight="bold", linespacing=1.3)
+    _draw_complex(axes[1], grow_st, grow_amp, max_mag=grow_max,
+                  punch_holes=(HOLE_B,))
+    axes[1].set_title(f"after: handle open  (b_1 = {b1[2]})\n"
+                      f"matched meridian REALIZES:  r = {grow_v.residual:.2e}",
+                      fontsize=13.5, fontweight="bold", linespacing=1.3)
+    fig.suptitle("Surgery move:  b_1 moves 0 -> 1 on its own  "
+                 f"(removals = {grow_v.surgery_removals}, dW held bit-exact)",
+                 fontsize=16.5, fontweight="bold")
+    fig.tight_layout(rect=(0, 0, 1, 0.93))
+    paths["surgery"] = os.path.join(out_dir, "emergent_bulk_surgery.png")
+    _save(fig, paths["surgery"], dpi)
+
+    # --- 4b. the period sign matters: matched vs flipped on the SAME annulus. ---
+    # Same topology (b_1=1); only circle B's period sign differs. The conjugation
+    # geo(psi_A) || conj(geo(psi_B)) (p_A = -p_B) floors even here -- the
+    # cohomological obstruction is separate from the topological one.
+    flipped, _fe, fvals = E._meridian_target(flip=True)
+    fp_a, fp_b = E._periods(fvals)
+    ftgt_amp = _target_edge_amp(flipped)
+    ftgt_max = max((abs(z) for z in ftgt_amp.values()), default=tgt_max)
+    _, fann_v = _verdict(E._annulus, flipped)
+    fig, axes = plt.subplots(1, 2, figsize=(15.0, 8.2))
+    _draw_complex(axes[0], ann_st, tgt_amp, max_mag=tgt_max, punch_holes=(HOLE_B,))
+    axes[0].set_title("matched   p_A = p_B = "
+                      f"{p_a.real:+.2f}\nmeridian REALIZES:  r = {ann_v.residual:.2e}",
+                      fontsize=13.5, fontweight="bold", linespacing=1.3,
+                      color=(0.0, 0.45, 0.0))
+    _draw_complex(axes[1], ann_st, ftgt_amp, max_mag=ftgt_max, punch_holes=(HOLE_B,))
+    axes[1].set_title("flipped  (conjugation)   p_A = "
+                      f"{fp_a.real:+.2f},  p_B = {fp_b.real:+.2f}\n"
+                      f"meridian FLOORS:  r = {fann_v.residual:.2e}",
+                      fontsize=13.5, fontweight="bold", linespacing=1.3,
+                      color=(0.7, 0.0, 0.0))
+    fig.suptitle("The period sign matters: SAME annulus (b_1 = 1), only circle B's "
+                 "period flipped\nmatched realizes; the conjugation floors -- a "
+                 "cohomological obstruction no filling can fix",
+                 fontsize=15.5, fontweight="bold")
+    fig.legend(handles=_form_legend(tgt_max), loc="lower center", ncol=5,
+               fontsize=10, frameon=False, bbox_to_anchor=(0.5, 0.005))
+    fig.tight_layout(rect=(0, 0.05, 1, 0.92))
+    paths["flipped"] = os.path.join(out_dir, "emergent_bulk_flipped.png")
+    _save(fig, paths["flipped"], dpi)
+
+    # --- 5. composite: tile the four panels. ---
+    fig, axes = plt.subplots(2, 2, figsize=(15.0, 16.0))
+    _draw_complex(axes[0, 0], ann_st, tgt_amp, max_mag=tgt_max, draw_faces=False,
+                  only_edges=E.CYCLE_A + E.CYCLE_B, label_holes=False)
+    axes[0, 0].set_title("1. geo(psi_A) || geo(psi_B): two boundary meridians "
+                         f"(p_A=p_B={p_a.real:+.2f})", fontsize=13,
+                         fontweight="bold")
+    _draw_complex(axes[0, 1], disk_st, tgt_amp, max_mag=tgt_max)
+    axes[0, 1].set_title(f"2. disk (b_1=0): meridian FLOORS  r={disk_v.residual:.1e}",
+                         fontsize=13, fontweight="bold")
+    _draw_complex(axes[1, 0], ann_st, ann_amp, max_mag=ann_max,
+                  punch_holes=(HOLE_B,))
+    axes[1, 0].set_title("3. annulus (b_1=1): meridian REALIZES  "
+                         f"r={ann_v.residual:.1e}", fontsize=13, fontweight="bold")
+    _draw_complex(axes[1, 1], grow_st, grow_amp, max_mag=grow_max,
+                  punch_holes=(HOLE_B,))
+    axes[1, 1].set_title(f"4. surgery-grown bulk (b_1: 0->{b1[2]})  "
+                         f"r={grow_v.residual:.1e}", fontsize=13,
+                         fontweight="bold")
+    fig.legend(handles=_form_legend(ann_max), loc="lower center", ncol=5,
+               fontsize=10.5, frameon=False, bbox_to_anchor=(0.5, 0.005))
+    fig.suptitle(
+        "Emergent-bulk realizability at k=1: surgery makes b_1 an OUTPUT\n"
+        "the matched two-boundary meridian realizes iff b_1=1 "
+        "(disk floors, annulus realizes; surgery opens the handle on its own)",
+        fontsize=16.5, fontweight="bold")
+    fig.tight_layout(rect=(0, 0.04, 1, 0.94))
+    paths["composite"] = os.path.join(out_dir, "emergent_bulk_composite.png")
+    _save(fig, paths["composite"], dpi)
+
+    return paths, dict(disk=disk_v, annulus=ann_v, grow=grow_v, b1=b1)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", default="/tmp/cobordism",
+                    help="output directory for the PNGs (default /tmp/cobordism, "
+                         "not committed).")
+    ap.add_argument("--layout-seed", type=int, default=42,
+                    help="seed for the surgery search (default 42).")
+    ap.add_argument("--dpi", type=int, default=130, help="PNG dpi (default 130).")
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    print("Emergent-bulk visualization -- the disk/annulus/surgery panels\n")
+    paths, verds = build(args.out, dpi=args.dpi, layout_seed=args.layout_seed)
+    b1d, b1a, b1g = verds["b1"]
+    print(f"  disk    b_1={b1d}  meridian r={verds['disk'].residual:.2e} (floored)")
+    print(f"  annulus b_1={b1a}  meridian r={verds['annulus'].residual:.2e} "
+          f"(realized, eig={verds['annulus'].eigenvalue:.1e})")
+    print(f"  surgery b_1: 0->{b1g}  removals={verds['grow'].surgery_removals}  "
+          f"r={verds['grow'].residual:.2e} (realized)")
+    print()
+    for tag in ("boundary", "disk", "annulus", "surgery", "flipped", "composite"):
+        print(f"  {tag:10} -> {paths[tag]}")
+    print("\n  (PNGs are PR artifacts -- upload to the issue-attachments release; "
+          "not committed.)")
+    raise SystemExit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -286,6 +287,40 @@ class EigenstateSynthesis {
     /// these cells' vertices, reproducing `growInterior`'s 1-skeleton.
     [[nodiscard]] std::vector<std::vector<std::uint64_t>> topCells() const;
 
+    // === Surgery: the topology-changing interior remove move (#196) ===
+
+    /// The interior top cells eligible for surgery removal: top cells whose
+    /// vertices are **all interior** (on no \f$ \partial W \f$ face), as sorted
+    /// vertex-id tuples. Removing such a cell (`removeInteriorCell`) cannot touch
+    /// \f$ \partial W \f$ — none of its faces is a boundary face — so it is the
+    /// boundary-fixed **topology-CHANGING** move: unlike `growInterior`'s
+    /// topology-preserving stellar subdivision and the purely additive
+    /// `attachInteriorVertex`, removing a cell can open a hole / handle, so
+    /// \f$ b_k \f$ of the complex **moves** (the emergent topology the experiment
+    /// reads off the witness). The candidate pool a surgery search enumerates.
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> interiorTopCells() const;
+
+    /// Surgery (#196): remove the interior top cell `cell` (a sorted vertex-id
+    /// tuple from `interiorTopCells()`) together with any of its edges left
+    /// **orphaned** — belonging to no remaining top cell — so the result stays a
+    /// valid downward-closed complex. This is **topology-changing**: removing the
+    /// cell opens a hole/handle, so \f$ b_k \f$ **moves** (e.g. a filled disk
+    /// \f$ b_1\!=\!0 \f$ becomes an annulus \f$ b_1\!=\!1 \f$). The pinned boundary
+    /// \f$ \partial W \f$ is held bit-exact: the cell has no boundary vertex
+    /// (so no \f$ \partial W \f$ face is removed) and the move is **rejected**
+    /// (complex unchanged) if any \f$ \partial W \f$ edge would vanish or change;
+    /// the newly EXPOSED interior boundary (the opened hole) is allowed — that is
+    /// the emergent surgery. Records the removal for `restoreLastRemoval`
+    /// (try / score / roll back). Returns `false`, complex unchanged, if `cell`
+    /// is not an interior top cell or the removal would touch \f$ \partial W \f$.
+    bool removeInteriorCell(const std::vector<std::uint64_t> &cell);
+
+    /// Undo the most recent `removeInteriorCell` (LIFO): re-create the removed top
+    /// cell and the edges it orphaned, restoring their squared-lengths and phases
+    /// bit-exactly, and re-capture. Returns `false` if there is no removal to undo.
+    /// The surgery analogue of `detachLastInteriorVertex`.
+    bool restoreLastRemoval();
+
   private:
     std::shared_ptr<Spacetime> st_;
     int k_{0};  // the Hodge degree of L_k that apply()/residual() score against
@@ -324,6 +359,22 @@ class EigenstateSynthesis {
       std::vector<::tessera::mesh::Simplex *> createdSimplices{};
     };
     std::vector<Attachment> attachments_{};
+
+    // One removeInteriorCell() record, for exact restore. The removed top cell's
+    // sorted vertex tuple (its vertices are kept — only the top simplex and its
+    // orphaned edges are deleted), plus each orphaned edge as (u, v, squaredLength,
+    // phase) so restoreLastRemoval re-creates them bit-exactly.
+    struct Removal {
+      std::vector<std::uint64_t> cell{};
+      std::vector<std::tuple<std::uint64_t, std::uint64_t, double, double>>
+          removedEdges{};
+    };
+    std::vector<Removal> removals_{};
+
+    // Re-create the top cell of a Removal (createSimplexTracked rebuilds its
+    // missing edges = the orphaned ones) and restore those edges' weights/phases.
+    // Does not re-capture (callers do). Returns false if a cell vertex is gone.
+    bool applyRestore(const Removal &rem);
 
     // Remove everything an attachment created (its simplices, then its freshly
     // inserted edges, then its vertex) — the inverse of attachInteriorVertex's

--- a/include/cobordism/RealizabilityOracle.h
+++ b/include/cobordism/RealizabilityOracle.h
@@ -129,7 +129,19 @@ class RealizabilityOracle {
       /// (which existing vertices it wires to), score each by the residual it
       /// reaches after the weight/phase optimization, and keep the best — so the
       /// realized topology is what the residual selects, not a cone artifact.
-      FreeConnectivity
+      FreeConnectivity,
+      /// **Surgery** (#196): the topology-CHANGING move-set. Alongside the
+      /// additive attach, at each step score every interior-top-cell **removal**
+      /// (`EigenstateSynthesis::removeInteriorCell`, which opens a hole/handle
+      /// with \f$ \partial W \f$ held bit-exact) by the residual it reaches after
+      /// the weight optimization, and commit the best **improving** move. Unlike
+      /// `FreeConnectivity` (additive only — spectrally inert at \f$ k\geq 1 \f$,
+      /// so \f$ b_k \f$ is frozen at the seed), removal lets the search reach an
+      /// arbitrary valid complex with the fixed boundary: \f$ b_k \f$ **moves on
+      /// its own**, so the realizability obstruction either falls out of the grown
+      /// topology or dissolves. The intended companion of the `harmonic` criterion
+      /// (a boundary class is realizable iff it is **carried** by \f$ H_k(W) \f$).
+      Surgery
     };
 
     /// The oracle's verdict on \f$ U \f$: the realizability decision, the
@@ -187,6 +199,10 @@ class RealizabilityOracle {
       /// The bent target \f$ \psi_U=\mathrm{vec}(U)/\lVert\cdot\rVert \f$
       /// (length \f$ d_A d_B \f$) the output boundary is matched against.
       std::vector<std::complex<double>> target{};
+      /// Interior top-cell **removals** committed by the surgery search
+      /// (`Surgery` mode only; 0 otherwise). Each is a topology-changing move that
+      /// can shift \f$ b_k \f$ of the witness — the emergent-topology trace.
+      int surgeryRemovals{0};
       /// The realized bulk \f$ W_{AB} \f$ — the witness cobordism (realizable),
       /// or the complex on which the residual floors (non-realizable).
       std::shared_ptr<Spacetime> witness{};
@@ -219,12 +235,21 @@ class RealizabilityOracle {
     /// @throws std::invalid_argument if \f$ U \f$'s size \f$ \neq d_A d_B \f$, a
     ///   dimension is non-positive, or the bulk has fewer vertices than
     ///   \f$ d_A d_B \f$ (no room for the output-boundary support).
+    /// @param harmonic  when `true`, score the **harmonic** residual
+    ///                  \f$ \lVert L\psi\rVert^2 \f$ (distance from \f$ \ker L \f$)
+    ///                  instead of the eigenvalue-agnostic
+    ///                  \f$ \lVert(I-\psi\psi^\dagger)L\psi\rVert^2 \f$: realizable
+    ///                  then means \f$ \psi \f$ is **carried as a harmonic**
+    ///                  (eigenvalue \f$ \to 0 \f$), i.e. the boundary class lies in
+    ///                  \f$ \mathrm{image}(H_k(\partial W)\to H_k(W)) \f$ — the
+    ///                  physical realizability test that distinguishes topologies.
     [[nodiscard]] Verdict decide(const std::vector<std::complex<double>> &U,
                                  int dA, int dB, double epsilon = 1e-10,
                                  int restarts = 64, int maxCones = 4,
                                  std::uint64_t seed = 0,
                                  GrowthMode mode = GrowthMode::Cone,
-                                 int connectivityCandidates = 8);
+                                 int connectivityCandidates = 8,
+                                 bool harmonic = false);
 
     /// Decide whether a target **boundary harmonic** \f$ k \f$-form (\f$ k =
     /// \texttt{target.degree()} \f$, the \f$ k=1 \f$ DW setting) is realizable on
@@ -254,11 +279,20 @@ class RealizabilityOracle {
     /// @throws std::invalid_argument if `target` is empty, its degree is negative,
     ///   or none of its \f$ k \f$-cells are boundary cells of the bulk (the surface
     ///   does not match \f$ \partial W \f$).
+    /// @param harmonic  when `true`, score \f$ \lVert L_k\psi\rVert^2 \f$ (the
+    ///                  distance from \f$ \ker L_k = H_k(W) \f$) so realizable
+    ///                  means the boundary \f$ k \f$-form is **carried as a bulk
+    ///                  harmonic** (the meridian/longitude survival test): the
+    ///                  class lies in \f$ \mathrm{image}(H_k(\partial W)\to H_k(W))
+    ///                  \f$. The default (`false`) keeps the eigenvalue-agnostic
+    ///                  residual (any eigenvalue), which is under-constrained on
+    ///                  small boundaries (it accepts a non-harmonic eigenvector).
     [[nodiscard]] Verdict decideHarmonic(const Cochain &target,
                                          double epsilon = 1e-10, int restarts = 64,
                                          int maxCones = 4, std::uint64_t seed = 0,
                                          GrowthMode mode = GrowthMode::Cone,
-                                         int connectivityCandidates = 8);
+                                         int connectivityCandidates = 8,
+                                         bool harmonic = false);
 
   private:
     // §4b search box — identical to GeometrySynthesizer so the interior fill is
@@ -300,9 +334,9 @@ class RealizabilityOracle {
         const std::map<std::vector<std::uint64_t>, std::complex<double>>
             &pinnedByTuple,
         double epsilon, int restarts, int maxCones, std::uint64_t seed,
-        GrowthMode mode, int connectivityCandidates,
+        GrowthMode mode, int connectivityCandidates, bool harmonic,
         std::vector<std::complex<double>> &witnessOut, int &conesApplied,
-        int &candidatesOut, int &triangleCandidatesOut,
+        int &candidatesOut, int &triangleCandidatesOut, int &surgeryRemovals,
         std::size_t &spaceSizeOut) const;
 
     // One fixed-complex optimization pass over the current `es`: the
@@ -315,8 +349,23 @@ class RealizabilityOracle {
         EigenstateSynthesis &es,
         const std::map<std::vector<std::uint64_t>, std::complex<double>>
             &pinnedByTuple,
-        double epsilon, int restarts, std::uint64_t passSeed,
+        double epsilon, int restarts, std::uint64_t passSeed, bool harmonic,
         std::vector<std::complex<double>> &witnessOut) const;
+
+    // One surgery growth step (`Surgery` mode): score every interior-top-cell
+    // removal (`EigenstateSynthesis::interiorTopCells` /`removeInteriorCell`) by
+    // the residual it reaches after `optimizePass`, restoring after each trial,
+    // and COMMIT the single best removal iff it strictly improves on
+    // `currentResidual` (and leaves every pinned boundary tuple present). The
+    // committed move is topology-changing — it can shift b_k — so the realized
+    // bulk topology is what the residual selects. Returns true (and increments
+    // `removalsOut`) iff a removal was committed.
+    [[nodiscard]] bool growBestSurgery(
+        EigenstateSynthesis &es,
+        const std::map<std::vector<std::uint64_t>, std::complex<double>>
+            &pinnedByTuple,
+        double epsilon, int restarts, std::uint64_t seed, bool harmonic,
+        double currentResidual, int &removalsOut) const;
 
     // One free-connectivity growth step. Generates the bounded candidate breadth
     // — edge fans at every degree and, at k>=1, the triangle (2-simplex) fans the
@@ -341,7 +390,7 @@ class RealizabilityOracle {
         const std::map<std::vector<std::uint64_t>, std::complex<double>>
             &pinnedByTuple,
         double epsilon, int restarts, std::uint64_t seed, int nCandidates,
-        int &candidatesOut, int &triangleCandidatesOut,
+        bool harmonic, int &candidatesOut, int &triangleCandidatesOut,
         std::size_t &spaceSizeOut) const;
 
     // The bounded, documented candidate-connectivity generator: deterministic

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -449,7 +449,29 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "face of exactly one top cell (a 'boundary-star' candidate).")
       .def("topCells", &EigenstateSynthesis::topCells,
            "The top cells as sorted vertex-id tuples (the d+1-vertex simplices); "
-           "wiring the new vertex to one reproduces growInterior's 1-skeleton.");
+           "wiring the new vertex to one reproduces growInterior's 1-skeleton.")
+      // ----- Surgery: the topology-changing interior remove move (#196) -----
+      .def("interiorTopCells", &EigenstateSynthesis::interiorTopCells,
+           "The interior top cells (all-interior vertices, on no dW face) as "
+           "sorted vertex-id tuples — the surgery removal candidates. Removing one "
+           "(removeInteriorCell) cannot touch dW, so it is the boundary-fixed "
+           "TOPOLOGY-CHANGING move that can open a hole/handle and MOVE b_k, unlike "
+           "growInterior's subdivision and the additive attach.")
+      .def("removeInteriorCell", &EigenstateSynthesis::removeInteriorCell,
+           py::arg("cell"),
+           "Surgery (#196): remove the interior top cell `cell` (a tuple from "
+           "interiorTopCells()) and any edges it leaves orphaned, keeping a valid "
+           "downward-closed complex. Topology-CHANGING: b_k moves (a filled disk "
+           "b_1=0 becomes an annulus b_1=1). dW is held bit-exact — the cell has no "
+           "boundary vertex, and the move is rejected if a dW edge would vanish; "
+           "the EXPOSED interior boundary (the opened hole) is allowed. Records the "
+           "removal for restoreLastRemoval. Returns False, complex unchanged, if "
+           "`cell` is not an interior top cell or the removal would touch dW.")
+      .def("restoreLastRemoval", &EigenstateSynthesis::restoreLastRemoval,
+           "Undo the most recent removeInteriorCell (LIFO): re-create the removed "
+           "top cell and the edges it orphaned, restoring their weights/phases bit-"
+           "exactly, and re-capture. Returns False if there is no removal to undo. "
+           "Lets a surgery search try a removal, score it, and roll back.");
 
   // ----- §4b cone-and-retry synthesis loop → geo(ψ) (#134) -----
   py::class_<GeometrySynthesizer> gs(m, "GeometrySynthesizer",
@@ -568,7 +590,16 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
              RealizabilityOracle::GrowthMode::FreeConnectivity,
              "Free interior connectivity (#200): search a bounded set of candidate "
              "interior connectivities for the new vertex at each growth step and "
-             "keep the one reaching the lowest residual — topology is emergent.");
+             "keep the one reaching the lowest residual — topology is emergent.")
+      .value("SURGERY", RealizabilityOracle::GrowthMode::Surgery,
+             "Surgery (#196): the topology-CHANGING move-set. At each step score "
+             "every interior-top-cell removal (removeInteriorCell, which opens a "
+             "hole/handle with dW held bit-exact) and commit the best improving "
+             "one. Unlike FREE_CONNECTIVITY (additive only — spectrally inert at "
+             "k>=1, so b_k is frozen at the seed), removal lets the search reach an "
+             "arbitrary valid complex with the fixed boundary: b_k MOVES on its "
+             "own. The companion of harmonic=True (realizable iff the boundary "
+             "class is carried by H_k(W)).");
 
   py::class_<RealizabilityOracle::Verdict>(ro, "Verdict",
       "The oracle's verdict on U: the realizability decision, the residual (the "
@@ -616,6 +647,12 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
                     "Full per-step incidence space (2^N - 1 nonempty vertex "
                     "subsets) the candidates are pruned from at the last growth "
                     "step — connectivity_candidates << this documents the bound.")
+      .def_readonly("surgery_removals",
+                    &RealizabilityOracle::Verdict::surgeryRemovals,
+                    "Interior top-cell removals committed by the surgery search "
+                    "(SURGERY mode only; 0 otherwise). Each is a topology-changing "
+                    "move that can shift b_k of the witness — the emergent-topology "
+                    "trace (read the grown b_k off the witness with ChainComplex).")
       .def_readonly("state", &RealizabilityOracle::Verdict::state,
                     "The witness state: the realized unit Laplacian eigenvector on "
                     "W_AB (length = the bulk's vertex count); its first dA*dB "
@@ -637,7 +674,7 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
            py::arg("dB"), py::arg("epsilon") = 1e-10, py::arg("restarts") = 64,
            py::arg("max_cones") = 4, py::arg("seed") = 0,
            py::arg("growth_mode") = RealizabilityOracle::GrowthMode::Cone,
-           py::arg("connectivity_candidates") = 8,
+           py::arg("connectivity_candidates") = 8, py::arg("harmonic") = false,
            "Decide whether the dA x dB operator U (flat row-major) is realizable "
            "as a bulk cobordism: bend it to vec(U), fill the pinned-boundary "
            "interior to drive the §4b residual to zero (multi-restart "
@@ -653,7 +690,7 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
            py::arg("target"), py::arg("epsilon") = 1e-10, py::arg("restarts") = 64,
            py::arg("max_cones") = 4, py::arg("seed") = 0,
            py::arg("growth_mode") = RealizabilityOracle::GrowthMode::Cone,
-           py::arg("connectivity_candidates") = 8,
+           py::arg("connectivity_candidates") = 8, py::arg("harmonic") = false,
            "Decide whether a target boundary harmonic k-form (a degree-k Cochain, "
            "k = target.degree(); the k=1 DW setting) is realizable on the held "
            "3-manifold-with-boundary bulk W: pin the boundary surface dW byte-"

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -516,6 +516,202 @@ std::vector<std::uint64_t> EigenstateSynthesis::boundaryVertexIds() const {
   return boundaryVertexIdsSorted_;
 }
 
+// === Surgery: the topology-changing interior remove move (#196) ===
+
+std::vector<std::vector<std::uint64_t>>
+EigenstateSynthesis::interiorTopCells() const {
+  std::vector<std::vector<std::uint64_t>> cells;
+  if (!st_) return cells;
+  const int d = st_->getMetric()->getSignature()->getDimensions();
+  const std::size_t topVerts = (d >= 0) ? static_cast<std::size_t>(d) + 1 : 0;
+  if (topVerts == 0) return cells;
+  const std::unordered_set<std::uint64_t> bverts(
+      boundaryVertexIdsSorted_.begin(), boundaryVertexIdsSorted_.end());
+  for (const auto s : st_->getSimplices()) {
+    if (s == nullptr || s->size() != topVerts) continue;
+    std::vector<std::uint64_t> ids;
+    ids.reserve(topVerts);
+    bool allInterior = true;
+    for (const auto v : s->getVertices()) {
+      if (v == nullptr) { allInterior = false; break; }
+      ids.push_back(v->getId());
+      if (bverts.find(v->getId()) != bverts.end()) allInterior = false;
+    }
+    if (!allInterior || ids.size() != topVerts) continue;
+    std::sort(ids.begin(), ids.end());
+    cells.push_back(std::move(ids));
+  }
+  std::sort(cells.begin(), cells.end());
+  cells.erase(std::unique(cells.begin(), cells.end()), cells.end());
+  return cells;
+}
+
+bool EigenstateSynthesis::removeInteriorCell(
+    const std::vector<std::uint64_t> &cell) {
+  if (!st_) return false;
+  const int d = st_->getMetric()->getSignature()->getDimensions();
+  const std::size_t topVerts = (d >= 0) ? static_cast<std::size_t>(d) + 1 : 0;
+  if (topVerts < 2 || cell.size() != topVerts) return false;
+  std::vector<std::uint64_t> want(cell.begin(), cell.end());
+  std::sort(want.begin(), want.end());
+
+  // The cell must be interior: no boundary vertex (so no ∂W face is removed).
+  const std::unordered_set<std::uint64_t> bverts(
+      boundaryVertexIdsSorted_.begin(), boundaryVertexIdsSorted_.end());
+  for (const std::uint64_t id : want)
+    if (bverts.find(id) != bverts.end()) return false;
+
+  // Locate the matching top simplex, and collect the OTHER top cells' vertex
+  // sets (to tell which of `want`'s edges remain covered after removal). Refuse
+  // to remove the last top cell of the top dimension (it would drop the complex
+  // dimension and promote orphan facets to top cells).
+  ::tessera::mesh::Simplex *target = nullptr;
+  std::vector<std::vector<std::uint64_t>> otherTop;
+  for (const auto s : st_->getSimplices()) {
+    if (s == nullptr || s->size() != topVerts) continue;
+    std::vector<std::uint64_t> ids;
+    ids.reserve(topVerts);
+    for (const auto v : s->getVertices())
+      if (v != nullptr) ids.push_back(v->getId());
+    std::sort(ids.begin(), ids.end());
+    if (target == nullptr && ids == want)
+      target = s;
+    else
+      otherTop.push_back(std::move(ids));
+  }
+  if (target == nullptr || otherTop.empty()) return false;
+
+  // An edge {u,v} of the cell is orphaned iff no other top cell contains both
+  // endpoints. Map endpoint pairs -> Edge* for the orphaned ones.
+  std::map<std::pair<std::uint64_t, std::uint64_t>, ::tessera::mesh::Edge *>
+      edgeByPair;
+  for (const auto e : edges_) {
+    const std::uint64_t a = e->getSource()->getId();
+    const std::uint64_t b = e->getTarget()->getId();
+    edgeByPair[{std::min(a, b), std::max(a, b)}] = e;
+  }
+  const auto covered = [&](std::uint64_t u, std::uint64_t v) {
+    for (const auto &c : otherTop) {
+      const bool hu = std::find(c.begin(), c.end(), u) != c.end();
+      const bool hv = std::find(c.begin(), c.end(), v) != c.end();
+      if (hu && hv) return true;
+    }
+    return false;
+  };
+
+  Removal rem;
+  rem.cell = want;
+  std::vector<::tessera::mesh::Edge *> toRemove;
+  for (std::size_t i = 0; i + 1 < want.size(); ++i)
+    for (std::size_t j = i + 1; j < want.size(); ++j) {
+      const std::uint64_t u = want[i];
+      const std::uint64_t v = want[j];
+      if (covered(u, v)) continue;  // edge survives in another top cell
+      const auto it = edgeByPair.find({u, v});
+      if (it == edgeByPair.end()) continue;  // already absent
+      rem.removedEdges.emplace_back(u, v, it->second->getSquaredLength(),
+                                    it->second->getPhase());
+      toRemove.push_back(it->second);
+    }
+
+  // Snapshot ∂W (id-pair -> (w, theta)) for the bit-exact check.
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::pair<double, double>>
+      boundaryBefore;
+  for (const auto i : boundaryEdgeIdx_) {
+    const std::uint64_t a = edges_[i]->getSource()->getId();
+    const std::uint64_t b = edges_[i]->getTarget()->getId();
+    boundaryBefore[{std::min(a, b), std::max(a, b)}] = {
+        edges_[i]->getSquaredLength(), edges_[i]->getPhase()};
+  }
+
+  // Mutate: drop the top cell, then its orphaned edges.
+  st_->removeSimplex(target);
+  for (auto *e : toRemove)
+    if (e != nullptr) st_->removeEdge(e);
+
+  laplacian_ = HodgeLaplacian(st_);
+  capture();
+  classifyBoundary();
+
+  // ∂W must be preserved bit-exactly: every previously-boundary edge still
+  // present with the same weight/phase (newly EXPOSED boundary edges are allowed
+  // — the opened hole — so this is a subset check, not equality).
+  bool valid = true;
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::pair<double, double>>
+      liveWeights;
+  for (const auto e : edges_) {
+    const std::uint64_t a = e->getSource()->getId();
+    const std::uint64_t b = e->getTarget()->getId();
+    const std::pair<std::uint64_t, std::uint64_t> key{std::min(a, b),
+                                                      std::max(a, b)};
+    liveWeights[key] = {e->getSquaredLength(), e->getPhase()};
+  }
+  for (const auto &[key, wp] : boundaryBefore) {
+    const auto it = liveWeights.find(key);
+    if (it == liveWeights.end() || it->second.first != wp.first ||
+        it->second.second != wp.second) {
+      valid = false;
+      break;
+    }
+  }
+
+  if (!valid) {
+    applyRestore(rem);
+    laplacian_ = HodgeLaplacian(st_);
+    capture();
+    classifyBoundary();
+    return false;
+  }
+  removals_.push_back(std::move(rem));
+  return true;
+}
+
+bool EigenstateSynthesis::applyRestore(const Removal &rem) {
+  if (!st_) return false;
+  std::unordered_map<std::uint64_t, ::tessera::mesh::Vertex *> idToVert;
+  for (const auto v : st_->getVertexList()->toVector())
+    if (v != nullptr) idToVert.emplace(v->getId(), v);
+  ::tessera::mesh::VertexPtrs verts;
+  verts.reserve(rem.cell.size());
+  for (const std::uint64_t id : rem.cell) {
+    const auto it = idToVert.find(id);
+    if (it == idToVert.end()) return false;  // a cell vertex vanished
+    verts.push_back(it->second);
+  }
+  // Re-create the top cell; createSimplexTracked rebuilds exactly the missing
+  // edges (the orphaned ones removed above), leaving surviving edges untouched.
+  st_->createSimplexTracked(verts);
+  // Restore the removed edges' weights/phases bit-exactly.
+  std::map<std::pair<std::uint64_t, std::uint64_t>, ::tessera::mesh::Edge *>
+      edgeByPair;
+  for (const auto e : st_->getEdgeList()->toVector()) {
+    if (e == nullptr || e->getSource() == nullptr || e->getTarget() == nullptr)
+      continue;
+    const std::uint64_t a = e->getSource()->getId();
+    const std::uint64_t b = e->getTarget()->getId();
+    edgeByPair[{std::min(a, b), std::max(a, b)}] = e;
+  }
+  for (const auto &[u, v, w, theta] : rem.removedEdges) {
+    const auto it = edgeByPair.find({std::min(u, v), std::max(u, v)});
+    if (it != edgeByPair.end()) {
+      it->second->setSquaredLength(w);
+      it->second->setPhase(theta);
+    }
+  }
+  return true;
+}
+
+bool EigenstateSynthesis::restoreLastRemoval() {
+  if (!st_ || removals_.empty()) return false;
+  const Removal rem = std::move(removals_.back());
+  removals_.pop_back();
+  applyRestore(rem);
+  laplacian_ = HodgeLaplacian(st_);
+  capture();
+  classifyBoundary();
+  return true;
+}
+
 std::vector<std::vector<std::uint64_t>> EigenstateSynthesis::topCells() const {
   std::vector<std::vector<std::uint64_t>> cells;
   if (!st_) return cells;

--- a/src/cobordism/RealizabilityOracle.cpp
+++ b/src/cobordism/RealizabilityOracle.cpp
@@ -66,7 +66,8 @@ std::vector<cd> RealizabilityOracle::bend(const std::vector<cd> &U, int dA,
 double RealizabilityOracle::optimizePass(
     EigenstateSynthesis &es,
     const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
-    int restarts, std::uint64_t passSeed, std::vector<cd> &witnessOut) const {
+    int restarts, std::uint64_t passSeed, bool harmonic,
+    std::vector<cd> &witnessOut) const {
   // The U(1) phases enter only the k=0 graph Laplacian; the metric Hodge L_k
   // (k>=1) is assembled from integer boundary maps and real volume weights, so
   // interior phases are not tuned there (they would be wasted search dimensions).
@@ -110,7 +111,7 @@ double RealizabilityOracle::optimizePass(
   // complement (∂W itself is never touched), normalize the assembled ψ, and
   // return the stacked g = L_kψ - λψ ([Re; Im], length 2·order) whose ‖g‖² is
   // r(ψ) — the residual the Levenberg–Marquardt loop drives to zero.
-  const auto residual = [&es, &buildPsi, m, nW, usePhases,
+  const auto residual = [&es, &buildPsi, m, nW, usePhases, harmonic,
                          order](const Eigen::VectorXd &x) -> Eigen::VectorXd {
     if (m > 0) {
       std::vector<double> w(m);
@@ -131,9 +132,12 @@ double RealizabilityOracle::optimizePass(
       for (cd &z : psi) z *= inv;
     }
     const std::vector<cd> Lp = es.apply(psi);
+    // Eigenvalue-agnostic residual subtracts the Rayleigh-quotient component
+    // (accepts ANY eigenvalue); the harmonic residual pins λ = 0, so the cost is
+    // ‖Lψ‖² — the distance from ker L, i.e. whether ψ is carried as a HARMONIC.
     cd lam(0.0, 0.0);
     for (std::size_t i = 0; i < order; ++i) lam += std::conj(psi[i]) * Lp[i];
-    const double lambda = lam.real();
+    const double lambda = harmonic ? 0.0 : lam.real();
     Eigen::VectorXd f(static_cast<Eigen::Index>(2 * order));
     for (std::size_t i = 0; i < order; ++i) {
       const cd g = Lp[i] - lambda * psi[i];
@@ -323,8 +327,9 @@ RealizabilityOracle::triangleConnectivityCandidates(const EigenstateSynthesis &e
 bool RealizabilityOracle::growBestConnectivity(
     EigenstateSynthesis &es,
     const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
-    int restarts, std::uint64_t seed, int nCandidates, int &candidatesOut,
-    int &triangleCandidatesOut, std::size_t &spaceSizeOut) const {
+    int restarts, std::uint64_t seed, int nCandidates, bool harmonic,
+    int &candidatesOut, int &triangleCandidatesOut,
+    std::size_t &spaceSizeOut) const {
   const std::vector<std::uint64_t> verts = es.vertexIds();
   const std::size_t N = verts.size();
   if (N == 0) return false;
@@ -355,7 +360,8 @@ bool RealizabilityOracle::growBestConnectivity(
       if (!es.attachInteriorVertex(specs)) continue;  // skip if it would touch ∂W
       const double r =
           optimizePass(es, pinnedByTuple, epsilon, restarts,
-                       seed + 1 + static_cast<std::uint64_t>(c), tmpWitness);
+                       seed + 1 + static_cast<std::uint64_t>(c), harmonic,
+                       tmpWitness);
       if (r < bestR) {
         bestR = r;
         bestSpecs = specs;
@@ -388,35 +394,90 @@ bool RealizabilityOracle::growBestConnectivity(
   return es.growInterior(seed);
 }
 
+bool RealizabilityOracle::growBestSurgery(
+    EigenstateSynthesis &es,
+    const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
+    int restarts, std::uint64_t seed, bool harmonic, double currentResidual,
+    int &removalsOut) const {
+  // Enumerate the topology-changing candidates: every interior top cell whose
+  // removal opens a hole/handle with ∂W held bit-exact. Score each by the
+  // residual it reaches after the weight optimization (try → score → restore),
+  // and commit the single best one iff it strictly improves on the current
+  // residual AND keeps every pinned boundary tuple present (so the target form
+  // still has its support). The committed move shifts b_k — emergent topology.
+  const std::vector<std::vector<std::uint64_t>> cells = es.interiorTopCells();
+  CLOG(INFO_LEVEL, "surgery grow (k=", es.degree(), "): scoring ", cells.size(),
+       " interior-top-cell removals against residual ", currentResidual);
+  if (cells.empty()) return false;
+
+  double bestR = currentResidual;
+  std::vector<std::uint64_t> bestCell;
+  std::vector<cd> tmpWitness;
+  for (std::size_t c = 0; c < cells.size(); ++c) {
+    if (!es.removeInteriorCell(cells[c])) continue;  // would touch ∂W: skip
+    // The pinned boundary k-cells must all survive the removal, else the target
+    // form loses its support and the score is meaningless.
+    bool pinnedIntact = true;
+    {
+      std::set<std::vector<std::uint64_t>> live(es.cellSimplices().begin(),
+                                                es.cellSimplices().end());
+      for (const auto &kv : pinnedByTuple)
+        if (live.find(kv.first) == live.end()) { pinnedIntact = false; break; }
+    }
+    if (pinnedIntact) {
+      const double r =
+          optimizePass(es, pinnedByTuple, epsilon, restarts,
+                       seed + 1 + static_cast<std::uint64_t>(c), harmonic,
+                       tmpWitness);
+      if (r < bestR) {
+        bestR = r;
+        bestCell = cells[c];
+      }
+    }
+    es.restoreLastRemoval();
+  }
+  if (bestCell.empty()) return false;  // no improving removal
+  if (!es.removeInteriorCell(bestCell)) return false;
+  ++removalsOut;
+  return true;
+}
+
 double RealizabilityOracle::fillInterior(
     EigenstateSynthesis &es,
     const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
     int restarts, int maxCones, std::uint64_t seed, GrowthMode mode,
-    int connectivityCandidates, std::vector<cd> &witnessOut, int &conesApplied,
-    int &candidatesOut, int &triangleCandidatesOut,
-    std::size_t &spaceSizeOut) const {
+    int connectivityCandidates, bool harmonic, std::vector<cd> &witnessOut,
+    int &conesApplied, int &candidatesOut, int &triangleCandidatesOut,
+    int &surgeryRemovals, std::size_t &spaceSizeOut) const {
   double bestR = std::numeric_limits<double>::infinity();
   conesApplied = 0;
   candidatesOut = 0;
   triangleCandidatesOut = 0;
+  surgeryRemovals = 0;
   spaceSizeOut = 0;
 
   for (int cone = 0;; ++cone) {
     // Optimize the current complex (seed + cone preserves the cone-path seed
     // sequence exactly, so the historical decide() is byte-for-byte unchanged).
     bestR = optimizePass(es, pinnedByTuple, epsilon, restarts,
-                         seed + static_cast<std::uint64_t>(cone), witnessOut);
+                         seed + static_cast<std::uint64_t>(cone), harmonic,
+                         witnessOut);
 
     // Stop on convergence, an exhausted budget, or a complex that cannot grow
     // (growth is the capacity/structure gate; it leaves ∂W byte-fixed).
     if (bestR < epsilon) break;
     if (cone >= maxCones) break;
     bool grew;
-    if (mode == GrowthMode::FreeConnectivity)
+    if (mode == GrowthMode::Surgery)
+      // The topology-changing move-set: commit the best b_k-shifting removal.
+      grew = growBestSurgery(es, pinnedByTuple, epsilon, restarts,
+                             seed + 1000 + static_cast<std::uint64_t>(cone),
+                             harmonic, bestR, surgeryRemovals);
+    else if (mode == GrowthMode::FreeConnectivity)
       grew = growBestConnectivity(
           es, pinnedByTuple, epsilon, restarts,
           seed + 1000 + static_cast<std::uint64_t>(cone), connectivityCandidates,
-          candidatesOut, triangleCandidatesOut, spaceSizeOut);
+          harmonic, candidatesOut, triangleCandidatesOut, spaceSizeOut);
     else
       grew = es.growInterior(seed + 1000 + static_cast<std::uint64_t>(cone));
     if (!grew) break;
@@ -428,7 +489,7 @@ double RealizabilityOracle::fillInterior(
 RealizabilityOracle::Verdict RealizabilityOracle::decide(
     const std::vector<cd> &U, int dA, int dB, double epsilon, int restarts,
     int maxCones, std::uint64_t seed, GrowthMode mode,
-    int connectivityCandidates) {
+    int connectivityCandidates, bool harmonic) {
   const std::vector<cd> target = bend(U, dA, dB);  // ψ_U, length dA·dB
 
   EigenstateSynthesis es(bulk_);  // k = 0: the vertex graph Laplacian
@@ -449,9 +510,10 @@ RealizabilityOracle::Verdict RealizabilityOracle::decide(
   Verdict v;
   v.target = target;
   const double r = fillInterior(es, pinnedByTuple, epsilon, restarts, maxCones,
-                                seed, mode, connectivityCandidates, v.state,
-                                v.conesApplied, v.connectivityCandidates,
-                                v.triangleCandidates, v.connectivitySpaceSize);
+                                seed, mode, connectivityCandidates, harmonic,
+                                v.state, v.conesApplied, v.connectivityCandidates,
+                                v.triangleCandidates, v.surgeryRemovals,
+                                v.connectivitySpaceSize);
   v.residual = r;
   v.realizable = (r < epsilon);
   v.floor = v.realizable ? 0.0 : r;
@@ -464,7 +526,8 @@ RealizabilityOracle::Verdict RealizabilityOracle::decide(
 
 RealizabilityOracle::Verdict RealizabilityOracle::decideHarmonic(
     const Cochain &target, double epsilon, int restarts, int maxCones,
-    std::uint64_t seed, GrowthMode mode, int connectivityCandidates) {
+    std::uint64_t seed, GrowthMode mode, int connectivityCandidates,
+    bool harmonic) {
   const int k = target.degree();
   if (k < 0 || target.size() == 0)
     throw std::invalid_argument(
@@ -514,9 +577,10 @@ RealizabilityOracle::Verdict RealizabilityOracle::decideHarmonic(
   // and those are NOT spectrally inert here. The candidate breadth (edge fans +
   // triangle fans) is surfaced in the Verdict and logged.
   const double r = fillInterior(es, pinnedByTuple, epsilon, restarts, maxCones,
-                                seed, mode, connectivityCandidates, v.state,
-                                v.conesApplied, v.connectivityCandidates,
-                                v.triangleCandidates, v.connectivitySpaceSize);
+                                seed, mode, connectivityCandidates, harmonic,
+                                v.state, v.conesApplied, v.connectivityCandidates,
+                                v.triangleCandidates, v.surgeryRemovals,
+                                v.connectivitySpaceSize);
   v.residual = r;
   v.realizable = (r < epsilon);
   v.floor = v.realizable ? 0.0 : r;

--- a/tests/cobordism/test_emergent_bulk_python.py
+++ b/tests/cobordism/test_emergent_bulk_python.py
@@ -1,0 +1,293 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Emergent-bulk realizability: surgery makes b_1 a pure output (the #196 capability).
+
+Independent re-derivation of the claims the example
+(``examples/cobordism/emergent_bulk_realizability.py``) makes, plus a self-verify
+that the committed example exits 0:
+
+  1. **The surgery remove primitive moves b_1, holding the boundary bit-exact.**
+     ``EigenstateSynthesis.removeInteriorCell`` on a disk filling opens the handle
+     (b_1: 0 -> 1) with the pinned boundary untouched; ``restoreLastRemoval`` puts it
+     back bit-exactly; a boundary-touching cell is refused.
+  2. **The two-boundary meridian 2x2 (the heart of the experiment).** The meridian
+     is carried on BOTH boundary circles. With MATCHED periods (p_A = p_B, the
+     annulus's own H_1 generator) it FLOORS on the disk filling (b_1=0) and REALIZES
+     as a bulk harmonic on the annulus (b_1=1). With one period sign-FLIPPED
+     (p_A = -p_B, the cobordism conjugation) it FLOORS on BOTH fillings -- opposite
+     periods are not the restriction of any closed form. Realizable iff the filling
+     has b_1=1 AND the periods match; the realizable set is image(H_1(dW)->H_1(W)).
+  3. **Surgery moves b_1 on its own.** From the disk seed the SURGERY search commits
+     a removal scored purely by the harmonic residual, so b_1 moves 0 -> 1 for both
+     targets. The matched meridian then REALIZES; the flipped one still FLOORS on the
+     opened handle -- the period mismatch is a separate, cohomological obstruction.
+  4. **Only removal moves b_1.** The additive attach is boundary-locked at k>=1, so
+     it is refused and b_1 stays frozen -- removal is the load-bearing move.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+SURGERY = cob.RealizabilityOracle.GrowthMode.SURGERY
+
+DEEP_EPS = 1e-7
+REALIZE = 1e-3
+CERT_FLOOR = 1e-2
+RESTARTS = 64
+
+# The octahedron surface (a triangulated S^2), built generically from a face list.
+_OCT = [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 1, 4),
+        (5, 1, 2), (5, 2, 3), (5, 3, 4), (5, 1, 4)]
+HOLE_A, HOLE_B = (0, 1, 2), (3, 4, 5)
+CYCLE_A, CYCLE_B = [(0, 1), (0, 2), (1, 2)], [(3, 4), (3, 5), (4, 5)]
+
+
+def _surface(faces, weight=1.0, phase=0.0):
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {i: st.createVertex(i) for i in sorted({v for f in faces for v in f})}
+    for f in faces:
+        t = sorted(f)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]]])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(weight)
+        e.setPhase(phase)
+    return st
+
+
+def _delete(*faces):
+    drop = {tuple(sorted(f)) for f in faces}
+    return [f for f in _OCT if tuple(sorted(f)) not in drop]
+
+
+def _disk():
+    return _surface(_delete(HOLE_A))
+
+
+def _annulus():
+    return _surface(_delete(HOLE_A, HOLE_B))
+
+
+def _b1(st):
+    return int(cob.ChainComplex.fromSpacetime(st).bettiNumbers()[1])
+
+
+def _periods(vals):
+    """The two boundary periods of a 1-form on CYCLE_A + CYCLE_B: p_A around
+    0->1->2->0, p_B around 3->4->5->3."""
+    v = {e: c for e, c in zip(CYCLE_A + CYCLE_B, vals)}
+    p_a = v[(0, 1)] + v[(1, 2)] - v[(0, 2)]
+    p_b = v[(3, 4)] + v[(4, 5)] - v[(3, 5)]
+    return complex(p_a), complex(p_b)
+
+
+def _meridian_target(flip=False):
+    """The meridian carried on both boundary circles, read off the annulus's own
+    harmonic 1-form. flip=False keeps equal periods (matched); flip=True negates
+    circle B's period (the sign-flipped cobordism conjugation)."""
+    h = cob.HodgeLaplacian(_annulus()).harmonics(1)[0]
+    edges = CYCLE_A + CYCLE_B
+    vals = [complex(h.amplitudeFor(list(e))) for e in edges]
+    if flip:
+        vals = vals[:3] + [-v for v in vals[3:]]
+    return cob.Cochain(1, edges, np.asarray(vals, dtype=complex)), vals
+
+
+def _decide(st, target, *, max_cones, seed=1):
+    return cob.RealizabilityOracle(st).decideHarmonic(
+        target, epsilon=DEEP_EPS, restarts=RESTARTS, max_cones=max_cones,
+        seed=seed, growth_mode=SURGERY, connectivity_candidates=8, harmonic=True)
+
+
+# --------------------------------------------------------------------------- #
+class SurgeryRemovePrimitiveTest(unittest.TestCase):
+    """1: removeInteriorCell moves b_1 with the boundary held bit-exact."""
+
+    def test_remove_opens_handle_and_restore_is_bit_exact(self):
+        st = _disk()
+        es = cob.EigenstateSynthesis(st, 1)
+        self.assertEqual(_b1(st), 0)                       # disk
+        self.assertEqual(es.interiorTopCells(), [[3, 4, 5]])
+        weights_before = list(es.weights())
+        bnd_before = sorted(es.boundaryEdges())
+
+        self.assertTrue(es.removeInteriorCell([3, 4, 5]))  # open the handle
+        self.assertEqual(_b1(st), 1)                       # annulus: b_1 moved 0->1
+
+        self.assertTrue(es.restoreLastRemoval())
+        self.assertEqual(_b1(st), 0)                       # disk again
+        self.assertEqual(list(es.weights()), weights_before)
+        self.assertEqual(sorted(es.boundaryEdges()), bnd_before)
+
+    def test_boundary_touching_cell_is_refused(self):
+        st = _disk()
+        es = cob.EigenstateSynthesis(st, 1)
+        # {0,1,4} contains the boundary vertices 0,1 -> not an interior cell.
+        self.assertFalse(es.removeInteriorCell([0, 1, 4]))
+        self.assertEqual(_b1(st), 0)
+
+
+# --------------------------------------------------------------------------- #
+class MeridianTwoBoundaryTest(unittest.TestCase):
+    """2: the two-boundary meridian 2x2 -- matched realizes only on the annulus;
+    the sign-flipped conjugation floors on both fillings."""
+
+    def test_matched_and_flipped_have_equal_and_opposite_periods(self):
+        # The matched target is the annulus harmonic's restriction: equal periods
+        # on the two circles. The flip negates circle B, leaving circle A intact.
+        _, matched = _meridian_target(flip=False)
+        _, flipped = _meridian_target(flip=True)
+        pa_m, pb_m = _periods(matched)
+        pa_f, pb_f = _periods(flipped)
+        self.assertGreater(abs(pa_m), 0.5)               # a genuine nonzero meridian
+        self.assertLess(abs(pa_m - pb_m), 1e-6)          # matched: p_A = p_B
+        self.assertLess(abs(pa_f - pa_m), 1e-6)          # flip leaves circle A alone
+        self.assertLess(abs(pa_f + pb_f), 1e-6)          # flipped: p_A = -p_B
+
+    def test_matched_meridian_floors_on_disk_realizes_on_annulus(self):
+        target, _ = _meridian_target(flip=False)
+        disk = _decide(_disk(), target, max_cones=0)
+        ann = _decide(_annulus(), target, max_cones=0)
+        self.assertGreater(disk.residual, CERT_FLOOR)    # b_1=0: it bounds -> floored
+        self.assertLess(ann.residual, REALIZE)           # b_1=1: survives -> realized
+        self.assertLess(abs(ann.eigenvalue), 1e-2)       # carried as a harmonic
+
+    def test_flipped_meridian_floors_on_both_fillings(self):
+        target, _ = _meridian_target(flip=True)
+        disk = _decide(_disk(), target, max_cones=0)
+        ann = _decide(_annulus(), target, max_cones=0)
+        # Opposite periods are not the restriction of any closed form, so the flip
+        # floors even on the annulus, where the topology (b_1=1) is right.
+        self.assertGreater(disk.residual, CERT_FLOOR)
+        self.assertGreater(ann.residual, CERT_FLOOR)
+
+    def test_the_two_fillings_have_different_b1(self):
+        self.assertEqual(_b1(_disk()), 0)
+        self.assertEqual(_b1(_annulus()), 1)
+
+
+# --------------------------------------------------------------------------- #
+class SurgeryMovesB1Test(unittest.TestCase):
+    """3: the SURGERY search moves b_1 0 -> 1 on its own; the matched meridian then
+    realizes, the flipped one still floors on the opened handle."""
+
+    def test_surgery_opens_handle_and_matched_meridian_realizes(self):
+        target, _ = _meridian_target(flip=False)
+        for seed in (0, 1, 2):
+            st = _disk()
+            self.assertEqual(_b1(st), 0)                    # seed b_1
+            v = _decide(st, target, max_cones=3, seed=seed)
+            self.assertEqual(_b1(st), 1, f"seed {seed}: b_1 did not move")
+            self.assertGreaterEqual(v.surgery_removals, 1, f"seed {seed}")
+            self.assertLess(v.residual, REALIZE, f"seed {seed}: meridian floored")
+
+    def test_surgery_opens_handle_but_flipped_meridian_still_floors(self):
+        target, _ = _meridian_target(flip=True)
+        for seed in (0, 1, 2):
+            st = _disk()
+            v = _decide(st, target, max_cones=3, seed=seed)
+            # Surgery still opens the handle (the annulus floor < the disk floor, so
+            # the removal improves the residual and is committed) ...
+            self.assertEqual(_b1(st), 1, f"seed {seed}: b_1 did not move")
+            self.assertGreaterEqual(v.surgery_removals, 1, f"seed {seed}")
+            # ... but the flipped meridian never realizes: the period mismatch is a
+            # cohomological obstruction surgery cannot fix.
+            self.assertGreater(v.residual, CERT_FLOOR, f"seed {seed}")
+
+    def test_surgery_is_residual_driven_not_indiscriminate(self):
+        # On the annulus (already b_1=1, no interior top cell) the search has no
+        # removal to make: b_1 stays 1, zero removals -- it removes only what helps.
+        target, _ = _meridian_target(flip=False)
+        st = _annulus()
+        self.assertEqual(cob.EigenstateSynthesis(st, 1).interiorTopCells(), [])
+        v = _decide(st, target, max_cones=3)
+        self.assertEqual(v.surgery_removals, 0)
+        self.assertEqual(_b1(st), 1)
+
+
+# --------------------------------------------------------------------------- #
+class OnlyRemovalMovesB1Test(unittest.TestCase):
+    """4: without the remove move b_1 is frozen and the matched meridian floors."""
+
+    def test_no_growth_leaves_b1_frozen(self):
+        target, _ = _meridian_target(flip=False)
+        st = _disk()
+        v = _decide(st, target, max_cones=0)
+        self.assertEqual(_b1(st), 0)
+        self.assertGreater(v.residual, CERT_FLOOR)
+
+    def test_additive_attach_is_boundary_locked(self):
+        # Wiring a fresh triangle over an interior edge would grow dW -> the bit-
+        # exact boundary guard refuses it, so additive growth cannot move b_1.
+        st = _disk()
+        es = cob.EigenstateSynthesis(st, 1)
+        self.assertFalse(es.attachInteriorVertex([[3, 4]]))
+        self.assertEqual(_b1(st), 0)
+
+
+# --------------------------------------------------------------------------- #
+class HarmonicCriterionTest(unittest.TestCase):
+    """The harmonic residual (carried-by-H_1) is what separates the topologies;
+    the eigenvalue-agnostic residual is under-constrained on a small boundary."""
+
+    def test_eigenvalue_agnostic_residual_does_not_separate(self):
+        target, _ = _meridian_target(flip=False)
+        # Without harmonic=True a non-harmonic eigenvector is accepted, so even the
+        # disk filling can host the meridian at a nonzero eigenvalue -> no clean
+        # obstruction. (Contrast test_matched_meridian_floors_on_disk_realizes_on_annulus.)
+        st = _disk()
+        v = cob.RealizabilityOracle(st).decideHarmonic(
+            target, epsilon=DEEP_EPS, restarts=RESTARTS, max_cones=0, seed=1,
+            growth_mode=SURGERY, connectivity_candidates=8, harmonic=False)
+        # It can be driven well below the harmonic floor (an eigenvector at some
+        # lambda != 0), confirming the harmonic criterion is the discriminating one.
+        self.assertLess(v.residual, CERT_FLOOR)
+        self.assertGreater(abs(v.eigenvalue), 1e-2)
+
+
+# --------------------------------------------------------------------------- #
+class ExampleSelfVerifiesTest(unittest.TestCase):
+    """The committed example runs end-to-end and exits 0 (its own assertions)."""
+
+    def test_example_exits_zero(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        example = os.path.join(here, "..", "..", "examples", "cobordism",
+                               "emergent_bulk_realizability.py")
+        self.assertTrue(os.path.exists(example))
+        result = subprocess.run(
+            [sys.executable, example, "--no-write"],
+            capture_output=True, text=True, timeout=900)
+        self.assertEqual(result.returncode, 0,
+                         msg=f"example exited {result.returncode}\n"
+                             f"{result.stdout[-2000:]}\n{result.stderr[-2000:]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Finishes the emergent-bulk experiment with the capability the earlier #208 draft was
missing: a **topology-changing (surgery) move**. Fix only the boundary, grow the
interior, and read `b₁` **off the witness** — but now the move-set can *change* the
topology, so `b₁` is a genuine **output** and the realizability obstruction **falls
out** instead of being installed by a hand-picked filling.

This supersedes the draft's "at k=1 the obstruction is installed, free growth can't
move it" conclusion: that was true only for **additive** growth (which is
boundary-locked / spectrally inert at k≥1). The boundary-fixed **remove**
(`EigenstateSynthesis::removeInteriorCell`, exposed as
`RealizabilityOracle.GrowthMode.SURGERY`, #196) opens a hole/handle with `∂W` held
bit-exact, so `b₁` moves on its own.

**Headline (`exit 0`).** At k=1, realizability separates into two clean obstructions:

- **Topological (does the handle exist?).** The matched two-boundary meridian
  **floors on the disk** (`b₁=0`, `r≈0.45`) and **realizes on the annulus** (`b₁=1`,
  `r≈6.9e-8`, eigenvalue→0). The surgery search, handed only the disk seed, **opens
  the handle on its own** (`b₁: 0→1`, scored purely by the harmonic residual) and the
  floored meridian realizes (`r≈3.5e-5…1.1e-4` across seeds).
- **Cohomological (do the periods match?).** A sign-flipped control — the conjugation
  `geo(ψ_A) ‖ conj(geo(ψ_B))`, `p_A=−p_B` — **floors on every filling, even after
  surgery opens the handle**: opposite periods are not the restriction of any closed
  form, so no bulk topology carries them.

So the realizable set is exactly `image(H¹(W) → H¹(∂W))` for the `W` the **search
grows**, with `b₁` read off the witness.

The 2×2 (E1), no growth:

| filling \ target | matched (`p_A=p_B`) | flipped (`p_A=−p_B`) |
|---|---|---|
| disk (`b₁=0`)    | floor `4.5e-1` | floor `9.9e-1` |
| annulus (`b₁=1`) | **REALIZE `6.9e-8`** | floor `2.0e-1` |

E2 surgery from the disk seed opens the handle (`b₁: 0→1`, 1 removal) for **both**
targets; only the matched meridian then realizes, the flipped one still floors. E3:
no boundary-fixed **additive** move can move `b₁` (the remove is load-bearing).

## Deliverables

- `examples/cobordism/emergent_bulk_realizability.py` — the matched/flipped 2×2 +
  surgery tables (`exit 0`; raw JSON → `/tmp/cobordism/`, not committed).
- `examples/cobordism/visualize_emergent_bulk.py` — the diagram generator (Schlegel
  panels: the two boundary meridians, disk-floors, annulus-realizes, the surgery
  before/after, the matched-vs-flipped negative control, and a composite; large
  titles + explicit legends; PNGs → `issue-attachments` release, not committed).
- `include/cobordism/EigenstateSynthesis.{h,cpp}` + `RealizabilityOracle.{h,cpp}` +
  `src/cobordism/Bindings.cpp` — the surgery move (`removeInteriorCell` /
  `interiorTopCells` / `restoreLastRemoval`; `GrowthMode::Surgery`).
- `docs/source/quantum-experiments/cobordism-correspondence-retest-k1-report.md` —
  rewritten with the corrected result (in the toctree). The superseded
  `cobordism-emergent-bulk-report.md` is removed and its dangling toctree entry
  dropped.
- `tests/cobordism/test_emergent_bulk_python.py` — independent re-derivation
  (surgery primitive, the 2×2, surgery emergence, the additive lock) + a self-verify
  that the committed example exits 0.

Validity-only interior; `∂W` held bit-exact; no re-pinned topology; no iTensor; the
10-CPU cap honored.

## Test plan

- [x] `python examples/cobordism/emergent_bulk_realizability.py` → `exit 0`
- [x] `python examples/cobordism/visualize_emergent_bulk.py` → 6 PNGs
- [x] `pytest tests/cobordism` → **511 passed, 1 skipped, 719 subtests passed**
- [x] `sphinx-build -E` clean (report renders, in the toctree)

## Build / rebase note

Rebased onto current `main` (047d405), which carries #211 (Debug-import fix) and
**#213** ("gate fast linker off Release — lld emits empty `_tessera.so`"). #213
independently fixes a real build bug surfaced while finishing this: lld 18.1.3 +
pybind11's Release LTO silently emits an empty module with no `PyInit__tessera`
(CI never imports, so it slipped through — #212). With #213 the default
`pip install -e ".[dev]"` Release build links correctly under bfd and is fast via
ccache; no linker override is needed.

Closes #207.
