### PR TITLE
docs(cobordism): Regge-mediated gate-battery report — realizable gates vs β + H3 (#250)

### DIFF
--- a/docs/source/quantum-experiments/state-operation-cobordism/index.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/index.md
@@ -12,7 +12,11 @@ layers; the [results companion](cobordism-results.md) organizes the
 numerical evidence under each hypothesis — all of it decided by the
 continuous spectral method — ending with the realizable gate set (the
 charge-conservation criterion) and the per-output gallery. The
-Dijkgraaf–Witten layer that scaffolded the method is recorded in
+[Regge-mediated results](regge-mediated-results.md) then add the dual
+Lorentzian Regge action as a mediator and sweep its coupling β, showing
+the realizable set contract as a strong gravitational prior prices out
+the topology the gates need. The Dijkgraaf–Witten layer that scaffolded
+the method is recorded in
 [earlier work](../earlier-work/dijkgraaf-witten-scaffold.md).
 
 ```{toctree}
@@ -20,4 +24,5 @@ Dijkgraaf–Witten layer that scaffolded the method is recorded in
 
 cobordism
 cobordism-results
+regge-mediated-results
 ```

--- a/docs/source/quantum-experiments/state-operation-cobordism/regge-mediated-results.md
+++ b/docs/source/quantum-experiments/state-operation-cobordism/regge-mediated-results.md
@@ -1,0 +1,106 @@
+# Regge-Mediated Bulk Synthesis: results
+
+> The results companion for the **Regge-mediation track** — the geometry-selection
+> question raised at the end of
+> [`cobordism-results.md`](cobordism-results.md): *among the carriers of a
+> realizable operation, which one does the synthesis pick, and does it matter?*
+> The base layer answers H1–H3 by the **spectral residual** alone; here the
+> **dual Lorentzian Regge action** enters as a mediator, and we sweep its coupling
+> $\beta$. Every number below is produced by
+> [`examples/cobordism/mediated_gate_battery.py`](https://github.com/akellehe/tessera/blob/main/examples/cobordism/mediated_gate_battery.py)
+> (the design is `docs/design/cobordism-implementation-details.pdf` §8–§11). The
+> framing is spectral/continuous throughout — no Dijkgraaf–Witten layer.
+
+## The mediated objective
+
+Each bulk candidate $W$ is scored by
+
+$$ F_\beta(W) \;=\; r_U(W) \;+\; \beta\,\bigl|S_{\mathrm{Regge}}(W^{*})\bigr|, $$
+
+the realizability residual $r_U$ on the **primal** Hodge Laplacian (the base layer's
+$\lVert(I-\psi\psi^\dagger)L_1\psi\rVert^2$) plus $\beta$ times the **magnitude of the
+dual Lorentzian Regge action** on the circumcentric dual $W^{*}$ — the gravitational
+prior, evaluated with rapidity-carrying (boost) dihedral angles on timelike hinges
+(Regge 1961; Sorkin, *Lorentzian angles*, arXiv:1908.10022; Asante–Dittrich–Padua-Argüelles,
+arXiv:2104.00485). The mutual-information / Van Raamsdonk reading of the dual metric
+is Cao–Carroll–Michalakis's (arXiv:1606.08444); the contribution here is the
+fixed-boundary, dual-side mediation and the inverse direction. At $\beta=0$ the
+objective is $r_U$ alone, so the search **reproduces the base layer exactly**.
+
+## The mechanism: holes cost gravitational action
+
+The carrier the base layer uses is a triangulated sphere with three holonomy holes
+opened by surgery, so its harmonic space $\ker L_1$ (the register) is two-dimensional
+and carries the 13 charge-conserving gates. Opening each hole drives the residual of a
+carried gate to zero — but it **raises** the dual Regge action monotonically:
+
+| holes open $k$ | $b_1$ | $\lvert S_{\mathrm{Regge}}\rvert$ | residual (Identity) |
+|:---:|:---:|:---:|:---:|
+| 0 | 0 | 9.07 | floored |
+| 1 | 0 | 10.43 | floored |
+| 2 | 1 | 11.79 | floored |
+| **3** | **2** | **13.15** | **$1.1\times10^{-29}$ (realized)** |
+
+So $F_\beta$ is a genuine trade-off: a gate realizes only once enough holes are open
+(b_1 = 2), and each hole is a fixed gravitational cost. A large enough $\beta$ makes
+the search stop short of the topology a gate needs — the gate then **floors out of the
+realizable set**. This is the conformal-mode intuition made discrete: the action term
+is regularized by the vertex/volume bound, and increasing $\beta$ prices out structure.
+
+## Realizable gates vs $\beta$
+
+![Realizable gates vs beta](https://github.com/akellehe/tessera/releases/download/issue-attachments/regge_mediated_realizable_vs_beta.png)
+
+The headline result. At $\beta=0$ the search opens all three holes for every carried
+gate and recovers the **13-gate base layer bit-for-bit**. As $\beta$ rises the
+realizable set **contracts** — $13 \to 11 \to 0$ — because the gravitational cost of
+the holes overtakes their residual benefit. Requiring low gravitational action
+**does** shrink what is realizable, and the curve says where: the bulk of the set
+survives to $\beta\approx 2.5$, then the geometry that the charge-conserving gates need
+($b_1=2$, three holes) becomes too expensive and the set collapses past $\beta\approx 3$.
+
+The contraction is genuine physics of the *combined* objective, not a post-hoc
+tie-break: $\beta$ enters the score the search minimizes, so a strong gravitational
+prior can prevent $r_U$ from reaching zero within the volume bound. (Were $\beta$ only
+post-selecting among already-realized fillings, this curve would be flat.)
+
+## H3 amplitude error vs $\beta$
+
+![H3 amplitude error vs beta](https://github.com/akellehe/tessera/releases/download/issue-attachments/regge_mediated_h3_vs_beta.png)
+
+For every gate that *does* realize, at every $\beta$, the explicit amplitude
+deviation $\lvert Z - \langle\psi_A|U|\psi_B\rangle\rvert$ — the holonomy-charge leak
+$\lvert\Sigma(U|\psi_B\rangle)\rvert$, computed directly from the gate matrix and
+**not** inferred from $r_U\to 0$ — sits at machine precision ($\approx 4.5\times
+10^{-16}$, below the $\sim 10^{-15}$ target). Mediation **changes which** gates
+realize, but it does not degrade the fidelity of the ones that survive: the value
+equation $Z = \langle\psi_A|U|\psi_B\rangle$ holds under the Regge prior. The points
+thin out left-to-right exactly as the realizable set contracts.
+
+## H1–H3 under mediation
+
+- **H1 (realizable).** $\beta=0$ realizes the 13 charge-conserving gates
+  (`3-cycle (0231)`, `3-cycle (0312)`, `CNOT`, `CSX`, `CSXdg`, `H(x)H`, `Identity`,
+  `SWAP`, `rev-CSX`, `rev-CSXdg`, `reversed-CNOT`, `sqrt-SWAP`, `sqrt-SWAP-dg`) —
+  the base-layer set. The count contracts to 11 for $1\le\beta\le 2.5$ and to 0 for
+  $\beta\ge 3$.
+- **H2 (boundary byte-fixed).** The input register-edge geometry and the input
+  periods are byte-identical across every gate and every $\beta$; the synthesis only
+  opens interior holes and never perturbs the input boundary data.
+- **H3 (value equation).** Holds to $\approx 4.5\times10^{-16}$ for every realized
+  gate at every $\beta$ (plot above) — within the base-layer tolerance.
+
+## Finding
+
+Introducing the dual Regge action as a mediator **selects geometry**: at zero coupling
+it is invisible (the base layer is recovered exactly), and as the coupling grows it
+**contracts the realizable set** by pricing out the topology charge-conserving gates
+require, while leaving the amplitude fidelity of the survivors intact. The realizable
+gate set is therefore a genuine function of the gravitational coupling — the central
+claim of the milestone, now quantified.
+
+Reproduce with:
+
+```bash
+python examples/cobordism/mediated_gate_battery.py --plots /tmp/cobordism/plots
+```

--- a/examples/cobordism/mediated_gate_battery.py
+++ b/examples/cobordism/mediated_gate_battery.py
@@ -1,0 +1,226 @@
+"""Regge-mediated gate-battery re-test of H1-H3 across beta (#249).
+
+Milestone "Bulk Synthesis with Regge Action Mediation v0.1", chain step 5. Re-runs
+the spectral gate battery of spectral_gate_realizability.py under the mediated
+objective and sweeps the gravitational coupling beta.
+
+The base layer builds a triangulated sphere (icosahedron `_ICO`), punches 3
+triangular holes in it by surgery (`removeInteriorCell` of `_CLASS_HOLES`) so it
+carries a 2-D space of harmonic 1-forms (ker L_1 = the "register"), and asks, per
+gate U, whether U|psi_B> stays in that space (the Hodge residual -> 0). 13 gates do
+(the charge-conserving set).
+
+Mediation: opening a hole drives the residual down but RAISES the dual Regge action
+|S_Regge| (computed on the holed sphere via ReggeSolver.dualReggeAction, #247:
+|S| = 9.07, 10.43, 11.79, 13.15 for k = 0,1,2,3 holes open). So per gate and per
+beta we pick the hole count k in {0..3} that minimizes
+
+    F_beta(k) = residual_k(U) + beta * |S_Regge(k)|,
+
+commit it, and record:
+
+  H1  realized      residual at the chosen k < REALIZE (1e-9)
+  H2  input fixed   the 9 register-edge geometries + the input periods _CP_IN are
+                    byte-identical across every (gate, beta) run -- the synthesis
+                    never perturbs the input boundary data
+  H3  amplitude     the holonomy-charge leak |Sigma(U|psi_B>)| = |sum(U_block @
+                    _CP_IN)|, computed explicitly from the gate matrix (NOT inferred
+                    from residual -> 0), cross-checked against the spectral residual
+
+plus r_U, |S_Regge|, and the chosen k.
+
+beta = 0 reproduces the base layer (k = 3, the 13 charge-conserving gates). As beta
+grows, the cost of the 3rd hole outweighs its residual benefit, the chosen k drops,
+and gates contract out of the realizable set -- the headline realizable-gates-vs-beta
+curve, plus the H3 deviation vs beta.
+
+Reuses spectral_gate_realizability.py (Register, _gates, _ICO, _CLASS_HOLES,
+_CP_IN, REALIZE, _surface, _betti1) + ReggeSolver.dualReggeAction. Results are
+written as JSON under /tmp/cobordism/ (attach to the PR; not committed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import spectral_gate_realizability as base  # noqa: E402
+
+import tessera  # noqa: E402
+
+cob = tessera.cobordism
+
+BETAS_DEFAULT = [0.0, 0.1, 0.3, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 5.0, 10.0]
+H3_TOL = 1e-9  # H3 amplitude tolerance (the realized leak is ~1e-15 in practice)
+KMAX = len(base._CLASS_HOLES)  # 3 holonomy holes -> k in 0..3
+
+
+def _regge_magnitude(st):
+    """|S_Regge(W*)| on the (holed) sphere: the modulus of the dual Lorentzian Regge
+    action (ReggeSolver.dualReggeAction, #247). Built in C++ so the facet/coface
+    materialization stays consistent (the Python getFacets bindings copy)."""
+    s = tessera.ReggeSolver(st, tessera.MatterConfiguration()).dualReggeAction()
+    return float(abs(s))
+
+
+def _kstage(k):
+    """The icosahedron with the first k holonomy holes opened. Returns
+    (spacetime, EigenstateSynthesis, cell list, |S_Regge|)."""
+    st = base._surface(base._ICO)
+    es = cob.EigenstateSynthesis(st, 1)
+    for hole in base._CLASS_HOLES[:k]:
+        es.removeInteriorCell(list(hole))
+    cells = [tuple(int(v) for v in c) for c in es.cellSimplices()]
+    return st, es, cells, _regge_magnitude(st)
+
+
+def _build_stages():
+    """Precompute the k = 0..KMAX stages once: each carries its complex, residual
+    engine, cell order, |S_Regge|, b_1, and |V|. Reused for every gate."""
+    canon = base.Register()  # the k=3 register: harmonic basis + orientation signs
+    stages = []
+    for k in range(KMAX + 1):
+        st, es, cells, S = _kstage(k)
+        stages.append({"k": k, "st": st, "es": es, "cells": cells, "S": S,
+                       "b1": int(base._betti1(st)),
+                       "nV": int(st.getVertexList().size())})
+    return canon, stages
+
+
+def _residual_at(canon, stage, U):
+    """The gate's spectral residual on the k-hole sphere: build U|psi_B>'s output
+    harmonic (in the k=3 register's basis), restrict it to this stage's cells, and
+    apply the genuine metric Hodge L_1 residual -- exactly base.identity_anchor's
+    per-k evaluation, generalized to any gate."""
+    u_reg = np.asarray(U, dtype=complex)[1:4, 1:4]
+    cp_out = u_reg @ base._CP_IN.astype(complex)
+    psi_full = canon.harmonic_form(canon.sign * cp_out)
+    by_cell = {canon.cells[i]: psi_full[i] for i in range(len(canon.cells))}
+    psi = np.array([by_cell.get(c, 0.0) for c in stage["cells"]], dtype=complex)
+    return float(stage["es"].residual([complex(z) for z in psi]))
+
+
+def _charge_leak(U):
+    """H3 amplitude, explicit: the holonomy-charge leakage |Sigma(U|psi_B>)| =
+    |sum(U_block @ _CP_IN)|. 0 iff U conserves total holonomy charge (the all-ones
+    covector is preserved) -- the algebraic statement of Z = <psi_A|U|psi_B>,
+    independent of the residual."""
+    u_reg = np.asarray(U, dtype=complex)[1:4, 1:4]
+    return float(abs((u_reg @ base._CP_IN.astype(complex)).sum()))
+
+
+def _register_edge_fingerprint(stage):
+    """H2 witness: the (squared-length, phase) of every edge of the opened holes,
+    plus the input periods _CP_IN. Held byte-identical across the whole sweep."""
+    emap = {}
+    for e in stage["st"].getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        emap[(min(a, b), max(a, b))] = (e.getSquaredLength(), e.getPhase())
+    reg = {str(k): emap[k] for k in base._REG_EDGES if k in emap}
+    return reg, [float(x) for x in base._CP_IN]
+
+
+def sweep(betas, gates=None):
+    """Run the mediated battery sweep. Returns (rows, h2). rows: one record per
+    (gate, beta). h2: the H2 fixed-input check (the same for all runs)."""
+    canon, stages = _build_stages()
+    gate_list = gates if gates is not None else base._gates()
+    S_by_k = {st["k"]: st["S"] for st in stages}
+    b1_by_k = {st["k"]: st["b1"] for st in stages}
+
+    # H2: the input register-edge geometry + _CP_IN are identical across all stages
+    # (the synthesis only opens interior holes; it never rewrites the input). Compare
+    # every stage's register-edge fingerprint to k=0's.
+    base_fp, base_cp = _register_edge_fingerprint(stages[0])
+    h2_ok = True
+    for st in stages:
+        fp, cp = _register_edge_fingerprint(st)
+        if fp != base_fp or cp != base_cp:
+            h2_ok = False
+    h2 = {"input_boundary_byte_fixed": bool(h2_ok),
+          "register_edges": len(base_fp), "cp_in": base_cp}
+
+    rows = []
+    for name, U, fam in gate_list:
+        res_by_k = {st["k"]: _residual_at(canon, st, U) for st in stages}
+        leak = _charge_leak(U)
+        for beta in betas:
+            # F_beta(k) = residual_k + beta * |S_Regge(k)|; commit the minimizing k.
+            kstar = min(res_by_k, key=lambda k: res_by_k[k] + beta * S_by_k[k])
+            r = res_by_k[kstar]
+            realized = bool(r < base.REALIZE)
+            rows.append({
+                "gate": name, "family": fam, "beta": float(beta),
+                "k_star": int(kstar), "b1": int(b1_by_k[kstar]),
+                "r_U": r, "S_regge": float(S_by_k[kstar]),
+                "F_beta": float(r + beta * S_by_k[kstar]),
+                "realizable": realized,            # H1
+                "charge_leak": leak,               # H3 (explicit amplitude deviation)
+                # H3: for a REALIZED gate the explicit amplitude must match (leak ~ 0);
+                # vacuous for a gate mediation floored (we make no H3 claim about it).
+                "h3_holds": bool((not realized) or (leak < H3_TOL)),
+            })
+    return rows, h2
+
+
+def summarize(rows, betas):
+    """Per-beta: realizable count, the realized-set identity, max H3 leak among
+    realized gates, and whether every H3 cross-check held."""
+    out = []
+    for beta in betas:
+        br = [r for r in rows if r["beta"] == beta]
+        realized = sorted(r["gate"] for r in br if r["realizable"])
+        max_leak_realized = max((r["charge_leak"] for r in br if r["realizable"]),
+                                default=0.0)
+        out.append({
+            "beta": float(beta),
+            "n_realizable": len(realized),
+            "realized": realized,
+            "max_charge_leak_realized": max_leak_realized,  # H3 vs beta
+            "h3_holds": all(r["h3_holds"] for r in br),
+        })
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--betas", type=float, nargs="+", default=BETAS_DEFAULT)
+    ap.add_argument("--canonical-only", action="store_true",
+                    help="restrict to the 13-gate CANONICAL_SET (a fast slice)")
+    ap.add_argument("--out", default="/tmp/cobordism/mediated_gate_battery.json")
+    args = ap.parse_args()
+
+    gates = None
+    if args.canonical_only:
+        keep = set(base.CANONICAL_SET)
+        gates = [g for g in base._gates() if g[0] in keep]
+
+    rows, h2 = sweep(args.betas, gates=gates)
+    summary = summarize(rows, args.betas)
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump({"betas": args.betas, "h2": h2, "summary": summary, "rows": rows},
+                  f, indent=2)
+
+    print(f"H2 input-boundary byte-fixed: {h2['input_boundary_byte_fixed']}")
+    print(f"{'beta':>8}  {'#realizable':>11}  {'max H3 leak (realized)':>22}  "
+          f"{'H3 holds':>9}")
+    for s in summary:
+        print(f"{s['beta']:>8}  {s['n_realizable']:>11}  "
+              f"{s['max_charge_leak_realized']:>22.3e}  "
+              f"{str(s['h3_holds']):>9}")
+    base_set = next(s for s in summary if s["beta"] == 0.0)["realized"] \
+        if 0.0 in args.betas else None
+    if base_set is not None:
+        print(f"\nbeta=0 realized set ({len(base_set)} gates): {base_set}")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/mediated_gate_battery.py
+++ b/examples/cobordism/mediated_gate_battery.py
@@ -187,11 +187,66 @@ def summarize(rows, betas):
     return out
 
 
+def make_plots(summary, rows, outdir):
+    """The two #250 deliverable plots: (a) realizable-gates-vs-beta, (b) the H3
+    amplitude error of each realized gate vs beta. matplotlib is imported lazily so
+    a plain sweep never pulls it in. Returns the two file paths."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    os.makedirs(outdir, exist_ok=True)
+    betas = [s["beta"] for s in summary]
+    x = list(range(len(betas)))
+    labels = ["0" if b == 0 else f"{b:g}" for b in betas]
+
+    # (a) realizable gate count vs beta -- the contraction curve.
+    fig, ax = plt.subplots(figsize=(6.5, 4.0))
+    ax.plot(x, [s["n_realizable"] for s in summary], marker="o", color="#1f77b4")
+    ax.axhline(13, ls="--", color="grey", alpha=0.6, label="base layer (13 gates)")
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels)
+    ax.set_xlabel(r"$\beta$  (gravitational coupling)")
+    ax.set_ylabel("# realizable gates")
+    ax.set_title(r"Realizable gates vs $\beta$  ($F_\beta = r_U + \beta\,|S_{Regge}|$)")
+    ax.set_ylim(-0.5, 14.0)
+    ax.legend()
+    fig.tight_layout()
+    pa = os.path.join(outdir, "regge_mediated_realizable_vs_beta.png")
+    fig.savefig(pa, dpi=140)
+    plt.close(fig)
+
+    # (b) H3 amplitude error per realized gate vs beta -- fidelity under mediation.
+    fig, ax = plt.subplots(figsize=(6.5, 4.0))
+    for i, b in enumerate(betas):
+        leaks = [r["charge_leak"] for r in rows if r["beta"] == b and r["realizable"]]
+        if leaks:
+            ax.scatter([i] * len(leaks), [max(v, 1e-18) for v in leaks],
+                       s=20, color="#2ca02c", alpha=0.6,
+                       label="realized gate" if i == 0 else None)
+    ax.set_yscale("log")
+    ax.set_ylim(1e-18, 1e-8)
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels)
+    ax.axhline(1e-15, ls="--", color="grey", alpha=0.6, label=r"$\sim 10^{-15}$ target")
+    ax.set_xlabel(r"$\beta$")
+    ax.set_ylabel(r"$|Z - \langle\psi_A|U|\psi_B\rangle|$  (per realized gate)")
+    ax.set_title(r"H3 amplitude error vs $\beta$")
+    ax.legend()
+    fig.tight_layout()
+    pb = os.path.join(outdir, "regge_mediated_h3_vs_beta.png")
+    fig.savefig(pb, dpi=140)
+    plt.close(fig)
+    return pa, pb
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--betas", type=float, nargs="+", default=BETAS_DEFAULT)
     ap.add_argument("--canonical-only", action="store_true",
                     help="restrict to the 13-gate CANONICAL_SET (a fast slice)")
+    ap.add_argument("--plots", metavar="DIR", default=None,
+                    help="also write the two deliverable plots (#250) to DIR")
     ap.add_argument("--out", default="/tmp/cobordism/mediated_gate_battery.json")
     args = ap.parse_args()
 
@@ -220,6 +275,10 @@ def main():
     if base_set is not None:
         print(f"\nbeta=0 realized set ({len(base_set)} gates): {base_set}")
     print(f"\nwrote {args.out}")
+
+    if args.plots:
+        pa, pb = make_plots(summary, rows, args.plots)
+        print(f"wrote plots:\n  {pa}\n  {pb}")
 
 
 if __name__ == "__main__":

--- a/tests/cobordism/test_mediated_gate_battery_python.py
+++ b/tests/cobordism/test_mediated_gate_battery_python.py
@@ -1,0 +1,72 @@
+"""Regge-mediated gate-battery β-sweep (#249).
+
+Locks in the headline claims of examples/cobordism/mediated_gate_battery.py:
+  * β=0 reproduces the base-layer 13-gate set bit-for-bit, with H3 (the holonomy-
+    charge leak) at machine precision;
+  * H2 (the input boundary data) is byte-fixed across the sweep;
+  * mediation contracts the realizable set as β grows;
+  * H3 holds (the explicit amplitude matches) for every realized gate at every β.
+
+The sweep is cheap (per-gate residual projections + 4 precomputed |S_Regge| values),
+so the whole battery runs in-process.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+import pytest
+
+_EX = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))), "examples", "cobordism")
+sys.path.insert(0, _EX)
+
+try:
+    import tessera  # noqa: F401
+    import spectral_gate_realizability as base
+    import mediated_gate_battery as mgb
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+
+class MediatedGateBattery(unittest.TestCase):
+    def test_beta0_reproduces_13_gate_base_layer(self):
+        rows, h2 = mgb.sweep([0.0])
+        s = mgb.summarize(rows, [0.0])[0]
+        self.assertEqual(s["n_realizable"], 13)
+        self.assertEqual(set(s["realized"]), set(base.CANONICAL_SET))
+        self.assertTrue(h2["input_boundary_byte_fixed"])          # H2
+        self.assertLess(s["max_charge_leak_realized"], 1e-9)      # H3 at β=0
+
+    def test_mediation_contracts_the_realizable_set(self):
+        rows, _ = mgb.sweep([0.0, 10.0])
+        by_beta = {s["beta"]: s["n_realizable"]
+                   for s in mgb.summarize(rows, [0.0, 10.0])}
+        self.assertEqual(by_beta[0.0], 13)
+        self.assertLess(by_beta[10.0], by_beta[0.0])  # a strong gravitational prior shrinks it
+
+    def test_h3_holds_for_every_realized_gate(self):
+        rows, _ = mgb.sweep([0.0, 1.0, 3.0])
+        for r in rows:
+            if r["realizable"]:
+                # the explicit amplitude (charge leak) matches at machine precision
+                self.assertLess(r["charge_leak"], 1e-9)
+                self.assertTrue(r["h3_holds"])
+
+    def test_realized_gates_pick_all_three_holes_at_beta0(self):
+        # at β=0 the search pays nothing for holes, so every realized gate opens the
+        # full register (k=3, b_1=2) — the base-layer topology.
+        rows, _ = mgb.sweep([0.0])
+        for r in rows:
+            if r["realizable"]:
+                self.assertEqual(r["k_star"], 3)
+                self.assertEqual(r["b1"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Milestone "Bulk Synthesis with Regge Action Mediation v0.1", chain step 6 — the **headline deliverable**. Reports what changes when the dual Lorentzian Regge action mediates synthesis: the realizable gate set as a function of β, and the H3 amplitude fidelity of the realized gates.

Branches off `main` (not stacked). **Also re-lands the #249 harness** (`mediated_gate_battery.py` + its test), which was stranded off `main` when #263 merged into its stacked base after that base had already merged via #258.

## Result — realizable gates vs β
![realizable vs beta](https://github.com/akellehe/tessera/releases/download/issue-attachments/regge_mediated_realizable_vs_beta.png)

- **β=0 reproduces the 13-gate base layer bit-for-bit.**
- Raising β **contracts the realizable set**: 13 → 11 (1≤β≤2.5) → 0 (β≥3). Each holonomy hole the charge-conserving gates need costs gravitational action (|S_Regge| rises 9.07→13.15 across k=0..3 holes), so a strong enough prior prices out the b₁=2 topology.

## Result — H3 amplitude error vs β
![H3 vs beta](https://github.com/akellehe/tessera/releases/download/issue-attachments/regge_mediated_h3_vs_beta.png)

Every realized gate, at every β, has `|Z − ⟨ψ_A|U|ψ_B⟩|` ≈ 4.5e-16 (below the ~1e-15 target). Mediation changes *which* gates realize but not the fidelity of the survivors. The points thin out as the set contracts.

## What's here
- `mediated_gate_battery.py --plots`: generates both figures from the sweep data.
- `docs/.../state-operation-cobordism/regge-mediated-results.md`: the results page, companion to `cobordism-results.md`, wired into the toctree.
- The #249 harness + test (re-landed).

## Test plan
- [x] both plots produced from the gate-battery data; β=0 column = base layer (13 gates)
- [x] H2 boundary byte-fixed; H3 ≈ 4.5e-16 for realized gates at every β
- [x] `sphinx-build` warning-clean (the new page reads + passes consistency, 0 warnings; the `make` nonzero is pre-existing Doxygen, no C++ touched)
- [x] harness regression test green (`test_mediated_gate_battery_python.py`, 4 tests)

The metric-preserving re-triangulation consistency check (acceptance iv, shared with #246/#247) is **not** in scope here — flagged for a followup.

Closes #250.
