### PR TITLE
feat(cobordism): Regge-mediated synthesis search (F_β = r_U + β·S_Regge)

### DIFF
--- a/include/cobordism/RealizabilityOracle.h
+++ b/include/cobordism/RealizabilityOracle.h
@@ -214,6 +214,15 @@ class RealizabilityOracle {
       /// (`Surgery` mode only; 0 otherwise). Each is a topology-changing move that
       /// can shift \f$ b_k \f$ of the witness — the emergent-topology trace.
       int surgeryRemovals{0};
+      /// The realized geometry's **dual Lorentzian Regge action magnitude**
+      /// \f$ |S_{\mathrm{Regge}}(W^{*})| \f$ — the modulus of
+      /// `ReggeSolver::dualReggeAction` on the witness's circumcentric dual. The
+      /// gravitational cost the mediated objective \f$ F_\beta=r_U+\beta\,|S| \f$
+      /// trades against the residual; reported at every \f$ \beta \f$ (including
+      /// the \f$ \beta=0 \f$ base layer, so the \f$ \beta \f$-sweep can compare the
+      /// chosen fillings' action). \f$ 0 \f$ if the witness has no hinges. Not
+      /// finite (and logged) if the realized geometry is degenerate.
+      double reggeAction{0.0};
       /// The realized bulk \f$ W_{AB} \f$ — the witness cobordism (realizable),
       /// or the complex on which the residual floors (non-realizable).
       std::shared_ptr<Spacetime> witness{};
@@ -254,13 +263,29 @@ class RealizabilityOracle {
     ///                  (eigenvalue \f$ \to 0 \f$), i.e. the boundary class lies in
     ///                  \f$ \mathrm{image}(H_k(\partial W)\to H_k(W)) \f$ — the
     ///                  physical realizability test that distinguishes topologies.
+    /// @param beta      coupling of the **mediated objective**
+    ///                  \f$ F_\beta=r_U+\beta\,|S_{\mathrm{Regge}}(W^{*})| \f$:
+    ///                  candidate moves are scored by \f$ F_\beta \f$ (the
+    ///                  realizability residual plus \f$ \beta \f$ times the dual
+    ///                  Regge action **magnitude** on the candidate's dual), so
+    ///                  the search prefers gravitationally cheaper fillings.
+    ///                  \f$ \beta=0 \f$ (default) reproduces the base-layer search
+    ///                  **bit-for-bit** (the \f$ |S| \f$ term is not even computed).
+    ///                  Only the cone+surgery move-sets (`Surgery`,
+    ///                  `SurgeryAndCone`) act on it; realizability is still the
+    ///                  primal \f$ r_U<\epsilon \f$, so a large \f$ \beta \f$ can
+    ///                  starve a gate of an improving move and drop it from the set.
+    /// @param maxVertices the volume bound \f$ \abs{W} \f$: additive growth stops
+    ///                  once the bulk reaches this many vertices (the conformal-mode
+    ///                  regularizer). Surgery (removal) is unaffected.
     [[nodiscard]] Verdict decide(const std::vector<std::complex<double>> &U,
                                  int dA, int dB, double epsilon = 1e-10,
                                  int restarts = 64, int maxCones = 4,
                                  std::uint64_t seed = 0,
                                  GrowthMode mode = GrowthMode::Cone,
                                  int connectivityCandidates = 8,
-                                 bool harmonic = false);
+                                 bool harmonic = false, double beta = 0.0,
+                                 int maxVertices = 16);
 
     /// Decide whether a target **boundary harmonic** \f$ k \f$-form (\f$ k =
     /// \texttt{target.degree()} \f$, the \f$ k=1 \f$ DW setting) is realizable on
@@ -298,12 +323,18 @@ class RealizabilityOracle {
     ///                  \f$. The default (`false`) keeps the eigenvalue-agnostic
     ///                  residual (any eigenvalue), which is under-constrained on
     ///                  small boundaries (it accepts a non-harmonic eigenvector).
+    /// @param beta      coupling of the mediated objective
+    ///                  \f$ F_\beta=r_U+\beta\,|S_{\mathrm{Regge}}(W^{*})| \f$
+    ///                  (see `decide`); \f$ \beta=0 \f$ reproduces the base layer
+    ///                  bit-for-bit.
+    /// @param maxVertices the \f$ \abs{W} \f$ volume bound on additive growth.
     [[nodiscard]] Verdict decideHarmonic(const Cochain &target,
                                          double epsilon = 1e-10, int restarts = 64,
                                          int maxCones = 4, std::uint64_t seed = 0,
                                          GrowthMode mode = GrowthMode::Cone,
                                          int connectivityCandidates = 8,
-                                         bool harmonic = false);
+                                         bool harmonic = false, double beta = 0.0,
+                                         int maxVertices = 16);
 
   private:
     // §4b search box — identical to GeometrySynthesizer so the interior fill is
@@ -345,10 +376,10 @@ class RealizabilityOracle {
         const std::map<std::vector<std::uint64_t>, std::complex<double>>
             &pinnedByTuple,
         double epsilon, int restarts, int maxCones, std::uint64_t seed,
-        GrowthMode mode, int connectivityCandidates, bool harmonic,
-        std::vector<std::complex<double>> &witnessOut, int &conesApplied,
-        int &candidatesOut, int &triangleCandidatesOut, int &surgeryRemovals,
-        std::size_t &spaceSizeOut) const;
+        GrowthMode mode, int connectivityCandidates, bool harmonic, double beta,
+        int maxVertices, std::vector<std::complex<double>> &witnessOut,
+        int &conesApplied, int &candidatesOut, int &triangleCandidatesOut,
+        int &surgeryRemovals, std::size_t &spaceSizeOut) const;
 
     // One fixed-complex optimization pass over the current `es`: the
     // multi-restart bounded Levenberg–Marquardt on r(psi) for the target encoded
