### PR TITLE
fix(cobordism): pin the register's unit metric through additive growth

### DIFF
--- a/examples/cobordism/spectral_gate_realizability.py
+++ b/examples/cobordism/spectral_gate_realizability.py
@@ -371,6 +371,18 @@ class Register:
                 self.es.detachLastInteriorVertex()
                 continue
             grown += 1
+        if grown:
+            # attachInteriorVertex wires the new edges through
+            # createSimplexTracked, whose metric follows the endpoints' TIME
+            # rule (timelike l^2 = -alpha*a on a time difference) rather than
+            # Simplex::cone's causal vertex placement. On the all-same-time
+            # register seeds that already yields spacelike unit edges, but the
+            # documented unit cochain metric should hold by construction, not
+            # by the default-time coincidence: re-pin the bulk uniform exactly
+            # as _surface does at build.
+            for e in self.st.getEdgeList().toVector():
+                e.setSquaredLength(1.0)
+                e.setPhase(0.0)
         return grown
 
     def _period(self, vec, tri):

--- a/tests/cobordism/test_surgery_and_cone_python.py
+++ b/tests/cobordism/test_surgery_and_cone_python.py
@@ -171,6 +171,19 @@ class RegisterAdditiveGrowthTest(unittest.TestCase):
             self.assertEqual(bool(res < self.GATE.REALIZE),
                              self.GATE.conserves_charge(U), msg=name)
 
+    def test_grown_register_keeps_the_unit_cochain_metric(self):
+        """attachInteriorVertex's new edges inherit createSimplexTracked's
+        time rule (timelike l^2 < 0 on a time difference) rather than
+        Simplex::cone's causal vertex placement; _stellar_grow re-pins the
+        bulk uniform so the register's unit metric holds BY CONSTRUCTION.
+        Every edge must be spacelike at exactly 1.0 with zero phase, and the
+        k=1 Hodge weights exactly unit."""
+        w = np.asarray(cob.HodgeLaplacian(self.reg.st).weights(1), dtype=float)
+        self.assertEqual(float(np.max(np.abs(w - 1.0))), 0.0)
+        for e in self.reg.st.getEdgeList().toVector():
+            self.assertEqual(e.getSquaredLength(), 1.0)
+            self.assertEqual(e.getPhase(), 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #241, prompted by review: `Register._stellar_grow` composes its stellar subdivision from `attachInteriorVertex` + `removeInteriorCell` rather than `Simplex::cone`. The difference that matters: `Simplex::cone` explicitly manages the new vertex's **time placement** for Lorentzian causality, while `attachInteriorVertex` inherits `createSimplexTracked`'s time rule for the new edges' metric — spacelike `l² = a` only when the endpoints share a time, **timelike `l² = −α·a` when they don't**.

Verified consequences today: none — on the register seeds every vertex sits at the same time, so the grown metric is exactly unit (probed: `weights(1)` = 1.0 on all 39 edges of a grown register; all `squaredLength` 1.0, phases 0). The oracle growth paths are immune by design (the LM fill overwrites interior weights immediately). But the register's documented unit cochain metric was holding by default-time coincidence; a future seed with mixed vertex times would silently inject timelike edges into the register's L₁.

The fix makes it by-construction: `_stellar_grow` re-pins the bulk uniform (`squaredLength=1.0`, `phase=0.0` — exactly `_surface`'s build-time pin) after growth, and the growth test now asserts every edge spacelike at exactly 1.0 with the k=1 Hodge weights exactly unit.

## Test plan

- [x] New assertion: `test_grown_register_keeps_the_unit_cochain_metric` (weights exactly unit; every edge spacelike 1.0, phase 0)
- [x] `test_surgery_and_cone` + `test_spectral_h3`: 18 passed
- [x] `spectral_gate_realizability.py --retries 20 --jobs 10`: exit 0, SUPPORTED — 15 genuine registers, all exactly the 13 criterion gates
- [x] Full `pytest tests/cobordism` green

Closes #242.