### PR TITLE
fix(build): lld emits empty _tessera.so for Release — gate fast linker off Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,20 @@ endif()
 # Linking _tessera against ITensor + Eigen + a BLAS/LAPACK backend is link-heavy;
 # mold and lld cut link time sharply versus the default BFD ld. Preferred order
 # mold > lld. Auto-enabled when found; set TESSERA_FAST_LINKER=0 to opt out.
-if (NOT "$ENV{TESSERA_FAST_LINKER}" STREQUAL "0")
+#
+# Release is DELIBERATELY excluded. The Release module links with LTO
+# (-flto=auto, enabled by pybind11) at -O3, and lld 18.1.3 silently emits an
+# empty _tessera.so with no PyInit__tessera for that link, so `import tessera`
+# fails (#212). The identical Release objects link correctly under the default
+# BFD ld (and gold), and lld links Debug fine. CI is build-only and never
+# imports, so it slipped through. mold + Release is untested, so it is treated
+# as equally unsafe. The fast linker therefore only applies to non-Release
+# configs (Debug etc.), where it both links and runs and dev builds want the
+# speed; Release falls back to the system default linker. This is a
+# single-config build (scikit-build sets CMAKE_BUILD_TYPE), so a plain
+# CMAKE_BUILD_TYPE guard is sufficient.
+if (NOT "$ENV{TESSERA_FAST_LINKER}" STREQUAL "0"
+        AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
     find_program(MOLD_PROGRAM mold)
     find_program(LLD_PROGRAM ld.lld)
     if (MOLD_PROGRAM)


### PR DESCRIPTION
## Summary
#209 wired a fast linker (`-fuse-ld=lld`; mold is preferred but isn't installed on the build box) as the default for **all** builds. lld 18.1.3 silently links the `-O3` Release `_tessera` module (built with LTO, `-flto=auto` via pybind11) into an empty `.so` with **no `PyInit__tessera`**, so `import tessera` fails. The identical Release objects link correctly under the default BFD ld (and gold), and lld links Debug fine — and since CI is build-only (never imports), it slipped through (found while fixing #210).

This gates the fast-linker `add_link_options(-fuse-ld=...)` block off Release (covering **both** the mold and lld branches, since mold+Release is untested), so Release falls back to the system default linker (bfd, known-good). Debug and other non-Release configs keep the fast linker; the `TESSERA_FAST_LINKER=0` opt-out is unchanged. Single-config build, so a `CMAKE_BUILD_TYPE` guard suffices. See the issue's Scope for the full breakdown.

## Test plan
- [ ] Reproduce: Release+lld → ~4 KB `_tessera.so`, 0 `PyInit`, `import tessera` raises `... no PyInit__tessera`
- [ ] Baseline: Release+bfd (`TESSERA_FAST_LINKER=0`) → multi-MB `.so` with `PyInit__tessera`, imports OK
- [ ] Fix — Release (default): full `.so` with `PyInit__tessera`, `import tessera` OK; cmake prints **no** `Fast linker enabled`
- [ ] Fix — Debug: cmake prints `Fast linker enabled: lld`, `.so` has `PyInit__tessera` (links fine; the Debug *import* abort is the orthogonal #210 / PR #211 `free()` bug)

All diagnostics CUDA-off (the linker bug is host-side, CUDA-orthogonal).

**Follow-up (not in this PR):** gold also links Release correctly, so a future change could prefer gold for Release rather than plain bfd.

Closes #212.