### PR TITLE
fix(build): Debug build aborts at import — free(): invalid pointer (latent invalid-free masked by -O3)

### DIFF
--- a/src/quantum/Bindings.cpp
+++ b/src/quantum/Bindings.cpp
@@ -22,6 +22,28 @@
 // Plus the existing data classes (QuantumConfig, GroundStateResult,
 // SchmidtSpectra, …) and the MajorizationPredicate hierarchy.
 
+// pybind11 must be included *before* any quantum header that transitively pulls
+// in <itensor/all.h> (ChoiState.hpp, MutualInformation.hpp, Schmidt.hpp) — i.e.
+// before the rest of this translation unit. ITensor's itensor/global.h does an
+// unconditional `#define NDEBUG` to silence its own asserts. pybind11 auto-
+// enables PYBIND11_DETAILED_ERROR_MESSAGES only while NDEBUG is *un*defined
+// (detail/common.h), and that flag adds a `std::string type` member to
+// pybind11::arg_v. Every other binding TU is ITensor-free, so it parses pybind11
+// with NDEBUG undefined and gets the larger arg_v; letting ITensor's NDEBUG leak
+// reach pybind11 here first gives this one TU the smaller arg_v instead. The two
+// layouts are an ODR violation: arg_v's vague-linkage destructor is merged
+// across TUs, and the size-mismatched copy over-reads the `type` member and
+// frees a borrowed string-literal pointer at import — `free(): invalid pointer`,
+// which aborts every Debug build. (Release defines NDEBUG uniformly up front, so
+// both sides agree and the bug stays latent.) Parsing pybind11 first locks
+// arg_v's layout to match the rest of the module regardless of ITensor's later
+// #define, because the member's `#if` is resolved when cast.h is parsed.
+#include <pybind11/complex.h>
+#include <pybind11/eigen.h>
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
 #include "quantum/CausalCompare.hpp"
 #include "quantum/CausetChain.hpp"
 #include "quantum/ChoiJamiolkowski.h"
@@ -37,12 +59,6 @@
 #include "quantum/Schmidt.hpp"
 #include "quantum/TDVPRunner.hpp"
 #include "spacetime/Spacetime.h"  // full type needed for py::cast<Spacetime*>()
-
-#include <pybind11/complex.h>
-#include <pybind11/eigen.h>
-#include <pybind11/functional.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 namespace py = pybind11;
 


### PR DESCRIPTION
## Summary

A **Debug** build (`pip install -e ".[dev]" -C cmake.build-type=Debug`) aborts
deterministically at `import tessera` with `free(): invalid pointer` (SIGABRT,
exit 134). A **Release** build of the same commit imports cleanly. This is a
genuine memory-safety bug (an ODR layout mismatch / invalid free) that `-O3`
only *masked*.

## Root cause (gdb)

The abort is in the destructor of a `pybind11::arg_v` temporary at
`src/quantum/Bindings.cpp:347` (`py::arg("tol") = 1e-12`):

```
#8  __GI___libc_free (mem=0x7ffff5790ac2)
#9  std::__new_allocator<char>::deallocate (__p=0x7ffff5790ac2 "tol", ...)
#14 std::__cxx11::basic_string<...>::~basic_string (this=0x7fffffffa6d0)
#15 pybind11::arg_v::~arg_v (this=0x7fffffffa6b0)        cast.h
#16 register_quantum (m=...)                              src/quantum/Bindings.cpp:347
#17 pybind11_init__tessera (...)                          src/bindings.cpp:222
```

`free()` is called on `0x7ffff5790ac2` — a pointer to the **string literal
`"tol"`** in `.rodata` (the `arg::name`), not a heap allocation. The `arg_v`
destructor is reading a `std::string type` member at an offset where this TU
never stored one.

Why: `pybind11::arg_v` has a `std::string type` member that exists **only when
`PYBIND11_DETAILED_ERROR_MESSAGES` is defined**, which pybind11 auto-enables iff
`NDEBUG` is **un**defined (`detail/common.h:1417`). ITensor's
`third_party/itensor/itensor/global.h:78` does an unconditional `#define NDEBUG`.
`src/quantum/Bindings.cpp` included the ITensor-pulling quantum headers
(`ChoiState.hpp`, `MutualInformation.hpp`, `Schmidt.hpp` → `<itensor/all.h>`)
**before** pybind11, so pybind11 parsed `arg_v` with `NDEBUG` defined → the
smaller layout (no `type` member). Every other binding TU is ITensor-free and
parsed pybind11 with `NDEBUG` undefined → the larger layout (with `type`).

`arg_v`'s implicit destructor has vague linkage and is merged across TUs by the
linker. The merged (larger) destructor runs on this TU's smaller temporary,
over-reads the `type` member off the end of the object, and frees the adjacent
`"tol"` pointer → `free(): invalid pointer`.

- **Why Release masks it:** Release puts `-DNDEBUG` on the command line for
  *every* TU up front, so all binding TUs agree on the small `arg_v` and never
  touch a `type` member. The mismatch only appears in Debug, where `NDEBUG` is
  absent from the command line and the inconsistency is entirely driven by
  ITensor's header `#define`.

## Fix

Move the pybind11 includes ahead of the ITensor-pulling headers in
`src/quantum/Bindings.cpp` — the include ordering every other binding TU already
uses. The `type`-member `#if` is resolved when `cast.h` is parsed, so parsing
pybind11 first locks `arg_v`'s layout (and the whole pybind11 ABI in this TU) to
match the rest of the module, regardless of ITensor's later `#define NDEBUG`.
One-file change; **no Release behaviour change** (Release already defines NDEBUG
before any include).

## Test plan

- [x] **Before:** Debug `import tessera` → `free(): invalid pointer`, exit 134
  (reproduced 3/3, then 5/5).
- [x] **After:** Debug `import tessera` → exit 0 (reproduced 5/5); clean under
  `gdb` (`[Inferior 1 exited normally]`).
- [x] Broad smoke import on the Debug build: `mesh`, `spacetime`, `observables`,
  `simulations`, `cobordism`, `quantum`, `quantum.holography`; constructed
  `Signature`/`Metric`; instantiated the previously-crashing
  `StandardMajorization` / `LogConcaveMajorization` / `PeakRadialMajorization`.
- [x] **Release** build still imports and works.
- [x] `pytest tests/cobordism` green (10-CPU cap).
- [x] Bonus: Debug build imports clean under ASan (`TESSERA_ASAN=1`).

Closes #210.
