### PR TITLE
docs(cobordism): cite the literature in the results report (+ DW-era citations on the scaffold)

### DIFF
--- a/docs/source/causal_sets.md
+++ b/docs/source/causal_sets.md
@@ -8,7 +8,7 @@ Lieb–Robinson cone, and the causet order on the same label set.
 The motivation, in one sentence: the underlying causal structure of a
 Lorentzian manifold is captured by the **partial order** on its points,
 and a spacetime can be reconstructed up to conformal factor from that
-order alone {cite}`MalamentSorkin1977,BombelliLeeMeyerSorkin1987`. tessera
+order alone {cite}`C-MalamentSorkin1977, C-BombelliLeeMeyerSorkin1987`. tessera
 exposes this partial order as a concrete data structure
 (`tessera.Poset`) and provides factories that derive it from a
 triangulated `tessera.Spacetime` or from a Schwinger TDVP quench run.
@@ -262,16 +262,25 @@ position, snapshot index, and physical time.
 
 ## Reading list
 
-* {cite}`MalamentSorkin1977` — the order-reconstructs-conformal-class
+* {cite}`C-MalamentSorkin1977` — the order-reconstructs-conformal-class
   theorem.
-* {cite}`BombelliLeeMeyerSorkin1987` — the causet program; spacetime
+* {cite}`C-BombelliLeeMeyerSorkin1987` — the causet program; spacetime
   emerges from a locally finite partial order.
-* {cite}`LiebRobinson1972` — the Lieb–Robinson bound that bounds the
+* {cite}`C-LiebRobinson1972` — the Lieb–Robinson bound that bounds the
   $\preceq_{\rm LR}$ order.
-* {cite}`HastingsKoma2006` — refined LR bound for lattice systems
+* {cite}`C-HastingsKoma2006` — refined LR bound for lattice systems
   relevant to the Schwinger TDVP setup.
 
 See also [Emergent Causal Order from Majorization](quantum-experiments/earlier-work/emergent-causal-order-from-majorization.md) §1 and §4.4 for the
 scientific motivation behind the three-order comparison, and
 [Emergent Spectral Dimension from the Schwinger TDVP State](quantum-experiments/earlier-work/emergent-spectral-dimension-schwinger-tdvp.md) §5 for
 the integration of `CausetChain` with the holography pipeline.
+
+## References
+
+```{bibliography}
+:filter: docname in docnames
+:keyprefix: C-
+:labelprefix: C
+:style: unsrt
+```

--- a/docs/source/quantum-experiments/earlier-work/dijkgraaf-witten-scaffold.md
+++ b/docs/source/quantum-experiments/earlier-work/dijkgraaf-witten-scaffold.md
@@ -1,8 +1,12 @@
 # The Dijkgraaf–Witten scaffold: the quantized shadow of the spectral Z
 
-The $\mathbb{Z}_2$ Dijkgraaf–Witten state sum was the topological layer the
+The $\mathbb{Z}_2$ Dijkgraaf–Witten state sum
+{cite}`S-DijkgraafWitten1990Topological` — in its triangulation/state-sum form
+{cite}`S-Wakui1992DWInvariant`, rigorously quantized as a functorial TQFT in
+{cite}`S-FreedQuinn1993FiniteGauge` — was the topological layer the
 State–Operation–Cobordism programme was built on: it certified that the bulk
-$Z$ is a genuine cobordism functor, carried the sign invariant, calibrated the
+$Z$ is a genuine cobordism functor {cite}`S-Atiyah1988TQFT`, carried the sign
+invariant, calibrated the
 spectral reading against an independent metric-free oracle, and supplied the
 first (pinned) realizable-gate image. With H3 now validated on the spectral
 data alone — the value equation
@@ -30,7 +34,9 @@ Dijkgraaf–Witten state sum $Z(W)$ is a well-defined cobordism functor
   for harmonic-1-form boundary states $\psi\in\ker L_1(T^2)$; residual
   $6.28\times10^{-16}$.
 - **T2 — triangulation independence (make-or-break).** $Z(S^2\times S^1)$ drifts by