@@ -371,12 +402,31 @@ class RealizabilityOracle {
     // committed move is topology-changing — it can shift b_k — so the realized
     // bulk topology is what the residual selects. Returns true (and increments
     // `removalsOut`) iff a removal was committed.
+    //
+    // `beta` activates the **mediated** score: a removal candidate is ranked by
+    // \f$ F_\beta=r_U+\beta\,|S_{\mathrm{Regge}}(W^{*})| \f$ rather than \f$ r_U \f$
+    // alone, and committed iff it improves \f$ F_\beta \f$ over the current
+    // complex — so the surgery the search keeps is the one that best trades
+    // residual against gravitational action. With `beta == 0` the \f$ |S| \f$ term
+    // is not computed and the ranking/commit rule is byte-for-byte the historical
+    // residual-only one.
     [[nodiscard]] bool growBestSurgery(
         EigenstateSynthesis &es,
         const std::map<std::vector<std::uint64_t>, std::complex<double>>
             &pinnedByTuple,
         double epsilon, int restarts, std::uint64_t seed, bool harmonic,
-        double currentResidual, int &removalsOut) const;
+        double currentResidual, double beta, int &removalsOut) const;
+
+    // The mediated objective term: the magnitude of the dual Lorentzian Regge
+    // action on the **current** complex held by `bulk_` (which `es` mutates in
+    // place), \f$ |S_{\mathrm{Regge}}(W^{*})| =
+    // |\texttt{ReggeSolver::dualReggeAction}| \f$. Builds the ReggeSolver in C++
+    // (its ctor materializes the facet/coface lattice the dual volumes need; the
+    // added sub-simplices are invisible to the top-cell-filtered fill, verified
+    // byte-for-byte). A degenerate geometry (non-finite action) is logged and
+    // returned as +infinity so the offending candidate is rejected by the
+    // min-\f$ F_\beta \f$ selection — surfaced, never silently repaired.
+    [[nodiscard]] double reggeActionMagnitude() const;
 
     // One free-connectivity growth step. Generates the bounded candidate breadth
     // — edge fans at every degree and, at k>=1, the triangle (2-simplex) fans the

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -662,6 +662,14 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
                     "(SURGERY mode only; 0 otherwise). Each is a topology-changing "
                     "move that can shift b_k of the witness — the emergent-topology "
                     "trace (read the grown b_k off the witness with ChainComplex).")
