### PR TITLE
feat(cobordism): circumcentric dual cell volumes on Simplex (Lorentzian)

### DIFF
--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -321,6 +321,35 @@ class Simplex {
     /// triangle inequalities. Fewer than two vertices is trivially admissible.
     void assertSpacelikeAdmissible(double tol = 1e-12) const;
 
+    /// Circumcenter of this simplex in **barycentric** coordinates
+    /// (λ_0..λ_d, Σλ = 1), computed intrinsically from the signature-aware edge
+    /// lengths (no embedding). λ_i is the weight on ``getVertices()[i]``. Solves
+    /// G β = ½·diag(G) with G the Gram matrix relative to vertex 0, then
+    /// λ_0 = 1 − Σβ, λ_i = β_i. Eigen-free (uses the determinant/cofactor
+    /// helpers). A vertex falling outside the simplex has a negative λ.
+    [[nodiscard]] std::vector<double> circumcenterBarycentric() const;
+
+    /// Signed circumradius squared R² of this simplex (intrinsic, signature-
+    /// aware): R² = ½·Σ_i β_i G_ii. Positive for a spacelike simplex; can be
+    /// negative when the circumcenter–vertex displacement is timelike.
+    [[nodiscard]] double circumradiusSquared() const;
+
+    /// Signed **circumcentric dual cell volume** |★σ| of this k-simplex in the
+    /// surrounding complex (the dual is (n−k)-dimensional, n = top dimension
+    /// reached via cofaces). Built from circumcenters by the standard DEC
+    /// recursion |★σ_k| = (1/(n−k)) Σ_{σ_{k+1}⊃σ_k} h·|★σ_{k+1}|, with a top
+    /// cell's dual a point (volume 1) and h the signed circumcentric height
+    /// between c(σ_k) and c(σ_{k+1}); signs follow the circumcenter's
+    /// barycentric coordinate at the opposite vertex. Signature-aware: a
+    /// timelike height contributes signed content (sign·√|h²|), matching
+    /// ``volume()``. Negative content is meaningful, not an error.
+    [[nodiscard]] double dualVolume() const;
+
+    /// Diagonal Hodge-star ratio ⋆ = |★σ| / |σ| (dual content over primal
+    /// content) for this simplex — the bridge between the primal Laplacian
+    /// weights and the dual Regge action.
+    [[nodiscard]] double hodgeStar() const;
+
     /// Determinant of a square matrix (flat row-major, size n x n).
     [[nodiscard]] static double determinant(
         const std::vector<double> &M, int n);

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -344,7 +344,20 @@ facet.getCofaces() includes this simplex.)doc")
            "default; wickRotate=True takes |l^2|.")
       .def("volume", &Simplex::volume,
            "Signed d-content sqrt(det G)/d! on the honest (non-Wick-rotated) "
-           "geometry; negative for a Lorentzian cell with timelike content.");
+           "geometry; negative for a Lorentzian cell with timelike content.")
+      .def("circumcenterBarycentric", &Simplex::circumcenterBarycentric,
+           "Circumcenter in barycentric coordinates (sum 1), intrinsic from the "
+           "signature-aware edge lengths; entry i weights getVertices()[i].")
+      .def("circumradiusSquared", &Simplex::circumradiusSquared,
+           "Signed circumradius squared R^2 (intrinsic, signature-aware); can be "
+           "negative for a timelike circumcenter displacement.")
+      .def("dualVolume", &Simplex::dualVolume,
+           "Signed circumcentric dual cell content |*sigma| in the surrounding "
+           "complex (DEC recursion over cofaces, n = top dimension). "
+           "Signature-aware; negative content is meaningful.")
+      .def("hodgeStar", &Simplex::hodgeStar,
+           "Diagonal Hodge-star ratio |*sigma|/|sigma| (dual over primal "
+           "content).");
 
   py::class_<SimplexHash, std::shared_ptr<SimplexHash> >(m, "SimplexHash")
       .def(py::init<>());

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -865,4 +865,109 @@ void Simplex::assertSpacelikeAdmissible(double tol) const {
     }
 }
 