-  $0.00$ over 18 interior Pachner moves (including $1\!\to\!4$ moves that change
+  $0.00$ over 18 interior Pachner moves
+  {cite}`S-Pachner1987Bistellar, S-Pachner1991Shellings` (including $1\!\to\!4$
+  moves that change
   $\lvert V\rvert$), for both cocycle classes — $Z$ is invariant to machine
   precision with $\partial W$ fixed.
 - **T5 — composition / functoriality.** $\texttt{map}(\texttt{glue}(W_1,W_2))=
@@ -106,10 +112,13 @@ representation of a $GL(2,\mathbb{Z}_2)=SL(2,\mathbb{Z}_2)$ automorphism of
 $H^1(T^2;\mathbb{Z}_2)$, fixing the trivial class (index 0) and permuting the three
 non-trivial classes $\{[a],[b],[a{+}b]\}=\{1,2,3\}$. Two twisted cylinders generate
 the group (`realizable_image_sweep.py`): the coordinate **swap** $(1\,2)$ on the
-9-vertex product torus (its mod-2 reduction is the modular $S$) and the order-3
+9-vertex product torus (its mod-2 reduction is the modular $S$ of the torus
+state space {cite}`S-FreedQuinn1993FiniteGauge, S-DVVV1989Orbifold`) and the order-3
 **multiplier** $(1\,2\,3)$ on the 7-vertex Möbius torus. Every permutation of the
 three non-zero vectors of $(\mathbb{Z}_2)^2$ is automatically $GF(2)$-linear, so the
-pinned realizable image is the *full* $S_3$.
+pinned realizable image is the *full* $S_3$ — the finite mapping-class image
+the topological-quantum-computation literature leads one to expect of an
+abelian theory {cite}`S-Freedman2003TQC, S-NaiduRowell2011PropertyF`.
 
 The content of $S_3$ is **holonomy-class permutation without superposition** — and
 that is *not* computational separability. Several computational **entanglers** are
@@ -302,3 +311,12 @@ Raw tables and figures are written to `/tmp/cobordism/` and are **not
 committed**; the figures above are uploaded to the
 [`issue-attachments`](https://github.com/akellehe/tessera/releases/tag/issue-attachments)
 release and embedded by URL. The 10-CPU cap is honored (thread env set at launch).
+
+## References
+
+```{bibliography}
+:filter: docname in docnames
+:keyprefix: S-
+:labelprefix: S
+:style: unsrt
+```

--- a/docs/source/quantum-experiments/earlier-work/emergent-causal-order-from-majorization.md
+++ b/docs/source/quantum-experiments/earlier-work/emergent-causal-order-from-majorization.md
@@ -343,5 +343,7 @@ The scan scripts are `examples/quantum/lightcone_vs_majorization.py`
 and its N-scaling and cone-overflow companions in the same directory.
 
 ```{bibliography}
+:filter: docname in docnames
+:labelprefix: A
 :style: unsrt
 ```

--- a/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/cobordism-results.md
@@ -20,7 +20,11 @@
 
 A quantum operation $U:\mathcal H_B\to\mathcal H_A$ between two states is read as a
 **cobordism** whose boundary is the two states and whose TQFT value is their
-transition amplitude. The manifold is the operation; the amplitude is the number
+transition amplitude — the functorial reading of field theory
+{cite}`R-Atiyah1988TQFT, R-Segal2004Definition`, with states prepared by bounding
+geometries and amplitudes assigned to general boundaries
+{cite}`R-HartleHawking1983WaveFunction, R-Oeckl2003GeneralBoundary`. The manifold
+is the operation; the amplitude is the number
 it computes. Concretely (spec §1):
 
 - **H1.** $W_{AB}=\mathrm{geo}(U)$ is an $n$-cobordism.
@@ -30,8 +34,9 @@ it computes. Concretely (spec §1):
 
 **The falsifiable core, read spectrally.** The correspondence is *supported*
 iff (i) the trivial cobordism reproduces the inner product, (ii) the value is
-invariant under interior re-triangulation, and (iii) an obstructed class is
-genuinely distinguished — and *refuted* if any fails. All three hold on the
+invariant under interior re-triangulation (the Pachner-move test
+{cite}`R-Pachner1987Bistellar, R-Pachner1991Shellings`), and (iii) an obstructed
+class is genuinely distinguished — and *refuted* if any fails. All three hold on the
 spectral data (`spectral_gate_realizability.py --h3`): (i) the identity's
 spectral value equals $\langle\psi_A|\psi_B\rangle$ on every carried pair
 (worst $4.5\times10^{-16}$), and it realizes *only* once surgery has grown the
@@ -41,7 +46,8 @@ $9.7\times10^{-16}$), and a generic re-grown bulk deviates by precisely its
 register Gram defect, $a^\dagger(G-I)b$, matched to $\sim10^{-15}$; (iii) a
 leaked class has **no value at all** — every floored gate's post-state leaves
 the carried register ($\lvert\Sigma\rvert=0.21$–$2.60$), the value-level
-obstruction certificate. (The original Dijkgraaf–Witten formulation of this
+obstruction certificate. (The original Dijkgraaf–Witten
+{cite}`R-DijkgraafWitten1990Topological` formulation of this
 core — T1/T2 on the state sum and the T3 sign invariant — is recorded in
 [the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md).) The sections
 below place the rest of the evidence under the hypothesis it bears on.
@@ -98,8 +104,12 @@ representative becomes null," residual $3.36\times10^{-15}$.)
 
 ### rank $=$ Schmidt rank $=$ connectivity
 
-The engine of H1 is map–state duality (Choi–Jamiołkowski "bending"):
-$\operatorname{rank}(U)$ equals the Schmidt rank of $\operatorname{vec}(U)$, which
+The engine of H1 is map–state duality (Choi–Jamiołkowski "bending"
+{cite}`R-Choi1975CompletelyPositive, R-Jamiolkowski1972LinearTransformations`, the
+wire-bending of categorical quantum mechanics
+{cite}`R-AbramskyCoecke2004Categorical`):
+$\operatorname{rank}(U)$ equals the Schmidt rank of $\operatorname{vec}(U)$
+(the operator-Schmidt rank {cite}`R-Nielsen2003DynamicsResource`), which
 equals the connectivity of $W_{AB}$. A rank-1 $U$ factors through the unit object,
 so its cobordism is **disconnected** (a separable bent state); a full-rank $U$
 gives a **connected** cobordism (an entangled bent state). The realized witnesses
@@ -140,7 +150,9 @@ $\mathrm{geo}(\psi_B)$.
 The value equation is validated on the staged-synthesis register itself —
 no DW input anywhere (`spectral_gate_realizability.py --h3`). The spectral
 value $Z_{\text{spec}}(W;\psi_A,U\psi_B)$ is the Hodge pairing of the
-carried harmonic representatives on the surgery-grown bulk (the register
+carried harmonic representatives — harmonic cochains in the sense of
+discrete Hodge theory {cite}`R-Eckmann1945Harmonische, R-Lim2020HodgeLaplacians`
+— on the surgery-grown bulk (the register
 bulk carries the unit cochain metric, so the pairing is the plain Hermitian
 contraction), with **one** global scale fixed by the T1 anchor
 $Z_{\text{spec}}(\psi_B,\psi_B)=\langle\psi_B|\psi_B\rangle$; after that,
@@ -332,6 +344,54 @@ operation-side echo of the $b_1$-hole result in
 [the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md): surgery
 enlarges the realizable *state* space, not the realizable *gate* set.
 
+## Relation to the literature
+
+The correspondence itself is the functorial reading of field theory
+{cite}`R-Atiyah1988TQFT, R-Segal2004Definition` instantiated on discrete data;
+what this report tests is whether tessera's machinery genuinely realizes it.
+The gate-set question — *which unitaries does a topological theory realize?*
+— is the founding question of topological quantum computation
+{cite}`R-Freedman2003TQC, R-FreedmanKitaevWang2002Simulation, R-FreedmanLarsenWang2002Universal`, where the known answer-shape for abelian
+theories is a **finite** braiding/mapping-class image (the Property-F
+circle {cite}`R-NaiduRowell2011PropertyF`): the pinned $S_3$ image recorded in
+[the DW scaffold](../earlier-work/dijkgraaf-witten-scaffold.md) is exactly
+that expectation. The move that enlarged it — topology change as the
+computational operation itself — has established cousins in lattice surgery
+{cite}`R-Horsman2012LatticeSurgery` and in twist defects and genons enlarging
+the power of abelian phases
+{cite}`R-Bombin2010Twist, R-BarkeshliJianQi2013TwistDefects`, formulated there
+in stabilizer-code rather than spectral language.
+
+The spectral value reading has a precise neighborhood without, to our
+knowledge, a direct precedent. Laplacian data enter TQFT classically as
+*determinant prefactors*: abelian BF/Chern–Simons partition functions equal
+Ray–Singer analytic torsion {cite}`R-RaySinger1971RTorsion, R-Schwarz1978Torsion, R-Witten1989Jones`, reproduced on triangulations by simplicial Hodge theory
+{cite}`R-Adams1996RTorsion, R-Adams1997DoubledCS`. Harmonic zero modes serve as
+the abelian Chern–Simons state space in canonical quantization
+{cite}`R-BosNair1989Blocks`; cellular BF theory builds boundary state spaces
+from the cohomology of a cellular cobordism
+{cite}`R-CattaneoMnevReshetikhin2020Cellular`; and projections onto
+$\ker L_k$ with overlaps against harmonic representatives are the
+operational core of quantum topological-data analysis
+{cite}`R-Lloyd2016TopologicalData`. What this report adds to that neighborhood
+is the amplitude itself read as a T1-anchored Hodge pairing of carried
+harmonic representatives on a *synthesized* triangulated cobordism, validated
+against the operator amplitude at machine precision.
+
+The realizability methodology likewise has strong cousins: which boundary
+*operators* admit an interior geometry, with non-existence certified by
+obstructions rather than enumeration, is classical for circular planar
+resistor networks {cite}`R-CurtisIngermanMorrow1998Circular`; existence-as-
+optimization with rigorous non-existence certificates is the shape of the
+quantum marginal hierarchy {cite}`R-Yu2021MarginalHierarchy`; *which boundary
+data admit a bulk geometry* is the holographic entropy cone
+{cite}`R-Bao2015EntropyCone`; and least-squares formulations of inverse
+spectral problems are canonical {cite}`R-ChuGolub2005InverseEigenvalue`. The
+instantiation here — an eigenvector-residual floor on synthesized simplicial
+bulks, cross-checked against independent global minima, as the
+non-realizability certificate — is the report's own combination of those
+ingredients.
+
 ## Figures
 
 A per-output force-directed render of the simplicial complexes the experiments
@@ -410,3 +470,12 @@ Parameter sweeps, raw tables, and figures are written to `/tmp/cobordism/` and a
 artifacts; the figures above are uploaded to the
 [`issue-attachments`](https://github.com/akellehe/tessera/releases/tag/issue-attachments)
 release and embedded by URL. The 10-CPU cap is honored (thread env set at launch).
+
+## References
+
+```{bibliography}
+:filter: docname in docnames
+:keyprefix: R-
+:labelprefix: R
+:style: unsrt
+```

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -261,3 +261,402 @@
   eprint       = {1809.01197},
   archivePrefix = {arXiv}
 }
+
+% ─── State–Operation–Cobordism correspondence ────────────────────────────
+
+@article{Atiyah1988TQFT,
+  author  = {Atiyah, Michael F.},
+  title   = {Topological quantum field theories},
+  journal = {Publications Math\'ematiques de l'IH\'ES},
+  volume  = {68},
+  pages   = {175--186},
+  year    = {1988},
+  doi     = {10.1007/BF02698547}
+}
+
+@article{Oeckl2003GeneralBoundary,
+  author  = {Oeckl, Robert},
+  title   = {A ``general boundary'' formulation for quantum mechanics and quantum gravity},
+  journal = {Phys. Lett. B},
+  volume  = {575},
+  pages   = {318--324},
+  year    = {2003},
+  doi     = {10.1016/j.physletb.2003.08.043},
+  eprint  = {hep-th/0306025},
+  archivePrefix = {arXiv}
+}
+
+@article{DijkgraafWitten1990Topological,
+  author  = {Dijkgraaf, Robbert and Witten, Edward},
+  title   = {Topological gauge theories and group cohomology},
+  journal = {Commun. Math. Phys.},
+  volume  = {129},
+  pages   = {393--429},
+  year    = {1990},
+  doi     = {10.1007/BF02096988}
+}
+
+@article{FreedQuinn1993FiniteGauge,
+  author  = {Freed, Daniel S. and Quinn, Frank},
+  title   = {Chern--Simons theory with finite gauge group},
+  journal = {Commun. Math. Phys.},
+  volume  = {156},
+  pages   = {435--472},
+  year    = {1993},
+  doi     = {10.1007/BF02096860},
+  eprint  = {hep-th/9111004},
+  archivePrefix = {arXiv}
+}
+
+@article{Wakui1992DWInvariant,
+  author  = {Wakui, Michihisa},
+  title   = {On {D}ijkgraaf--{W}itten invariant for 3-manifolds},
+  journal = {Osaka J. Math.},
+  volume  = {29},
+  number  = {4},
+  pages   = {675--696},
+  year    = {1992}
+}
+
+@article{Pachner1991Shellings,
+  author  = {Pachner, Udo},
+  title   = {P.L. homeomorphic manifolds are equivalent by elementary shellings},
+  journal = {European J. Combin.},
+  volume  = {12},
+  number  = {2},
+  pages   = {129--145},
+  year    = {1991},
+  doi     = {10.1016/S0195-6698(13)80080-7}
+}
+
+@inproceedings{AbramskyCoecke2004Categorical,
+  author    = {Abramsky, Samson and Coecke, Bob},
+  title     = {A categorical semantics of quantum protocols},
+  booktitle = {Proc. 19th IEEE Symposium on Logic in Computer Science (LiCS'04)},
+  pages     = {415--425},
+  year      = {2004},
+  doi       = {10.1109/LICS.2004.1319636},
+  eprint    = {quant-ph/0402130},
+  archivePrefix = {arXiv}
+}
+
+@article{Freedman2003TQC,
+  author  = {Freedman, Michael H. and Kitaev, Alexei and Larsen, Michael J. and Wang, Zhenghan},
+  title   = {Topological quantum computation},
+  journal = {Bull. Amer. Math. Soc.},
+  volume  = {40},
+  pages   = {31--38},
+  year    = {2003},
+  doi     = {10.1090/S0273-0979-02-00964-3},
+  eprint  = {quant-ph/0101025},
+  archivePrefix = {arXiv}
+}
+
+@article{FreedmanLarsenWang2002Universal,
+  author  = {Freedman, Michael H. and Larsen, Michael J. and Wang, Zhenghan},
+  title   = {A modular functor which is universal for quantum computation},
+  journal = {Commun. Math. Phys.},
+  volume  = {227},
+  number  = {3},
+  pages   = {605--622},
+  year    = {2002},
+  doi     = {10.1007/s002200200645},
+  eprint  = {quant-ph/0001108},
+  archivePrefix = {arXiv}
+}
+
+@article{NaiduRowell2011PropertyF,
+  author  = {Naidu, Deepak and Rowell, Eric C.},
+  title   = {A finiteness property for braided fusion categories},
+  journal = {Algebr. Represent. Theory},
+  volume  = {14},
+  number  = {5},
+  pages   = {837--855},
+  year    = {2011},
+  doi     = {10.1007/s10468-010-9219-5},
+  eprint  = {0903.4157},
+  archivePrefix = {arXiv}
+}
+
+@article{Horsman2012LatticeSurgery,
+  author  = {Horsman, Clare and Fowler, Austin G. and Devitt, Simon and Van Meter, Rodney},
+  title   = {Surface code quantum computing by lattice surgery},
+  journal = {New J. Phys.},
+  volume  = {14},
+  pages   = {123011},
+  year    = {2012},
+  doi     = {10.1088/1367-2630/14/12/123011},
+  eprint  = {1111.4022},
+  archivePrefix = {arXiv}
+}
+
+@incollection{Segal2004Definition,
+  author    = {Segal, Graeme},
+  title     = {The definition of conformal field theory},
+  booktitle = {Topology, Geometry and Quantum Field Theory},
+  editor    = {Tillmann, Ulrike},
+  series    = {London Mathematical Society Lecture Note Series},
+  volume    = {308},
+  publisher = {Cambridge University Press},
+  pages     = {421--577},
+  year      = {2004},
+  doi       = {10.1017/CBO9780511526398.019},
+  note      = {Manuscript circulated from 1988}
+}
+
+@article{HartleHawking1983WaveFunction,
+  author  = {Hartle, James B. and Hawking, Stephen W.},
+  title   = {Wave function of the {U}niverse},
+  journal = {Phys. Rev. D},
+  volume  = {28},
+  pages   = {2960--2975},
+  year    = {1983},
+  doi     = {10.1103/PhysRevD.28.2960}
+}
+
+@article{Choi1975CompletelyPositive,
+  author  = {Choi, Man-Duen},
+  title   = {Completely positive linear maps on complex matrices},
+  journal = {Linear Algebra Appl.},
+  volume  = {10},
+  number  = {3},
+  pages   = {285--290},
+  year    = {1975},
+  doi     = {10.1016/0024-3795(75)90075-0}
+}
+
+@article{Jamiolkowski1972LinearTransformations,
+  author  = {Jamio{\l}kowski, Andrzej},
+  title   = {Linear transformations which preserve trace and positive semidefiniteness of operators},
+  journal = {Rep. Math. Phys.},
+  volume  = {3},
+  number  = {4},
+  pages   = {275--278},
+  year    = {1972},
+  doi     = {10.1016/0034-4877(72)90011-0}
+}
+
+@article{Nielsen2003DynamicsResource,
+  author  = {Nielsen, Michael A. and Dawson, Christopher M. and Dodd, Jennifer L. and Gilchrist, Alexei and Mortimer, Duncan and Osborne, Tobias J. and Bremner, Michael J. and Harrow, Aram W. and Hines, Andrew},
+  title   = {Quantum dynamics as a physical resource},
+  journal = {Phys. Rev. A},
+  volume  = {67},
+  pages   = {052301},
+  year    = {2003},
+  doi     = {10.1103/PhysRevA.67.052301},
+  eprint  = {quant-ph/0208077},
+  archivePrefix = {arXiv}
+}
+
+@article{FreedmanKitaevWang2002Simulation,
+  author  = {Freedman, Michael H. and Kitaev, Alexei and Wang, Zhenghan},
+  title   = {Simulation of topological field theories by quantum computers},
+  journal = {Commun. Math. Phys.},
+  volume  = {227},
+  number  = {3},
+  pages   = {587--603},
+  year    = {2002},
+  doi     = {10.1007/s002200200635},
+  eprint  = {quant-ph/0001071},
+  archivePrefix = {arXiv}
+}
+
+@article{Bombin2010Twist,
+  author  = {Bombin, H{\'e}ctor},
+  title   = {Topological order with a twist: {I}sing anyons from an {A}belian model},
+  journal = {Phys. Rev. Lett.},
+  volume  = {105},
+  pages   = {030403},
+  year    = {2010},
+  doi     = {10.1103/PhysRevLett.105.030403},
+  eprint  = {1004.1838},
+  archivePrefix = {arXiv}
+}
+
+@article{BarkeshliJianQi2013TwistDefects,
+  author  = {Barkeshli, Maissam and Jian, Chao-Ming and Qi, Xiao-Liang},
+  title   = {Twist defects and projective non-{A}belian braiding statistics},
+  journal = {Phys. Rev. B},
+  volume  = {87},
+  pages   = {045130},
+  year    = {2013},
+  doi     = {10.1103/PhysRevB.87.045130},
+  eprint  = {1208.4834},
+  archivePrefix = {arXiv}
+}
+
+@article{Eckmann1945Harmonische,
+  author  = {Eckmann, Beno},
+  title   = {Harmonische {F}unktionen und {R}andwertaufgaben in einem {K}omplex},
+  journal = {Comment. Math. Helv.},
+  volume  = {17},
+  pages   = {240--255},
+  year    = {1945},
+  doi     = {10.1007/BF02566245}
+}
+
+@article{Lim2020HodgeLaplacians,
+  author  = {Lim, Lek-Heng},
+  title   = {Hodge {L}aplacians on graphs},
+  journal = {SIAM Review},
+  volume  = {62},
+  number  = {3},
+  pages   = {685--715},
+  year    = {2020},
+  doi     = {10.1137/18M1223101},
+  eprint  = {1507.05379},
+  archivePrefix = {arXiv}
+}
+
+@article{RaySinger1971RTorsion,
+  author  = {Ray, Daniel B. and Singer, Isadore M.},
+  title   = {R-torsion and the {L}aplacian on {R}iemannian manifolds},
+  journal = {Adv. Math.},
+  volume  = {7},
+  number  = {2},
+  pages   = {145--210},
+  year    = {1971},
+  doi     = {10.1016/0001-8708(71)90045-4}
+}
+
+@article{Schwarz1978Torsion,
+  author  = {Schwarz, Albert S.},
+  title   = {The partition function of degenerate quadratic functional and {R}ay--{S}inger invariants},
+  journal = {Lett. Math. Phys.},
+  volume  = {2},
+  number  = {3},
+  pages   = {247--252},
+  year    = {1978},
+  doi     = {10.1007/BF00406412}
+}
+
+@article{Witten1989Jones,
+  author  = {Witten, Edward},
+  title   = {Quantum field theory and the {J}ones polynomial},
+  journal = {Commun. Math. Phys.},
+  volume  = {121},
+  number  = {3},
+  pages   = {351--399},
+  year    = {1989},
+  doi     = {10.1007/BF01217730}
+}
+
+@misc{Adams1996RTorsion,
+  author        = {Adams, David H.},
+  title         = {R-torsion and linking numbers from simplicial abelian gauge theories},
+  howpublished  = {arXiv preprint},
+  year          = {1996},
+  eprint        = {hep-th/9612009},
+  archivePrefix = {arXiv}
+}
+
+@article{Adams1997DoubledCS,
+  author  = {Adams, David H.},
+  title   = {A doubled discretization of abelian {C}hern--{S}imons theory},
+  journal = {Phys. Rev. Lett.},
+  volume  = {78},
+  number  = {22},
+  pages   = {4155--4158},
+  year    = {1997},
+  doi     = {10.1103/PhysRevLett.78.4155},
+  eprint  = {hep-th/9704150},
+  archivePrefix = {arXiv}
+}
+
+@article{Pachner1987Bistellar,
+  author  = {Pachner, Udo},
+  title   = {Konstruktionsmethoden und das kombinatorische {H}om{\"o}omorphieproblem f{\"u}r {T}riangulationen kompakter semilinearer {M}annigfaltigkeiten},
+  journal = {Abh. Math. Sem. Univ. Hamburg},
+  volume  = {57},
+  pages   = {69--86},
+  year    = {1987},
+  doi     = {10.1007/BF02941601}
+}
+
+@article{DVVV1989Orbifold,
+  author  = {Dijkgraaf, Robbert and Vafa, Cumrun and Verlinde, Erik and Verlinde, Herman},
+  title   = {The operator algebra of orbifold models},
+  journal = {Commun. Math. Phys.},
+  volume  = {123},
+  number  = {3},
+  pages   = {485--526},
+  year    = {1989},
+  doi     = {10.1007/BF01238812}
+}
+
+@article{CattaneoMnevReshetikhin2020Cellular,
+  author  = {Cattaneo, Alberto S. and Mnev, Pavel and Reshetikhin, Nicolai},
+  title   = {A cellular topological field theory},
+  journal = {Commun. Math. Phys.},
+  volume  = {374},
+  pages   = {1229--1320},
+  year    = {2020},
+  doi     = {10.1007/s00220-020-03687-3},
+  eprint  = {1701.05874},
+  archivePrefix = {arXiv}
+}
+
+@article{BosNair1989Blocks,
+  author  = {Bos, Marcel and Nair, V. Parameswaran},
+  title   = {{U(1)} {C}hern--{S}imons theory and c=1 conformal blocks},
+  journal = {Phys. Lett. B},
+  volume  = {223},
+  pages   = {61--66},
+  year    = {1989},
+  doi     = {10.1016/0370-2693(89)90920-9}
+}
+
+@article{Lloyd2016TopologicalData,
+  author  = {Lloyd, Seth and Garnerone, Silvano and Zanardi, Paolo},
+  title   = {Quantum algorithms for topological and geometric analysis of data},
+  journal = {Nature Commun.},
+  volume  = {7},
+  pages   = {10138},
+  year    = {2016},
+  doi     = {10.1038/ncomms10138},
+  eprint  = {1408.3106},
+  archivePrefix = {arXiv}
+}
+
+@article{CurtisIngermanMorrow1998Circular,
+  author  = {Curtis, Edward B. and Ingerman, David and Morrow, James A.},
+  title   = {Circular planar graphs and resistor networks},
+  journal = {Linear Algebra Appl.},
+  volume  = {283},
+  number  = {1--3},
+  pages   = {115--150},
+  year    = {1998},
+  doi     = {10.1016/S0024-3795(98)10087-3}
+}
+
+@article{Yu2021MarginalHierarchy,
+  author  = {Yu, Xiao-Dong and Simnacher, Timo and Wyderka, Nikolai and Nguyen, H. Chau and G{\"u}hne, Otfried},
+  title   = {A complete hierarchy for the pure state marginal problem in quantum mechanics},
+  journal = {Nature Commun.},
+  volume  = {12},
+  pages   = {1012},
+  year    = {2021},
+  doi     = {10.1038/s41467-020-20799-5},
+  eprint  = {2008.02124},
+  archivePrefix = {arXiv}
+}
+
+@article{Bao2015EntropyCone,
+  author  = {Bao, Ning and Nezami, Sepehr and Ooguri, Hirosi and Stoica, Bogdan and Sully, James and Walter, Michael},
+  title   = {The holographic entropy cone},
+  journal = {JHEP},
+  volume  = {09},
+  pages   = {130},
+  year    = {2015},
+  doi     = {10.1007/JHEP09(2015)130},
+  eprint  = {1505.07839},
+  archivePrefix = {arXiv}
+}
+
+@book{ChuGolub2005InverseEigenvalue,
+  author    = {Chu, Moody T. and Golub, Gene H.},
+  title     = {Inverse Eigenvalue Problems: Theory, Algorithms, and Applications},
+  publisher = {Oxford University Press},
+  year      = {2005},
+  doi       = {10.1093/acprof:oso/9780198566649.001.0001}
+}

--- a/docs/source/wilson_loops.md
+++ b/docs/source/wilson_loops.md
@@ -37,7 +37,7 @@ analogue is the holonomy of the Levi-Civita connection, which in 2D
 reduces to $W = \cos(\sum_h \varepsilon_h)$ with $\varepsilon_h$ the
 deficit angle at each enclosed hinge, and in higher $d$ obeys
 $W = \frac{(d-2) + 2\cos\varepsilon}{d}$ for an elementary hinge loop
-in U(1) approximation {cite}`Regge1961,Williams1992`. tessera computes
+in U(1) approximation {cite}`B-Regge1961, B-Williams1992`. tessera computes
 exactly this in `DEFICIT_ANGLE` mode; the other two modes give
 complementary topological and causal probes of the same loop.
 
@@ -359,12 +359,21 @@ holonomy up to choice of normal frame. Higher-rank Wilson loops
 
 ## Reading list
 
-* {cite}`Regge1961` — Regge's discrete general relativity and deficit
+* {cite}`B-Regge1961` — Regge's discrete general relativity and deficit
   angles.
-* {cite}`Williams1992` — Wilson loops on Regge triangulations.
-* {cite}`AmbjornJurkiewiczLoll2005` — causal dynamical triangulations,
+* {cite}`B-Williams1992` — Wilson loops on Regge triangulations.
+* {cite}`B-AmbjornJurkiewiczLoll2005` — causal dynamical triangulations,
   causal foliation, time-orientation structure.
 
 See also `docs/source/theory.md` for the broader Regge / CDT
 background and `docs/source/simplices.md` for the mesh primitives that
 underlie `LoopPath`.
+
+## References
+
+```{bibliography}
+:filter: docname in docnames
+:keyprefix: B-
+:labelprefix: B
+:style: unsrt
+```


### PR DESCRIPTION
## Summary

Per #255: the results report and the DW scaffold cite the canonical literature behind their claims, sourced from a two-pass deep-research sweep (every reference adversarially verified against the publisher/arXiv record; the handful of DOIs filled from background knowledge re-confirmed via Crossref).

- **35 new entries in `references.bib`** (house key convention, doi+eprint).
- **`cobordism-results.md`**: `{cite}` markers at the claims they back — the functorial/boundary-state reading (Atiyah, Segal, Hartle–Hawking, Oeckl), Choi–Jamiołkowski bending + operator-Schmidt rank (Choi, Jamiołkowski, Abramsky–Coecke, Nielsen et al.), the Pachner test (1987 + 1991 — wording matters: closed-manifold bistellar equivalence is the 1987 theorem), and discrete Hodge theory at the spectral value (Eckmann, Lim). A new native **Relation to the literature** section positions the two distinctive moves against the sweep's verified closest prior art: the torsion line (Ray–Singer, Schwarz, Witten, Adams ×2), zero-mode quantization (Bos–Nair), cellular BF on cobordisms (Cattaneo–Mnev–Reshetikhin), and quantum TDA (Lloyd–Garnerone–Zanardi) for the Hodge value reading; circular-planar resistor networks (Curtis–Ingerman–Morrow), the marginal-problem hierarchy (Yu et al.), the holographic entropy cone (Bao et al.), and inverse eigenvalue problems (Chu–Golub) for the residual-floor certificates — plus the TQC gate-set frame (FKLW trio, Naidu–Rowell) and topology-change-as-operation cousins (Horsman et al., Bombin, Barkeshli–Jian–Qi).
- **`dijkgraaf-witten-scaffold.md`**: the DW canon (Dijkgraaf–Witten 1990, Wakui 1992, Freed–Quinn 1993, DVVV 1989, Pachner 1987+1991) and the finite-abelian-image expectation at the pinned $S_3$ result.
- **Bibliography plumbing**: every citing page now carries a page-local bibliography (`:filter: docname in docnames` + per-page `:keyprefix:`), fixing a latent wart — `wilson_loops` and `causal_sets` cited entries that only rendered on the causal-order charter's unfiltered global list.

## Test plan

- [x] All 35 new bibliographic records sweep-verified; 13 spot-checked DOIs resolve to the right papers via Crossref
- [x] `doxygen` + `sphinx-build -E`: **0 warnings** (duplicate-citation collisions resolved via keyprefixes)
- [x] All five citing pages render their own reference lists; href sweep clean
- [ ] After merge: pages deploy green; References sections live

Closes #255.