### PR TITLE
feat(cobordism): Regge action on the dual complex, with rapidity

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -660,3 +660,27 @@
   year      = {2005},
   doi       = {10.1093/acprof:oso/9780198566649.001.0001}
 }
+
+% ─── Lorentzian Regge calculus (Sorkin angles, dual action) ──────────────
+@article{Sorkin2019LorentzianAngles,
+  author  = {Sorkin, Rafael D.},
+  title   = {Lorentzian angles and trigonometry including lightlike vectors},
+  journal = {arXiv preprint},
+  year    = {2019},
+  eprint  = {1908.10022},
+  archivePrefix = {arXiv},
+  note    = {Defines Lorentzian (boost) dihedral angles and the light-cone-crossing integer used in the dual Regge action}
+}
+
+@article{AsanteDittrichPaduaArguelles2021,
+  author  = {Asante, Seth K. and Dittrich, Bianca and Padua-Arg{\"u}elles, Jos{\'e}},
+  title   = {Effective Spin Foam Models for {L}orentzian Quantum Gravity},
+  journal = {Classical and Quantum Gravity},
+  volume  = {38},
+  number  = {19},
+  pages   = {195002},
+  year    = {2021},
+  eprint  = {2104.00485},
+  archivePrefix = {arXiv},
+  note    = {Computational Lorentzian Regge dihedral/deficit formulas (Eq. 10): spacelike-hinge boost vs timelike-hinge angle, complex action}
+}

--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -23,6 +23,7 @@
 #define TESSERA_SIMPLEX_H
 
 #include "mesh/ForwardDeclarations.h"
+#include <complex>
 #include <memory>
 #include <vector>
 #include <functional>
@@ -291,6 +292,25 @@ class Simplex {
     /// Deficit angle at this hinge: 2*pi minus the sum of dihedral angles
     /// from all top-simplices containing this hinge.
     [[nodiscard]] double deficitAngle() const;
+
+    /// Lorentzian (Sorkin) dihedral angle at ``hinge`` within this top simplex,
+    /// as a complex number. Built from the **signed** (non-Wick) Cayley-Menger
+    /// cofactor ratio r, UN-clamped: for an ordinary (spacelike-normal-plane)
+    /// wedge |r| <= 1 and this returns the real Euclidean angle; for a timelike
+    /// normal plane |r| > 1 (the boost regime) ``std::acos`` returns a complex
+    /// value whose imaginary part is the rapidity (boost) and whose real part
+    /// (0 or pi) carries the light-cone-crossing structure (Sorkin's N pi/2).
+    /// Unlike ``dihedralAngle`` (which Wick-rotates and clamps), this keeps the
+    /// boost. Refs: Regge (1961); Sorkin, Lorentzian angles & trigonometry;
+    /// Asante-Dittrich-Padua-Arguelles, arXiv:2104.00485 Eq. (10).
+    [[nodiscard]] std::complex<double>
+    lorentzianDihedralAngle(SimplexPtr hinge) const;
+
+    /// Complex Lorentzian deficit at this hinge: 2*pi minus the sum of
+    /// ``lorentzianDihedralAngle`` over the top simplices containing it. Real
+    /// for an all-spacelike (Euclidean) neighbourhood (the ordinary angle
+    /// defect); complex when timelike cells contribute boosts.
+    [[nodiscard]] std::complex<double> lorentzianDeficitAngle() const;
 
     /// Area of this simplex interpreted as a triangular hinge (3 vertices).
     /// Uses Heron's formula on the three edge squared lengths; ``wickRotate``

--- a/include/simulations/ReggeSolver.h
+++ b/include/simulations/ReggeSolver.h
@@ -3,6 +3,7 @@
 
 #include "mesh/ForwardDeclarations.h"
 #include "matter/MatterConfiguration.h"
+#include <complex>
 #include <functional>
 #include <memory>
 #include <tuple>
@@ -78,6 +79,19 @@ class ReggeSolver {
 
     /// Gravitational Regge action: \f$S_{\text{grav}} = \sum_h A_h\,\varepsilon_h\f$.
     [[nodiscard]] double reggeAction() const;
+
+    /// **Dual** Lorentzian Regge action on \f$W^*\f$:
+    /// \f$S_{\text{Regge}}(W^*) = \sum_h |\!\star\! h|\,\varepsilon_h\f$, the
+    /// circumcentric **dual** content of each (d-2)-hinge
+    /// (``Simplex::dualVolume``) weighted by its **complex Lorentzian** deficit
+    /// (``Simplex::lorentzianDeficitAngle``). Returns ``std::complex``: the real
+    /// part is the angle-defect curvature, the imaginary part the boost
+    /// (rapidity / light-cone) content from timelike-normal-plane hinges. Pure
+    /// gravity (matter-independent); the gravitational prior for the
+    /// Regge-mediated synthesis objective. Refs: Regge (1961);
+    /// Ambjorn-Jurkiewicz-Loll (Lorentzian CDT); Sorkin (Lorentzian angles);
+    /// Asante-Dittrich arXiv:2104.00485.
+    [[nodiscard]] std::complex<double> dualReggeAction() const;
 
     /// Point-particle matter action: \f$S_{\text{matter}} = -M \sum_{e \in W} \sqrt{-\ell^2_e}\f$.
     [[nodiscard]] double matterAction() const;

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -357,7 +357,17 @@ facet.getCofaces() includes this simplex.)doc")
            "Signature-aware; negative content is meaningful.")
       .def("hodgeStar", &Simplex::hodgeStar,
            "Diagonal Hodge-star ratio |*sigma|/|sigma| (dual over primal "
-           "content).");
+           "content).")
+      .def("lorentzianDihedralAngle", &Simplex::lorentzianDihedralAngle,
+           py::arg("hinge"),
+           "Complex Lorentzian (Sorkin) dihedral angle at the hinge: real for "
+           "an ordinary wedge, complex (imaginary part = boost rapidity) for a "
+           "timelike normal plane. Unlike dihedralAngle it is not clamped/Wick-"
+           "rotated, so boosts survive.")
+      .def("lorentzianDeficitAngle", &Simplex::lorentzianDeficitAngle,
+           "Complex Lorentzian deficit 2π − Σ lorentzianDihedralAngle over the "
+           "top cells at this hinge; real for an all-spacelike neighbourhood, "
+           "complex when timelike cells contribute boosts.");
 
   py::class_<SimplexHash, std::shared_ptr<SimplexHash> >(m, "SimplexHash")
       .def(py::init<>());

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
 #include <numbers>
 #include <stdexcept>
 #include <string>
@@ -789,6 +790,55 @@ double Simplex::deficitAngle() const {
             sum += sigma->dihedralAngle(const_cast<Simplex*>(this), /*wickRotate=*/true);
     }
     return 2.0 * std::numbers::pi - sum;
+}
+
+std::complex<double> Simplex::lorentzianDihedralAngle(SimplexPtr hinge) const {
+    const int dPlus1 = static_cast<int>(vertices.size());
+    // The two vertices of this simplex not in the hinge.
+    const auto hingeVerts = hinge->getVertices();
+    std::vector<int> opposite;
+    for (int k = 0; k < dPlus1; ++k) {
+        bool inHinge = false;
+        for (const auto &hv : hingeVerts)
+            if (hv->getId() == vertices[k]->getId()) { inHinge = true; break; }
+        if (!inHinge) opposite.push_back(k);
+    }
+    if (opposite.size() != 2) return {0.0, 0.0};
+    const int vi = opposite[0], vj = opposite[1];
+
+    // Signed (non-Wick) Cayley-Menger cofactors → the dihedral cosine ratio r,
+    // UN-clamped. std::acos on its complex extension returns the ordinary angle
+    // for |r| <= 1 and a boost (complex) for |r| > 1 — see the header.
+    const int n = dPlus1 + 1;
+    const auto B = cayleyMengerMatrix(/*wickRotate=*/false);
+    const auto cof = cofactorMatrix(B, n);
+    const int bi = vi + 1, bj = vj + 1;
+    const double Cij = cof[static_cast<std::size_t>(bi) * n + bj];
+    const double Cii = cof[static_cast<std::size_t>(bi) * n + bi];
+    const double Cjj = cof[static_cast<std::size_t>(bj) * n + bj];
+    double denom = std::sqrt(std::abs(Cii * Cjj));
+    if (denom < 1e-15) return {0.0, 0.0};
+    if (Cii < 0.0) denom = -denom;  // (-1)^d diagonal-sign fix (see dihedralAngle)
+    const double r = -Cij / denom;
+    return std::acos(std::complex<double>(r, 0.0));
+}
+
+std::complex<double> Simplex::lorentzianDeficitAngle() const {
+    using cd = std::complex<double>;
+    const cd twoPi(2.0 * std::numbers::pi, 0.0);
+    if (!spacetime || vertices.empty()) return twoPi;
+    const int topSize =
+        spacetime->getMetric()->getSignature()->getDimensions() + 1;
+    cd sum(0.0, 0.0);
+    for (const auto &sigma : vertices[0]->getSimplices()) {
+        if (static_cast<int>(sigma->size()) != topSize) continue;
+        bool containsAll = true;
+        for (std::size_t i = 1; i < vertices.size(); ++i)
+            if (!sigma->hasVertex(vertices[i])) { containsAll = false; break; }
+        if (containsAll)
+            sum += sigma->lorentzianDihedralAngle(const_cast<Simplex *>(this));
+    }
+    return twoPi - sum;
 }
 
 double Simplex::area(bool wickRotate) const {

--- a/src/simulations/Bindings.cpp
+++ b/src/simulations/Bindings.cpp
@@ -275,6 +275,11 @@ Einstein equations).  F ≥ 0, and F = 0 at the solution.)doc")
            "Area of a triangular hinge (Heron's formula).")
       .def("reggeAction", &ReggeSolver::reggeAction,
            "Gravitational Regge action: S_grav = Σ_h A_h · ε_h.")
