### PR TITLE
feat(cobordism): combined additive+surgical growth, with --max-additional-vertices (default 20) on both gate pipelines

### DIFF
--- a/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
@@ -57,16 +57,19 @@ outcomes the hypothesis predicts. A **realizable** $U$ is realized with its bulk
 $W_{AB}$ ($r\to0$); an **obstructed** $U$ is certified non-realizable by a
 **residual floor** bounded away from zero — a spectral obstruction under the
 fixed-boundary constraint, not a failure to search hard enough
-(`realizability_report.py`):
+(`realizability_report.py`; the growable witnesses run with **additions as
+well as surgical cuts**, the added vertices capped by
+`--max-additional-vertices`, default 20, while the floor control stays pinned
+at fixed complexity):
 
-| operation $U$ | bulk | verdict | $r$ / floor | cones | interior $\lvert V\rvert$ | $\lambda$ |
+| operation $U$ | bulk | verdict | $r$ / floor | added $\lvert V\rvert$ | cuts | $\lambda$ |
 |---|---|---|---|---|---|---|
 | $\left(\begin{smallmatrix}1&1\\1&1\end{smallmatrix}\right)$ (zero mode) | bipyramid | **realizable** | $r=9.49\times10^{-11}$ | 0 | 0 | $0.000000$ |
-| $\left(\begin{smallmatrix}1&0.3{+}0.5i&-0.8{+}0.2i\end{smallmatrix}\right)$ ($1\times3$) | triangle | **realizable** | $r=1.19\times10^{-13}$ | 1 | 1 | $3.923719$ |
+| $\left(\begin{smallmatrix}1&0.3{+}0.5i&-0.8{+}0.2i\end{smallmatrix}\right)$ ($1\times3$) | triangle | **realizable** | $r=3.52\times10^{-11}$ | 1 | 0 | $3.955356$ |
 | $\left(\begin{smallmatrix}1&2\\3&4\end{smallmatrix}\right)$ (generic) | bipyramid | **obstructed** | floor $=2.35\times10^{-2}$ | 0 | 0 | $1.176471$ |
 
-The realizable residuals ($\sim10^{-11}$, $\sim10^{-13}$) sit **nine to twelve
-orders of magnitude** below the obstruction floor ($2.35\times10^{-2}$): the
+The realizable residuals ($\sim10^{-11}$) sit **nine orders of magnitude**
+below the obstruction floor ($2.35\times10^{-2}$): the
 separation is unambiguous. The floor is a genuine non-existence certificate, not
 a stuck optimizer — it is seed-independent, equals $2/85$ to machine precision,
 and matches an independent numpy global-min over the lone interior edge

--- a/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
@@ -80,7 +80,7 @@ on the one-interior-edge bipyramid, the residual lifts off zero immediately
 ($t{=}0$: $9.5\times10^{-11}$, realizable; $t{=}0.1$: $5.3\times10^{-3}$, floored)
 and saturates near $2.4\times10^{-2}$. Growth converts an obstruction into a
 realization where the topology allows it — the $1\times3$ operation floors at
-$9.6\times10^{-1}$ with no budget and drops to $1.2\times10^{-13}$ after a single
+$9.6\times10^{-1}$ with no budget and drops to $3.5\times10^{-11}$ after a single
 boundary-fixed cone.
 
 Triangulation invariance of the bulk is certified at the value level by the

--- a/examples/cobordism/realizability_report.py
+++ b/examples/cobordism/realizability_report.py
@@ -221,15 +221,19 @@ def synthesize_boundary(c0, c1, seed, restarts=80, max_cones=4):
 # --------------------------------------------------------------------------- #
 # §5.0 realizability decisions.
 # --------------------------------------------------------------------------- #