+namespace {
+
+// Signed real square root: sign(x)·sqrt(|x|). The signed-content convention
+// (matching Simplex::volume), so a timelike circumcentric height contributes
+// negative content rather than throwing on a negative radicand.
+double signedSqrt(double x) {
+    return (x < 0.0) ? -std::sqrt(-x) : std::sqrt(x);
+}
+
+// Circumcenter (barycentric) + signed R² from the Gram matrix G (flat d×d,
+// relative to vertex 0). Solves G β = ½·diag(G) Eigen-free via the adjugate
+// (cofactorᵀ/det); λ_0 = 1−Σβ, λ_i = β_i; R² = Σ_i β_i·(½ G_ii).
+void circumFromGram(const std::vector<double>& G, int d,
+                    std::vector<double>& bary, double& r2) {
+    bary.assign(static_cast<std::size_t>(d) + 1, 0.0);
+    if (d <= 0) { bary[0] = 1.0; r2 = 0.0; return; }  // single vertex
+    std::vector<double> halfDiag(d);
+    for (int i = 0; i < d; ++i)
+        halfDiag[i] = 0.5 * G[static_cast<std::size_t>(i) * d + i];
+    const double detG = ::tessera::mesh::Simplex::determinant(G, d);
+    const std::vector<double> cof =
+        ::tessera::mesh::Simplex::cofactorMatrix(G, d);  // cof[r*d+c] = C_rc
+    // β_i = Σ_j (G⁻¹)_ij·halfDiag_j, with (G⁻¹)_ij = adj_ij/det = C_ji/det.
+    std::vector<double> beta(d, 0.0);
+    double sum = 0.0;
+    for (int i = 0; i < d; ++i) {
+        double acc = 0.0;
+        for (int j = 0; j < d; ++j)
+            acc += cof[static_cast<std::size_t>(j) * d + i] * halfDiag[j];
+        beta[i] = (detG != 0.0) ? acc / detG : 0.0;
+        bary[static_cast<std::size_t>(i) + 1] = beta[i];
+        sum += beta[i];
+    }
+    bary[0] = 1.0 - sum;
+    r2 = 0.0;
+    for (int i = 0; i < d; ++i) r2 += beta[i] * halfDiag[i];
+}
+
+// Sign (±1) of the circumcenter of coface `cf` at the vertex of `cf` not in its
+// facet `s` — the side of the facet's hull on which c(cf) sits.
+double oppositeVertexSign(const ::tessera::mesh::Simplex* cf,
+                          const ::tessera::mesh::Simplex* s) {
+    const auto& cfv = cf->getVertices();
+    const auto& sv = s->getVertices();
+    int oppIdx = -1;
+    for (std::size_t i = 0; i < cfv.size(); ++i) {
+        bool inS = false;
+        for (const auto* w : sv)
+            if (w->getId() == cfv[i]->getId()) { inS = true; break; }
+        if (!inS) { oppIdx = static_cast<int>(i); break; }
+    }
+    if (oppIdx < 0) return 1.0;
+    const std::vector<double> bary = cf->circumcenterBarycentric();
+    return (bary[static_cast<std::size_t>(oppIdx)] < 0.0) ? -1.0 : 1.0;
+}
+
+// Recursive signed circumcentric dual content of `s` in an n-complex.
+double dualVolRec(const ::tessera::mesh::Simplex* s, int n) {
+    const int k = static_cast<int>(s->size()) - 1;
+    if (k >= n) return 1.0;  // top cell: dual is a point (content 1)
+    const double rk2 = s->circumradiusSquared();
+    double acc = 0.0;
+    for (const auto& cf : s->getCofaces()) {
+        const double h =
+            oppositeVertexSign(cf, s) * signedSqrt(cf->circumradiusSquared() - rk2);
+        acc += h * dualVolRec(cf, n);
+    }
+    return acc / static_cast<double>(n - k);
+}
+
+}  // namespace
+
+std::vector<double> Simplex::circumcenterBarycentric() const {
+    const int d = static_cast<int>(size()) - 1;
+    std::vector<double> bary;
+    double r2 = 0.0;
+    circumFromGram(gramMatrix(/*wickRotate=*/false), d, bary, r2);
+    return bary;
+}
+
+double Simplex::circumradiusSquared() const {
+    const int d = static_cast<int>(size()) - 1;
+    std::vector<double> bary;
+    double r2 = 0.0;
+    circumFromGram(gramMatrix(/*wickRotate=*/false), d, bary, r2);
+    return r2;
+}
+
+double Simplex::dualVolume() const {
+    // Ambient top dimension: walk up cofaces to a top simplex (empty cofaces).
+    const Simplex* top = this;
+    while (!top->getCofaces().empty()) top = top->getCofaces()[0];
+    const int n = static_cast<int>(top->size()) - 1;
+    return dualVolRec(this, n);
+}
+
+double Simplex::hodgeStar() const {
+    const double v = volume();
+    if (v == 0.0) {
+        throw std::runtime_error(
+            "Simplex::hodgeStar: primal volume is zero (degenerate simplex)");
+    }
+    return dualVolume() / v;
+}
+
 }