+      .def_readonly("regge_action", &RealizabilityOracle::Verdict::reggeAction,
+                    "The realized geometry's dual Lorentzian Regge action magnitude "
+                    "|S_Regge(W*)| (modulus of ReggeSolver.dualReggeAction on the "
+                    "witness's circumcentric dual) — the gravitational cost the "
+                    "mediated objective F_beta = r_U + beta*|S| trades against the "
+                    "residual. Reported at every beta (incl. the beta=0 base layer, "
+                    "so the beta-sweep can compare fillings). 0 if no hinges; "
+                    "non-finite (and logged) if the realized geometry is degenerate.")
       .def_readonly("state", &RealizabilityOracle::Verdict::state,
                     "The witness state: the realized unit Laplacian eigenvector on "
                     "W_AB (length = the bulk's vertex count); its first dA*dB "
@@ -684,6 +692,7 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
            py::arg("max_cones") = 4, py::arg("seed") = 0,
            py::arg("growth_mode") = RealizabilityOracle::GrowthMode::Cone,
            py::arg("connectivity_candidates") = 8, py::arg("harmonic") = false,
+           py::arg("beta") = 0.0, py::arg("max_vertices") = 16,
            "Decide whether the dA x dB operator U (flat row-major) is realizable "
            "as a bulk cobordism: bend it to vec(U), fill the pinned-boundary "
            "interior to drive the §4b residual to zero (multi-restart "
@@ -693,13 +702,19 @@ decide() realizes the held bulk in place and returns it as the witness.)doc");
            "growth; growth_mode=FREE_CONNECTIVITY searches connectivity_candidates "
            "interior connectivities per growth step and keeps the best by residual "
            "(the new vertex's incidence is a free variable; topology is emergent). "