-def decide(bulk_factory, U, dA, dB, seed, restarts, max_cones):
+def decide(bulk_factory, U, dA, dB, seed, restarts, max_cones, growth_mode=None):
     """Bend U → vec(U), pin the bulk boundary, and let the oracle fill the
-    interior. Returns the Verdict."""
+    interior. `growth_mode` defaults to the historical cone-only growth;
+    SURGERY_AND_CONE allows additions as well as surgical cuts (max_cones then
+    budgets the added vertices only). Returns the Verdict."""
     bulk = bulk_factory()
     _pin_all(bulk, w=1.0, phase=0.0)
     target = _bend(U, dA, dB)
     oracle = cob.RealizabilityOracle(bulk)
+    if growth_mode is None:
+        growth_mode = cob.RealizabilityOracle.GrowthMode.CONE
     return oracle.decide(target, dA, dB, epsilon=EPSILON, restarts=restarts,
-                         max_cones=max_cones, seed=seed)
+                         max_cones=max_cones, seed=seed, growth_mode=growth_mode)
 
 
 def _np_floor_oracle(U, dA, dB, w_bounds=(0.1, 10.0), n=60):
@@ -440,6 +444,14 @@ def main():
                     help="synthesis / sweep seed (default 0).")
     ap.add_argument("--restarts", type=int, default=80,
                     help="multi-restart count for the LM solver (default 80).")
+    ap.add_argument("--max-additional-vertices", type=int, default=20,
+                    help="cap on the vertices the growth may ADD: the cone "
+                         "budget of the §4b boundary synthesis and of the "
+                         "growable realizability cases, which run with "
+                         "additions as well as surgical cuts "
+                         "(SURGERY_AND_CONE). The obstruction-floor controls "
+                         "stay pinned at budget 0 — they certify floors at "
+                         "fixed complexity by design (default 20).")
     ap.add_argument("--out", default="/tmp/cobordism",
                     help="directory for sweeps + figures (default /tmp/cobordism).")
     ap.add_argument("--no-plot", action="store_true", help="skip the figures.")
@@ -453,7 +465,8 @@ def main():
     # cone-and-retry grows the minimal complex (the triangle K_3) realizing it.
     c0, c1 = math.sqrt(0.8), math.sqrt(0.2)
     geo, floor_seed = synthesize_boundary(complex(c0), complex(c1), seed=args.seed,
-                                          restarts=args.restarts)
+                                          restarts=args.restarts,
+                                          max_cones=args.max_additional_vertices)
     print("  §4b  boundary-state synthesis  geo(ψ),  "
           f"ψ = (√0.8, √0.2)  (|c0| ≠ |c1|)")
     print(f"       two-vertex seed floors at r = {floor_seed:.3e}  "
@@ -463,35 +476,47 @@ def main():
           f"cones={geo.cones_applied}  λ={geo.eigenvalue:.6f}\n")
 
     # ---- §5.0: realizability decisions ------------------------------------ #
+    # The growable cases run with the composed move-set (additions as well as
+    # surgical cuts, the added vertices capped by --max-additional-vertices);
+    # the obstruction-floor control stays pinned at budget 0 / cone mode so it
+    # certifies the floor at fixed complexity, cross-checked below against the
+    # single-interior-edge numpy oracle.
+    both = cob.RealizabilityOracle.GrowthMode.SURGERY_AND_CONE
+    cone = cob.RealizabilityOracle.GrowthMode.CONE
+    grow = args.max_additional_vertices
     cases = [
         ("[[1,1],[1,1]] zero-mode", _bipyramid,
-         [[1.0 + 0j, 1.0 + 0j], [1.0 + 0j, 1.0 + 0j]], 2, 2, 0, True),
+         [[1.0 + 0j, 1.0 + 0j], [1.0 + 0j, 1.0 + 0j]], 2, 2, grow, both, True),
         ("[[1,.3+.5j,-.8+.2j]] 1×3", _solid_triangle,
-         [[1.0 + 0j, 0.3 + 0.5j, -0.8 + 0.2j]], 1, 3, 4, True),
+         [[1.0 + 0j, 0.3 + 0.5j, -0.8 + 0.2j]], 1, 3, grow, both, True),
         ("[[1,2],[3,4]] generic", _bipyramid,
-         [[1.0 + 0j, 2.0 + 0j], [3.0 + 0j, 4.0 + 0j]], 2, 2, 0, False),
+         [[1.0 + 0j, 2.0 + 0j], [3.0 + 0j, 4.0 + 0j]], 2, 2, 0, cone, False),
     ]
 
     print("  §5.0  realizability of U : H_B → H_A  (bend → pin dW → fill "
-          "interior → residual verdict)\n")
+          "interior → residual verdict;")
+    print(f"        growable cases: additions + surgical cuts, at most "
+          f"{grow} added vertices; the floor control: budget 0, fixed "
+          f"complexity)\n")
     header = (f"  {'operation U':26} {'bulk':11} {'verdict':11} "
-              f"{'r / floor':>12}  {'cones':>5} {'interior':>8} {'λ (Rayleigh)':>13}")
+              f"{'r / floor':>12}  {'steps':>5} {'cuts':>4} {'interior':>8} "
+              f"{'λ (Rayleigh)':>13}")
     print(header)
     print("  " + "-" * (len(header) - 2))
 
     all_ok = True
     verdicts = []
-    for name, factory, U, dA, dB, max_cones, expect_real in cases:
+    for name, factory, U, dA, dB, max_cones, mode, expect_real in cases:
         v = decide(factory, U, dA, dB, seed=args.seed, restarts=args.restarts,
-                   max_cones=max_cones)
+                   max_cones=max_cones, growth_mode=mode)
         verdicts.append((name, v, expect_real))
         bulk = "bipyramid" if factory is _bipyramid else "triangle"
         verdict = "REALIZABLE" if v.realizable else "OBSTRUCTED"
         metric = (f"r={v.residual:.2e}" if v.realizable
                   else f"f={v.floor:.2e}")
         print(f"  {_fmt_op(name):26} {bulk:11} {verdict:11} {metric:>12}  "
-              f"{v.cones_applied:>5} {v.interior_vertex_count:>8} "
-              f"{v.eigenvalue:>13.6f}")
+              f"{v.cones_applied:>5} {v.surgery_removals:>4} "
+              f"{v.interior_vertex_count:>8} {v.eigenvalue:>13.6f}")
 
         # Acceptance: realizable cases reach r < ε; the obstructed floor is a
         # certificate bounded above CERT_FLOOR (and floor == residual there).

--- a/examples/cobordism/spectral_gate_realizability.py
+++ b/examples/cobordism/spectral_gate_realizability.py
@@ -117,11 +117,17 @@ Parameters (additive -- the default run is the verified criterion sweep)
                   certificate, and bulk independence across re-grown genuine registers.
   --retries N     The surgery-topology search: score N RANDOMIZED surgery-grown
                   topologies (varied S^2 seeds -- the icosahedron and its geodesic
-                  subdivisions -- varied vertex-disjoint holonomy-hole triples, and
-                  extra `removeInteriorCell` surgeries that grow b_1) to ask whether a
-                  BIGGER topology search finds a richer emergent register carrying a
-                  currently-floored gate beyond the criterion set (it cannot -- the
-                  criterion is topology-free). Parallel; scales to large N.
+                  subdivisions -- varied vertex-disjoint holonomy-hole triples, extra
+                  `removeInteriorCell` surgeries that grow b_1, and ADDED vertices via
+                  seeded growInterior stellar subdivisions) to ask whether a BIGGER
+                  topology search -- cuts and additions both -- finds a richer emergent
+                  register carrying a currently-floored gate beyond the criterion set
+                  (it cannot -- the criterion is topology-free). Parallel; scales to
+                  large N.
+  --max-additional-vertices M
+                  Cap on the vertices a search draw may ADD (each --retries draw adds
+                  0..M via seeded stellar subdivision, alongside its cuts; default 20).
+                  The default sweep, --gate, and --h3 use the canonical register.
   --jobs J        Worker processes (clamped to the 10-CPU cap). Each worker is pinned to
                   ONE BLAS thread, so procs x threads <= 10 (default 10 x 1).
   --all-plots     Render force-directed simplicial-complex PNGs for every output (the
@@ -300,13 +306,16 @@ class Register:
     Sigma = 0. All OUTPUTS read off the grown bulk.
 
     The default `Register()` is the verified icosahedron / 3-canonical-hole register.
-    The optional `faces` / `class_holes` / `extra_holes` parameters drive the surgery-
-    topology search (`--retries`): a different triangulated-S^2 seed, a different
-    vertex-disjoint holonomy-hole triple, and extra `removeInteriorCell` surgeries that
-    grow b_1 -- the same construction on a richer grown topology.
+    The optional `faces` / `class_holes` / `extra_holes` / `grow_vertices` parameters
+    drive the surgery-topology search (`--retries`): a different triangulated-S^2 seed,
+    a different vertex-disjoint holonomy-hole triple, extra `removeInteriorCell`
+    surgeries that grow b_1, and ADDITIVE growth -- seeded `growInterior` stellar
+    subdivisions that add interior vertices (capped by --max-additional-vertices) --
+    so the search space holds additions as well as surgical cuts.
     """
 
