### PR TITLE
docs(cobordism): split the DW scaffold out of the results page into Earlier work

### DIFF
--- a/docs/source/quantum-experiments/earlier-work/dijkgraaf-witten-scaffold.md
+++ b/docs/source/quantum-experiments/earlier-work/dijkgraaf-witten-scaffold.md
@@ -1,0 +1,304 @@
+# The Dijkgraaf–Witten scaffold: the quantized shadow of the spectral Z
+
+The $\mathbb{Z}_2$ Dijkgraaf–Witten state sum was the topological layer the
+State–Operation–Cobordism programme was built on: it certified that the bulk
+$Z$ is a genuine cobordism functor, carried the sign invariant, calibrated the
+spectral reading against an independent metric-free oracle, and supplied the
+first (pinned) realizable-gate image. With H3 now validated on the spectral
+data alone — the value equation
+$Z_{\text{spec}}=\langle\psi_A|U|\psi_B\rangle$ holds at machine precision on
+every realized gate, with triangulation invariance and the obstruction
+certificate read off the same spectrum (see the
+[results page](../state-operation-cobordism/cobordism-results.md)) — the DW
+layer carries no live evidence. This page is its record: the functoriality
+checks, the sign invariant, the bridge, the pinned image, and the
+$b_1$-hole retest that together motivated the continuous spectral method.
+
+The through-line, established by the bridge below and confirmed by the staged
+synthesis: **the DW invariant is the quantized shadow of the continuous
+spectral $Z$** — integer-valued on the flat-connection lattice, a strict
+subset of what the spectrum carries.
+
+## The state sum is a triangulation-invariant TQFT (T1, T2, T5)
+
+On the topological layer ($n=3$, simplicial), the $\mathbb{Z}_2$
+Dijkgraaf–Witten state sum $Z(W)$ is a well-defined cobordism functor
+(`topological_correspondence.py`):
+
+- **T1 — cylinder $=$ identity.** For $W=\Sigma\times[0,T]$, $\texttt{map}(T^2\times I)$
+  is exactly $\mathrm{id}_4$ and $\langle\psi_A|Z(W)|\psi_B\rangle=\langle\psi_A|\psi_B\rangle$
+  for harmonic-1-form boundary states $\psi\in\ker L_1(T^2)$; residual
+  $6.28\times10^{-16}$.
+- **T2 — triangulation independence (make-or-break).** $Z(S^2\times S^1)$ drifts by
+  $0.00$ over 18 interior Pachner moves (including $1\!\to\!4$ moves that change
+  $\lvert V\rvert$), for both cocycle classes — $Z$ is invariant to machine
+  precision with $\partial W$ fixed.
+- **T5 — composition / functoriality.** $\texttt{map}(\texttt{glue}(W_1,W_2))=
+  \texttt{map}(W_2)\,\texttt{map}(W_1)$ (the matrix product), with
+  $\operatorname{Tr}(\texttt{map})=Z_{\text{closed}}$ on the self-glue.
+
+## The sign carries an invariant (T3), and the holonomy is consistent (T4)
+
+The nontrivial cocycle is a genuine topological invariant, not a phase artefact:
+$Z_{\text{sign}}(\mathbb{RP}^3)=0\neq1=Z_{\text{triv}}(\mathbb{RP}^3)$ (T3,
+`topological_correspondence.py`). The twist is the mod-2 cup-cube
+$(-1)^{\langle g^3,[W]\rangle}$, so the positive control needs a 1-class with
+$g^3\neq0$: $\mathbb{RP}^3$ ($H^*=\mathbb{Z}_2[t]/t^4$, $t^3\neq0$), whose
+2-torsion $H_1=\mathbb{Z}_2$ is exactly what separates it from the **negative
+controls** $S^2\times S^1$ and $T^3$ (free $H_1$, $g^3=0$). The untwisted
+normalization is $Z_{\text{triv}}(W)=2^{\,b_1(\mathbb{Z}_2)-1}$. Cross-layer
+consistency holds too (T4, residual $0.00$): the bulk $\mathbb{Z}_2$ holonomy
+equals the cycle flux $\Phi_\gamma$ restricted to $\{0,\pi\}$. (The brute-force
+flat-connection enumeration is $2^{\dim Z^1}$, capped at $\dim Z^1\le24$, so the
+state sum runs on small manifolds — $S^3$, $S^2\times S^1$, $\mathbb{RP}^3$ — and
+$T^3$, $\dim Z^1=29$, is used only for the combinatorial T2 checks.)
+
+## The DW–spectral bridge: three independent readings agree (and only on the lattice)
+
+On a shared boundary surface $\Sigma=T^2$ (with $b_1=2$, $Z(\Sigma)=\mathbb{C}^4$,
+spectral qubit $\ker L_1(T^2)=\mathbb{C}^2$) the value of the cobordism at a pair
+of prepared boundary states is computed three *independent* ways — the
+topological Dijkgraaf–Witten state sum $Z_{DW}$ (metric-free: topology and cocycle
+only), the operation's transition amplitude $\langle\psi_A|U|\psi_B\rangle$, and
+the spectral Hodge harmonic $Z_{\text{spec}}$ — testing
+$Z_{DW}(W_{AB})=\langle\psi_A|U|\psi_B\rangle=Z_{\text{spec}}$
+(`dw_spectral_bridge.py`). On longitude-aligned states all three agree to
+$\sim10^{-15}$:
+
+| $(a,b)$ | $Z_{DW}$ (topo) | $\langle\psi_A|\,\mathrm{id}\,|\psi_B\rangle$ (op) | $Z_{\text{spec}}$ (Hodge) | max $\Delta$ |
+|---|---|---|---|---|
+| $1,\,1$ | $+1.000000+0.000000i$ | $+1.000000+0.000000i$ | $+1.000000+0.000000i$ | $1.1\times10^{-15}$ |
+| $e^{i\pi/3},\,0.6{+}0.8i$ | $+0.992820-0.119615i$ | $+0.992820-0.119615i$ | $+0.992820-0.119615i$ | $7.8\times10^{-16}$ |
+| $0.5{-}0.5i,\,i$ | $-0.500000+0.500000i$ | $-0.500000+0.500000i$ | $-0.500000+0.500000i$ | $7.9\times10^{-16}$ |
+| $2,\,0.25{+}0.97i$ | $+0.500000+1.940000i$ | $+0.500000+1.940000i$ | $+0.500000+1.940000i$ | $1.4\times10^{-15}$ |
+
+The spectral side is a certified harmonic: the longitude is realized on the solid
+torus at $r=9.65\times10^{-29}$, $\lambda=-4.25\times10^{-17}$ with witness
+boundary-block overlap $1.000000$, while the meridian — which bounds a disk and
+dies in $H_1(W)$ — floors at $15.2567$ (matching an independent numpy Hodge oracle
+to $\Delta=5.3\times10^{-15}$). Crucially, the bridge holds **on the
+DW-representable subset and only there**. With the cobordism (hence $Z_{DW}$) held
+fixed, a generic $U$ departs from $Z_{DW}$:
+
+| operation $U$ | representable? | $\langle\psi_A|U|\psi_B\rangle$ | $\Delta=\lvert\text{amp}-Z_{DW}\rvert$ |
+|---|---|---|---|
+| $\mathrm{id}_4\;(=Z(T^2\times[0,T]))$ | **yes** | $+0.992820-0.119615i$ | $0.0$ |
+| Hadamard on the qubit block | no | $+0.521099-0.062782i$ | $4.75\times10^{-1}$ |
+| Haar-random $U(4)$ (seed 7) | no | $-0.291344+0.172837i$ | $1.32\times10^{0}$ |
+| Haar-random $U(4)$ (seed 23) | no | $-0.553146+0.040816i$ | $1.55\times10^{0}$ |
+
+The $\mathbb{Z}_2$ DW maps are integer-quantized in the flat-connection basis
+($\mathrm{id}_4$ for both cocycles, solid-torus cap $[1,0,1,0]$); a generic complex
+amplitude cannot be hit. Over 200 Haar $U(4)$ the gap has minimum $0.218$ and
+median $1.03$ — a generic $U$ is uniformly bounded away from the DW image, not a
+measure-zero accident. **The DW invariant is the quantized shadow of the
+continuous spectral $Z$:** the spectral oracle realizes the longitude *and a
+neighborhood of it*, so $\{Z(W)\}_{\mathbb{Z}_2\text{-DW}}\subsetneq\{\text{spectrally
+realizable}\}$, and the two coincide exactly where the operation lands on the
+lattice.
+
+## The pinned operation image: $S_3$
+
+When is an operation $U$ on $Z(T^2)=\mathbb{C}[H^1(T^2;\mathbb{Z}_2)]=\mathbb{C}^4$
+DW-realizable on a **pinned** cobordism — a twisted cylinder of fixed topology?
+Exactly when it is one of the **six holonomy permutations** — the permutation
+representation of a $GL(2,\mathbb{Z}_2)=SL(2,\mathbb{Z}_2)$ automorphism of
+$H^1(T^2;\mathbb{Z}_2)$, fixing the trivial class (index 0) and permuting the three
+non-trivial classes $\{[a],[b],[a{+}b]\}=\{1,2,3\}$. Two twisted cylinders generate
+the group (`realizable_image_sweep.py`): the coordinate **swap** $(1\,2)$ on the
+9-vertex product torus (its mod-2 reduction is the modular $S$) and the order-3
+**multiplier** $(1\,2\,3)$ on the 7-vertex Möbius torus. Every permutation of the
+three non-zero vectors of $(\mathbb{Z}_2)^2$ is automatically $GF(2)$-linear, so the
+pinned realizable image is the *full* $S_3$.
+
+The content of $S_3$ is **holonomy-class permutation without superposition** — and
+that is *not* computational separability. Several computational **entanglers** are
+holonomy permutations and so realize: `CNOT`, reversed-`CNOT`, `SWAP`, and the
+double-`CNOT` each permute the holonomy classes (each fixes $[0]$), so each is
+DW-realizable despite entangling in the computational basis (operator-Schmidt
+rank $2$–$4$). What floors is **holonomy superposition** — a gate that sends a
+holonomy class to a *superposition* of classes (`H`-type), or that lands off the
+$0/1$ permutation lattice with a phase or sign (`CZ`, `T`, `S`, `iSWAP`, `CPHASE`,
+$\sqrt{\mathrm{SWAP}}$). Realizability under the pinned construction is a property
+of the holonomy action, indifferent to a gate's name:
+
+| gate | pinned-DW realizable? | reason (action on the holonomy classes) |
+|---|---|---|
+| Identity | **yes** | fixes every class (the trivial permutation) |
+| `SWAP` $=(1\,2)$ | **yes** | exchanges $[a]\leftrightarrow[b]$, fixes $[0]$ |
+| `CNOT` $=(2\,3)$ | **yes** | transposes $[b]\leftrightarrow[a{+}b]$, fixes $[0]$ |
+| reversed-`CNOT` $=(1\,3)$ | **yes** | transposes $[a]\leftrightarrow[a{+}b]$, fixes $[0]$ |
+| 3-cycles $(1\,2\,3),(1\,3\,2)$ | **yes** | cycle the three non-trivial classes, fix $[0]$ |
+| Hadamard ($H{\otimes}H$) | no | mixing — off the permutation lattice ($\texttt{gap}=2.00$) |
+| `T`, `S` | no | diagonal phase, not a $0/1$ permutation |
+| `CZ` $=\mathrm{diag}(1,1,1,-1)$ | no | diagonal sign, not a permutation |
+| `iSWAP` | no | permutes with $i$ phases (complex permutation), not $0/1$ |
+| `CPHASE` | no | diagonal phase, not a permutation |
+| Pauli-`X` | no | moves the trivial class ($0\to3$) |
+
+The separator is clean. Of $S_4$'s 24 permutation matrices, exactly the **6**
+fixing index 0 are realizable; the **18** that move the trivial class are not.
+Across the full labeled sweep, the predicate `is_holonomy_perm` (fixes $[0]$ and
+permutes $\{1,2,3\}$) is the *only* property that separates the pinned image with no
+errors — **19 TP / 0 FP / 0 FN / 210 TN over 229 operations**. Every weaker
+predicate leaks (*is a permutation* admits the 18 that move index 0; *fixes the
+trivial class* admits diagonal sign matrices; *near-$I_4$* catches only the seven
+identity copies). The realizable rate by family makes the same point:
+
+| family | realizable / total |
+|---|---|
+| `realizable_s3` | 6 / 6 |
+| permutation (the 24 of $S_4$) | 6 / 24 |
+| gate | 3 / 23 |
+| interp | 3 / 33 |
+| diagonal | 1 / 48 |
+| signed_perm | 0 / 20 |
+| mixing (Hadamard / DFT / Haar / GL) | 0 / 75 |
+
+The staged spectral synthesis later showed this image to be an artefact of the
+**bit-exact boundary pinning**, not of the physics: synthesizing the boundary
+lifts the integrality constraint, and the realizable set becomes the
+charge-conservation criterion — a continuous group containing $S_3$ — with the
+value equation holding spectrally on all of it (see the
+[results page](../state-operation-cobordism/cobordism-results.md)).
+
+## What the $b_1$ hole adds: superposed states, not new gates
+
+The pinned image above fixes the bulk topology in advance; it need not. The
+emergent-bulk work loosened it — handing the realizability search a
+**topology-changing surgery move** (a boundary-fixed interior-cell *remove*) so the
+first Betti number $b_1$ becomes an **output** rather than an input — on the
+conjecture that the resulting $b_1=1$ hole, which carries a superposed boundary
+state, would bring the floored superposition/entangling gates into the realizable
+set. `loosened_gate_retest.py` tests that conjecture directly, two ways, and reports
+the residuals — not a hoped-for answer.
+
+**As operations, the hole adds nothing — every gate floors.** Bending each gate to
+its Choi state $\operatorname{vec}(U)$ (length $d_Ad_B=16$) and handing it to the
+surgery oracle with $b_1$ free — `decide(vec(U),4,4,growth_mode=SURGERY,
+harmonic=True)` on a filled-disk bulk ($b_1=0$, 19 vertices, the rim the pinned
+output support) whose interior core triangle the search may remove — **every gate
+floors** at $r\approx0.38$–$0.41$: the six $S_3$ controls (the identity included,
+$r=0.40$) and every superposition/entangling gate alike, none below the
+$\texttt{REALIZE}=10^{-3}$ line.
+
+| gate | family | pinned DW ($\texttt{gap\_to\_S3}$) | superposition? | entangling? | loosened operation ($r$, $b_1$) |
+|---|---|---|---|---|---|
+| Identity | $S_3$ control | **realizable** ($0.00$) | no | no | floor ($0.40$, $b_1=0$) |
+| `SWAP` | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.39$, $b_1:0\to1$) |
+| `CNOT` | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.39$, $b_1=0$) |
+| reversed-`CNOT` | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.39$, $b_1:0\to1$) |
+| 3-cycles | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.38$, $b_1:0\to1$) |
+| `DCNOT` | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.39$, $b_1:0\to1$) |
+| $H{\otimes}I$ | superposition | floor ($2.27$) | yes | no | floor ($0.39$, $b_1:0\to1$) |
+| $I{\otimes}H$ | superposition | floor ($2.27$) | yes | no | floor ($0.40$, $b_1=0$) |
+| $H{\otimes}H$ | superposition | floor ($2.00$) | yes | no | floor ($0.38$, $b_1=0$) |
+| $\sqrt{\mathrm{SWAP}}$ | superposition | floor ($1.41$) | yes | yes | floor ($0.38$, $b_1:0\to1$) |
+| $\sqrt{\mathrm{iSWAP}}$ | superposition | floor ($1.08$) | yes | yes | floor ($0.39$, $b_1:0\to1$) |
+| `CZ` | phase/entangler | floor ($2.00$) | no | yes | floor ($0.41$, $b_1:0\to1$) |
+| `CPHASE`$(\pi/4)$ | phase/entangler | floor ($0.77$) | no | yes | floor ($0.40$, $b_1=0$) |
+| $T{\otimes}I$ | phase | floor ($1.08$) | no | no | floor ($0.40$, $b_1=0$) |
+| $S{\otimes}I$ | phase | floor ($2.00$) | no | no | floor ($0.40$, $b_1:0\to1$) |
+| `iSWAP` | phase/entangler | floor ($2.00$) | no | yes | floor ($0.39$, $b_1:0\to1$) |
+| $X{\otimes}X$ | Pauli perm | floor ($2.00$) | no | no | floor ($0.39$, $b_1:0\to1$) |
+| $Z{\otimes}Z$ | diagonal sign | floor ($2.00$) | no | no | floor ($0.40$, $b_1:0\to1$) |
+
+The surgery search opens the handle ($b_1:0\to1$) for many gates, yet the residual
+floors regardless: **$b_1$ development is decoupled from realizability.** The reason
+is structural — at the Choi-vec degree $k=0$ the harmonic kernel $\ker L_0$ is the
+locally-constant functions (dimension $b_0=1$ on a connected bulk), so opening a
+$b_1$ handle cannot enlarge it; the hole is spectrally inert for an operation
+target. (The eigenvalue-agnostic mode is under-constrained and is *not* a
+topological realization: `harmonic=False` drives $H{\otimes}H$ to $r=9.9\times10^{-4}$
+but at $\lambda=2.93$ — a non-harmonic eigenvector, accepted only because that
+criterion asks for *any* eigenvector, not a $\ker L$ one.)
+
+**As states, the hole adds the superposition — that is exactly what it carries.** At
+the Hodge-qubit degree $k=1$ the same surgery move makes $b_1$ an output for a
+boundary *1-cycle*. The superposed meridian carried on both boundary circles — the
+state an `H`-type gate would create — **floors on the disk** ($b_1=0$,
+$r=4.5\times10^{-1}$) and **realizes on the annulus** ($b_1=1$, $r=6.9\times10^{-8}$,
+$\lambda\to0$); from the disk seed the surgery search opens the handle on its own
+($b_1:0\to1$, scored purely by the harmonic residual, $\partial W$ held bit-exact)
+and the meridian then realizes ($r\sim10^{-5}$), while the sign-flipped (non-closed)
+conjugation floors on every filling ($r\approx0.22$) — the period-matching
+obstruction is genuinely separate from the topological one
+(`emergent_bulk_realizability.py`). Removal is the load-bearing move — boundary-fixed
+*additive* growth is topology-preserving at $k\ge1$ — so the realizable *state* set
+is exactly $\mathrm{image}\big(H_1(\partial W)\to H_1(W)\big)$ for the $W$ the search
+grows.
+
+**The verdict.** $S_3$ is and remains the realizable *operation* image of the pinned
+DW construction. Loosening the topology so $b_1$ emerges does **not** enlarge it: no
+superposition or entangling gate realizes as an operation, hole open or closed. What
+the hole enlarges is the realizable *state* space — a superposed/entangled boundary
+cycle, unrealizable on the $b_1=0$ filling, realizes once surgery opens $b_1=1$. The
+hole represents superposition, as the conjecture held — but it does so for **states**
+(homology classes on $\partial W$), not for gate operations. The quantized-shadow
+reading of the bridge says the same from the value side: the $\mathbb{Z}_2$-DW
+operation image is a discrete lattice that a generic superposition/entangling $U$ is
+uniformly bounded away from (gap median $1.03$ over 200 Haar $U(4)$), and the
+continuous freedom the hole supplies lives in the *state* — the spectral $Z$ — not
+in new realizable maps. The construction that finally carried the superposition
+*gates* themselves is the staged spectral synthesis with the boundary synthesized,
+whose realizable set is the charge-conservation criterion and whose value equation
+holds spectrally — the
+[results page](../state-operation-cobordism/cobordism-results.md) reports it.
+
+## Figures
+
+A per-output force-directed render of the simplicial complexes these experiments
+build (`force_layout_3d` / `layout_from_spacetime`, vertices colored by
+amplitude magnitude where a state is carried).
+
+![A pinned-realizable gate's cobordism W: the SWAP twisted cylinder](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_gate_W.png)
+*Figure 1 — A pinned-realizable gate as a cobordism.* The `SWAP` gate's bulk
+$W=\texttt{twistedCylinder}(T^2,\,\text{swap})$ — the $(1\,2)$ holonomy
+permutation. `SWAP` realizes under the pinned construction because it fixes the
+trivial class and exchanges $[a]\leftrightarrow[b]$.
+
+![The disk filling, b1=0](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_disk.png)
+*Figure 2 — The disk filling ($b_1=0$).* The octahedron minus one face: the
+boundary meridian bounds the still-filled antipodal cell, so it floors.
+
+![The annulus filling, b1=1](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_annulus.png)
+*Figure 3 — The annulus filling ($b_1=1$).* The octahedron minus two antipodal
+faces: the meridian survives in $H_1$, so the cobordism carries it as a bulk
+harmonic.
+
+![The surgery-grown bulk](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_surgery.png)
+*Figure 4 — The surgery-grown bulk.* From the disk seed, the boundary-fixed remove
+opens the handle ($b_1:0\to1$) on its own under residual minimization, and the
+floored meridian realizes.
+
+## Method, conventions, and reproduction
+
+These experiments are pure orchestration of separately-tested classes —
+`DijkgraafWitten` (the $\mathbb{Z}_2$ state sum + `map` / `amplitude`),
+`Cobordism.twistedCylinder` (the pinned maps), `BoundaryStateSpace` (the
+$\ker L_1(\Sigma)\to Z(\Sigma)$ preparation), `ChoiJamiolkowski` (the bend), and
+`EigenstateSynthesis` / `RealizabilityOracle` (the surgery oracle of the loosened
+retest). DW-specific conventions:
+
+- The DW reading is **metric-free** (topology + cocycle only); the Frobenius norm
+  $\lVert\cdot\rVert$ scores $\texttt{gap\_to\_S3}=\min_{g\in S_3}\lVert U-g\rVert$,
+  with $\texttt{realizable}:=\texttt{gap\_to\_S3}<10^{-7}$.
+- The brute-force flat-connection enumeration is $2^{\dim Z^1}$, capped at
+  $\dim Z^1\le24$.
+
+To reproduce:
+
+```
+pip install -e ".[dev]" -C cmake.define.TESSERA_CUDA=OFF
+python examples/cobordism/topological_correspondence.py   # T1–T5 (the state-sum functor) + the §5.6 Lorentzian variant
+python examples/cobordism/dw_spectral_bridge.py           # the DW–spectral bridge
+python examples/cobordism/realizable_image_sweep.py       # the pinned operation image (S₃)
+python examples/cobordism/emergent_bulk_realizability.py  # b₁ as an output (states)
+python examples/cobordism/loosened_gate_retest.py         # the loosened gate re-test (k=0)
+python -m pytest tests/cobordism
+```
+
+Raw tables and figures are written to `/tmp/cobordism/` and are **not
+committed**; the figures above are uploaded to the
+[`issue-attachments`](https://github.com/akellehe/tessera/releases/tag/issue-attachments)
+release and embedded by URL. The 10-CPU cap is honored (thread env set at launch).

--- a/docs/source/quantum-experiments/earlier-work/index.md
+++ b/docs/source/quantum-experiments/earlier-work/index.md
@@ -1,11 +1,13 @@
 # Earlier work
 
-The work that preceded the State–Operation–Cobordism Correspondence
-line. None of this is the current state of the project, but each
-piece contributed an idea or a falsification that shaped what came
-next: the Schwinger-era charters and subsystem reference, the
-experiment writeups they produced, and the Charged Cartan Monte
-Carlo programme that followed them.
+The work that led to the current State–Operation–Cobordism
+Correspondence line. None of this is the current state of the
+project, but each piece contributed an idea or a falsification that
+shaped what came next: the Schwinger-era charters and subsystem
+reference, the experiment writeups they produced, the Charged Cartan
+Monte Carlo programme that followed them, and the Dijkgraaf–Witten
+scaffold that calibrated the cobordism line's spectral method before
+H3 was validated spectrally.
 
 ```{toctree}
 :maxdepth: 1
@@ -19,4 +21,5 @@ temporally_connected_entangled_spacetime
 interaction_branching_simplex
 interaction_history_monte_carlo
 charged-cartan/index
+dijkgraaf-witten-scaffold
 ```

--- a/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
@@ -3,17 +3,18 @@
 > The consolidated results companion to the specification
 > [`cobordism.md`](cobordism.md). The spec (§1) states the correspondence as
 > three hypotheses **H1/H2/H3**; this report organizes the numerical evidence
-> under each, ending with the realizable gate set and a per-output gallery.
-> Every number below names the runnable example that produced it:
-> `topological_correspondence.py` (the Stage-2 TQFT checks T1–T5),
-> `realizability_report.py` (boundary synthesis + bulk realizability),
-> `dw_spectral_bridge.py` (the DW–spectral bridge), and
-> `realizable_image_sweep.py` / `loosened_gate_retest.py` /
-> `spectral_gate_realizability.py` (the gate set: pinned ($S_3$), loosened at
-> $k=0$, and the staged spectral synthesis with the boundary synthesized
-> (the charge-conservation criterion; 13 named gates); its `--h3` mode
-> validates the value equation $Z_{\text{spec}}=\langle\psi_A|U|\psi_B\rangle$
-> on the realized set, spectrally) — all under `examples/cobordism/`.
+> under each — all of it read off the **continuous spectral method** (the
+> genuine Hodge spectrum) — ending with the realizable gate set and a
+> per-output gallery. Every number below names the runnable example that
+> produced it: `realizability_report.py` (boundary synthesis + bulk
+> realizability) and `spectral_gate_realizability.py` (the staged spectral
+> synthesis: the charge-conservation gate criterion, 13 named gates; its
+> `--h3` mode validates the value equation
+> $Z_{\text{spec}}=\langle\psi_A|U|\psi_B\rangle$ on the realized set) — both
+> under `examples/cobordism/`. The Dijkgraaf–Witten layer that scaffolded and
+> calibrated this method — the state-sum functoriality checks, the sign
+> invariant, the bridge, and the pinned $S_3$ image — is recorded in
+> [the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md).
 
 ## The correspondence
 
@@ -27,14 +28,23 @@ it computes. Concretely (spec §1):
 - **H3.** $Z(W_{AB})=\langle\psi_A|\,U\,|\psi_B\rangle$, with
   $\operatorname{rank}(U)=\text{Schmidt rank of }\operatorname{vec}(U)=\text{connectivity of }W_{AB}$.
 
-**The falsifiable core.** The correspondence is *supported* iff (i) the cylinder
-cobordism reproduces the inner product, (ii) $Z(W)$ is invariant under interior
-re-triangulation, and (iii) a nontrivial sign class produces a $Z(W)$ distinct
-from the trivial one — and *refuted* if any fails. All three hold: (i) the
-torus cylinder is exactly the identity (T1, residual $6.28\times10^{-16}$); (ii)
-$Z$ drifts by $0$ over 18 interior Pachner moves (T2); (iii)
-$Z_{\text{sign}}(\mathbb{RP}^3)=0\neq1=Z_{\text{triv}}(\mathbb{RP}^3)$ (T3). The
-sections below place the rest of the evidence under the hypothesis it bears on.
+**The falsifiable core, read spectrally.** The correspondence is *supported*
+iff (i) the trivial cobordism reproduces the inner product, (ii) the value is
+invariant under interior re-triangulation, and (iii) an obstructed class is
+genuinely distinguished — and *refuted* if any fails. All three hold on the
+spectral data (`spectral_gate_realizability.py --h3`): (i) the identity's
+spectral value equals $\langle\psi_A|\psi_B\rangle$ on every carried pair
+(worst $4.5\times10^{-16}$), and it realizes *only* once surgery has grown the
+full register — on every smaller seed it floors; (ii) the value carries over
+**exactly** to a symmetry-preserving re-triangulation (drift
+$9.7\times10^{-16}$), and a generic re-grown bulk deviates by precisely its
+register Gram defect, $a^\dagger(G-I)b$, matched to $\sim10^{-15}$; (iii) a
+leaked class has **no value at all** — every floored gate's post-state leaves
+the carried register ($\lvert\Sigma\rvert=0.21$–$2.60$), the value-level
+obstruction certificate. (The original Dijkgraaf–Witten formulation of this
+core — T1/T2 on the state sum and the T3 sign invariant — is recorded in
+[the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md).) The sections
+below place the rest of the evidence under the hypothesis it bears on.
 
 ## H1 — the operation is a cobordism
 
@@ -70,28 +80,18 @@ realization where the topology allows it — the $1\times3$ operation floors at
 $9.6\times10^{-1}$ with no budget and drops to $1.2\times10^{-13}$ after a single
 boundary-fixed cone.
 
-### The bulk is a triangulation-invariant TQFT (T1, T2, T5)
+Triangulation invariance of the bulk is certified at the value level by the
+H3 bulk-independence result below (the value carries exactly over a
+symmetry-preserving re-triangulation, and a generic re-grown bulk deviates by
+precisely its measured Gram defect); the state-sum functoriality checks that
+first established it (T1/T2/T5 on the Dijkgraaf–Witten functor) are recorded
+in [the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md).
 
-On the topological layer ($n=3$, simplicial), the $\mathbb{Z}_2$
-Dijkgraaf–Witten state sum $Z(W)$ is a well-defined cobordism functor
-(`topological_correspondence.py`):
-
-- **T1 — cylinder $=$ identity.** For $W=\Sigma\times[0,T]$, $\texttt{map}(T^2\times I)$
-  is exactly $\mathrm{id}_4$ and $\langle\psi_A|Z(W)|\psi_B\rangle=\langle\psi_A|\psi_B\rangle$
-  for harmonic-1-form boundary states $\psi\in\ker L_1(T^2)$; residual
-  $6.28\times10^{-16}$.
-- **T2 — triangulation independence (make-or-break).** $Z(S^2\times S^1)$ drifts by
-  $0.00$ over 18 interior Pachner moves (including $1\!\to\!4$ moves that change
-  $\lvert V\rvert$), for both cocycle classes — $Z$ is invariant to machine
-  precision with $\partial W$ fixed.
-- **T5 — composition / functoriality.** $\texttt{map}(\texttt{glue}(W_1,W_2))=
-  \texttt{map}(W_2)\,\texttt{map}(W_1)$ (the matrix product), with
-  $\operatorname{Tr}(\texttt{map})=Z_{\text{closed}}$ on the self-glue.
-
-(The §5.6 Lorentzian variant corroborates: on the 3-cycle with one timelike edge
-the spectrum is exactly $\{0,3,1-2/\alpha\}$ and the harmonic's indefinite norm
-$(2-\alpha)/3$ crosses zero at $\alpha=2$ — a concrete "harmonic representative
-becomes null," residual $3.36\times10^{-15}$.)
+(The §5.6 Lorentzian variant corroborates the spectral layer
+(`topological_correspondence.py`): on the 3-cycle with one timelike edge the
+spectrum is exactly $\{0,3,1-2/\alpha\}$ and the harmonic's indefinite norm
+$(2-\alpha)/3$ crosses zero at $\alpha=2$ — a concrete "harmonic
+representative becomes null," residual $3.36\times10^{-15}$.)
 
 ### rank $=$ Schmidt rank $=$ connectivity
 
@@ -179,208 +179,22 @@ the inner product only once surgery has grown the full register (the T1
 anchor), and a leaked class produces *no* value at all rather than a wrong
 one.
 
-### The DW–spectral bridge: three independent readings agree (and only on the lattice)
+Before this validation existed, the value equation was certified by
+cross-calibrating three independent readings — the DW state sum, the operator
+amplitude, and the spectral harmonic — on the torus cylinder, where the DW
+invariant turned out to be the **quantized shadow** of the continuous spectral
+$Z$. That bridge, together with the T3 sign invariant, is recorded in
+[the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md); H3 on this
+page no longer rests on it.
 
-On a shared boundary surface $\Sigma=T^2$ (with $b_1=2$, $Z(\Sigma)=\mathbb{C}^4$,
-spectral qubit $\ker L_1(T^2)=\mathbb{C}^2$) the value of the cobordism at a pair
-of prepared boundary states is computed three *independent* ways — the
-topological Dijkgraaf–Witten state sum $Z_{DW}$ (metric-free: topology and cocycle
-only), the operation's transition amplitude $\langle\psi_A|U|\psi_B\rangle$, and
-the spectral Hodge harmonic $Z_{\text{spec}}$ — testing
-$Z_{DW}(W_{AB})=\langle\psi_A|U|\psi_B\rangle=Z_{\text{spec}}$
-(`dw_spectral_bridge.py`). On longitude-aligned states all three agree to
-$\sim10^{-15}$:
+## The realizable gate set: the charge-conservation criterion
 
-| $(a,b)$ | $Z_{DW}$ (topo) | $\langle\psi_A|\,\mathrm{id}\,|\psi_B\rangle$ (op) | $Z_{\text{spec}}$ (Hodge) | max $\Delta$ |
-|---|---|---|---|---|
-| $1,\,1$ | $+1.000000+0.000000i$ | $+1.000000+0.000000i$ | $+1.000000+0.000000i$ | $1.1\times10^{-15}$ |
-| $e^{i\pi/3},\,0.6{+}0.8i$ | $+0.992820-0.119615i$ | $+0.992820-0.119615i$ | $+0.992820-0.119615i$ | $7.8\times10^{-16}$ |
-| $0.5{-}0.5i,\,i$ | $-0.500000+0.500000i$ | $-0.500000+0.500000i$ | $-0.500000+0.500000i$ | $7.9\times10^{-16}$ |
-| $2,\,0.25{+}0.97i$ | $+0.500000+1.940000i$ | $+0.500000+1.940000i$ | $+0.500000+1.940000i$ | $1.4\times10^{-15}$ |
-
-The spectral side is a certified harmonic: the longitude is realized on the solid
-torus at $r=9.65\times10^{-29}$, $\lambda=-4.25\times10^{-17}$ with witness
-boundary-block overlap $1.000000$, while the meridian — which bounds a disk and
-dies in $H_1(W)$ — floors at $15.2567$ (matching an independent numpy Hodge oracle
-to $\Delta=5.3\times10^{-15}$). Crucially, the bridge holds **on the
-DW-representable subset and only there**. With the cobordism (hence $Z_{DW}$) held
-fixed, a generic $U$ departs from $Z_{DW}$:
-
-| operation $U$ | representable? | $\langle\psi_A|U|\psi_B\rangle$ | $\Delta=\lvert\text{amp}-Z_{DW}\rvert$ |
-|---|---|---|---|
-| $\mathrm{id}_4\;(=Z(T^2\times[0,T]))$ | **yes** | $+0.992820-0.119615i$ | $0.0$ |
-| Hadamard on the qubit block | no | $+0.521099-0.062782i$ | $4.75\times10^{-1}$ |
-| Haar-random $U(4)$ (seed 7) | no | $-0.291344+0.172837i$ | $1.32\times10^{0}$ |
-| Haar-random $U(4)$ (seed 23) | no | $-0.553146+0.040816i$ | $1.55\times10^{0}$ |
-
-The $\mathbb{Z}_2$ DW maps are integer-quantized in the flat-connection basis
-($\mathrm{id}_4$ for both cocycles, solid-torus cap $[1,0,1,0]$); a generic complex
-amplitude cannot be hit. Over 200 Haar $U(4)$ the gap has minimum $0.218$ and
-median $1.03$ — a generic $U$ is uniformly bounded away from the DW image, not a
-measure-zero accident. **The DW invariant is the quantized shadow of the
-continuous spectral $Z$:** the spectral oracle realizes the longitude *and a
-neighborhood of it*, so $\{Z(W)\}_{\mathbb{Z}_2\text{-DW}}\subsetneq\{\text{spectrally
-realizable}\}$, and the two coincide exactly where the operation lands on the
-lattice.
-
-### The sign carries an invariant (T3), and the holonomy is consistent (T4)
-
-The nontrivial cocycle is a genuine topological invariant, not a phase artefact:
-$Z_{\text{sign}}(\mathbb{RP}^3)=0\neq1=Z_{\text{triv}}(\mathbb{RP}^3)$ (T3,
-`topological_correspondence.py`). The twist is the mod-2 cup-cube
-$(-1)^{\langle g^3,[W]\rangle}$, so the positive control needs a 1-class with
-$g^3\neq0$: $\mathbb{RP}^3$ ($H^*=\mathbb{Z}_2[t]/t^4$, $t^3\neq0$), whose
-2-torsion $H_1=\mathbb{Z}_2$ is exactly what separates it from the **negative
-controls** $S^2\times S^1$ and $T^3$ (free $H_1$, $g^3=0$). The untwisted
-normalization is $Z_{\text{triv}}(W)=2^{\,b_1(\mathbb{Z}_2)-1}$. Cross-layer
-consistency holds too (T4, residual $0.00$): the bulk $\mathbb{Z}_2$ holonomy
-equals the cycle flux $\Phi_\gamma$ restricted to $\{0,\pi\}$. (The brute-force
-flat-connection enumeration is $2^{\dim Z^1}$, capped at $\dim Z^1\le24$, so the
-state sum runs on small manifolds — $S^3$, $S^2\times S^1$, $\mathbb{RP}^3$ — and
-$T^3$, $\dim Z^1=29$, is used only for the combinatorial T2 checks.)
-
-## The realizable gate set: $S_3$ is the pinned operation image
-
-When is an operation $U$ on $Z(T^2)=\mathbb{C}[H^1(T^2;\mathbb{Z}_2)]=\mathbb{C}^4$
-DW-realizable on a **pinned** cobordism — a twisted cylinder of fixed topology?
-Exactly when it is one of the **six holonomy permutations** — the permutation
-representation of a $GL(2,\mathbb{Z}_2)=SL(2,\mathbb{Z}_2)$ automorphism of
-$H^1(T^2;\mathbb{Z}_2)$, fixing the trivial class (index 0) and permuting the three
-non-trivial classes $\{[a],[b],[a{+}b]\}=\{1,2,3\}$. Two twisted cylinders generate
-the group (`realizable_image_sweep.py`): the coordinate **swap** $(1\,2)$ on the
-9-vertex product torus (its mod-2 reduction is the modular $S$) and the order-3
-**multiplier** $(1\,2\,3)$ on the 7-vertex Möbius torus. Every permutation of the
-three non-zero vectors of $(\mathbb{Z}_2)^2$ is automatically $GF(2)$-linear, so the
-pinned realizable image is the *full* $S_3$.
-
-The content of $S_3$ is **holonomy-class permutation without superposition** — and
-that is *not* computational separability. Several computational **entanglers** are
-holonomy permutations and so realize: `CNOT`, reversed-`CNOT`, `SWAP`, and the
-double-`CNOT` each permute the holonomy classes (each fixes $[0]$), so each is
-DW-realizable despite entangling in the computational basis (operator-Schmidt
-rank $2$–$4$). What floors is **holonomy superposition** — a gate that sends a
-holonomy class to a *superposition* of classes (`H`-type), or that lands off the
-$0/1$ permutation lattice with a phase or sign (`CZ`, `T`, `S`, `iSWAP`, `CPHASE`,
-$\sqrt{\mathrm{SWAP}}$). Realizability is a property of the holonomy action,
-indifferent to a gate's name:
-
-| gate | realizable? | reason (action on the holonomy classes) |
-|---|---|---|
-| Identity | **yes** | fixes every class (the trivial permutation) |
-| `SWAP` $=(1\,2)$ | **yes** | exchanges $[a]\leftrightarrow[b]$, fixes $[0]$ |
-| `CNOT` $=(2\,3)$ | **yes** | transposes $[b]\leftrightarrow[a{+}b]$, fixes $[0]$ |
-| reversed-`CNOT` $=(1\,3)$ | **yes** | transposes $[a]\leftrightarrow[a{+}b]$, fixes $[0]$ |
-| 3-cycles $(1\,2\,3),(1\,3\,2)$ | **yes** | cycle the three non-trivial classes, fix $[0]$ |
-| Hadamard ($H{\otimes}H$) | no | mixing — off the permutation lattice ($\texttt{gap}=2.00$) |
-| `T`, `S` | no | diagonal phase, not a $0/1$ permutation |
-| `CZ` $=\mathrm{diag}(1,1,1,-1)$ | no | diagonal sign, not a permutation |
-| `iSWAP` | no | permutes with $i$ phases (complex permutation), not $0/1$ |
-| `CPHASE` | no | diagonal phase, not a permutation |
-| Pauli-`X` | no | moves the trivial class ($0\to3$) |
-
-The separator is clean. Of $S_4$'s 24 permutation matrices, exactly the **6**
-fixing index 0 are realizable; the **18** that move the trivial class are not.
-Across the full labeled sweep, the predicate `is_holonomy_perm` (fixes $[0]$ and
-permutes $\{1,2,3\}$) is the *only* property that separates the pinned image with no
-errors — **19 TP / 0 FP / 0 FN / 210 TN over 229 operations**. Every weaker
-predicate leaks (*is a permutation* admits the 18 that move index 0; *fixes the
-trivial class* admits diagonal sign matrices; *near-$I_4$* catches only the seven
-identity copies). The realizable rate by family makes the same point:
-
-| family | realizable / total |
-|---|---|
-| `realizable_s3` | 6 / 6 |
-| permutation (the 24 of $S_4$) | 6 / 24 |
-| gate | 3 / 23 |
-| interp | 3 / 33 |
-| diagonal | 1 / 48 |
-| signed_perm | 0 / 20 |
-| mixing (Hadamard / DFT / Haar / GL) | 0 / 75 |
-
-## What the $b_1$ hole adds: superposed states, not new gates
-
-The pinned image above fixes the bulk topology in advance; it need not. The
-emergent-bulk work loosened it — handing the realizability search a
-**topology-changing surgery move** (a boundary-fixed interior-cell *remove*) so the
-first Betti number $b_1$ becomes an **output** rather than an input — on the
-conjecture that the resulting $b_1=1$ hole, which carries a superposed boundary
-state, would bring the floored superposition/entangling gates into the realizable
-set. `loosened_gate_retest.py` tests that conjecture directly, two ways, and reports
-the residuals — not a hoped-for answer.
-
-**As operations, the hole adds nothing — every gate floors.** Bending each gate to
-its Choi state $\operatorname{vec}(U)$ (length $d_Ad_B=16$) and handing it to the
-surgery oracle with $b_1$ free — `decide(vec(U),4,4,growth_mode=SURGERY,
-harmonic=True)` on a filled-disk bulk ($b_1=0$, 19 vertices, the rim the pinned
-output support) whose interior core triangle the search may remove — **every gate
-floors** at $r\approx0.38$–$0.41$: the six $S_3$ controls (the identity included,
-$r=0.40$) and every superposition/entangling gate alike, none below the
-$\texttt{REALIZE}=10^{-3}$ line.
-
-| gate | family | pinned DW ($\texttt{gap\_to\_S3}$) | superposition? | entangling? | loosened operation ($r$, $b_1$) |
-|---|---|---|---|---|---|
-| Identity | $S_3$ control | **realizable** ($0.00$) | no | no | floor ($0.40$, $b_1=0$) |
-| `SWAP` | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.39$, $b_1:0\to1$) |
-| `CNOT` | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.39$, $b_1=0$) |
-| reversed-`CNOT` | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.39$, $b_1:0\to1$) |
-| 3-cycles | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.38$, $b_1:0\to1$) |
-| `DCNOT` | $S_3$ control | **realizable** ($0.00$) | no | yes | floor ($0.39$, $b_1:0\to1$) |
-| $H{\otimes}I$ | superposition | floor ($2.27$) | yes | no | floor ($0.39$, $b_1:0\to1$) |
-| $I{\otimes}H$ | superposition | floor ($2.27$) | yes | no | floor ($0.40$, $b_1=0$) |
-| $H{\otimes}H$ | superposition | floor ($2.00$) | yes | no | floor ($0.38$, $b_1=0$) |
-| $\sqrt{\mathrm{SWAP}}$ | superposition | floor ($1.41$) | yes | yes | floor ($0.38$, $b_1:0\to1$) |
-| $\sqrt{\mathrm{iSWAP}}$ | superposition | floor ($1.08$) | yes | yes | floor ($0.39$, $b_1:0\to1$) |
-| `CZ` | phase/entangler | floor ($2.00$) | no | yes | floor ($0.41$, $b_1:0\to1$) |
-| `CPHASE`$(\pi/4)$ | phase/entangler | floor ($0.77$) | no | yes | floor ($0.40$, $b_1=0$) |
-| $T{\otimes}I$ | phase | floor ($1.08$) | no | no | floor ($0.40$, $b_1=0$) |
-| $S{\otimes}I$ | phase | floor ($2.00$) | no | no | floor ($0.40$, $b_1:0\to1$) |
-| `iSWAP` | phase/entangler | floor ($2.00$) | no | yes | floor ($0.39$, $b_1:0\to1$) |
-| $X{\otimes}X$ | Pauli perm | floor ($2.00$) | no | no | floor ($0.39$, $b_1:0\to1$) |
-| $Z{\otimes}Z$ | diagonal sign | floor ($2.00$) | no | no | floor ($0.40$, $b_1:0\to1$) |
-
-The surgery search opens the handle ($b_1:0\to1$) for many gates, yet the residual
-floors regardless: **$b_1$ development is decoupled from realizability.** The reason
-is structural — at the Choi-vec degree $k=0$ the harmonic kernel $\ker L_0$ is the
-locally-constant functions (dimension $b_0=1$ on a connected bulk), so opening a
-$b_1$ handle cannot enlarge it; the hole is spectrally inert for an operation
-target. (The eigenvalue-agnostic mode is under-constrained and is *not* a
-topological realization: `harmonic=False` drives $H{\otimes}H$ to $r=9.9\times10^{-4}$
-but at $\lambda=2.93$ — a non-harmonic eigenvector, accepted only because that
-criterion asks for *any* eigenvector, not a $\ker L$ one.)
-
-**As states, the hole adds the superposition — that is exactly what it carries.** At
-the Hodge-qubit degree $k=1$ the same surgery move makes $b_1$ an output for a
-boundary *1-cycle*. The superposed meridian carried on both boundary circles — the
-state an `H`-type gate would create — **floors on the disk** ($b_1=0$,
-$r=4.5\times10^{-1}$) and **realizes on the annulus** ($b_1=1$, $r=6.9\times10^{-8}$,
-$\lambda\to0$); from the disk seed the surgery search opens the handle on its own
-($b_1:0\to1$, scored purely by the harmonic residual, $\partial W$ held bit-exact)
-and the meridian then realizes ($r\sim10^{-5}$), while the sign-flipped (non-closed)
-conjugation floors on every filling ($r\approx0.22$) — the period-matching
-obstruction is genuinely separate from the topological one
-(`emergent_bulk_realizability.py`). Removal is the load-bearing move — boundary-fixed
-*additive* growth is topology-preserving at $k\ge1$ — so the realizable *state* set
-is exactly $\mathrm{image}\big(H_1(\partial W)\to H_1(W)\big)$ for the $W$ the search
-grows.
-
-**The verdict.** $S_3$ is and remains the realizable *operation* image of the pinned
-DW construction. Loosening the topology so $b_1$ emerges does **not** enlarge it: no
-superposition or entangling gate realizes as an operation, hole open or closed. What
-the hole enlarges is the realizable *state* space — a superposed/entangled boundary
-cycle, unrealizable on the $b_1=0$ filling, realizes once surgery opens $b_1=1$. The
-hole represents superposition, as the conjecture held — but it does so for **states**
-(homology classes on $\partial W$), not for gate operations. The H3 quantized-shadow
-reading says the same from the value side: the $\mathbb{Z}_2$-DW operation image is a
-discrete lattice that a generic superposition/entangling $U$ is uniformly bounded
-away from (gap median $1.03$ over 200 Haar $U(4)$), and the continuous freedom the hole
-supplies lives in the *state* — the spectral $Z$ — not in new realizable maps.
-
-## The gate set with the boundary synthesized: the charge-conservation criterion
-
-The $S_3$ image above pins the cobordism's boundary bit-exact — it is the restriction of
-one global form on a fixed twisted cylinder, and that integrality is exactly what holds
-the realizable set down to the six holonomy permutations. A third construction
-(`spectral_gate_realizability.py`) **synthesizes the boundary instead of pinning it**: it
+The first construction pinned the cobordism's boundary bit-exact — the restriction of
+one global form on a fixed twisted cylinder — and that integrality held its realizable
+image down to the six holonomy permutations ($S_3$; recorded with the
+$b_1$-hole retest in
+[the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md)). The final
+construction (`spectral_gate_realizability.py`) **synthesizes the boundary instead of pinning it**: it
 runs each gate through a *staged spectral synthesis* and decides realizability by the
 **continuous spectral method** — the genuine Hodge Laplacian spectrum, $\ker L_1$ of the
 surgery-grown bulk read by eigendecomposition — with **no** Levenberg–Marquardt
