### PR TITLE
feat(cobordism): validate H3 spectrally — Z_spec equals the amplitude across the realized gate set

### DIFF
--- a/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
@@ -11,7 +11,9 @@
 > `realizable_image_sweep.py` / `loosened_gate_retest.py` /
 > `spectral_gate_realizability.py` (the gate set: pinned ($S_3$), loosened at
 > $k=0$, and the staged spectral synthesis with the boundary synthesized
-> (the charge-conservation criterion; 13 named gates)) — all under `examples/cobordism/`.
+> (the charge-conservation criterion; 13 named gates); its `--h3` mode
+> validates the value equation $Z_{\text{spec}}=\langle\psi_A|U|\psi_B\rangle$
+> on the realized set, spectrally) — all under `examples/cobordism/`.
 
 ## The correspondence
 
@@ -129,6 +131,53 @@ outgoing $\mathrm{geo}(\psi_A)$ and the orientation-reversed incoming
 $\mathrm{geo}(\psi_B)$.
 
 ## H3 — the value is the amplitude
+
+### H3 on the spectral data: $Z_{\text{spec}}$ equals the amplitude on every realized gate
+
+The value equation is validated on the staged-synthesis register itself —
+no DW input anywhere (`spectral_gate_realizability.py --h3`). The spectral
+value $Z_{\text{spec}}(W;\psi_A,U\psi_B)$ is the Hodge pairing of the
+carried harmonic representatives on the surgery-grown bulk (the register
+bulk carries the unit cochain metric, so the pairing is the plain Hermitian
+contraction), with **one** global scale fixed by the T1 anchor
+$Z_{\text{spec}}(\psi_B,\psi_B)=\langle\psi_B|\psi_B\rangle$; after that,
+every number — every pair, every gate, every re-grown bulk — is a
+prediction with no freedom left.
+
+- **The register chart is a scaled isometry.** The Gram of the period map
+  $V\to\ker L_1$ on a flat-orthonormal basis of the $\Sigma=0$ subspace is
+  the identity to $7.8\times10^{-16}$. By Schur's lemma this is exactly the
+  $S_3$-equivariance of the carried register: $V$ is the irreducible
+  standard representation, so any invariant inner product on it is
+  proportional to the flat one — the proportionality constant being the one
+  scale T1 fixes.
+- **$Z_{\text{spec}}=\langle\psi_A|U|\psi_B\rangle$ for every realized
+  gate.** Worst pair deviation $5.0\times10^{-16}$ across the 13 criterion
+  gates $\times$ 9 carried pairs (the $V$-generic input plus 8 random
+  carried $\psi_A$); the independent Choi/operator reading
+  (`quantum::ChoiJamiolkowski.transitionAmplitude` on the $\mathbb{C}^4$
+  holonomy embedding) agrees to $1.6\times10^{-16}$.
+- **A floored gate has no spectral value.** Its post-interaction periods
+  leak out of $V$ ($\lvert\Sigma\rvert=0.21$–$2.60$ across the 39 floored
+  gates), so no carried representative exists — the value-level
+  obstruction certificate, the same mechanism as the residual floor.
+- **Bulk independence, with its mechanism.** The symmetry-preserving
+  re-triangulation (one geodesic subdivision, each holonomy hole re-placed
+  on the central child of its original hole face) carries the value
+  *exactly*: Gram defect $7.6\times10^{-16}$, value drift
+  $9.7\times10^{-16}$. A generic vertex-disjoint hole draw still realizes
+  the same gates, but its chart is anisotropic (Gram defects $0.11$ and
+  $0.25$ on two draws) and its value deviation ($0.14$, $0.26$) equals the
+  Gram-defect prediction $a^\dagger(G-I)b$ to $\sim10^{-15}$. **The
+  value-level H3 is the charge-conservation criterion plus the isometric
+  register chart**: surgery decides *which* gates are carried
+  (topology-free), and equivariance makes the carried pairing *be* the
+  amplitude.
+
+Read at the value level, the falsifiable core says: the identity reproduces
+the inner product only once surgery has grown the full register (the T1
+anchor), and a leaked class produces *no* value at all rather than a wrong
+one.
 
 ### The DW–spectral bridge: three independent readings agree (and only on the lattice)
 