-    def __init__(self, faces=_ICO, class_holes=_CLASS_HOLES, extra_holes=()):
+    def __init__(self, faces=_ICO, class_holes=_CLASS_HOLES, extra_holes=(),
+                 grow_vertices=0, grow_seed=0):
         self.faces = list(faces)
         self.class_holes = [tuple(sorted(h)) for h in class_holes]
         self.reg_edges = [e for tri in self.class_holes for e in _cedges(tri)]
@@ -316,6 +325,7 @@ class Register:
         self.es = cob.EigenstateSynthesis(self.st, 1)
         for hole in self.class_holes:                       # the holonomy holes
             self.es.removeInteriorCell(list(hole))
+        self.grown = self._stellar_grow(grow_vertices, grow_seed)
         self.extra_opened = []                              # extra surgery (b_1 growth)
         for cell in extra_holes:
             cs = tuple(sorted(cell))
@@ -337,6 +347,31 @@ class Register:
         self.n = (n_raw / n_raw[np.argmax(np.abs(n_raw))]).real
         self.sign = np.sign(self.n)
         self.sign[self.sign == 0] = 1.0
+
+    def _stellar_grow(self, n, seed):
+        """ADD up to *n* interior vertices by boundary-fixed stellar subdivision,
+        composed from the two documented surgery primitives: cone a fresh vertex
+        onto an interior top cell's three edges (`attachInteriorVertex` with the
+        triangle fan — dW untouched, the new edges interior), then remove the
+        subdivided face (`removeInteriorCell` — its edges keep two faces, so dW
+        stays bit-exact). Each application adds exactly ONE vertex and preserves
+        ker L_1 (the fan is homotopic to the face it replaces); sites are drawn
+        by the seeded RNG from the current interior top cells."""
+        rng = random.Random(int(seed))
+        grown = 0
+        for _ in range(int(n)):
+            cells = sorted(tuple(sorted(int(v) for v in c))
+                           for c in self.es.interiorTopCells())
+            if not cells:
+                break
+            a, b, c = rng.choice(cells)
+            if not self.es.attachInteriorVertex([[a, b], [b, c], [a, c]]):
+                continue
+            if not self.es.removeInteriorCell([a, b, c]):
+                self.es.detachLastInteriorVertex()
+                continue
+            grown += 1
+        return grown
 
     def _period(self, vec, tri):
         """The induced (raw) oriented loop sum of a register-edge 1-form on `tri`."""