--- a/tests/mesh/test_circumcentric_dual_python.py
+++ b/tests/mesh/test_circumcentric_dual_python.py
@@ -1,0 +1,125 @@
+"""Circumcentric dual cell volumes on Simplex (#246).
+
+Intrinsic, signature-aware circumcenters / dual volumes from the edge lengths
+(Cayley-Menger / Gram), verified on the equilateral triangle where everything
+is known in closed form:
+  * circumradius²  R² = a²/3   (here a² = 1 → 1/3);
+  * circumcenter = centroid (barycentric 1/3, 1/3, 1/3);
+  * edge circumradius² = a²/4;
+  * each vertex's circumcentric dual area = area/3, and the three sum to the
+    triangle area (the circumcentric subdivision partitions the cell);
+  * top cell's dual is a point (content 1); Hodge star ⋆ = |★σ|/|σ|.
+
+Continuous/spectral only; Lorentzian (signed) content, not Euclidean.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+import pytest
+
+try:
+    import tessera
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+
+def _spacetime(dim, topology):
+    sig = tessera.Signature(dim, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, topology)
+
+
+def _solid_triangle():
+    st = _spacetime(2, tessera.SolidSimplex(2))
+    st.build()
+    return st
+
+
+def _edge_map(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _triangle(st):
+    for s in st.getSimplices():
+        if len(s.getEdges()) == 3:
+            return s
+    raise AssertionError("no triangle simplex in spacetime")
+
+
+def _set_equilateral(st, a2=1.0):
+    for e in _edge_map(st).values():
+        e.setSquaredLength(a2)
+        e.setPhase(0.0)
+
+
+class TestCircumcenter(unittest.TestCase):
+    def test_equilateral_circumradius_squared(self):
+        st = _solid_triangle(); _set_equilateral(st, 1.0)
+        self.assertAlmostEqual(_triangle(st).circumradiusSquared(),
+                               1.0 / 3.0, places=10)
+
+    def test_equilateral_circumcenter_is_centroid(self):
+        st = _solid_triangle(); _set_equilateral(st, 1.0)
+        for b in _triangle(st).circumcenterBarycentric():
+            self.assertAlmostEqual(b, 1.0 / 3.0, places=10)
+
+    def test_edge_circumradius_squared(self):
+        st = _solid_triangle(); _set_equilateral(st, 1.0)
+        edge_simplex = _triangle(st).getFacets()[0]  # a 1-simplex
+        self.assertAlmostEqual(edge_simplex.circumradiusSquared(), 0.25, places=10)
+
+    def test_timelike_edge_carries_signed_content(self):
+        # A timelike edge (squaredLength < 0) yields a signed circumradius² —
+        # no crash, no Euclidean |.|.
+        st = _solid_triangle(); _set_equilateral(st, 1.0)
+        em = _edge_map(st)
+        em[(1, 2)].setSquaredLength(-1.0)
+        edge_simplex = None
+        for e in _triangle(st).getFacets():
+            ids = sorted(v.getId() for v in e.getVertices())
+            if ids == [1, 2]:
+                edge_simplex = e
+        self.assertIsNotNone(edge_simplex)
+        self.assertAlmostEqual(edge_simplex.circumradiusSquared(), -0.25, places=10)
+
+
+class TestDualVolume(unittest.TestCase):
+    def test_top_cell_dual_is_a_point(self):
+        st = _solid_triangle(); _set_equilateral(st, 1.0)
+        self.assertAlmostEqual(_triangle(st).dualVolume(), 1.0, places=10)
+
+    def test_hodge_star_top_cell(self):
+        st = _solid_triangle(); _set_equilateral(st, 1.0)
+        tri = _triangle(st)
+        self.assertAlmostEqual(tri.hodgeStar(), 1.0 / tri.volume(), places=10)
+
+    def test_vertex_dual_partitions_the_area(self):
+        st = _solid_triangle(); _set_equilateral(st, 1.0)
+        tri = _triangle(st)
+        area = tri.volume()  # sqrt(3)/4 for a = 1
+        # Materialize the facet/coface skeleton: triangle -> edges -> vertices.
+        verts = {}
+        for e in tri.getFacets():
+            for v in e.getFacets():
+                key = tuple(x.getId() for x in v.getVertices())
+                verts[key] = v
+        self.assertEqual(len(verts), 3)
+        duals = [v.dualVolume() for v in verts.values()]
+        for d in duals:
+            self.assertAlmostEqual(d, area / 3.0, places=8)
+        self.assertAlmostEqual(sum(duals), area, places=8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mesh/test_circumcentric_dual_python.py
+++ b/tests/mesh/test_circumcentric_dual_python.py
@@ -121,5 +121,102 @@ class TestDualVolume(unittest.TestCase):
         self.assertAlmostEqual(sum(duals), area, places=8)
 
 
+# --------------------------------------------------------------------------- #
+# Hand calculations on explicit geometries.
+# --------------------------------------------------------------------------- #
+def _all_vertex_simplices(st):
+    """0-simplices of every top triangle, keyed by vertex id (materializes the
+    facet/coface skeleton via getFacets). Snapshot the top simplices first:
+    getFacets() registers new simplices, which would invalidate a live
+    iteration over getSimplices()."""
+    tops = [s for s in st.getSimplices() if len(s.getEdges()) == 3]
+    verts = {}
+    for s in tops:
+        for e in s.getFacets():
+            for v in e.getFacets():
+                verts[v.getVertices()[0].getId()] = v
+    return verts
+
+
+class TestRightTriangleHandCalc(unittest.TestCase):
+    """Legs 1 and 1, right angle at vertex 0. Circumcenter sits at the
+    hypotenuse midpoint (R² = 1/2); the per-vertex circumcentric dual areas are
+    1/4 (right-angle vertex) and 1/8, 1/8 — hand-computed."""
+
+    def _right_triangle(self):
+        st = _solid_triangle()
+        em = _edge_map(st)
+        em[(0, 1)].setSquaredLength(1.0)   # leg
+        em[(0, 2)].setSquaredLength(1.0)   # leg
+        em[(1, 2)].setSquaredLength(2.0)   # hypotenuse (√2)
+        for e in em.values():
+            e.setPhase(0.0)
+        return st
+
+    def test_circumcenter_is_hypotenuse_midpoint(self):
+        st = self._right_triangle()  # keep the spacetime alive (owns the simplices)
+        tri = _triangle(st)
+        self.assertAlmostEqual(tri.circumradiusSquared(), 0.5, places=10)
+        order = [v.getId() for v in tri.getVertices()]
+        bmap = dict(zip(order, tri.circumcenterBarycentric()))
+        self.assertAlmostEqual(bmap[0], 0.0, places=10)   # on the hypotenuse
+        self.assertAlmostEqual(bmap[1], 0.5, places=10)
+        self.assertAlmostEqual(bmap[2], 0.5, places=10)
+
+    def test_per_vertex_dual_areas(self):
+        st = self._right_triangle()  # keep the spacetime alive (owns the simplices)
+        verts = _all_vertex_simplices(st)
+        dv = {vid: v.dualVolume() for vid, v in verts.items()}
+        self.assertAlmostEqual(dv[0], 0.25, places=8)    # right-angle vertex
+        self.assertAlmostEqual(dv[1], 0.125, places=8)
+        self.assertAlmostEqual(dv[2], 0.125, places=8)
+        self.assertAlmostEqual(sum(dv.values()), 0.5, places=8)  # = area
+
+
+# --------------------------------------------------------------------------- #
+# Full triangulations: one unit square, split two ways. Every vertex's dual
+# area is 1/4 and the total equals the area, independent of the triangulation
+# (re-triangulation invariance).
+# --------------------------------------------------------------------------- #
+def _unit_square_diag(diag):
+    st = _solid_triangle()  # triangle 0-1-2
+    vmap = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    if diag == (0, 2):
+        st.createSimplex([vmap[0], vmap[2], v3])     # triangle 0-2-3
+        sides = [(0, 1), (1, 2), (2, 3), (0, 3)]
+    elif diag == (0, 1):
+        st.createSimplex([vmap[0], vmap[1], v3])     # triangle 0-1-3
+        sides = [(0, 2), (1, 2), (1, 3), (0, 3)]
+    else:
+        raise ValueError(diag)
+    em = _edge_map(st)
+    for key in sides:
+        em[key].setSquaredLength(1.0)
+        em[key].setPhase(0.0)
+    em[diag].setSquaredLength(2.0)   # diagonal = √2
+    em[diag].setPhase(0.0)
+    return st
+
+
+class TestUnitSquareTriangulations(unittest.TestCase):
+    def _check_square(self, st):
+        tops = [s for s in st.getSimplices() if len(s.getEdges()) == 3]
+        self.assertEqual(len(tops), 2)
+        self.assertAlmostEqual(sum(t.volume() for t in tops), 1.0, places=8)
+        verts = _all_vertex_simplices(st)
+        self.assertEqual(len(verts), 4)
+        duals = [v.dualVolume() for v in verts.values()]
+        for d in duals:
+            self.assertAlmostEqual(d, 0.25, places=8)        # hand calc
+        self.assertAlmostEqual(sum(duals), 1.0, places=8)    # = total area
+
+    def test_diagonal_02(self):
+        self._check_square(_unit_square_diag((0, 2)))
+
+    def test_diagonal_01(self):
+        self._check_square(_unit_square_diag((0, 1)))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Chain step 2 of "Bulk Synthesis with Regge Action Mediation v0.1" (builds on #251). Genuine **circumcentric dual cell volumes** on `Simplex`, intrinsic from the edge lengths (Gram / Cayley-Menger), **signature-aware (Lorentzian)** — so the Regge action can later be evaluated on the true dual `W*`. `Simplex::volume` stays the primal content; the two relate by the Hodge star `⋆ = |★σ|/|σ|`. Signed dual volumes (negative content meaningful; no well-centeredness assumption).

- `circumcenterBarycentric` / `circumradiusSquared` — solve `G β = ½·diag(G)` Eigen-free (adjugate/det); `R² = ½·Σ β_i G_ii`.
- `dualVolume` — signed DEC recursion over cofaces (top cell's dual is a point; signed circumcentric heights; sign from the opposite-vertex barycentric coord).
- `hodgeStar = |★σ| / |σ|`.

## Test plan
- [x] circumcenter / R² **hand-checked**: equilateral (`R²=a²/3`, centroid), right triangle (circumcenter at the hypotenuse midpoint, `R²=1/2`), edge (`R²=a²/4`)
- [x] **per-vertex dual areas, hand-calculated**: right triangle → `1/4` (right-angle vertex), `1/8`, `1/8`; equilateral → `area/3` each
- [x] **full triangulations / re-triangulation invariance**: a unit square split two ways (diagonals 02 and 01) — every vertex's dual area is `1/4`, the total equals the area `1`, independent of the triangulation
- [x] timelike edge carries signed `R²` (`−0.25`); top cell's dual is a point; Hodge star `= 1/volume`
- [x] tests green locally — `tests/mesh/`: **52 passed** (CI is build-only)

Closes #246.