@@ -544,6 +593,8 @@ python examples/cobordism/realizable_image_sweep.py       # the pinned gate set 
 python examples/cobordism/emergent_bulk_realizability.py  # b₁ as an output
 python examples/cobordism/loosened_gate_retest.py         # the loosened gate re-test (k=0)
 python examples/cobordism/spectral_gate_realizability.py                   # the staged gate set (charge-conservation criterion, 13 named)
+python examples/cobordism/spectral_gate_realizability.py --h3              # H3 at the value level: Z_spec = <psi_A|U|psi_B> on the realized set
+python -m pytest tests/cobordism/test_spectral_h3_python.py                # the pinned H3 invariants
 python examples/cobordism/spectral_gate_realizability.py --gate sqrt-SWAP   # solve for one named gate (52-gate battery)
 python examples/cobordism/spectral_gate_realizability.py --retries 10000 --jobs 10  # parallel surgery-topology search (confirms the criterion)
 python examples/cobordism/spectral_gate_realizability.py --all-plots        # force-directed renders → issue-attachments

--- a/examples/cobordism/spectral_gate_realizability.py
+++ b/examples/cobordism/spectral_gate_realizability.py
@@ -107,6 +107,14 @@ Parameters (additive -- the default run is the verified criterion sweep)
                   staged synthesis (synthesize states -> union as boundary -> grow by
                   surgery -> spectral L_1 residual) and reports that gate's residual,
                   realize/floor verdict, and emergent b_1.