@@ -1007,12 +1042,14 @@ def _extra_holes(faces, holes, n, rng):
     return out
 
 
-def score_variant(faces, holes, extra):
+def score_variant(faces, holes, extra, grow=0, grow_seed=0):
     """Build the staged-synthesis register on one surgery-grown topology and re-decide
     the full battery by the genuine Hodge L_1 spectrum. Returns a compact, picklable
-    summary: the topology (seed size, b_1, ker L_1, carried-period rank), the realized
-    set, and the validity/classification flags."""
-    reg = Register(faces=faces, class_holes=holes, extra_holes=extra)
+    summary: the topology (seed size, b_1, ker L_1, carried-period rank, vertices
+    added by stellar growth), the realized set, and the validity/classification
+    flags."""
+    reg = Register(faces=faces, class_holes=holes, extra_holes=extra,
+                   grow_vertices=grow, grow_seed=grow_seed)
     realized, by_name = [], {}
     for name, U, _fam in _gates():
         res, _b1, _leak = post_interaction(reg, U)
@@ -1035,6 +1072,7 @@ def score_variant(faces, holes, extra):
         "level": None, "nV": int(reg.st.getVertexList().size()),
         "b1": _betti1(reg.st), "dim": reg.dim, "rank": rank,
         "n_holes": n_holes, "n_extra": len(reg.extra_opened),
+        "n_grown": reg.grown,
         "realized": realized, "n_realized": len(realized),
         "identity": identity_ok, "s3_all": s3_all,
         "saturated": bool(rank >= n_holes), "genuine": genuine, "extends": extends,
@@ -1073,8 +1111,9 @@ def _sweep_worker(name):
 
 def _retry_worker(task):
     """One surgery-topology retry: pick a seed surface, a vertex-disjoint holonomy-hole
-    triple, and extra surgeries by the retry's RNG, then score the variant."""
-    idx, base_seed, kmax = task
+    triple, extra surgeries, and a count of ADDED vertices (seeded stellar growth, at
+    most --max-additional-vertices) by the retry's RNG, then score the variant."""
+    idx, base_seed, kmax, max_add = task
     rng = random.Random(base_seed * 1_000_003 + idx)
     level = rng.choices([0, 1, 2], weights=[3, 4, 1])[0]
     faces = _seed_surface(level)
@@ -1083,8 +1122,10 @@ def _retry_worker(task):
         return None
     n_extra = rng.randint(0, kmax)
     extra = _extra_holes(faces, holes, n_extra, rng)
+    n_grow = rng.randint(0, max(int(max_add), 0))
+    grow_seed = rng.randrange(1, 2**31)
     try:
-        out = score_variant(faces, holes, extra)
+        out = score_variant(faces, holes, extra, grow=n_grow, grow_seed=grow_seed)
     except Exception:                                       # a degenerate draw
         return None
     out["level"] = level
@@ -1148,12 +1189,15 @@ def run_sweep(reg, jobs, on_progress=None):
     return rows
 
 
-def surgery_search(retries, jobs, base_seed=12345, kmax=3, on_progress=None):
+def surgery_search(retries, jobs, base_seed=12345, kmax=3, max_add=20,
+                   on_progress=None):
     """Score *retries* randomized surgery-grown topologies in parallel and aggregate:
     how many genuine vs saturated vs invalid registers, the genuine realizable-set
     sizes, and whether ANY genuine variant carries a gate beyond the criterion set.
+    Each draw may both CUT (the holonomy holes + extra removals) and ADD (seeded
+    stellar growth, 0..max_add vertices — the --max-additional-vertices cap).
     *on_progress* ticks per scored topology (the live counter)."""