+      .def("dualReggeAction", &ReggeSolver::dualReggeAction,
+           "Dual Lorentzian Regge action S_Regge(W*) = Σ_h |*h| · ε_h: each "
+           "(d-2)-hinge's circumcentric dual content (Simplex.dualVolume) times "
+           "its complex Lorentzian deficit. Returns a Python complex (real = "
+           "angle-defect curvature, imag = boost/light-cone content).")
       .def("matterAction", &ReggeSolver::matterAction,
            "Point-particle matter action: S_matter = -M Σ √(-ℓ²) along worldlines.")
       .def("totalAction", &ReggeSolver::totalAction,

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -37,18 +37,31 @@ using namespace ::tessera::quantum;
 ReggeSolver::ReggeSolver(std::shared_ptr<Spacetime> spacetime,
                          MatterConfiguration matter)
     : spacetime_(std::move(spacetime)), matter_(std::move(matter)) {
-    // Ensure all sub-simplices down to hinges (d-2) are registered.
-    // Top-simplices → facets (d-1) are registered during build().
-    // We need facets of facets → hinges (d-2).
-    // Use index-based iteration since getFacets() may grow simplicesVec.
-    {
-        int d = spacetime_->getMetric()->getSignature()->getDimensions();
-        auto nBefore = spacetime_->getSimplices().size();
-        for (std::size_t i = 0; i < nBefore; ++i) {
-            auto s = spacetime_->getSimplices()[i];
-            if (static_cast<int>(s->size()) == d) // (d-1)-simplices
-                (void)s->getFacets(); // registers (d-2)-simplices (hinges)
-        }
+    // Materialize the facet/coface lattice down to the (d-2)-hinges, in C++.
+    //
+    // dualVolume() walks a hinge UP through its cofaces to a top cell, so every
+    // coface link from the hinge up to the top must exist.  getFacets() on a
+    // k-simplex creates its (k-1)-facets and registers itself as their coface,
+    // so we must call it on every simplex of size >= d: the top d-cells (size
+    // d+1) register the (d-1)-facets, and the (d-1)-facets (size d) register the
+    // (d-2)-hinges.  build() does not guarantee the (d-1)-facets exist (e.g. a
+    // freshly built SolidSimplex holds only its top cells), so we start from the
+    // tops rather than assuming the facets are already present.
+    //
+    // This MUST run in C++.  The Python getFacets()/getCofaces() bindings use
+    // return_value_policy::copy, so driving materialization from Python would
+    // register *copies* of the sub-simplices — each carrying an incomplete
+    // coface list — onto the shared vertices, and the fingerprint-keyed
+    // hasCoface() guard would then block the canonical facets.  dualVolume()
+    // would then see half the cofaces it should.
+    //
+    // getFacets() grows simplicesVec as it registers new sub-simplices, so the
+    // loop re-reads size() each iteration rather than snapshotting it.
+    const int d = spacetime_->getMetric()->getSignature()->getDimensions();
+    for (std::size_t i = 0; i < spacetime_->getSimplices().size(); ++i) {
+        auto s = spacetime_->getSimplices()[i];
+        if (static_cast<int>(s->size()) >= d)
+            (void)s->getFacets();
     }
 }
 
@@ -98,6 +111,17 @@ double ReggeSolver::reggeAction() const {
     double S = 0.0;
     for (const auto &h : collectHinges()) {
         S += hingeArea(h) * deficitAngle(h);
+    }
+    return S;
+}
+
+std::complex<double> ReggeSolver::dualReggeAction() const {
+    // S_Regge(W*) = sum_h |*h| * eps_h: the circumcentric dual content of each
+    // (d-2)-hinge weighted by its complex Lorentzian deficit. Hinges must be
+    // registered (sub-simplices materialize via getFacets), as for reggeAction().
+    std::complex<double> S(0.0, 0.0);
+    for (const auto &h : collectHinges()) {
+        S += h->dualVolume() * h->lorentzianDeficitAngle();
     }
     return S;
 }

--- a/tests/mesh/test_lorentzian_regge_python.py
+++ b/tests/mesh/test_lorentzian_regge_python.py
@@ -1,0 +1,228 @@
+"""Lorentzian (Sorkin) Regge angles + dual Regge action (#247).
+
+All targets are hand-computed.
+
+Euclidean / all-spacelike (real):
+  - equilateral-triangle dihedral angle at a vertex = π/3;
+  - flat flower (4 right triangles tiling a square around a centre) → centre
+    deficit 0;
+  - regular tetrahedron surface (closed S²): each vertex's complex deficit = π,
+    Σ deficits = 4π (Gauss–Bonnet 2πχ, χ=2); each vertex's circumcentric dual
+    cell = √3/4, Σ = √3 = total surface area; and
+    dualReggeAction = Σ |*h|·ε_h = √3·π (real).
+
+Lorentzian (complex / boost):
+  - a 1+1 triangle with two timelike edges meeting at vertex 0: the dihedral
+    there is a boost of rapidity acosh(2/√3) ≈ 0.5493 — captured as a non-zero
+    imaginary part, where the existing clamped/Wick `dihedralAngle` loses it;
+  - a tetra surface with one timelike edge → the dual action goes complex.
+
+Materialization note: the facet/coface skeleton is built in C++ by constructing
+a ReggeSolver (its constructor walks getFacets() down to the hinges).  We do NOT
+materialize from Python: getFacets()/getCofaces() are bound with
+return_value_policy::copy, so calling them from Python yields *copies* of the
+sub-simplices; registering those copies — each with a partial coface list — onto
+the shared vertices corrupts dualVolume().  After constructing the solver we read
+the canonical sub-simplices back from getSimplices().
+
+Refs: Regge (1961); Sorkin (Lorentzian angles, arXiv:1908.10022);
+Asante–Dittrich–Padua-Argüelles (arXiv:2104.00485, Eq. 10).
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+import pytest
+
+try:
+    import tessera
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+def _spacetime(dim, topology):
+    sig = tessera.Signature(dim, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, topology)
+
+
+def _solid_triangle():
+    st = _spacetime(2, tessera.SolidSimplex(2))
+    st.build()
+    return st
+
+
+def _edge_map(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _set_edges(st, mapping, default=None):
+    for k, e in _edge_map(st).items():
+        if k in mapping:
+            e.setSquaredLength(mapping[k])
+        elif default is not None:
+            e.setSquaredLength(default)
+        e.setPhase(0.0)
+
+
+def _solver(st):
+    """Construct a ReggeSolver, which materializes the facet/coface skeleton in
+    C++ (canonical sub-simplices + cofaces).  Return the solver."""
+    return tessera.ReggeSolver(st, tessera.MatterConfiguration())
+
+
+def _materialize(st):
+    """Build the skeleton in C++ (see module docstring) and discard the solver;
+    the sub-simplices now live in st.getSimplices()."""
+    _solver(st)
+
+
+def _by_size(st, n):
+    return [s for s in st.getSimplices() if len(s.getVertices()) == n]
+
+
+def _vertices_by_id(st):
+    """Canonical vertex 0-simplices keyed by vertex id (from getSimplices, not
+    the copying getFacets() binding).  Requires a prior _materialize/_solver."""
+    return {s.getVertices()[0].getId(): s for s in _by_size(st, 1)}
+
+
+def _triangle(st):
+    tris = _by_size(st, 3)
+    if not tris:
+        raise AssertionError("no triangle simplex (did you materialize?)")
+    return tris[0]
+
+
+def _flat_flower():
+    """Unit square tiled by 4 right triangles around centre 0: triangles 012,
+    023, 034, 041; centre-corner edges = √(1/2) (s=0.5), sides = 1. The four
+    right angles at the centre sum to 2π → zero deficit."""
+    st = _solid_triangle()  # triangle 0-1-2
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    v4 = st.createVertex(4)
+    st.createSimplex([v[0], v[2], v3])   # 0-2-3
+    st.createSimplex([v[0], v3, v4])     # 0-3-4
+    st.createSimplex([v[0], v4, v[1]])   # 0-4-1
+    _set_edges(st, {(0, 1): 0.5, (0, 2): 0.5, (0, 3): 0.5, (0, 4): 0.5,
+                    (1, 2): 1.0, (2, 3): 1.0, (3, 4): 1.0, (1, 4): 1.0})
+    return st
+
+
+def _tetra_surface(timelike_edge=None):
+    """Closed S² = the 4 triangles of a regular tetrahedron's surface
+    (012, 013, 023, 123), all edges equilateral (s=1) unless one is overridden
+    to a timelike value."""
+    st = _solid_triangle()  # 0-1-2
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    st.createSimplex([v[0], v[1], v3])   # 0-1-3
+    st.createSimplex([v[0], v[2], v3])   # 0-2-3
+    st.createSimplex([v[1], v[2], v3])   # 1-2-3
+    overrides = {} if timelike_edge is None else {timelike_edge: -1.0}
+    _set_edges(st, overrides, default=1.0)
+    return st
+
+
+# --------------------------------------------------------------------------- #
+# Euclidean / all-spacelike (real)
+# --------------------------------------------------------------------------- #
+class TestEuclideanAngles(unittest.TestCase):
+    def test_equilateral_dihedral_is_pi_over_3(self):
+        st = _solid_triangle()
+        _set_edges(st, {}, default=1.0)             # equilateral
+        _materialize(st)
+        tri = _triangle(st)
+        v0 = _vertices_by_id(st)[0]
+        theta = tri.lorentzianDihedralAngle(v0)     # interior angle at vertex 0
+        self.assertAlmostEqual(theta.real, math.pi / 3.0, places=10)
+        self.assertAlmostEqual(theta.imag, 0.0, places=12)
+
+    def test_flat_flower_centre_deficit_zero(self):
+        st = _flat_flower()
+        _materialize(st)
+        centre = _vertices_by_id(st)[0]
+        eps = centre.lorentzianDeficitAngle()       # 2π − 4·(π/2) = 0
+        self.assertAlmostEqual(eps.real, 0.0, places=8)
+        self.assertAlmostEqual(eps.imag, 0.0, places=10)
+
+
+class TestTetrahedronSurface(unittest.TestCase):
+    def test_vertex_deficit_and_gauss_bonnet(self):
+        st = _tetra_surface()
+        _materialize(st)
+        verts = _vertices_by_id(st)
+        self.assertEqual(len(verts), 4)
+        defs = [v.lorentzianDeficitAngle() for v in verts.values()]
+        for e in defs:
+            self.assertAlmostEqual(e.real, math.pi, places=8)   # 2π − 3·(π/3)
+            self.assertAlmostEqual(e.imag, 0.0, places=10)
+        self.assertAlmostEqual(sum(e.real for e in defs),
+                               4.0 * math.pi, places=8)          # Gauss–Bonnet
+
+    def test_vertex_dual_cells_partition_the_surface(self):
+        # Circumcentric dual: each equilateral face (R²=1/3) contributes a
+        # quadrilateral to each of its 3 vertices; per vertex the dual cell is
+        # √3/4, and Σ over the 4 vertices = √3 = total surface area (4·√3/4).
+        st = _tetra_surface()
+        _materialize(st)
+        duals = [v.dualVolume() for v in _vertices_by_id(st).values()]
+        for dv in duals:
+            self.assertAlmostEqual(dv, math.sqrt(3.0) / 4.0, places=8)
+        self.assertAlmostEqual(sum(duals), math.sqrt(3.0), places=8)
+
+    def test_dual_regge_action_is_pi_root3(self):
+        st = _tetra_surface()
+        S = _solver(st).dualReggeAction()
+        # Σ_h |*h|·ε_h = (√3/4)·π summed over 4 vertices = √3·π.
+        self.assertAlmostEqual(S.real, math.pi * math.sqrt(3.0), places=7)
+        self.assertAlmostEqual(S.imag, 0.0, places=9)
+
+
+# --------------------------------------------------------------------------- #
+# Lorentzian (complex / boost)
+# --------------------------------------------------------------------------- #
+class TestLorentzianBoost(unittest.TestCase):
+    def test_timelike_dihedral_is_a_boost(self):
+        # Two timelike edges at vertex 0 (s = −4, −3), spacelike opposite (s = 1).
+        # ⟨v01,v02⟩ = (s01+s02−s12)/2 = −4; cosh β = 4/√(4·3) = 2/√3.
+        st = _solid_triangle()
+        _set_edges(st, {(0, 1): -4.0, (0, 2): -3.0, (1, 2): 1.0})
+        _materialize(st)
+        tri = _triangle(st)
+        v0 = _vertices_by_id(st)[0]
+        theta = tri.lorentzianDihedralAngle(v0)
+        beta = math.acosh(2.0 / math.sqrt(3.0))     # ≈ 0.54931
+        self.assertAlmostEqual(abs(theta.imag), beta, places=8)   # boost survives
+        # Real part sits at a light-cone branch point (0 or π).
+        self.assertTrue(abs(theta.real) < 1e-8 or
+                        abs(theta.real - math.pi) < 1e-8)
+        # Contrast: the clamped dihedralAngle throws the boost away — it lands at
+        # a real branch point (0 or π) instead of carrying the rapidity.
+        clamped = tri.dihedralAngle(v0, False)
+        self.assertGreater(abs(theta.imag), 1e-2)
+        self.assertTrue(abs(clamped) < 1e-8 or abs(clamped - math.pi) < 1e-8)
+
+    def test_dual_action_goes_complex_with_a_timelike_edge(self):
+        st = _tetra_surface(timelike_edge=(0, 1))   # one edge timelike
+        S = _solver(st).dualReggeAction()
+        self.assertTrue(math.isfinite(S.real) and math.isfinite(S.imag))
+        self.assertGreater(abs(S.imag), 1e-6)        # boost ⇒ imaginary part
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Chain step 3 of "Bulk Synthesis with Regge Action Mediation v0.1" (builds on #246/#254). Evaluates the Lorentzian **dual Regge action** `S_Regge(W*) = Σ_hinges |★h|·ε_h` — the deficit (intrinsic curvature) at each codim-2 hinge weighted by the hinge's **circumcentric dual content** (`Simplex::dualVolume`, #246), with deficits computed Lorentzian-aware (Gram cofactors → hyperbolic/rapidity angles on timelike hinges). Extends `ReggeSolver` (reuses `collectHinges`/`deficitAngle`); the gravitational prior for the synthesis objective `F_β = r_U + β·S_Regge(W*)` (#248).

Convention note: deficits are the primal intrinsic angle defects weighted by the dual hinge cell — the standard DEC Einstein-Hilbert pairing. Flagged for review; genuine dual-complex dihedral angles would be a further refinement.

## Test plan
- [ ] all-spacelike fixture: `S_Regge(W*)` matches an independent hand cross-check (Σ dual-area × angle-defect)
- [ ] a timelike hinge contributes a rapidity-based (signed/hyperbolic) deficit
- [ ] finite on a bounded geometry; null/degenerate fail loudly
- [ ] tests green locally (CI is build-only)

Closes #247.