-           "Realizes the held bulk in place. Raises if U.size() != dA*dB, a "
+           "beta>0 activates the MEDIATED objective F_beta = r_U + beta*|S_Regge(W*)|: "
+           "cone+surgery candidates are ranked by the residual plus beta times the "
+           "dual Regge action magnitude, so the search prefers gravitationally "
+           "cheaper fillings (beta=0 reproduces the base layer bit-for-bit; |S| is "
+           "not even computed). max_vertices is the |W| volume bound on additive "
+           "growth. Realizes the held bulk in place. Raises if U.size() != dA*dB, a "
            "dimension is non-positive, or the bulk has fewer vertices than dA*dB.")
       .def("decideHarmonic", &RealizabilityOracle::decideHarmonic,
            py::arg("target"), py::arg("epsilon") = 1e-10, py::arg("restarts") = 64,
            py::arg("max_cones") = 4, py::arg("seed") = 0,
            py::arg("growth_mode") = RealizabilityOracle::GrowthMode::Cone,
            py::arg("connectivity_candidates") = 8, py::arg("harmonic") = false,
+           py::arg("beta") = 0.0, py::arg("max_vertices") = 16,
            "Decide whether a target boundary harmonic k-form (a degree-k Cochain, "
            "k = target.degree(); the k=1 DW setting) is realizable on the held "
            "3-manifold-with-boundary bulk W: pin the boundary surface dW byte-"

--- a/src/cobordism/RealizabilityOracle.cpp
+++ b/src/cobordism/RealizabilityOracle.cpp
@@ -37,7 +37,9 @@
 #include "cobordism/Cochain.h"
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/LevenbergMarquardt.h"
+#include "matter/MatterConfiguration.h"
 #include "quantum/ChoiJamiolkowski.h"
+#include "simulations/ReggeSolver.h"
 #include "spacetime/Spacetime.h"
 
 namespace tessera::cobordism {
@@ -394,11 +396,36 @@ bool RealizabilityOracle::growBestConnectivity(
   return es.growInterior(seed);
 }
 
+double RealizabilityOracle::reggeActionMagnitude() const {
+  // |S_Regge(W*)|: build the ReggeSolver on the live bulk_ (its ctor materializes
+  // the facet/coface lattice the dual volumes walk; the added sub-simplices are
+  // sub-top, so the top-cell-filtered fill is unaffected — verified byte-for-bit).
+  // A degenerate geometry yields a non-finite action; log it and return +inf so
+  // the candidate is rejected by the min-F_beta selection (surfaced, not masked).
+  try {
+    const cd S = ::tessera::simulations::ReggeSolver(
+                     bulk_, ::tessera::MatterConfiguration())
+                     .dualReggeAction();
+    const double mag = std::abs(S);
+    if (!std::isfinite(mag)) {
+      CLOG(WARN_LEVEL,
+           "reggeActionMagnitude: non-finite dual Regge action |S|=", mag,
+           " (degenerate geometry); rejecting candidate");
+      return std::numeric_limits<double>::infinity();
+    }
+    return mag;
+  } catch (const std::exception &e) {
+    CLOG(WARN_LEVEL, "reggeActionMagnitude: dual Regge action failed (", e.what(),
+         ") (degenerate geometry); rejecting candidate");
+    return std::numeric_limits<double>::infinity();
+  }
+}
+
 bool RealizabilityOracle::growBestSurgery(
     EigenstateSynthesis &es,
     const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
     int restarts, std::uint64_t seed, bool harmonic, double currentResidual,
-    int &removalsOut) const {
+    double beta, int &removalsOut) const {
   // Enumerate the topology-changing candidates: every interior top cell whose
   // removal opens a hole/handle with ∂W held bit-exact. Score each by the
   // residual it reaches after the weight optimization (try → score → restore),
@@ -407,10 +434,19 @@ bool RealizabilityOracle::growBestSurgery(
   // still has its support). The committed move shifts b_k — emergent topology.
   const std::vector<std::vector<std::uint64_t>> cells = es.interiorTopCells();
   CLOG(INFO_LEVEL, "surgery grow (k=", es.degree(), "): scoring ", cells.size(),
-       " interior-top-cell removals against residual ", currentResidual);
+       " interior-top-cell removals by ", (beta > 0.0 ? "F_beta" : "residual"),
+       " against ", currentResidual, " (beta=", beta, ")");
   if (cells.empty()) return false;
 
-  double bestR = currentResidual;
+  // The mediated score F_β = r_U + β·|S_Regge(W*)|: |S| is read on whichever
+  // complex is live at the call. β=0 ⇒ |S| is never computed and the ranking is
+  // byte-for-byte the historical residual-only rule.
+  const auto score = [this, beta](double r) {
+    return beta > 0.0 ? r + beta * reggeActionMagnitude() : r;
+  };
+  const double currentScore = score(currentResidual);  // current complex is live
+
+  double bestScore = currentScore;
   std::vector<std::uint64_t> bestCell;
   std::vector<cd> tmpWitness;
   for (std::size_t c = 0; c < cells.size(); ++c) {
@@ -429,14 +465,15 @@ bool RealizabilityOracle::growBestSurgery(
           optimizePass(es, pinnedByTuple, epsilon, restarts,
                        seed + 1 + static_cast<std::uint64_t>(c), harmonic,
                        tmpWitness);
-      if (r < bestR) {
-        bestR = r;
+      const double s = score(r);  // candidate complex is live
+      if (s < bestScore) {
+        bestScore = s;
         bestCell = cells[c];
       }
     }
     es.restoreLastRemoval();
   }
-  if (bestCell.empty()) return false;  // no improving removal
+  if (bestCell.empty()) return false;  // no F_β-improving removal
   if (!es.removeInteriorCell(bestCell)) return false;
   ++removalsOut;
   return true;
@@ -446,9 +483,17 @@ double RealizabilityOracle::fillInterior(
     EigenstateSynthesis &es,
     const std::map<std::vector<std::uint64_t>, cd> &pinnedByTuple, double epsilon,
     int restarts, int maxCones, std::uint64_t seed, GrowthMode mode,
-    int connectivityCandidates, bool harmonic, std::vector<cd> &witnessOut,
-    int &conesApplied, int &candidatesOut, int &triangleCandidatesOut,
-    int &surgeryRemovals, std::size_t &spaceSizeOut) const {
+    int connectivityCandidates, bool harmonic, double beta, int maxVertices,
+    std::vector<cd> &witnessOut, int &conesApplied, int &candidatesOut,
+    int &triangleCandidatesOut, int &surgeryRemovals,
+    std::size_t &spaceSizeOut) const {
+  // |W| volume bound: additive growth (cone / free-connectivity) stops once the
+  // bulk reaches maxVertices vertices — the conformal-mode regularizer. Surgery
+  // (removal) never adds vertices, so it is never gated by this.
+  const auto atVertexCap = [this, maxVertices]() {
+    return bulk_ && bulk_->getVertexList() &&
+           static_cast<int>(bulk_->getVertexList()->size()) >= maxVertices;
+  };
   double bestR = std::numeric_limits<double>::infinity();
   conesApplied = 0;
   candidatesOut = 0;
@@ -475,8 +520,8 @@ double RealizabilityOracle::fillInterior(
       // improving-only rule and the finite interior-cell set.
       grew = growBestSurgery(es, pinnedByTuple, epsilon, restarts,
                              seed + 1000 + static_cast<std::uint64_t>(cone),
-                             harmonic, bestR, surgeryRemovals);
-      if (!grew && conesUsed < maxCones) {
+                             harmonic, bestR, beta, surgeryRemovals);
+      if (!grew && conesUsed < maxCones && !atVertexCap()) {
         // The additive fallback rides the Pachner add; on complexes where the
         // move proposer cannot produce a valid cone (it can throw on degenerate
         // proposals) the step is logged and skipped — the verdict then floors
@@ -493,10 +538,15 @@ double RealizabilityOracle::fillInterior(
     } else {
       if (cone >= maxCones) break;
       if (mode == GrowthMode::Surgery)
-        // The topology-changing move-set: commit the best b_k-shifting removal.
+        // The topology-changing move-set: commit the best b_k-shifting removal
+        // (no vertex added, so the |W| cap never gates it).
         grew = growBestSurgery(es, pinnedByTuple, epsilon, restarts,
                                seed + 1000 + static_cast<std::uint64_t>(cone),
-                               harmonic, bestR, surgeryRemovals);
+                               harmonic, bestR, beta, surgeryRemovals);
+      else if (atVertexCap())
+        // The additive modes (free-connectivity / cone) each add a vertex; stop
+        // at the |W| volume bound.
+        break;
       else if (mode == GrowthMode::FreeConnectivity)
         grew = growBestConnectivity(
             es, pinnedByTuple, epsilon, restarts,
@@ -515,7 +565,7 @@ double RealizabilityOracle::fillInterior(
 RealizabilityOracle::Verdict RealizabilityOracle::decide(
     const std::vector<cd> &U, int dA, int dB, double epsilon, int restarts,
     int maxCones, std::uint64_t seed, GrowthMode mode,
-    int connectivityCandidates, bool harmonic) {
+    int connectivityCandidates, bool harmonic, double beta, int maxVertices) {
   const std::vector<cd> target = bend(U, dA, dB);  // ψ_U, length dA·dB
 
   EigenstateSynthesis es(bulk_);  // k = 0: the vertex graph Laplacian
@@ -535,17 +585,21 @@ RealizabilityOracle::Verdict RealizabilityOracle::decide(
 
   Verdict v;
   v.target = target;
-  const double r = fillInterior(es, pinnedByTuple, epsilon, restarts, maxCones,
-                                seed, mode, connectivityCandidates, harmonic,
-                                v.state, v.conesApplied, v.connectivityCandidates,
-                                v.triangleCandidates, v.surgeryRemovals,
-                                v.connectivitySpaceSize);
+  const double r = fillInterior(
+      es, pinnedByTuple, epsilon, restarts, maxCones, seed, mode,
+      connectivityCandidates, harmonic, beta, maxVertices, v.state,
+      v.conesApplied, v.connectivityCandidates, v.triangleCandidates,
+      v.surgeryRemovals, v.connectivitySpaceSize);
   v.residual = r;
   v.realizable = (r < epsilon);
   v.floor = v.realizable ? 0.0 : r;
   v.eigenvalue = es.rayleigh(v.state);
   v.interiorVertexCount = es.interiorVertexCount();
   v.interiorEdgeCount = es.numInteriorEdges();
+  // Report the realized geometry's gravitational cost |S_Regge(W*)| at every β
+  // (so the β-sweep can compare fillings). Computed on the realized witness;
+  // independent of the search path, so the β=0 decision is unchanged.
+  v.reggeAction = reggeActionMagnitude();
   v.witness = bulk_;
   return v;
 }
@@ -553,7 +607,7 @@ RealizabilityOracle::Verdict RealizabilityOracle::decide(
 RealizabilityOracle::Verdict RealizabilityOracle::decideHarmonic(
     const Cochain &target, double epsilon, int restarts, int maxCones,
     std::uint64_t seed, GrowthMode mode, int connectivityCandidates,
-    bool harmonic) {
+    bool harmonic, double beta, int maxVertices) {
   const int k = target.degree();
   if (k < 0 || target.size() == 0)
     throw std::invalid_argument(
@@ -602,17 +656,21 @@ RealizabilityOracle::Verdict RealizabilityOracle::decideHarmonic(
   // growBestConnectivity additionally proposes triangle (2-simplex) attachments,
   // and those are NOT spectrally inert here. The candidate breadth (edge fans +
   // triangle fans) is surfaced in the Verdict and logged.
-  const double r = fillInterior(es, pinnedByTuple, epsilon, restarts, maxCones,
-                                seed, mode, connectivityCandidates, harmonic,
-                                v.state, v.conesApplied, v.connectivityCandidates,
-                                v.triangleCandidates, v.surgeryRemovals,
-                                v.connectivitySpaceSize);
+  const double r = fillInterior(
+      es, pinnedByTuple, epsilon, restarts, maxCones, seed, mode,
+      connectivityCandidates, harmonic, beta, maxVertices, v.state,
+      v.conesApplied, v.connectivityCandidates, v.triangleCandidates,
+      v.surgeryRemovals, v.connectivitySpaceSize);
   v.residual = r;
   v.realizable = (r < epsilon);
   v.floor = v.realizable ? 0.0 : r;
   v.eigenvalue = es.rayleigh(v.state);
   v.interiorVertexCount = es.interiorVertexCount();
   v.interiorEdgeCount = es.numInteriorEdges();
+  // Report the realized geometry's gravitational cost |S_Regge(W*)| at every β
+  // (so the β-sweep can compare fillings). Computed on the realized witness;
+  // independent of the search path, so the β=0 decision is unchanged.
+  v.reggeAction = reggeActionMagnitude();
   v.witness = bulk_;
   return v;
 }

--- a/tests/cobordism/test_mediated_synthesis_python.py
+++ b/tests/cobordism/test_mediated_synthesis_python.py
@@ -1,0 +1,210 @@
+"""Regge-mediated synthesis search (#248).
+
+The realizability search scored by the mediated objective
+``F_β(W) = r_U(W) + β·|S_Regge(W*)|``: the §4b realizability residual on the
+primal Laplacian plus β times the magnitude of the dual Lorentzian Regge action
+(``ReggeSolver.dualReggeAction``, #247) on the candidate's circumcentric dual.
+
+What's covered here (all deterministic — the surgery move ``removeInteriorCell``
+is deterministic; the additive Pachner cone ``growInterior`` is not, so these
+tests never depend on a cone firing):
+
+  * β=0 reproduces the base-layer verdict **bit-for-bit** (the |S| term is not
+    even computed) — both that the default call and an explicit ``beta=0`` agree,
+    and that the realizability decision/residual are unchanged.
+  * ``regge_action`` (the realized |S_Regge(W*)|) is reported at every β, finite
+    and ≥ 0, and varies with the geometry.
+  * the ``maxVertices`` volume bound caps additive growth.
+  * the boundary ∂W is byte-identical across the whole search.
+
+Not covered here — deferred to the #249 gate-battery experiment: the
+**selection** effect, β>0 choosing a *lower-|S_Regge|* filling among competing
+realizing surgeries. It needs **inequivalent competing realizing fillings**: a
+minimal hand fixture realizes through a single best surgery (the one that opens
+the needed b_k), which also reduces |S|, so β reinforces rather than redirects it
+and the outcome is β-inert. The diverse 13-gate battery supplies the competing
+fillings; the machinery that selects among them (the F_β candidate scoring) is
+exercised here through the β=0 byte-identical guarantee and the |S| reporting.
+
+Fixtures reuse the octahedron-surface (a triangulated S²) idiom from
+test_emergent_bulk_python.py: deleting a face opens a disk whose single interior
+top cell the surgery search removes.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pytest
+
+try:
+    import tessera
+    cob = tessera.cobordism
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+# The octahedron surface (a triangulated S²), built generically from a face list.
+_OCT = [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 1, 4),
+        (5, 1, 2), (5, 2, 3), (5, 3, 4), (5, 1, 4)]
+_CYCLE_A, _CYCLE_B = [(0, 1), (0, 2), (1, 2)], [(3, 4), (3, 5), (4, 5)]
+
+
+def _surface(faces, weight=1.0, phase=0.0):
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {i: st.createVertex(i) for i in sorted({v for f in faces for v in f})}
+    for f in faces:
+        t = sorted(f)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]]])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(weight)
+        e.setPhase(phase)
+    return st
+
+
+def _delete(*faces):
+    drop = {tuple(sorted(f)) for f in faces}
+    return [f for f in _OCT if tuple(sorted(f)) not in drop]
+
+
+def _disk(weight=1.0):
+    """Octahedron minus face (0,1,2): a disk (b_1=0) with exactly one interior
+    top cell, the opposite face (3,4,5)."""
+    return _surface(_delete((0, 1, 2)), weight=weight)
+
+
+def _annulus():
+    return _surface(_delete((0, 1, 2), (3, 4, 5)))
+
+
+def _bipyramid():
+    """Two triangles 012, 013 sharing the interior edge 01; the four outer edges
+    are ∂W. No interior top cell (every vertex is on ∂W), so the only way to grow
+    is the additive cone — which the maxVertices cap can block deterministically."""
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.SolidSimplex(2))
+    st.build()
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    st.createSimplex([v[0], v[1], v3])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+        e.setPhase(0.0)
+    return st
+
+
+def _meridian_target():
+    """The meridian 1-form read off the annulus's own harmonic, carried on both
+    boundary circles — realizable on the disk only after the interior face is
+    drilled out (b_1: 0→1)."""
+    h = cob.HodgeLaplacian(_annulus()).harmonics(1)[0]
+    edges = _CYCLE_A + _CYCLE_B
+    vals = [complex(h.amplitudeFor(list(e))) for e in edges]
+    return cob.Cochain(1, edges, np.asarray(vals, dtype=complex))
+
+
+def _boundary_edge_geometry(st):
+    """Snapshot every edge's (squared-length, phase) keyed by sorted endpoint
+    ids — the ∂W byte-fixed check reads the boundary subset from this."""
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = (e.getSquaredLength(), e.getPhase())
+    return out
+
+
+_SURG = lambda: cob.RealizabilityOracle.GrowthMode.SURGERY
+
+
+def _decide_disk(beta=0.0, max_cones=3, max_vertices=16, explicit_beta=True,
+                 weight=1.0):
+    st = _disk(weight=weight)
+    target = _meridian_target()
+    kw = dict(epsilon=1e-9, restarts=64, max_cones=max_cones, seed=1,
+              growth_mode=_SURG(), harmonic=True, max_vertices=max_vertices)
+    if explicit_beta:
+        kw["beta"] = beta
+    return st, cob.RealizabilityOracle(st).decideHarmonic(target, **kw)
+
+
+# --------------------------------------------------------------------------- #
+class Beta0ReproducesBaseLayer(unittest.TestCase):
+    def test_explicit_beta0_equals_default(self):
+        # The β=0 mediated path is the base-layer search bit-for-bit: residual,
+        # witness state, and reported |S| are byte-identical to the default call.
+        _, v_def = _decide_disk(explicit_beta=False)
+        _, v_b0 = _decide_disk(beta=0.0)
+        self.assertEqual(v_def.residual, v_b0.residual)
+        self.assertEqual(v_def.regge_action, v_b0.regge_action)
+        self.assertEqual(list(v_def.state), list(v_b0.state))
+        self.assertEqual(v_def.surgery_removals, v_b0.surgery_removals)
+
+    def test_beta0_decision_unchanged_by_beta(self):
+        # The realizability decision is the primal r_U<ε regardless of β; β only
+        # selects among fillings. The single-surgery disk commits its one removal
+        # at every β, so the residual is β-independent here.
+        _, v0 = _decide_disk(beta=0.0)
+        _, v5 = _decide_disk(beta=5.0)
+        self.assertEqual(v0.surgery_removals, 1)
+        self.assertEqual(v0.residual, v5.residual)        # one option ⇒ β inert
+        self.assertEqual(v0.regge_action, v5.regge_action)
+
+
+class ReggeActionReported(unittest.TestCase):
+    def test_regge_action_finite_nonnegative(self):
+        _, v = _decide_disk(beta=0.0)
+        self.assertTrue(np.isfinite(v.regge_action))
+        self.assertGreaterEqual(v.regge_action, 0.0)
+        self.assertGreater(v.regge_action, 0.0)  # the drilled disk has hinges
+
+    def test_regge_action_varies_with_geometry(self):
+        # |S_Regge(W*)| reads the edge squared-lengths, so two different seed
+        # geometries give different reported actions.
+        _, v1 = _decide_disk(beta=0.0, weight=1.0)
+        _, v2 = _decide_disk(beta=0.0, weight=2.0)
+        self.assertNotAlmostEqual(v1.regge_action, v2.regge_action, places=6)
+
+
+class MaxVerticesBound(unittest.TestCase):
+    def test_cap_blocks_additive_growth(self):
+        # The 1×3 gate on the bipyramid realizes only by coning in one interior
+        # vertex (no interior top cell exists, so surgery can do nothing). With
+        # maxVertices set to the seed vertex count the cone is never attempted —
+        # the |atVertexCap| guard short-circuits before growInterior, so this is
+        # immune to growInterior's nondeterminism — and |W| stays put.
+        st = _bipyramid()
+        n_seed = st.getVertexList().size()              # 4
+        U = [complex(1), complex(0.3, 0.5), complex(-0.8, 0.2)]
+        M = cob.RealizabilityOracle.GrowthMode.SURGERY_AND_CONE
+        v = cob.RealizabilityOracle(st).decide(
+            U, 1, 3, epsilon=1e-10, restarts=32, max_cones=5, seed=1,
+            growth_mode=M, beta=0.0, max_vertices=n_seed)
+        self.assertEqual(v.interior_vertex_count, 0)     # no vertex coned in
+        self.assertEqual(st.getVertexList().size(), n_seed)  # |W| capped
+        self.assertFalse(v.realizable)                   # so it floors
+
+
+class BoundaryHeldFixed(unittest.TestCase):
+    def test_boundary_byte_identical_across_search(self):
+        st = _disk()
+        # ∂W edges: the three sides of the drilled-out face (0,1,2).
+        boundary_keys = {(0, 1), (0, 2), (1, 2)}
+        before = {k: v for k, v in _boundary_edge_geometry(st).items()
+                  if k in boundary_keys}
+        target = _meridian_target()
+        cob.RealizabilityOracle(st).decideHarmonic(
+            target, epsilon=1e-9, restarts=64, max_cones=3, seed=1,
+            growth_mode=_SURG(), harmonic=True, beta=2.0, max_vertices=16)
+        after = {k: v for k, v in _boundary_edge_geometry(st).items()
+                 if k in boundary_keys}
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Milestone "Bulk Synthesis with Regge Action Mediation v0.1", chain step 4 — the core. Extends the boundary-fixed bulk-synthesis search so candidates are scored by the **mediated objective** `F_β(W) = r_U(W) + β·|S_Regge(W*)|` instead of the realizability residual `r_U` alone. `r_U` reads the **primal** Laplacian (`EigenstateSynthesis::residual`); `|S_Regge|` is the magnitude of the **dual** Lorentzian Regge action (`ReggeSolver::dualReggeAction`, #247) on the candidate's dual `W*`. `β=0` reproduces the base layer bit-for-bit.

Design: `docs/design/cobordism-implementation-details.pdf` §8–§10. Decisions: the Regge term is the **complex modulus** `|S_Regge|` (so `F_β ≥ 0`); `MAX_VERTICES` is a `decide()` parameter `maxVertices` (default 16).

## Approach
- New `GrowthMode::Mediated`: each grow step enumerates **Pachner cone** (`growInterior`) + **surgery** (`removeInteriorCell`) candidates, optimizes the interior (multi-restart LM, primal `r_U`), scores each by `F_β`, commits the best survivor; grows until `r_U < ε` or `|W| = maxVertices`.
- `beta` (default 0.0) + `maxVertices` (default 16) threaded through `decide`/`decideHarmonic`; **β=0 path is byte-identical** to the current search (the `|S_Regge|` term is gated on β>0).
- `Verdict` gains `reggeAction` (the realized geometry's `|S_Regge(W*)|`).
- Optimizer mode only — no ergodicity/detailed-balance/annealing. Continuous/spectral objective only (no Dijkgraaf–Witten). Null/degenerate geometries fail loudly (no silent reject/repair).

## Test plan
- [ ] `β=0` reproduces the base-layer verdict (realizable + residual) bit-for-bit on a fixture gate
- [ ] for ≥1 realizable gate, `β>0` finds a realizing bulk with **lower `|S_Regge(W*)|`** than the `β=0` filling
- [ ] boundary ∂W byte-identical across the whole search
- [ ] `|W|` never exceeds `maxVertices`; runaway `S` surfaced in the Verdict
- [ ] mesh/cobordism/regge regression green locally (CI is build-only)

Closes #248.