@@ -479,8 +293,10 @@ the count tracking the battery, not the physics. (An earlier 18-gate battery rep
 "$S_3 + H{\otimes}H + \sqrt{\mathrm{SWAP}} = 8$"; that was its realizable *subset*, missing
 $\mathrm{CSX}$ and $\sqrt{\mathrm{SWAP}}^\dagger$.) What still floors is genuine register
 *leakage* ($\Sigma\neq0$): a holonomy superposition or off-lattice phase that no emergent
-$b_1$ can carry, the $k=1$ analogue of the sign-flipped meridian that floors on every
-filling.
+$b_1$ can carry — the $k=1$ analogue of the sign-flipped meridian that floors on every
+filling
+([the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md) records that
+result).
 
 **The bigger search confirms the criterion.** A parallelized high-retry surgery-topology
 search (`spectral_gate_realizability.py --retries N --jobs 10` — ten worker processes, each
@@ -499,8 +315,9 @@ not the carrying of a new gate (no proper subspace is left for a state to leak o
 obstruction, and with it the discriminating content of "realizable", is gone). This is no
 accident: the criterion is a property of $U$'s holonomy-class block, *not* of the bulk
 topology, so no surgery can change it. Growing $b_1$ buys no new *operations* — the
-operation-side echo of the $b_1$-hole result above: surgery enlarges the realizable *state*
-space, not the realizable *gate* set.
+operation-side echo of the $b_1$-hole result in
+[the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md): surgery
+enlarges the realizable *state* space, not the realizable *gate* set.
 
 ## Figures
 
@@ -508,63 +325,45 @@ A per-output force-directed render of the simplicial complexes the experiments
 build (`force_layout_3d` / `layout_from_spacetime`, vertices colored by
 amplitude magnitude where a state is carried).
 
-![A realizable gate's cobordism W: the SWAP twisted cylinder](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_gate_W.png)
-*Figure 1 — A realizable gate as a cobordism.* The `SWAP` gate's bulk
-$W=\texttt{twistedCylinder}(T^2,\,\text{swap})$ — the $(1\,2)$ holonomy
-permutation. `SWAP` is realizable because it fixes the trivial class and exchanges
-$[a]\leftrightarrow[b]$.
-
 ![A synthesized boundary state geo(psi)](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_geo_psi.png)
-*Figure 2 — A synthesized boundary state $\mathrm{geo}(\psi_A)$.* The minimal
+*Figure 1 — A synthesized boundary state $\mathrm{geo}(\psi_A)$.* The minimal
 Hermitian-weighted complex whose $k=0$ Laplacian carries $\psi_A$ as an
 eigenvector; vertices are colored by $\lvert\psi\rvert$ (phase $\to$ hue),
 auxiliary zero-amplitude vertices desaturated.
-
-![The disk filling, b1=0](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_disk.png)
-*Figure 3 — The disk filling ($b_1=0$).* The octahedron minus one face: the
-boundary meridian bounds the still-filled antipodal cell, so it floors.
-
-![The annulus filling, b1=1](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_annulus.png)
-*Figure 4 — The annulus filling ($b_1=1$).* The octahedron minus two antipodal
-faces: the meridian survives in $H_1$, so the cobordism carries it as a bulk
-harmonic.
-
-![The surgery-grown bulk](https://github.com/akellehe/tessera/releases/download/issue-attachments/cobordism_results_surgery.png)
-*Figure 5 — The surgery-grown bulk.* From the disk seed, the boundary-fixed remove
-opens the handle ($b_1:0\to1$) on its own under residual minimization, and the
-floored meridian realizes.
 
 The staged spectral synthesis renders its own outputs with the same idiom
 (`spectral_gate_realizability.py --all-plots`): holonomy-hole edges thickened, edges
 colored by the carried 1-form (hue $=$ phase, brightness $=|\text{amp}|$).
 
 ![The surgery-grown S^2 bulk](https://github.com/akellehe/tessera/releases/download/issue-attachments/spectral_gate_grown_bulk.png)
-*Figure 6 — The surgery-grown bulk $W$ (staged synthesis).* The icosahedral $S^2$ with the
+*Figure 2 — The surgery-grown bulk $W$ (staged synthesis).* The icosahedral $S^2$ with the
 three holonomy holes opened by `removeInteriorCell` ($b_1=2$); the thick edges are the three
 boundary 1-cycles $\{[a],[b],[a{+}b]\}$.
 
 ![The emergent register ker L_1](https://github.com/akellehe/tessera/releases/download/issue-attachments/spectral_gate_register.png)
-*Figure 7 — The emergent register $V=\ker L_1$.* The 2-dimensional $S_3$ standard
+*Figure 3 — The emergent register $V=\ker L_1$.* The 2-dimensional $S_3$ standard
 representation read from the spectrum (one carried harmonic shown on the register edges).
 
 ![A synthesized boundary state geo(psi_B)](https://github.com/akellehe/tessera/releases/download/issue-attachments/spectral_gate_geo_psiB.png)
-*Figure 8 — A synthesized boundary state $\mathrm{geo}(\psi_B)$.* The generic register
+*Figure 4 — A synthesized boundary state $\mathrm{geo}(\psi_B)$.* The generic register
 input, carried as a harmonic of $L_1$ (the stage-1 synthesis).
 
 ![A realized gate sqrt-SWAP](https://github.com/akellehe/tessera/releases/download/issue-attachments/spectral_gate_realized_sqrtswap.png)
-*Figure 9 — A realized gate, $\sqrt{\mathrm{SWAP}}$.* The post-interaction state
+*Figure 5 — A realized gate, $\sqrt{\mathrm{SWAP}}$.* The post-interaction state
 $U|\psi_B\rangle$ stays in $\ker L_1$ ($r\to0$) — the non-integer register automorphism the
 synthesized boundary admits.
+
+(The renders of the pinned twisted-cylinder cobordism and the disk/annulus/
+surgery meridian fillings live with their experiments in
+[the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md).)
 
 ## Method, conventions, and reproduction
 
 All experiments are pure orchestration of separately-tested classes —
-`ChoiJamiolkowski` (the bend), `HodgeLaplacian` (the $k=0$ and $k\ge1$
-Laplacians), `EigenstateSynthesis` / `RealizabilityOracle` (the fixed-boundary
-interior fill and its `decideHarmonic` / surgery modes), `DijkgraafWitten` (the
-$\mathbb{Z}_2$ state sum + `map` / `amplitude`), `BoundaryStateSpace` (the
-$\ker L_1(\Sigma)\to Z(\Sigma)$ preparation), and `Cobordism.twistedCylinder` (the
-realizable maps). Conventions held throughout:
+`ChoiJamiolkowski` (the bend and the operator amplitude), `HodgeLaplacian`
+(the $k=0$ and $k\ge1$ Laplacians, `weights`, `harmonics`), and
+`EigenstateSynthesis` / `RealizabilityOracle` (the fixed-boundary interior
+fill and its `decideHarmonic` / surgery modes). Conventions held throughout:
 
 - Operators are flat **row-major**; $\operatorname{vec}(U)$ is the row-major
   flatten (`ChoiJamiolkowski.vectorize`), the Choi bend.
@@ -577,21 +376,13 @@ realizable maps). Conventions held throughout:
   $\epsilon=10^{-10}$; an obstruction is a residual floor bounded above $10^{-2}$
   and cross-checked against an independent numpy global-min. The boundary
   $\partial W$ is **pinned** — the fill rewrites only interior edges.
-- The DW reading is **metric-free** (topology + cocycle only); the Frobenius norm
-  $\lVert\cdot\rVert$ scores $\texttt{gap\_to\_S3}=\min_{g\in S_3}\lVert U-g\rVert$,
-  with $\texttt{realizable}:=\texttt{gap\_to\_S3}<10^{-7}$.
 
 To reproduce (default Release build; the fast linker is auto-gated off Release so
 `bfd` links the LTO `_tessera`):
 
 ```
 pip install -e ".[dev]" -C cmake.define.TESSERA_CUDA=OFF
-python examples/cobordism/topological_correspondence.py   # T1–T5 + Lorentzian
 python examples/cobordism/realizability_report.py         # boundary synthesis + realizability
-python examples/cobordism/dw_spectral_bridge.py           # the DW–spectral bridge
-python examples/cobordism/realizable_image_sweep.py       # the pinned gate set (S₃)
-python examples/cobordism/emergent_bulk_realizability.py  # b₁ as an output
-python examples/cobordism/loosened_gate_retest.py         # the loosened gate re-test (k=0)
 python examples/cobordism/spectral_gate_realizability.py                   # the staged gate set (charge-conservation criterion, 13 named)
 python examples/cobordism/spectral_gate_realizability.py --h3              # H3 at the value level: Z_spec = <psi_A|U|psi_B> on the realized set
 python -m pytest tests/cobordism/test_spectral_h3_python.py                # the pinned H3 invariants

--- a/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
@@ -11,7 +11,9 @@
 > `realizable_image_sweep.py` / `loosened_gate_retest.py` /
 > `spectral_gate_realizability.py` (the gate set: pinned ($S_3$), loosened at
 > $k=0$, and the staged spectral synthesis with the boundary synthesized
-> (the charge-conservation criterion; 13 named gates)) — all under `examples/cobordism/`.
+> (the charge-conservation criterion; 13 named gates); its `--h3` mode
+> validates the value equation $Z_{\text{spec}}=\langle\psi_A|U|\psi_B\rangle$
+> on the realized set, spectrally) — all under `examples/cobordism/`.
 
 ## The correspondence
 
@@ -129,6 +131,53 @@ outgoing $\mathrm{geo}(\psi_A)$ and the orientation-reversed incoming
 $\mathrm{geo}(\psi_B)$.
 
 ## H3 — the value is the amplitude
+
+### H3 on the spectral data: $Z_{\text{spec}}$ equals the amplitude on every realized gate
+
+The value equation is validated on the staged-synthesis register itself —
+no DW input anywhere (`spectral_gate_realizability.py --h3`). The spectral
+value $Z_{\text{spec}}(W;\psi_A,U\psi_B)$ is the Hodge pairing of the
+carried harmonic representatives on the surgery-grown bulk (the register
+bulk carries the unit cochain metric, so the pairing is the plain Hermitian
+contraction), with **one** global scale fixed by the T1 anchor
+$Z_{\text{spec}}(\psi_B,\psi_B)=\langle\psi_B|\psi_B\rangle$; after that,
+every number — every pair, every gate, every re-grown bulk — is a
+prediction with no freedom left.
+
+- **The register chart is a scaled isometry.** The Gram of the period map
+  $V\to\ker L_1$ on a flat-orthonormal basis of the $\Sigma=0$ subspace is
+  the identity to $7.8\times10^{-16}$. By Schur's lemma this is exactly the
+  $S_3$-equivariance of the carried register: $V$ is the irreducible
+  standard representation, so any invariant inner product on it is
+  proportional to the flat one — the proportionality constant being the one
+  scale T1 fixes.
+- **$Z_{\text{spec}}=\langle\psi_A|U|\psi_B\rangle$ for every realized
+  gate.** Worst pair deviation $5.0\times10^{-16}$ across the 13 criterion
+  gates $\times$ 9 carried pairs (the $V$-generic input plus 8 random
+  carried $\psi_A$); the independent Choi/operator reading
+  (`quantum::ChoiJamiolkowski.transitionAmplitude` on the $\mathbb{C}^4$
+  holonomy embedding) agrees to $1.6\times10^{-16}$.
+- **A floored gate has no spectral value.** Its post-interaction periods
+  leak out of $V$ ($\lvert\Sigma\rvert=0.21$–$2.60$ across the 39 floored
+  gates), so no carried representative exists — the value-level
+  obstruction certificate, the same mechanism as the residual floor.
+- **Bulk independence, with its mechanism.** The symmetry-preserving
+  re-triangulation (one geodesic subdivision, each holonomy hole re-placed
+  on the central child of its original hole face) carries the value
+  *exactly*: Gram defect $7.6\times10^{-16}$, value drift
+  $9.7\times10^{-16}$. A generic vertex-disjoint hole draw still realizes
+  the same gates, but its chart is anisotropic (Gram defects $0.11$ and
+  $0.25$ on two draws) and its value deviation ($0.14$, $0.26$) equals the
+  Gram-defect prediction $a^\dagger(G-I)b$ to $\sim10^{-15}$. **The
+  value-level H3 is the charge-conservation criterion plus the isometric
+  register chart**: surgery decides *which* gates are carried
+  (topology-free), and equivariance makes the carried pairing *be* the
+  amplitude.
+
+Read at the value level, the falsifiable core says: the identity reproduces
+the inner product only once surgery has grown the full register (the T1
+anchor), and a leaked class produces *no* value at all rather than a wrong
+one.
 
 ### The DW–spectral bridge: three independent readings agree (and only on the lattice)
 
@@ -544,6 +593,8 @@ python examples/cobordism/realizable_image_sweep.py       # the pinned gate set 
 python examples/cobordism/emergent_bulk_realizability.py  # b₁ as an output
 python examples/cobordism/loosened_gate_retest.py         # the loosened gate re-test (k=0)
 python examples/cobordism/spectral_gate_realizability.py                   # the staged gate set (charge-conservation criterion, 13 named)
+python examples/cobordism/spectral_gate_realizability.py --h3              # H3 at the value level: Z_spec = <psi_A|U|psi_B> on the realized set
+python -m pytest tests/cobordism/test_spectral_h3_python.py                # the pinned H3 invariants
 python examples/cobordism/spectral_gate_realizability.py --gate sqrt-SWAP   # solve for one named gate (52-gate battery)
 python examples/cobordism/spectral_gate_realizability.py --retries 10000 --jobs 10  # parallel surgery-topology search (confirms the criterion)
 python examples/cobordism/spectral_gate_realizability.py --all-plots        # force-directed renders → issue-attachments

--- a/docs/source/quantum-experiments/state-operation-cobordism/index.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/index.md
@@ -9,8 +9,11 @@ Hermitian-weighted simplicial complex.
 The [specification](cobordism.md) states the correspondence as three
 hypotheses (H1/H2/H3) and defines the algebraic and topological test
 layers; the [results companion](cobordism-results.md) organizes the
-numerical evidence under each hypothesis, ending with the realizable
-gate set and the per-output gallery.
+numerical evidence under each hypothesis — all of it decided by the
+continuous spectral method — ending with the realizable gate set (the
+charge-conservation criterion) and the per-output gallery. The
+Dijkgraaf–Witten layer that scaffolded the method is recorded in
+[earlier work](../earlier-work/dijkgraaf-witten-scaffold.md).
 
 ```{toctree}
 :maxdepth: 1

--- a/examples/cobordism/spectral_gate_realizability.py
+++ b/examples/cobordism/spectral_gate_realizability.py
@@ -107,6 +107,14 @@ Parameters (additive -- the default run is the verified criterion sweep)
                   staged synthesis (synthesize states -> union as boundary -> grow by
                   surgery -> spectral L_1 residual) and reports that gate's residual,
                   realize/floor verdict, and emergent b_1.
+  --h3            H3 at the VALUE level, on the spectral data alone: Z_spec(W; psi_A,
+                  U psi_B) -- the Hodge pairing of the carried harmonic representatives
+                  on the surgery-grown bulk, with ONE scale fixed by the T1 anchor --
+                  equals <psi_A|U|psi_B> for every realized gate, over the V-generic
+                  input and a battery of random carried psi_A. Also reports the register
+                  Gram (the period-map isometry; Schur/S_3-equivariance), the
+                  Choi/operator cross-check, the floored gates' no-carried-post-state
+                  certificate, and bulk independence across re-grown genuine registers.
   --retries N     The surgery-topology search: score N RANDOMIZED surgery-grown
                   topologies (varied S^2 seeds -- the icosahedron and its geodesic
                   subdivisions -- varied vertex-disjoint holonomy-hole triples, and
@@ -122,6 +130,7 @@ Parameters (additive -- the default run is the verified criterion sweep)
                   release, printing the embed URLs (--no-upload renders locally only).
 
 Run:  python examples/cobordism/spectral_gate_realizability.py
+      python examples/cobordism/spectral_gate_realizability.py --h3
       python examples/cobordism/spectral_gate_realizability.py --gate sqrt-SWAP
       python examples/cobordism/spectral_gate_realizability.py --retries 5000 --jobs 10
       python examples/cobordism/spectral_gate_realizability.py --all-plots
@@ -598,6 +607,298 @@ def gate_sweep(reg, on_progress=None):
         if on_progress is not None:
             on_progress()
     return rows
+
+
+# --------------------------------------------------------------------------- #
+# --h3: H3 at the VALUE level, on the spectral data alone. The staged synthesis
+# proves U|psi_B> is CARRIED (r -> 0); this leg checks the value equation itself,
+# Z_spec(W; psi_A, U psi_B) = <psi_A|U|psi_B>, for every gate the construction
+# realizes -- no DW input anywhere. Z_spec is the Hodge pairing of the carried
+# harmonic representatives on the surgery-grown bulk (the eigendecomposition's
+# ker L_1; the register bulk has the unit cochain metric, so the pairing is the
+# plain Hermitian contraction). ONE global scale is fixed by the T1 anchor
+# (Z_spec(psi_B, psi_B) = <psi_B|psi_B>); after that every number -- every pair,
+# every gate, every re-grown topology -- is a prediction with no freedom left.
+# --------------------------------------------------------------------------- #
+def _carried_form(reg, raw_periods):
+    """The pure ker-L_1 representative of `raw_periods` on the surgery-grown bulk
+    (the register harmonics combined by least squares; NO leak correction), as a
+    full edge vector, plus the norm of the un-carried period remainder. The state
+    is a boundary state of the register iff that remainder is ~ 0."""
+    raw = np.asarray(raw_periods, dtype=complex)
+    coeffs, *_ = np.linalg.lstsq(reg.P.T, raw, rcond=None)
+    full = (coeffs @ reg.H_full).astype(complex)
+    leak = raw - coeffs @ reg.P
+    return full, float(np.linalg.norm(leak))
+
+
+def random_carried_states(n, seed):
+    """n random unit register states: signed periods cp with Sigma = 0 (the carried
+    subspace V), every component bounded away from zero (V-generic)."""
+    rng = np.random.default_rng(seed)
+    out = []
+    while len(out) < n:
+        z = rng.standard_normal(3) + 1j * rng.standard_normal(3)
+        z = z - z.mean()                                  # project onto Sigma = 0
+        if float(np.min(np.abs(z))) < 1e-2:               # V-generic only
+            continue
+        out.append(z / np.linalg.norm(z))
+    return out
+
+
+def register_gram(reg, scale):
+    """The register Gram in period coordinates: G_kl = scale * <h(e_k), h(e_l)> on a
+    flat-orthonormal basis {e_k} of the Sigma = 0 subspace. H3 at the value level is
+    G = I -- the period map V -> ker L_1 is a scaled isometry. By Schur's lemma that
+    is exactly S_3-equivariance of the carried register: V is the irreducible S_3
+    standard rep, so any invariant inner product on it is proportional to the flat
+    one, and the single proportionality constant is what the T1 anchor fixes."""
+    e1 = np.array([1.0, -1.0, 0.0]) / np.sqrt(2.0)
+    e2 = np.array([1.0, 1.0, -2.0]) / np.sqrt(6.0)
+    forms = [_carried_form(reg, reg.sign * e.astype(complex))[0] for e in (e1, e2)]
+    return scale * np.array([[complex(np.vdot(a, b)) for b in forms] for a in forms])
+
+
+def _amp_choi(U, cp_a, cp_out_unused, cp_b):
+    """The operator/Choi reading of the same matrix element: <psi_A|U|psi_B> through
+    quantum::ChoiJamiolkowski.transitionAmplitude on the C^4 holonomy embedding
+    (zero trivial-class component). The independent operator-side cross-check."""
+    cj = tessera.quantum.ChoiJamiolkowski
+    psi_a = [complex(0.0)] + [complex(z) for z in cp_a]
+    psi_b = [complex(0.0)] + [complex(z) for z in cp_b]
+    u_flat = [complex(z) for z in np.asarray(U, dtype=complex).reshape(-1)]
+    return complex(cj.transitionAmplitude(psi_a, u_flat, psi_b, 4, 4))
+
+
+def h3_value_sweep(reg, n_states=8, seed=2026, on_progress=None):
+    """H3 on the spectral data, against every gate the construction realizes: for the
+    V-generic input psi_B and a battery of random carried psi_A, compare the spectral
+    value Z_spec = scale * <h(psi_A), h(U psi_B)> (Hodge pairing of the carried
+    harmonic representatives, scale fixed once on the T1 anchor) with the flat
+    register amplitude <psi_A|U|psi_B> and with the Choi/operator reading. A floored
+    gate has NO carried post-state (its periods leak out of V), so it has no spectral
+    value -- the value-level obstruction certificate. Returns (rows, info)."""
+    hodge = cob.HodgeLaplacian(reg.st)
+    w1 = np.asarray(hodge.weights(1), dtype=float)
+    info = {"unit_metric_dev": float(np.max(np.abs(w1 - 1.0)))}
+
+    cp_b = (_CP_IN / np.linalg.norm(_CP_IN)).astype(complex)
+    h_b, leak_b = _carried_form(reg, reg.sign * cp_b)
+    info["psi_b_leak"] = leak_b
+    scale = 1.0 / float(np.vdot(h_b, h_b).real)           # the T1 anchor
+    info["scale"] = scale
+    info["gram"] = register_gram(reg, scale)
+    info["gram_dev"] = float(np.max(np.abs(info["gram"] - np.eye(2))))
+
+    states = [cp_b] + random_carried_states(n_states, seed)
+    forms_a = [_carried_form(reg, reg.sign * cp)[0] for cp in states]
+
+    rows = []
+    for name, U, fam in _gates():
+        u_reg = np.asarray(U, dtype=complex)[1:4, 1:4]
+        cp_out = u_reg @ cp_b
+        res, _b1, leak = post_interaction(reg, U)
+        realized = bool(res < REALIZE)
+        if not realized:
+            rows.append({"gate": name, "family": fam, "realizable": False,
+                         "residual": res, "leak": leak,
+                         "max_dev": None, "choi_dev": None, "n_pairs": 0})
+            if on_progress is not None:
+                on_progress()
+            continue
+        h_out, _ = _carried_form(reg, reg.sign * cp_out)
+        devs, choi_devs = [], []
+        for cp_a, h_a in zip(states, forms_a):
+            amp = complex(np.vdot(cp_a, cp_out))          # <psi_A|U|psi_B>, flat
+            z = scale * complex(np.vdot(h_a, h_out))      # Z_spec, the Hodge pairing
+            devs.append(abs(z - amp))
+            choi_devs.append(abs(_amp_choi(U, cp_a, cp_out, cp_b) - amp))
+        rows.append({"gate": name, "family": fam, "realizable": True,
+                     "residual": res, "leak": leak,
+                     "max_dev": float(max(devs)), "choi_dev": float(max(choi_devs)),
+                     "n_pairs": len(states)})
+        if on_progress is not None:
+            on_progress()
+    return rows, info
+
+
+def _equivariant_variant():
+    """The symmetry-preserving re-triangulation: one geodesic subdivision of the
+    icosahedron with each holonomy hole re-placed on the CENTRAL CHILD of its
+    original hole face (the triangle of the three edge midpoints). Subdivision
+    commutes with the simplicial symmetries, so the register equivariance that makes
+    the Gram the identity is preserved -- the genuine bulk-independence witness."""
+    nxt = [max(v for f in _ICO for v in f) + 1]
+    mid = {}
+
+    def m(a, b):
+        key = (min(a, b), max(a, b))
+        if key not in mid:
+            mid[key] = nxt[0]
+            nxt[0] += 1
+        return mid[key]
+
+    faces, central = [], {}
+    for (a, b, c) in _ICO:
+        ab, bc, ca = m(a, b), m(b, c), m(c, a)
+        faces += [(a, ab, ca), (b, bc, ab), (c, ca, bc), (ab, bc, ca)]
+        central[tuple(sorted((a, b, c)))] = tuple(sorted((ab, bc, ca)))
+    holes = [central[h] for h in _CLASS_HOLES]
+    return Register(faces=[tuple(sorted(f)) for f in faces], class_holes=holes)
+
+
+def _anisotropic_variant_registers(n_variants, seed):
+    """Re-grown GENUINE registers with generic (seeded, vertex-disjoint) hole triples
+    on the subdivided sphere -- carried, but with no symmetry to enforce an isometric
+    period chart. Their Gram defect is the control the equivariant witness is read
+    against."""
+    rng = random.Random(seed)
+    out, tries = [], 0
+    faces = _seed_surface(1)
+    while len(out) < n_variants and tries < 60:
+        tries += 1
+        holes = _vertex_disjoint_holes(faces, 3, rng)
+        if holes is None:
+            continue
+        reg = Register(faces=faces, class_holes=holes)
+        if reg.dim != 2 or reg.rank >= len(reg.class_holes):
+            continue                                      # saturated / degenerate draw
+        if post_interaction(reg, _gates()[0][1])[0] >= REALIZE:
+            continue                                      # identity anchor must hold
+        out.append(reg)
+    return out
+
+
+def h3_invariance(n_variants=2, n_states=4, seed=2026, on_progress=None):
+    """Bulk independence of the value, and what it turns on. The H3 table is re-run on
+    re-grown genuine registers with the SAME state battery. On the symmetry-preserving
+    re-triangulation (`_equivariant_variant`) the value carries over exactly. On
+    generic hole draws the period chart is anisotropic (Gram != I), and the deviation
+    from the amplitude is predicted EXACTLY by the Gram defect: Z - amp =
+    a^dag (G - I) b in the flat-orthonormal coordinates of V. The value-level H3 is
+    the residual-level criterion PLUS the isometric (equivariant) register chart."""
+    cp_b = (_CP_IN / np.linalg.norm(_CP_IN)).astype(complex)
+    states = [cp_b] + random_carried_states(n_states, seed)
+    realized = [(name, np.asarray(U, dtype=complex)[1:4, 1:4])
+                for name, U, _f in _gates() if conserves_charge(U)]
+    e_basis = np.array([[1.0, -1.0, 0.0] / np.sqrt(2.0),
+                        [1.0, 1.0, -2.0] / np.sqrt(6.0)])
+
+    def survey(reg):
+        h_b, _ = _carried_form(reg, reg.sign * cp_b)
+        scale = 1.0 / float(np.vdot(h_b, h_b).real)
+        gram = register_gram(reg, scale)
+        forms_a = [_carried_form(reg, reg.sign * cp)[0] for cp in states]
+        vals, defect = {}, 0.0
+        for name, u_reg in realized:
+            cp_out = u_reg @ cp_b
+            h_out, _ = _carried_form(reg, reg.sign * cp_out)
+            b = e_basis @ cp_out
+            zs = []
+            for cp_a, h_a in zip(states, forms_a):
+                z = scale * complex(np.vdot(h_a, h_out))
+                amp = complex(np.vdot(cp_a, cp_out))
+                a = e_basis @ cp_a
+                predicted = complex(np.conj(a) @ (gram - np.eye(2)) @ b)
+                defect = max(defect, abs((z - amp) - predicted))
+                zs.append(z)
+            vals[name] = zs
+        return vals, float(np.max(np.abs(gram - np.eye(2)))), defect
+
+    base_vals, _gd, _dd = survey(Register())
+    if on_progress is not None:
+        on_progress()
+
+    def drift_vs_base(vals):
+        return float(max(abs(vals[name][k] - base_vals[name][k])
+                         for name in vals for k in range(len(states))))
+
+    eq = _equivariant_variant()
+    eq_vals, eq_gram_dev, eq_defect = survey(eq)
+    equivariant = {"nV": int(eq.st.getVertexList().size()), "rank": eq.rank,
+                   "gram_dev": eq_gram_dev, "drift": drift_vs_base(eq_vals),
+                   "defect_residual": eq_defect}
+    if on_progress is not None:
+        on_progress()
+
+    anisotropic = []
+    for reg in _anisotropic_variant_registers(n_variants, seed):
+        vals, gram_dev, defect = survey(reg)
+        anisotropic.append({"nV": int(reg.st.getVertexList().size()),
+                            "rank": reg.rank, "gram_dev": gram_dev,
+                            "drift": drift_vs_base(vals),
+                            "defect_residual": defect})
+        if on_progress is not None:
+            on_progress()
+    return {"equivariant": equivariant, "anisotropic": anisotropic,
+            "n_gates": len(realized), "n_pairs": len(states)}
+
+
+def _print_h3(rows, info, inv, check):
+    """Report the H3 value table in the house style and register its checks."""
+    realized = [r for r in rows if r["realizable"]]
+    floored = [r for r in rows if not r["realizable"]]
+    print("\n  H3 at the VALUE level (spectral data only; one scale fixed by the T1 "
+          "anchor, then every number is a prediction):")
+    print(f"      unit cochain metric: max|w_1 - 1| = {info['unit_metric_dev']:.1e}  "
+          f"(the Hodge pairing is the plain Hermitian contraction)")
+    g = info["gram"]
+    print(f"      register Gram on V (flat-orthonormal basis of Sigma=0): "
+          f"[[{g[0, 0]:.6f}, {g[0, 1]:.6f}], [{g[1, 0]:.6f}, {g[1, 1]:.6f}]]  "
+          f"max|G - I| = {info['gram_dev']:.2e}")
+    print("        (G = I is the period-map isometry -- by Schur, exactly the "
+          "S_3-equivariance of the carried register.)")
+    header = (f"      {'gate':16} {'family':16} {'r(U)':>10} "
+              f"{'max|Z_spec - amp|':>18} {'choi dev':>10} {'pairs':>6}")
+    print(header)
+    print("      " + "-" * (len(header) - 6))
+    for r in realized:
+        print(f"      {r['gate']:16} {r['family']:16} {r['residual']:>10.1e} "
+              f"{r['max_dev']:>18.2e} {r['choi_dev']:>10.1e} {r['n_pairs']:>6}")
+    lo = min(r["leak"] for r in floored)
+    hi = max(r["leak"] for r in floored)
+    print(f"      ({len(floored)} floored gates: no carried post-state -- leak "
+          f"|Sigma| in {lo:.2f}..{hi:.2f} -- so no spectral value exists; the "
+          f"value-level obstruction certificate.)")
+    eq = inv["equivariant"]
+    print(f"      bulk independence ({inv['n_gates']} gates x {inv['n_pairs']} pairs "
+          f"each): the symmetry-preserving re-triangulation (|V|={eq['nV']}, the "
+          f"subdivided icosahedron, central-child holes) carries the value EXACTLY -- "
+          f"Gram dev {eq['gram_dev']:.1e}, drift {eq['drift']:.2e}.")
+    for v in inv["anisotropic"]:
+        print(f"        generic hole draw (|V|={v['nV']}): Gram dev "
+              f"{v['gram_dev']:.2e}, value deviation {v['drift']:.2e} -- equal to the "
+              f"Gram-defect prediction a*(G-I)b to {v['defect_residual']:.1e}.")
+    print("        => the value is carried by every bulk whose register chart is "
+          "isometric (Gram = I, the equivariant draws); a generic draw deviates by "
+          "exactly its Gram defect. The value-level H3 is the residual-level "
+          "criterion PLUS the isometric register chart.")
+    worst = max(r["max_dev"] for r in realized)
+    worst_choi = max(r["choi_dev"] for r in realized)
+    print(f"        => Z_spec = <psi_A|U|psi_B> on every realized gate "
+          f"(worst pair deviation {worst:.2e}); the Choi/operator reading agrees "
+          f"(worst {worst_choi:.2e}).")
+    check("the register bulk has the unit cochain metric",
+          info["unit_metric_dev"] < 1e-12)
+    check("psi_B is carried (its periods lie in V)", info["psi_b_leak"] < 1e-9)
+    check("the register Gram is the identity (period map is a scaled isometry)",
+          info["gram_dev"] < 1e-9)
+    check("T1 anchor: the identity's spectral value is <psi_A|psi_B> on every pair",
+          realized[0]["gate"] == "Identity" and realized[0]["max_dev"] < 1e-9)
+    check("H3: Z_spec = <psi_A|U|psi_B> for EVERY realized gate, on every pair",
+          worst < 1e-9)
+    check("the Choi/operator reading agrees with the flat amplitude",
+          worst_choi < 1e-9)
+    check("every floored gate has no carried post-state (leak != 0)",
+          all(r["leak"] > 1e-6 for r in floored))
+    check("the value carries over exactly to the symmetry-preserving "
+          "re-triangulation (bulk independence)",
+          eq["gram_dev"] < 1e-9 and eq["drift"] < 1e-9)
+    check("a generic hole draw's value deviation equals its register Gram defect "
+          "(the value-level H3 selects the isometric chart)",
+          len(inv["anisotropic"]) >= 1
+          and all(v["defect_residual"] < 1e-9 for v in inv["anisotropic"]))
+    return worst
 
 
 # --------------------------------------------------------------------------- #
@@ -1201,6 +1502,12 @@ def main():
     ap.add_argument("--gate", default=None,
                     help="solve for ONE gate (e.g. H_x_H, sqrt-SWAP, CNOT); "
                          "'--gate help' lists the battery. Default: the full sweep.")
+    ap.add_argument("--h3", action="store_true",
+                    help="validate H3 at the value level on the spectral data: "
+                         "Z_spec(W; psi_A, U psi_B) = <psi_A|U|psi_B> for every "
+                         "realized gate (one scale fixed by the T1 anchor), plus the "
+                         "register Gram, the Choi/operator cross-check, and bulk "
+                         "independence across re-grown genuine registers.")
     ap.add_argument("--retries", type=int, default=0,
                     help="surgery-topology search: score N randomized surgery-grown "
                          "topologies in parallel (>0 enables it).")
@@ -1273,6 +1580,21 @@ def main():
     _check("every floored gate is certified (residual > CERT_FLOOR and leaks)",
            all(r["residual"] > CERT_FLOOR and r["leak"] > 1e-6 for r in floored))
 
+    # ---- H3 at the value level (--h3): Z_spec = <psi_A|U|psi_B> on the realized set #
+    h3_payload = None
+    if args.h3:
+        hprog = _progress()
+        hprog.phase("H3 value sweep", total=len(_gates()) + 4)
+        h3_rows, h3_info = h3_value_sweep(reg, on_progress=hprog.on_tick)
+        inv = h3_invariance(on_progress=hprog.on_tick)
+        hprog.finish("H3 value sweep done")
+        _print_h3(h3_rows, h3_info, inv, _check)
+        h3_payload = {"rows": h3_rows, "scale": h3_info["scale"],
+                      "gram": [[z.real, z.imag] for z in h3_info["gram"].reshape(-1)],
+                      "gram_dev": h3_info["gram_dev"],
+                      "unit_metric_dev": h3_info["unit_metric_dev"],
+                      "invariance": inv}
+
     # ---- the surgery-topology search (--retries): does the set grow past the criterion? #
     search = None
     if args.retries > 0:
@@ -1305,7 +1627,8 @@ def main():
         with open(path, "w") as handle:
             json.dump({"register_trace": trace, "register_constraint": reg.n.tolist(),
                        "identity_anchor": anchor, "stage1": stage1,
-                       "gate_sweep": rows, "surgery_search": search,
+                       "gate_sweep": rows, "h3": h3_payload,
+                       "surgery_search": search,
                        "plot_urls": plot_urls}, handle, indent=2)
         print(f"\n  raw table (PR artifact, not committed): {path}")
 

--- a/tests/cobordism/test_spectral_h3_python.py
+++ b/tests/cobordism/test_spectral_h3_python.py
@@ -1,0 +1,145 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""H3 at the VALUE level, on the spectral data alone (the --h3 leg of
+``examples/cobordism/spectral_gate_realizability.py``).
+
+The staged spectral synthesis proves a gate's post-interaction state is CARRIED
+(residual -> 0); these tests pin the value equation itself, with no DW input:
+
+  1. **The register Gram is the identity.** The period map V -> ker L_1 of the
+     surgery-grown icosahedral register is a scaled isometry (G = I after the T1
+     anchor fixes the one scale). By Schur's lemma that is exactly the
+     S_3-equivariance of the carried register: V is the irreducible S_3 standard
+     rep, so any invariant inner product on it is proportional to the flat one.
+  2. **Z_spec = <psi_A|U|psi_B> on every realized gate.** The Hodge pairing of the
+     carried harmonic representatives equals the flat register amplitude at machine
+     precision, over the V-generic input and random carried psi_A — and the
+     Choi/operator reading (quantum::ChoiJamiolkowski.transitionAmplitude on the
+     C^4 holonomy embedding) agrees independently.
+  3. **A floored gate has no spectral value.** Its post-interaction periods leak out
+     of V (|Sigma| != 0), so no carried representative exists — the value-level
+     obstruction certificate.
+  4. **Bulk independence, with its mechanism.** The symmetry-preserving
+     re-triangulation (one geodesic subdivision, holes on the central child of each
+     original hole face) carries the value exactly; a generic vertex-disjoint hole
+     draw deviates from the amplitude by EXACTLY its register Gram defect,
+     a^dag (G - I) b. The value-level H3 is the charge-conservation criterion PLUS
+     the isometric (equivariant) register chart.
+"""
+
+import importlib.util
+import os
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "spectral_gate_realizability.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("spectral_gate_realizability",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GATE = _load_example()
+
+# One register + one H3 sweep shared by every test below (the construction is
+# deterministic; building it once keeps the suite fast).
+_REG = GATE.Register()
+_ROWS, _INFO = GATE.h3_value_sweep(_REG, n_states=6, seed=7)
+_REALIZED = [r for r in _ROWS if r["realizable"]]
+_FLOORED = [r for r in _ROWS if not r["realizable"]]
+
+
+class RegisterChartIsIsometricTest(unittest.TestCase):
+    """1: the carried register's period chart is a scaled isometry (Gram = I)."""
+
+    def test_register_bulk_has_the_unit_cochain_metric(self):
+        self.assertLess(_INFO["unit_metric_dev"], 1e-12)
+
+    def test_generic_input_is_carried(self):
+        self.assertLess(_INFO["psi_b_leak"], 1e-9)
+
+    def test_register_gram_is_the_identity(self):
+        self.assertLess(_INFO["gram_dev"], 1e-12)
+
+
+class ValueEqualsAmplitudeTest(unittest.TestCase):
+    """2: Z_spec = <psi_A|U|psi_B> for every gate the construction realizes."""
+
+    def test_realized_set_is_the_charge_conservation_criterion(self):
+        self.assertEqual([r["gate"] for r in _REALIZED],
+                         list(GATE.CANONICAL_SET))
+
+    def test_t1_anchor_identity_reproduces_the_inner_product(self):
+        identity = _REALIZED[0]
+        self.assertEqual(identity["gate"], "Identity")
+        self.assertLess(identity["max_dev"], 1e-12)
+
+    def test_value_equals_amplitude_on_every_realized_gate(self):
+        for r in _REALIZED:
+            self.assertLess(r["max_dev"], 1e-12, msg=r["gate"])
+
+    def test_choi_operator_reading_agrees(self):
+        for r in _REALIZED:
+            self.assertLess(r["choi_dev"], 1e-12, msg=r["gate"])
+
+
+class FlooredGatesHaveNoValueTest(unittest.TestCase):
+    """3: a floored gate's post-state leaks out of V — no spectral value exists."""
+
+    def test_every_floored_gate_leaks(self):
+        self.assertEqual(len(_FLOORED), len(GATE._gates()) - len(GATE.CANONICAL_SET))
+        for r in _FLOORED:
+            self.assertGreater(r["leak"], 1e-6, msg=r["gate"])
+            self.assertIsNone(r["max_dev"], msg=r["gate"])
+
+
+class BulkIndependenceTest(unittest.TestCase):
+    """4: the value carries over exactly to the symmetry-preserving
+    re-triangulation; a generic draw deviates by exactly its Gram defect."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inv = GATE.h3_invariance(n_variants=1, n_states=3, seed=7)
+
+    def test_equivariant_retriangulation_carries_the_value_exactly(self):
+        eq = self.inv["equivariant"]
+        self.assertLess(eq["gram_dev"], 1e-12)
+        self.assertLess(eq["drift"], 1e-12)
+
+    def test_generic_draw_deviation_is_exactly_the_gram_defect(self):
+        self.assertGreaterEqual(len(self.inv["anisotropic"]), 1)
+        for v in self.inv["anisotropic"]:
+            # a non-trivial control: the chart is genuinely anisotropic...
+            self.assertGreater(v["gram_dev"], 1e-3)
+            # ...and the deviation is predicted by a^dag (G - I) b to machine zero.
+            self.assertLess(v["defect_residual"], 1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Per #238: `cobordism-results.md` now reports only the final experiment — the staged spectral synthesis, the charge-conservation criterion, and the H3 value-level validation from #237 — and the Dijkgraaf–Witten material moves to a new Earlier-work page, **The Dijkgraaf–Witten scaffold: the quantized shadow of the spectral Z**.

On the results page:
- The **falsifiable core is restated spectrally** with the #236 numbers: (i) the identity's value equals ⟨ψ_A|ψ_B⟩ (4.5e-16) and realizes only once the register emerges; (ii) the value carries exactly over a symmetry-preserving re-triangulation (9.7e-16), generic draws deviating by precisely their Gram defect; (iii) a leaked class has no value at all (the 39 floored gates, |Σ| 0.21–2.60).
- The gate-set section is retitled **"The realizable gate set: the charge-conservation criterion"** — the term now names the spectral result, not the pinned-DW image.
- Figures, method/class list, conventions, and the reproduction block are spectral-only; lineage pointers link the scaffold where the DW evidence is cited.

The scaffold page receives, content-intact: T1/T2/T5 state-sum functoriality, the T3 sign invariant + T4, the DW–spectral bridge (both tables + the quantized-shadow reading), the pinned operation image (retitled — it no longer claims "the realizable gate set"), the loosened k=0 / b₁-hole retest with its verdict, Figures (twisted cylinder, disk/annulus/surgery), the DW conventions, and the five DW-era reproduction commands — each section closing with what superseded it.

Stacked on #237 (contains its commits until it merges; the diff collapses after).

## Test plan

- [x] `doxygen` + `sphinx-build -E`: **0 warnings**
- [x] href sweep: every relative link on the results page, the scaffold page, and both section indexes resolves
- [x] No dangling narrative references on the trimmed page (all remaining DW/pinned mentions are scoped lineage pointers or the boundary-pinning convention)
- [ ] After merge: pages deploy green; scaffold URL 200 under earlier-work

Closes #238.