-    tasks = [(i, base_seed, kmax) for i in range(retries)]
+    tasks = [(i, base_seed, kmax, max_add) for i in range(retries)]
     results = [r for r in _parallel_map(_retry_worker, tasks, jobs,
                                         on_progress=on_progress) if r]
     genuine = [r for r in results if r["genuine"]]
@@ -1170,6 +1214,8 @@ def surgery_search(retries, jobs, base_seed=12345, kmax=3, on_progress=None):
         "levels": sorted(Counter(r["level"] for r in results).items()),
         "max_b1": max((r["b1"] for r in results), default=0),
         "max_nV": max((r["nV"] for r in results), default=0),
+        "max_grown": max((r.get("n_grown", 0) for r in results), default=0),
+        "max_add": max_add,
         "genuine_sizes": sorted(genuine_sizes.items()),
         "max_genuine_set": sorted(max_genuine),
         "extensions": extensions, "new_gates": new_gates,
@@ -1394,7 +1440,9 @@ def _print_search(search):
     print(f"\n  Surgery-topology search ({search['scored']}/{search['retries']} "
           f"randomized surgery-grown topologies scored in parallel; seeds = "
           f"icosahedron + geodesic subdivisions up to |V|={search['max_nV']}, "
-          f"max b_1 grown = {search['max_b1']}):")
+          f"max b_1 grown = {search['max_b1']}; cuts AND additions — up to "
+          f"{search.get('max_add', 0)} added vertices allowed, "
+          f"{search.get('max_grown', 0)} actually added in one draw):")
     print(f"      genuine registers (proper carried V, rank < #holes, S_3 anchor intact)"
           f": {search['n_genuine']}")
     print(f"      saturated registers (rank == #holes: V is the whole period space, so "
@@ -1465,6 +1513,7 @@ def run_single_gate(args, jobs):
         sprog = _progress()
         sprog.phase("surgery-topology search", total=args.retries)
         search = surgery_search(args.retries, jobs, base_seed=args.seed,
+                                max_add=args.max_additional_vertices,
                                 on_progress=sprog.on_tick)
         sprog.finish(f"scored {search['scored']} topologies")
         _print_search(search)
@@ -1511,6 +1560,12 @@ def main():
     ap.add_argument("--retries", type=int, default=0,
                     help="surgery-topology search: score N randomized surgery-grown "
                          "topologies in parallel (>0 enables it).")
+    ap.add_argument("--max-additional-vertices", type=int, default=20,
+                    help="cap on the vertices a search draw may ADD via seeded "
+                         "growInterior stellar subdivisions, alongside the "
+                         "surgical cuts; each --retries draw adds 0..N of them "
+                         "(default 20). The default sweep, --gate, and --h3 use "
+                         "the canonical register (no additions).")
     ap.add_argument("--jobs", type=int, default=min(10, os.cpu_count() or 1),
                     help="worker processes (clamped to the 10-CPU cap; each pinned to "
                          "1 BLAS thread, so procs x threads <= 10).")
@@ -1601,6 +1656,7 @@ def main():
         sprog = _progress()
         sprog.phase("surgery-topology search", total=args.retries)
         search = surgery_search(args.retries, jobs, base_seed=args.seed,
+                                max_add=args.max_additional_vertices,
                                 on_progress=sprog.on_tick)
         sprog.finish(f"scored {search['scored']} topologies")
         _print_search(search)

--- a/include/cobordism/RealizabilityOracle.h
+++ b/include/cobordism/RealizabilityOracle.h
@@ -141,7 +141,18 @@ class RealizabilityOracle {
       /// its own**, so the realizability obstruction either falls out of the grown
       /// topology or dissolves. The intended companion of the `harmonic` criterion
       /// (a boundary class is realizable iff it is **carried** by \f$ H_k(W) \f$).
-      Surgery
+      Surgery,
+      /// **Surgery + cone**: the composed move-set — additions as well as
+      /// surgical cuts. Each growth step first scores every interior-top-cell
+      /// removal (try → score → restore, exactly the `Surgery` step) and commits
+      /// the best **improving** cut; when no cut improves, it falls back to the
+      /// additive cone (`EigenstateSynthesis::growInterior`). Under this mode
+      /// `maxCones` budgets the **additive commits only** (the added vertices —
+      /// the resource a caller's `--max-additional-vertices` flag caps); cuts are
+      /// bounded by the improving-only rule and the finite interior-cell set, so
+      /// the fill terminates at convergence, an exhausted additive budget with no
+      /// improving cut left, or a complex that cannot grow.
+      SurgeryAndCone
     };
 
     /// The oracle's verdict on \f$ U \f$: the realizability decision, the

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -599,7 +599,16 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
              "k>=1, so b_k is frozen at the seed), removal lets the search reach an "
              "arbitrary valid complex with the fixed boundary: b_k MOVES on its "
              "own. The companion of harmonic=True (realizable iff the boundary "
-             "class is carried by H_k(W)).");
+             "class is carried by H_k(W)).")
+      .value("SURGERY_AND_CONE",
+             RealizabilityOracle::GrowthMode::SurgeryAndCone,
+             "The composed move-set: additions as well as surgical cuts. Each "
+             "growth step commits the best IMPROVING interior-top-cell removal "
+             "(the SURGERY step); when no cut improves it falls back to the "
+             "additive cone (growInterior). max_cones budgets the ADDITIVE "
+             "commits only — the added vertices, the resource a caller's "
+             "--max-additional-vertices flag caps; cuts are bounded by the "
+             "improving-only rule and the finite interior-cell set.");
 
   py::class_<RealizabilityOracle::Verdict>(ro, "Verdict",
       "The oracle's verdict on U: the realizability decision, the residual (the "

--- a/src/cobordism/RealizabilityOracle.cpp
+++ b/src/cobordism/RealizabilityOracle.cpp
@@ -456,6 +456,7 @@ double RealizabilityOracle::fillInterior(
   surgeryRemovals = 0;
   spaceSizeOut = 0;
 
+  int conesUsed = 0;  // additive commits — the budgeted resource in SurgeryAndCone
   for (int cone = 0;; ++cone) {
     // Optimize the current complex (seed + cone preserves the cone-path seed
     // sequence exactly, so the historical decide() is byte-for-byte unchanged).
@@ -466,20 +467,45 @@ double RealizabilityOracle::fillInterior(
     // Stop on convergence, an exhausted budget, or a complex that cannot grow
     // (growth is the capacity/structure gate; it leaves ∂W byte-fixed).
     if (bestR < epsilon) break;
-    if (cone >= maxCones) break;
     bool grew;
-    if (mode == GrowthMode::Surgery)
-      // The topology-changing move-set: commit the best b_k-shifting removal.
+    if (mode == GrowthMode::SurgeryAndCone) {
+      // The composed move-set: the best IMPROVING cut wins the step; when no
+      // cut improves, fall back to the additive cone. `maxCones` budgets the
+      // additive commits only (the added vertices); cuts are bounded by the
+      // improving-only rule and the finite interior-cell set.
       grew = growBestSurgery(es, pinnedByTuple, epsilon, restarts,
                              seed + 1000 + static_cast<std::uint64_t>(cone),
                              harmonic, bestR, surgeryRemovals);
-    else if (mode == GrowthMode::FreeConnectivity)
-      grew = growBestConnectivity(
-          es, pinnedByTuple, epsilon, restarts,
-          seed + 1000 + static_cast<std::uint64_t>(cone), connectivityCandidates,
-          harmonic, candidatesOut, triangleCandidatesOut, spaceSizeOut);
-    else
-      grew = es.growInterior(seed + 1000 + static_cast<std::uint64_t>(cone));
+      if (!grew && conesUsed < maxCones) {
+        // The additive fallback rides the Pachner add; on complexes where the
+        // move proposer cannot produce a valid cone (it can throw on degenerate
+        // proposals) the step is logged and skipped — the verdict then floors
+        // at the explored complexity rather than losing the decision.
+        try {
+          grew = es.growInterior(seed + 2000 + static_cast<std::uint64_t>(cone));
+        } catch (const std::exception &e) {
+          CLOG(WARN_LEVEL, "SurgeryAndCone: additive grow failed (", e.what(),
+               "); stopping growth at the explored complexity");
+          grew = false;
+        }
+        if (grew) ++conesUsed;
+      }
+    } else {
+      if (cone >= maxCones) break;
+      if (mode == GrowthMode::Surgery)
+        // The topology-changing move-set: commit the best b_k-shifting removal.
+        grew = growBestSurgery(es, pinnedByTuple, epsilon, restarts,
+                               seed + 1000 + static_cast<std::uint64_t>(cone),
+                               harmonic, bestR, surgeryRemovals);
+      else if (mode == GrowthMode::FreeConnectivity)
+        grew = growBestConnectivity(
+            es, pinnedByTuple, epsilon, restarts,
+            seed + 1000 + static_cast<std::uint64_t>(cone),
+            connectivityCandidates, harmonic, candidatesOut,
+            triangleCandidatesOut, spaceSizeOut);
+      else
+        grew = es.growInterior(seed + 1000 + static_cast<std::uint64_t>(cone));
+    }
     if (!grew) break;
     ++conesApplied;
   }

--- a/tests/cobordism/test_surgery_and_cone_python.py
+++ b/tests/cobordism/test_surgery_and_cone_python.py
@@ -1,0 +1,176 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The composed growth move-set: additions as well as surgical cuts.
+
+`RealizabilityOracle.GrowthMode.SURGERY_AND_CONE` composes the two existing
+moves per growth step — the best IMPROVING interior-top-cell removal (the
+SURGERY step), with the additive cone (`growInterior`) as the fallback when no
+cut improves. `max_cones` budgets the ADDITIVE commits only (the added
+vertices — the resource the examples' `--max-additional-vertices` flag caps);
+cuts are bounded by the improving-only rule and the finite interior-cell set.
+
+Covered here:
+  1. The mode realizes where cone growth realizes (the 1×3 solid-triangle
+     witness needs one added vertex), within the additive budget.
+  2. The mode realizes where surgery realizes (the superposed two-boundary
+     meridian on the disk seed realizes via a CUT that opens the annulus
+     handle), even at additive budget 0 — cuts do not consume the budget.
+  3. The additive budget is honored: at budget 0 with no improving cut, no
+     vertex is ever added.
+  4. The staged-synthesis `Register` accepts additive growth (seeded stellar
+     subdivisions) and stays a genuine register: the identity anchor holds and
+     the realizable set is still exactly the charge-conservation criterion.
+"""
+
+import importlib.util
+import os
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+MODE = cob.RealizabilityOracle.GrowthMode
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "spectral_gate_realizability.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("spectral_gate_realizability",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---- the 1×3 cone witness (the realizability_report growth case) ---------- #
+def _solid_triangle():
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0, tessera.PREFERRED,
+                           tessera.SolidSimplex(2))
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+        e.setPhase(0.0)
+    return st
+
+
+def _bend(U, dA, dB):
+    cj = tessera.quantum.ChoiJamiolkowski
+    flat = [complex(z) for z in np.asarray(U, dtype=complex).reshape(-1)]
+    return [complex(z) for z in cj.vectorize(flat, dA, dB)]
+
+
+_U13 = [[1.0 + 0j, 0.3 + 0.5j, -0.8 + 0.2j]]
+
+
+class ComposedModeIsExposedTest(unittest.TestCase):
+    def test_enum_value_exists(self):
+        self.assertTrue(hasattr(MODE, "SURGERY_AND_CONE"))
+        self.assertNotEqual(MODE.SURGERY_AND_CONE, MODE.SURGERY)
+        self.assertNotEqual(MODE.SURGERY_AND_CONE, MODE.CONE)
+
+
+class RealizesWhereConeRealizesTest(unittest.TestCase):
+    """1 + 3: the 1×3 witness floors at the seed and realizes once the additive
+    fallback may add a vertex; at budget 0 (no improving cut on this seed) the
+    composed mode adds nothing and floors."""
+
+    def test_one_added_vertex_realizes_the_1x3_witness(self):
+        v = cob.RealizabilityOracle(_solid_triangle()).decide(
+            _bend(_U13, 1, 3), 1, 3, epsilon=1e-10, restarts=80, max_cones=20,
+            seed=0, growth_mode=MODE.SURGERY_AND_CONE)
+        self.assertTrue(v.realizable)
+        self.assertLess(v.residual, 1e-10)
+        self.assertGreaterEqual(v.interior_vertex_count, 1)   # an ADDITION happened
+        self.assertLessEqual(v.interior_vertex_count, 20)     # within the budget
+
+    def test_budget_zero_adds_no_vertex(self):
+        v = cob.RealizabilityOracle(_solid_triangle()).decide(
+            _bend(_U13, 1, 3), 1, 3, epsilon=1e-10, restarts=40, max_cones=0,
+            seed=0, growth_mode=MODE.SURGERY_AND_CONE)
+        self.assertEqual(v.interior_vertex_count, 0)          # budget honored
+        self.assertFalse(v.realizable)                        # floors at the seed
+
+
+class RealizesWhereSurgeryRealizesTest(unittest.TestCase):
+    """2: the superposed two-boundary meridian realizes from the disk seed via a
+    CUT (the handle opens, b_1 0 -> 1) under the composed mode — with the
+    additive budget at 0, proving cuts do not consume it."""
+
+    @classmethod
+    def setUpClass(cls):
+        emergent = os.path.join(_HERE, "test_emergent_bulk_python.py")
+        spec = importlib.util.spec_from_file_location("emergent_bulk_fixture",
+                                                      emergent)
+        cls.fx = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.fx)
+
+    def test_meridian_realizes_via_a_cut_at_additive_budget_zero(self):
+        st = self.fx._disk()
+        matched, _vals = self.fx._meridian_target(flip=False)
+        self.assertEqual(self.fx._b1(st), 0)                  # the disk seed
+        v = cob.RealizabilityOracle(st).decideHarmonic(
+            matched, epsilon=self.fx.DEEP_EPS, restarts=self.fx.RESTARTS,
+            max_cones=0, seed=1, growth_mode=MODE.SURGERY_AND_CONE,
+            connectivity_candidates=8, harmonic=True)
+        self.assertEqual(self.fx._b1(st), 1)                  # the CUT opened b_1
+        self.assertGreaterEqual(v.surgery_removals, 1)
+        self.assertLess(v.residual, self.fx.REALIZE)          # carried (fixture bar)
+        self.assertEqual(v.interior_vertex_count, 0)          # additive budget intact
+
+
+class RegisterAdditiveGrowthTest(unittest.TestCase):
+    """4: the staged-synthesis Register grows additively (seeded stellar
+    subdivisions) and stays genuine — identity anchor + the criterion set."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.GATE = _load_example()
+        cls.reg = cls.GATE.Register(grow_vertices=3, grow_seed=7)
+
+    def test_growth_added_vertices_and_kept_the_register(self):
+        base = self.GATE.Register()
+        self.assertEqual(self.reg.grown, 3)
+        self.assertEqual(int(self.reg.st.getVertexList().size()),
+                         int(base.st.getVertexList().size()) + 3)
+        self.assertEqual(self.reg.dim, 2)                     # ker L_1 unchanged
+
+    def test_identity_anchor_holds_on_the_grown_register(self):
+        res, _b1, leak = self.GATE.post_interaction(self.reg,
+                                                    self.GATE._gates()[0][1])
+        self.assertLess(res, self.GATE.REALIZE)
+        self.assertLess(leak, 1e-9)
+
+    def test_realizable_set_is_still_the_criterion(self):
+        for name, U, _fam in self.GATE._gates():
+            res, _b1, _leak = self.GATE.post_interaction(self.reg, U)
+            self.assertEqual(bool(res < self.GATE.REALIZE),
+                             self.GATE.conserves_charge(U), msg=name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Per #240, both realizability pipelines can now grow their bulk by **additions as well as surgical cuts**, and both example scripts take **`--max-additional-vertices`** (default **20**) capping the vertices the search may add.

- **C++**: `RealizabilityOracle.GrowthMode.SURGERY_AND_CONE` composes the existing primitives per growth step — the best *improving* interior-top-cell removal wins the step; when no cut improves, the additive cone (`growInterior`) is the fallback. `max_cones` budgets the **additive commits only** (matching the flag's name); cuts are bounded by the improving-only rule and the finite cell set. `Cone`/`FreeConnectivity`/`Surgery` are byte-identical; `Verdict` is unchanged (additions read from `interior_vertex_count`, cuts from `surgery_removals`). The additive fallback catches a Pachner-proposer failure and floors at the explored complexity instead of losing the verdict.
- **`realizability_report.py`**: the growable witnesses run under the composed mode with the flag's budget; the obstruction-floor controls stay pinned at budget 0 / cone mode — the certified floor (2.35e-2 = 2/85) and its numpy cross-check are **unchanged**. The 1×3 witness realizes via one added vertex (r = 3.52e-11; the results-page table updated to the new numbers and gains added-|V|/cuts columns).
- **`spectral_gate_realizability.py`**: `Register` gains seeded additive growth — genuine stellar subdivisions composed from the two documented surgery primitives (`attachInteriorVertex` triangle fan, then `removeInteriorCell` of the subdivided face), each adding exactly one vertex with ∂W bit-exact and ker L₁ preserved. Each `--retries` draw adds 0..N vertices alongside its cuts. The default sweep, `--gate`, and `--h3` are untouched (canonical register). The CDT `AddMove`-based `growInterior` was probed and is unreliable on holed surfaces (degenerate proposals), hence the composed move.

Run evidence: a 60-draw search with cuts and additions (max |V| reached 179; one draw added all 20 vertices) yields 36 genuine registers, **every one realizing exactly the 13 charge-conserving gates** — the criterion is confirmed on the addition-enriched search space, as the issue predicted.

## Test plan

- [x] New `tests/cobordism/test_surgery_and_cone_python.py` (7 tests): mode exposed; realizes where cone realizes (1×3, one added vertex, within budget); realizes where surgery realizes (meridian via a cut at additive budget **0** — cuts don't consume the budget, b₁ moves); budget honored at 0; grown `Register` stays genuine (identity anchor + criterion intact across the full battery)
- [x] `pytest tests/cobordism`: **541 passed, 1 skipped, 719 subtests** — zero regressions (includes the examples' self-verify)
- [x] `realizability_report.py --no-plot` exits 0, SUPPORTED; floor control + numpy cross-check unchanged
- [x] `spectral_gate_realizability.py --retries 60 --jobs 10` exits 0, SUPPORTED
- [x] `sphinx-build -E`: 0 warnings (results-page table reconciled)
- [ ] After merge: pages deploy green

Closes #240.