### PR TITLE
chore(ci): bump deprecated Node-20 actions to current Node-24 releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"  # or match your project
 
@@ -50,7 +50,7 @@ jobs:
           make html
 
       - name: Upload artifact for GitHub Pages
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 
@@ -63,5 +63,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 


### PR DESCRIPTION
## Summary
Recent CI runs warn that the actions in both workflows run on Node 20 — which GitHub forces to Node 24 on 2026-06-16 and removes from runners on 2026-09-16. This bumps each to its current major across `build.yml` and `pages.yml`, with no logic changes:

- `actions/checkout@v4 → @v6`
- `actions/setup-python@v5 → @v6`
- `actions/upload-pages-artifact@v3 → @v5`
- `actions/deploy-pages@v4 → @v5`

## Test plan
- [ ] `build` workflow runs green on this PR (exercises the bumped `checkout` / `setup-python`)
- [ ] `pages.yml` goes green on the post-merge `main` run — it doesn't run on PRs (push-to-`main` only); verifiable on merge, or via `workflow_dispatch` on this branch first
- [ ] Node-20 deprecation warnings no longer appear in the run logs

Closes #230.