+  --h3            H3 at the VALUE level, on the spectral data alone: Z_spec(W; psi_A,
+                  U psi_B) -- the Hodge pairing of the carried harmonic representatives
+                  on the surgery-grown bulk, with ONE scale fixed by the T1 anchor --
+                  equals <psi_A|U|psi_B> for every realized gate, over the V-generic
+                  input and a battery of random carried psi_A. Also reports the register
+                  Gram (the period-map isometry; Schur/S_3-equivariance), the
+                  Choi/operator cross-check, the floored gates' no-carried-post-state
+                  certificate, and bulk independence across re-grown genuine registers.
   --retries N     The surgery-topology search: score N RANDOMIZED surgery-grown
                   topologies (varied S^2 seeds -- the icosahedron and its geodesic
                   subdivisions -- varied vertex-disjoint holonomy-hole triples, and
@@ -122,6 +130,7 @@ Parameters (additive -- the default run is the verified criterion sweep)
                   release, printing the embed URLs (--no-upload renders locally only).
 
 Run:  python examples/cobordism/spectral_gate_realizability.py
+      python examples/cobordism/spectral_gate_realizability.py --h3
       python examples/cobordism/spectral_gate_realizability.py --gate sqrt-SWAP
       python examples/cobordism/spectral_gate_realizability.py --retries 5000 --jobs 10
       python examples/cobordism/spectral_gate_realizability.py --all-plots
@@ -598,6 +607,298 @@ def gate_sweep(reg, on_progress=None):
         if on_progress is not None:
             on_progress()
     return rows
+
+
+# --------------------------------------------------------------------------- #
+# --h3: H3 at the VALUE level, on the spectral data alone. The staged synthesis
+# proves U|psi_B> is CARRIED (r -> 0); this leg checks the value equation itself,
+# Z_spec(W; psi_A, U psi_B) = <psi_A|U|psi_B>, for every gate the construction
+# realizes -- no DW input anywhere. Z_spec is the Hodge pairing of the carried
+# harmonic representatives on the surgery-grown bulk (the eigendecomposition's
+# ker L_1; the register bulk has the unit cochain metric, so the pairing is the
+# plain Hermitian contraction). ONE global scale is fixed by the T1 anchor
+# (Z_spec(psi_B, psi_B) = <psi_B|psi_B>); after that every number -- every pair,
+# every gate, every re-grown topology -- is a prediction with no freedom left.
+# --------------------------------------------------------------------------- #
+def _carried_form(reg, raw_periods):
+    """The pure ker-L_1 representative of `raw_periods` on the surgery-grown bulk
+    (the register harmonics combined by least squares; NO leak correction), as a
+    full edge vector, plus the norm of the un-carried period remainder. The state
+    is a boundary state of the register iff that remainder is ~ 0."""
+    raw = np.asarray(raw_periods, dtype=complex)
+    coeffs, *_ = np.linalg.lstsq(reg.P.T, raw, rcond=None)
+    full = (coeffs @ reg.H_full).astype(complex)
+    leak = raw - coeffs @ reg.P
+    return full, float(np.linalg.norm(leak))
+
+
+def random_carried_states(n, seed):
+    """n random unit register states: signed periods cp with Sigma = 0 (the carried
+    subspace V), every component bounded away from zero (V-generic)."""
+    rng = np.random.default_rng(seed)
+    out = []
+    while len(out) < n:
+        z = rng.standard_normal(3) + 1j * rng.standard_normal(3)
+        z = z - z.mean()                                  # project onto Sigma = 0
+        if float(np.min(np.abs(z))) < 1e-2:               # V-generic only
+            continue
+        out.append(z / np.linalg.norm(z))
+    return out
+
+
+def register_gram(reg, scale):
+    """The register Gram in period coordinates: G_kl = scale * <h(e_k), h(e_l)> on a
+    flat-orthonormal basis {e_k} of the Sigma = 0 subspace. H3 at the value level is
+    G = I -- the period map V -> ker L_1 is a scaled isometry. By Schur's lemma that
+    is exactly S_3-equivariance of the carried register: V is the irreducible S_3
+    standard rep, so any invariant inner product on it is proportional to the flat
+    one, and the single proportionality constant is what the T1 anchor fixes."""
+    e1 = np.array([1.0, -1.0, 0.0]) / np.sqrt(2.0)
+    e2 = np.array([1.0, 1.0, -2.0]) / np.sqrt(6.0)
+    forms = [_carried_form(reg, reg.sign * e.astype(complex))[0] for e in (e1, e2)]
+    return scale * np.array([[complex(np.vdot(a, b)) for b in forms] for a in forms])
+
+
+def _amp_choi(U, cp_a, cp_out_unused, cp_b):
+    """The operator/Choi reading of the same matrix element: <psi_A|U|psi_B> through
+    quantum::ChoiJamiolkowski.transitionAmplitude on the C^4 holonomy embedding
+    (zero trivial-class component). The independent operator-side cross-check."""
+    cj = tessera.quantum.ChoiJamiolkowski
+    psi_a = [complex(0.0)] + [complex(z) for z in cp_a]
+    psi_b = [complex(0.0)] + [complex(z) for z in cp_b]
+    u_flat = [complex(z) for z in np.asarray(U, dtype=complex).reshape(-1)]
+    return complex(cj.transitionAmplitude(psi_a, u_flat, psi_b, 4, 4))
+
+
+def h3_value_sweep(reg, n_states=8, seed=2026, on_progress=None):
+    """H3 on the spectral data, against every gate the construction realizes: for the
+    V-generic input psi_B and a battery of random carried psi_A, compare the spectral
+    value Z_spec = scale * <h(psi_A), h(U psi_B)> (Hodge pairing of the carried
+    harmonic representatives, scale fixed once on the T1 anchor) with the flat
+    register amplitude <psi_A|U|psi_B> and with the Choi/operator reading. A floored
+    gate has NO carried post-state (its periods leak out of V), so it has no spectral
+    value -- the value-level obstruction certificate. Returns (rows, info)."""
+    hodge = cob.HodgeLaplacian(reg.st)
+    w1 = np.asarray(hodge.weights(1), dtype=float)
+    info = {"unit_metric_dev": float(np.max(np.abs(w1 - 1.0)))}
+
+    cp_b = (_CP_IN / np.linalg.norm(_CP_IN)).astype(complex)
+    h_b, leak_b = _carried_form(reg, reg.sign * cp_b)
+    info["psi_b_leak"] = leak_b
+    scale = 1.0 / float(np.vdot(h_b, h_b).real)           # the T1 anchor
+    info["scale"] = scale
+    info["gram"] = register_gram(reg, scale)
+    info["gram_dev"] = float(np.max(np.abs(info["gram"] - np.eye(2))))
+
+    states = [cp_b] + random_carried_states(n_states, seed)
+    forms_a = [_carried_form(reg, reg.sign * cp)[0] for cp in states]
+
+    rows = []
+    for name, U, fam in _gates():
+        u_reg = np.asarray(U, dtype=complex)[1:4, 1:4]
+        cp_out = u_reg @ cp_b
+        res, _b1, leak = post_interaction(reg, U)
+        realized = bool(res < REALIZE)
+        if not realized:
+            rows.append({"gate": name, "family": fam, "realizable": False,
+                         "residual": res, "leak": leak,
+                         "max_dev": None, "choi_dev": None, "n_pairs": 0})
+            if on_progress is not None:
+                on_progress()
+            continue
+        h_out, _ = _carried_form(reg, reg.sign * cp_out)
+        devs, choi_devs = [], []
+        for cp_a, h_a in zip(states, forms_a):
+            amp = complex(np.vdot(cp_a, cp_out))          # <psi_A|U|psi_B>, flat
+            z = scale * complex(np.vdot(h_a, h_out))      # Z_spec, the Hodge pairing
+            devs.append(abs(z - amp))
+            choi_devs.append(abs(_amp_choi(U, cp_a, cp_out, cp_b) - amp))
+        rows.append({"gate": name, "family": fam, "realizable": True,
+                     "residual": res, "leak": leak,
+                     "max_dev": float(max(devs)), "choi_dev": float(max(choi_devs)),
+                     "n_pairs": len(states)})
+        if on_progress is not None:
+            on_progress()
+    return rows, info
+
+
+def _equivariant_variant():
+    """The symmetry-preserving re-triangulation: one geodesic subdivision of the
+    icosahedron with each holonomy hole re-placed on the CENTRAL CHILD of its
+    original hole face (the triangle of the three edge midpoints). Subdivision
+    commutes with the simplicial symmetries, so the register equivariance that makes
+    the Gram the identity is preserved -- the genuine bulk-independence witness."""
+    nxt = [max(v for f in _ICO for v in f) + 1]
+    mid = {}
+
+    def m(a, b):
+        key = (min(a, b), max(a, b))
+        if key not in mid:
+            mid[key] = nxt[0]
+            nxt[0] += 1
+        return mid[key]
+
+    faces, central = [], {}
+    for (a, b, c) in _ICO:
+        ab, bc, ca = m(a, b), m(b, c), m(c, a)
+        faces += [(a, ab, ca), (b, bc, ab), (c, ca, bc), (ab, bc, ca)]
+        central[tuple(sorted((a, b, c)))] = tuple(sorted((ab, bc, ca)))
+    holes = [central[h] for h in _CLASS_HOLES]
+    return Register(faces=[tuple(sorted(f)) for f in faces], class_holes=holes)
+
+
+def _anisotropic_variant_registers(n_variants, seed):
+    """Re-grown GENUINE registers with generic (seeded, vertex-disjoint) hole triples
+    on the subdivided sphere -- carried, but with no symmetry to enforce an isometric
+    period chart. Their Gram defect is the control the equivariant witness is read
+    against."""
+    rng = random.Random(seed)
+    out, tries = [], 0
+    faces = _seed_surface(1)
+    while len(out) < n_variants and tries < 60:
+        tries += 1
+        holes = _vertex_disjoint_holes(faces, 3, rng)
+        if holes is None:
+            continue
+        reg = Register(faces=faces, class_holes=holes)
+        if reg.dim != 2 or reg.rank >= len(reg.class_holes):
+            continue                                      # saturated / degenerate draw
+        if post_interaction(reg, _gates()[0][1])[0] >= REALIZE:
+            continue                                      # identity anchor must hold
+        out.append(reg)
+    return out
+
+
+def h3_invariance(n_variants=2, n_states=4, seed=2026, on_progress=None):
+    """Bulk independence of the value, and what it turns on. The H3 table is re-run on
+    re-grown genuine registers with the SAME state battery. On the symmetry-preserving
+    re-triangulation (`_equivariant_variant`) the value carries over exactly. On
+    generic hole draws the period chart is anisotropic (Gram != I), and the deviation
+    from the amplitude is predicted EXACTLY by the Gram defect: Z - amp =
+    a^dag (G - I) b in the flat-orthonormal coordinates of V. The value-level H3 is
+    the residual-level criterion PLUS the isometric (equivariant) register chart."""
+    cp_b = (_CP_IN / np.linalg.norm(_CP_IN)).astype(complex)
+    states = [cp_b] + random_carried_states(n_states, seed)
+    realized = [(name, np.asarray(U, dtype=complex)[1:4, 1:4])
+                for name, U, _f in _gates() if conserves_charge(U)]
+    e_basis = np.array([[1.0, -1.0, 0.0] / np.sqrt(2.0),
+                        [1.0, 1.0, -2.0] / np.sqrt(6.0)])
+
+    def survey(reg):
+        h_b, _ = _carried_form(reg, reg.sign * cp_b)
+        scale = 1.0 / float(np.vdot(h_b, h_b).real)
+        gram = register_gram(reg, scale)
+        forms_a = [_carried_form(reg, reg.sign * cp)[0] for cp in states]
+        vals, defect = {}, 0.0
+        for name, u_reg in realized:
+            cp_out = u_reg @ cp_b
+            h_out, _ = _carried_form(reg, reg.sign * cp_out)
+            b = e_basis @ cp_out
+            zs = []
+            for cp_a, h_a in zip(states, forms_a):
+                z = scale * complex(np.vdot(h_a, h_out))
+                amp = complex(np.vdot(cp_a, cp_out))
+                a = e_basis @ cp_a
+                predicted = complex(np.conj(a) @ (gram - np.eye(2)) @ b)
+                defect = max(defect, abs((z - amp) - predicted))
+                zs.append(z)
+            vals[name] = zs
+        return vals, float(np.max(np.abs(gram - np.eye(2)))), defect
+
+    base_vals, _gd, _dd = survey(Register())
+    if on_progress is not None:
+        on_progress()
+
+    def drift_vs_base(vals):
+        return float(max(abs(vals[name][k] - base_vals[name][k])
+                         for name in vals for k in range(len(states))))
+
+    eq = _equivariant_variant()
+    eq_vals, eq_gram_dev, eq_defect = survey(eq)
+    equivariant = {"nV": int(eq.st.getVertexList().size()), "rank": eq.rank,
+                   "gram_dev": eq_gram_dev, "drift": drift_vs_base(eq_vals),
+                   "defect_residual": eq_defect}
+    if on_progress is not None:
+        on_progress()
+
+    anisotropic = []
+    for reg in _anisotropic_variant_registers(n_variants, seed):
+        vals, gram_dev, defect = survey(reg)
+        anisotropic.append({"nV": int(reg.st.getVertexList().size()),
+                            "rank": reg.rank, "gram_dev": gram_dev,
+                            "drift": drift_vs_base(vals),
+                            "defect_residual": defect})
+        if on_progress is not None:
+            on_progress()
+    return {"equivariant": equivariant, "anisotropic": anisotropic,
+            "n_gates": len(realized), "n_pairs": len(states)}
+
+
+def _print_h3(rows, info, inv, check):
+    """Report the H3 value table in the house style and register its checks."""
+    realized = [r for r in rows if r["realizable"]]
+    floored = [r for r in rows if not r["realizable"]]
+    print("\n  H3 at the VALUE level (spectral data only; one scale fixed by the T1 "
+          "anchor, then every number is a prediction):")
+    print(f"      unit cochain metric: max|w_1 - 1| = {info['unit_metric_dev']:.1e}  "
+          f"(the Hodge pairing is the plain Hermitian contraction)")
+    g = info["gram"]
+    print(f"      register Gram on V (flat-orthonormal basis of Sigma=0): "
+          f"[[{g[0, 0]:.6f}, {g[0, 1]:.6f}], [{g[1, 0]:.6f}, {g[1, 1]:.6f}]]  "
+          f"max|G - I| = {info['gram_dev']:.2e}")
+    print("        (G = I is the period-map isometry -- by Schur, exactly the "
+          "S_3-equivariance of the carried register.)")
+    header = (f"      {'gate':16} {'family':16} {'r(U)':>10} "
+              f"{'max|Z_spec - amp|':>18} {'choi dev':>10} {'pairs':>6}")
+    print(header)
+    print("      " + "-" * (len(header) - 6))
+    for r in realized:
+        print(f"      {r['gate']:16} {r['family']:16} {r['residual']:>10.1e} "
+              f"{r['max_dev']:>18.2e} {r['choi_dev']:>10.1e} {r['n_pairs']:>6}")
+    lo = min(r["leak"] for r in floored)
+    hi = max(r["leak"] for r in floored)
+    print(f"      ({len(floored)} floored gates: no carried post-state -- leak "
+          f"|Sigma| in {lo:.2f}..{hi:.2f} -- so no spectral value exists; the "
+          f"value-level obstruction certificate.)")
+    eq = inv["equivariant"]
+    print(f"      bulk independence ({inv['n_gates']} gates x {inv['n_pairs']} pairs "
+          f"each): the symmetry-preserving re-triangulation (|V|={eq['nV']}, the "
+          f"subdivided icosahedron, central-child holes) carries the value EXACTLY -- "
+          f"Gram dev {eq['gram_dev']:.1e}, drift {eq['drift']:.2e}.")
+    for v in inv["anisotropic"]:
+        print(f"        generic hole draw (|V|={v['nV']}): Gram dev "
+              f"{v['gram_dev']:.2e}, value deviation {v['drift']:.2e} -- equal to the "
+              f"Gram-defect prediction a*(G-I)b to {v['defect_residual']:.1e}.")
+    print("        => the value is carried by every bulk whose register chart is "
+          "isometric (Gram = I, the equivariant draws); a generic draw deviates by "
+          "exactly its Gram defect. The value-level H3 is the residual-level "
+          "criterion PLUS the isometric register chart.")
+    worst = max(r["max_dev"] for r in realized)
+    worst_choi = max(r["choi_dev"] for r in realized)
+    print(f"        => Z_spec = <psi_A|U|psi_B> on every realized gate "
+          f"(worst pair deviation {worst:.2e}); the Choi/operator reading agrees "
+          f"(worst {worst_choi:.2e}).")
+    check("the register bulk has the unit cochain metric",
+          info["unit_metric_dev"] < 1e-12)
+    check("psi_B is carried (its periods lie in V)", info["psi_b_leak"] < 1e-9)
+    check("the register Gram is the identity (period map is a scaled isometry)",
+          info["gram_dev"] < 1e-9)
+    check("T1 anchor: the identity's spectral value is <psi_A|psi_B> on every pair",
+          realized[0]["gate"] == "Identity" and realized[0]["max_dev"] < 1e-9)
+    check("H3: Z_spec = <psi_A|U|psi_B> for EVERY realized gate, on every pair",
+          worst < 1e-9)
+    check("the Choi/operator reading agrees with the flat amplitude",
+          worst_choi < 1e-9)
+    check("every floored gate has no carried post-state (leak != 0)",
+          all(r["leak"] > 1e-6 for r in floored))
+    check("the value carries over exactly to the symmetry-preserving "
+          "re-triangulation (bulk independence)",
+          eq["gram_dev"] < 1e-9 and eq["drift"] < 1e-9)
+    check("a generic hole draw's value deviation equals its register Gram defect "
+          "(the value-level H3 selects the isometric chart)",
+          len(inv["anisotropic"]) >= 1
+          and all(v["defect_residual"] < 1e-9 for v in inv["anisotropic"]))
+    return worst
 
 
 # --------------------------------------------------------------------------- #
@@ -1201,6 +1502,12 @@ def main():
     ap.add_argument("--gate", default=None,
                     help="solve for ONE gate (e.g. H_x_H, sqrt-SWAP, CNOT); "
                          "'--gate help' lists the battery. Default: the full sweep.")
+    ap.add_argument("--h3", action="store_true",
+                    help="validate H3 at the value level on the spectral data: "
+                         "Z_spec(W; psi_A, U psi_B) = <psi_A|U|psi_B> for every "
+                         "realized gate (one scale fixed by the T1 anchor), plus the "
+                         "register Gram, the Choi/operator cross-check, and bulk "
+                         "independence across re-grown genuine registers.")
     ap.add_argument("--retries", type=int, default=0,
                     help="surgery-topology search: score N randomized surgery-grown "
                          "topologies in parallel (>0 enables it).")
@@ -1273,6 +1580,21 @@ def main():
     _check("every floored gate is certified (residual > CERT_FLOOR and leaks)",
            all(r["residual"] > CERT_FLOOR and r["leak"] > 1e-6 for r in floored))
 
+    # ---- H3 at the value level (--h3): Z_spec = <psi_A|U|psi_B> on the realized set #
+    h3_payload = None
+    if args.h3:
+        hprog = _progress()
+        hprog.phase("H3 value sweep", total=len(_gates()) + 4)
+        h3_rows, h3_info = h3_value_sweep(reg, on_progress=hprog.on_tick)
+        inv = h3_invariance(on_progress=hprog.on_tick)
+        hprog.finish("H3 value sweep done")
+        _print_h3(h3_rows, h3_info, inv, _check)
+        h3_payload = {"rows": h3_rows, "scale": h3_info["scale"],
+                      "gram": [[z.real, z.imag] for z in h3_info["gram"].reshape(-1)],
+                      "gram_dev": h3_info["gram_dev"],
+                      "unit_metric_dev": h3_info["unit_metric_dev"],
+                      "invariance": inv}
+
     # ---- the surgery-topology search (--retries): does the set grow past the criterion? #
     search = None
     if args.retries > 0:
@@ -1305,7 +1627,8 @@ def main():
         with open(path, "w") as handle:
             json.dump({"register_trace": trace, "register_constraint": reg.n.tolist(),
                        "identity_anchor": anchor, "stage1": stage1,
-                       "gate_sweep": rows, "surgery_search": search,
+                       "gate_sweep": rows, "h3": h3_payload,
+                       "surgery_search": search,
                        "plot_urls": plot_urls}, handle, indent=2)
         print(f"\n  raw table (PR artifact, not committed): {path}")
 

--- a/tests/cobordism/test_spectral_h3_python.py
+++ b/tests/cobordism/test_spectral_h3_python.py
@@ -1,0 +1,145 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""H3 at the VALUE level, on the spectral data alone (the --h3 leg of
+``examples/cobordism/spectral_gate_realizability.py``).
+
+The staged spectral synthesis proves a gate's post-interaction state is CARRIED
+(residual -> 0); these tests pin the value equation itself, with no DW input:
+
+  1. **The register Gram is the identity.** The period map V -> ker L_1 of the
+     surgery-grown icosahedral register is a scaled isometry (G = I after the T1
+     anchor fixes the one scale). By Schur's lemma that is exactly the
+     S_3-equivariance of the carried register: V is the irreducible S_3 standard
+     rep, so any invariant inner product on it is proportional to the flat one.
+  2. **Z_spec = <psi_A|U|psi_B> on every realized gate.** The Hodge pairing of the
+     carried harmonic representatives equals the flat register amplitude at machine
+     precision, over the V-generic input and random carried psi_A — and the
+     Choi/operator reading (quantum::ChoiJamiolkowski.transitionAmplitude on the
+     C^4 holonomy embedding) agrees independently.
+  3. **A floored gate has no spectral value.** Its post-interaction periods leak out
+     of V (|Sigma| != 0), so no carried representative exists — the value-level
+     obstruction certificate.
+  4. **Bulk independence, with its mechanism.** The symmetry-preserving
+     re-triangulation (one geodesic subdivision, holes on the central child of each
+     original hole face) carries the value exactly; a generic vertex-disjoint hole
+     draw deviates from the amplitude by EXACTLY its register Gram defect,
+     a^dag (G - I) b. The value-level H3 is the charge-conservation criterion PLUS
+     the isometric (equivariant) register chart.
+"""
+
+import importlib.util
+import os
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "spectral_gate_realizability.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("spectral_gate_realizability",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GATE = _load_example()
+
+# One register + one H3 sweep shared by every test below (the construction is
+# deterministic; building it once keeps the suite fast).
+_REG = GATE.Register()
+_ROWS, _INFO = GATE.h3_value_sweep(_REG, n_states=6, seed=7)
+_REALIZED = [r for r in _ROWS if r["realizable"]]
+_FLOORED = [r for r in _ROWS if not r["realizable"]]
+
+
+class RegisterChartIsIsometricTest(unittest.TestCase):
+    """1: the carried register's period chart is a scaled isometry (Gram = I)."""
+
+    def test_register_bulk_has_the_unit_cochain_metric(self):
+        self.assertLess(_INFO["unit_metric_dev"], 1e-12)
+
+    def test_generic_input_is_carried(self):
+        self.assertLess(_INFO["psi_b_leak"], 1e-9)
+
+    def test_register_gram_is_the_identity(self):
+        self.assertLess(_INFO["gram_dev"], 1e-12)
+
+
+class ValueEqualsAmplitudeTest(unittest.TestCase):
+    """2: Z_spec = <psi_A|U|psi_B> for every gate the construction realizes."""
+
+    def test_realized_set_is_the_charge_conservation_criterion(self):
+        self.assertEqual([r["gate"] for r in _REALIZED],
+                         list(GATE.CANONICAL_SET))
+
+    def test_t1_anchor_identity_reproduces_the_inner_product(self):
+        identity = _REALIZED[0]
+        self.assertEqual(identity["gate"], "Identity")
+        self.assertLess(identity["max_dev"], 1e-12)
+
+    def test_value_equals_amplitude_on_every_realized_gate(self):
+        for r in _REALIZED:
+            self.assertLess(r["max_dev"], 1e-12, msg=r["gate"])
+
+    def test_choi_operator_reading_agrees(self):
+        for r in _REALIZED:
+            self.assertLess(r["choi_dev"], 1e-12, msg=r["gate"])
+
+
+class FlooredGatesHaveNoValueTest(unittest.TestCase):
+    """3: a floored gate's post-state leaks out of V — no spectral value exists."""
+
+    def test_every_floored_gate_leaks(self):
+        self.assertEqual(len(_FLOORED), len(GATE._gates()) - len(GATE.CANONICAL_SET))
+        for r in _FLOORED:
+            self.assertGreater(r["leak"], 1e-6, msg=r["gate"])
+            self.assertIsNone(r["max_dev"], msg=r["gate"])
+
+
+class BulkIndependenceTest(unittest.TestCase):
+    """4: the value carries over exactly to the symmetry-preserving
+    re-triangulation; a generic draw deviates by exactly its Gram defect."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inv = GATE.h3_invariance(n_variants=1, n_states=3, seed=7)
+
+    def test_equivariant_retriangulation_carries_the_value_exactly(self):
+        eq = self.inv["equivariant"]
+        self.assertLess(eq["gram_dev"], 1e-12)
+        self.assertLess(eq["drift"], 1e-12)
+
+    def test_generic_draw_deviation_is_exactly_the_gram_defect(self):
+        self.assertGreaterEqual(len(self.inv["anisotropic"]), 1)
+        for v in self.inv["anisotropic"]:
+            # a non-trivial control: the chart is genuinely anisotropic...
+            self.assertGreater(v["gram_dev"], 1e-3)
+            # ...and the deviation is predicted by a^dag (G - I) b to machine zero.
+            self.assertLess(v["defect_residual"], 1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

H3 (the value is the amplitude) was certified only by the DW–spectral bridge; the staged synthesis proved *carried*, never the *value*. This adds `--h3` to `spectral_gate_realizability.py`: on the surgery-grown register, the Hodge pairing of the carried harmonic representatives — one global scale fixed by the T1/identity anchor, everything after that a prediction — is compared with the flat register amplitude ⟨ψ_A|U|ψ_B⟩ and the Choi/operator reading, for the V-generic input and a battery of random carried ψ_A, across the full 52-gate battery. No DW input anywhere.

Verified findings (run output; raw table on the [`issue-attachments` release](https://github.com/akellehe/tessera/releases/download/issue-attachments/spectral_gate_realizability_h3.json)):
- **Z_spec = ⟨ψ_A|U|ψ_B⟩ on every realized gate** — worst pair deviation 5.0e-16 over 13 gates × 9 pairs; the Choi reading agrees to 1.6e-16.
- **Register Gram = I to 7.8e-16** — the period map V → ker L₁ is a scaled isometry (by Schur, exactly the S₃-equivariance of the carried register).
- **Floored gates have no carried post-state** (leak |Σ| 0.21–2.60) — the value-level obstruction certificate.
- **Bulk independence with its mechanism**: the symmetry-preserving re-triangulation (subdivided icosahedron, central-child holes) carries the value exactly (drift 9.7e-16); generic hole draws deviate by exactly their Gram defect (a†(G−I)b matched to ~1e-15). **The value-level H3 is the charge-conservation criterion plus the isometric register chart.**

The results page's H3 section now leads with this spectral validation; the DW bridge remains as the cross-calibration but no longer carries H3 alone.

## Test plan

- [x] `python examples/cobordism/spectral_gate_realizability.py --h3` exits 0, all checks pass (default run unchanged)
- [x] New pytest `tests/cobordism/test_spectral_h3_python.py` — 10 tests pinning Gram, T1 anchor, per-gate value equality, Choi agreement, floored exclusion, equivariant invariance, and the Gram-defect prediction
- [x] `pytest tests/cobordism` green locally: 534 passed, 1 skipped, 719 subtests
- [x] `cobordism-results.md` H3 section leads with the spectral validation; `doxygen` + `sphinx-build -E` at **0 warnings**

Closes #236.
