### PR TITLE
fix(spacetime): make growInterior/AddMove deterministic under a fixed seed (#262)

### DIFF
--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -324,11 +324,20 @@ class Spacetime {
     /// Select a uniformly random vertex from the vertex list.
     /// Used by the (2d,2) delete move for blind-guessing vertex selection.
     /// @return A random vertex, or nullptr if none exist
+    ///
+    /// The no-argument form draws from the spacetime's own ``rng`` (seeded from
+    /// ``std::random_device`` unless ``setSeed`` was called). The overload draws
+    /// from a **caller-supplied** generator so a move with its own seeded engine
+    /// (e.g. ``AddMove``) selects reproducibly from that seed — without this, a
+    /// seeded move still made its random picks against the global ``rng`` and so
+    /// was nondeterministic (issue #262).
     [[nodiscard]] VertexPtr getRandomVertex();
+    [[nodiscard]] VertexPtr getRandomVertex(std::mt19937 &generator);
 
     /// Select a uniformly random simplex from the parallel access vector.
     /// @return A random simplex, or nullptr if the complex is empty
     [[nodiscard]] SimplexPtr getRandomSimplex();
+    [[nodiscard]] SimplexPtr getRandomSimplex(std::mt19937 &generator);
 
     /// The vertex count of a top-dimensional simplex: \f$ d+1 \f$, where
     /// \f$ d \f$ is the metric signature's dimension. This is the **single
@@ -343,7 +352,10 @@ class Spacetime {
     /// Select a uniformly random top-dimensional simplex.
     /// Used by the Metropolis algorithm to pick random move targets.
     /// @return A random d-simplex, or nullptr if none exist
+    /// The overload draws from a caller-supplied generator (see
+    /// ``getRandomVertex``; issue #262).
     [[nodiscard]] SimplexPtr getRandomTopSimplex();
+    [[nodiscard]] SimplexPtr getRandomTopSimplex(std::mt19937 &generator);
 
     /// Select a uniformly random simplex with a specific causal orientation.
     /// Tries random sampling first (fast when many match), then falls back

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -487,10 +487,14 @@ minimal test lattices, e.g. createSimplex((1, 4)) for a (1,4) simplex.)doc")
 This is the volume-fixing target per [RU] eq. 6.)doc")
       .def("getN32", &Spacetime::getN32,
            "Return N32: the count of (d-1,2) + (2,d-1) type simplices.")
-      .def("getRandomSimplex", &Spacetime::getRandomSimplex, py::return_value_policy::reference,
+      .def("getRandomSimplex",
+           static_cast<SimplexPtr (Spacetime::*)()>(&Spacetime::getRandomSimplex),
+           py::return_value_policy::reference,
            py::keep_alive<0, 1>(),  // single handle (weak-referenceable) keeps the Spacetime alive
            "Return a uniformly random simplex from the complex (any dimension).")
-      .def("getRandomTopSimplex", &Spacetime::getRandomTopSimplex, py::return_value_policy::reference,
+      .def("getRandomTopSimplex",
+           static_cast<SimplexPtr (Spacetime::*)()>(&Spacetime::getRandomTopSimplex),
+           py::return_value_policy::reference,
            py::keep_alive<0, 1>(),
            "Return a uniformly random top-dimensional simplex.")
       .def("getTopVertexCount", &Spacetime::getTopVertexCount,
@@ -501,7 +505,9 @@ for what registers as a top cell: a simplex joins topSimplicesVec (and is
 seen by getBoundary/getRandomTopSimplex) exactly when its vertex count
 equals this. Build a fixture with Signature(topology.dimension(), ...) so
 its top cells match.)doc")
-      .def("getRandomVertex", &Spacetime::getRandomVertex, py::return_value_policy::reference,
+      .def("getRandomVertex",
+           static_cast<VertexPtr (Spacetime::*)()>(&Spacetime::getRandomVertex),
+           py::return_value_policy::reference,
            py::keep_alive<0, 1>(),
            "Return a uniformly random vertex.")
       .def("removeSimplex", &Spacetime::removeSimplex, py::arg("simplex"),

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -809,23 +809,29 @@ const std::vector<SimplexPtr>& Spacetime::getSimplices() const noexcept {
   return simplicesVec;
 }
 
-VertexPtr Spacetime::getRandomVertex() {
+VertexPtr Spacetime::getRandomVertex() { return getRandomVertex(rng); }
+
+VertexPtr Spacetime::getRandomVertex(std::mt19937 &generator) {
   const auto &verts = vertexList->liveVector();
   if (verts.empty()) return nullptr;
   std::uniform_int_distribution<std::size_t> dist(0, verts.size() - 1);
-  return verts[dist(rng)];
+  return verts[dist(generator)];
 }
 
-SimplexPtr Spacetime::getRandomSimplex() {
+SimplexPtr Spacetime::getRandomSimplex() { return getRandomSimplex(rng); }
+
+SimplexPtr Spacetime::getRandomSimplex(std::mt19937 &generator) {
   if (simplicesVec.empty()) return nullptr;
   std::uniform_int_distribution<std::size_t> dist(0, simplicesVec.size() - 1);
-  return simplicesVec[dist(rng)];
+  return simplicesVec[dist(generator)];
 }
 
-SimplexPtr Spacetime::getRandomTopSimplex() {
+SimplexPtr Spacetime::getRandomTopSimplex() { return getRandomTopSimplex(rng); }
+
+SimplexPtr Spacetime::getRandomTopSimplex(std::mt19937 &generator) {
   if (topSimplicesVec.empty()) return nullptr;
   std::uniform_int_distribution<std::size_t> dist(0, topSimplicesVec.size() - 1);
-  return topSimplicesVec[dist(rng)];
+  return topSimplicesVec[dist(generator)];
 }
 
 SimplexPtr Spacetime::findSimplexByVerts(

--- a/src/spacetime/pachner/AddMove.cpp
+++ b/src/spacetime/pachner/AddMove.cpp
@@ -48,7 +48,7 @@ bool AddMove::propose() {
   // (rejection-sample with linear-scan fallback).
   SimplexPtr sigma = nullptr;
   for (int attempt = 0; attempt < 100; ++attempt) {
-    auto s = st_->getRandomTopSimplex();
+    auto s = st_->getRandomTopSimplex(*rng_);  // this move's seeded rng (#262)
     if (s && static_cast<int>(s->size()) == dPlus1 && isN41Type(s, d)) {
       sigma = s;
       break;
@@ -135,7 +135,7 @@ bool AddMove::propose() {
 }
 
 bool AddMove::proposePreGeometric() {
-  SimplexPtr sigma = st_->getRandomTopSimplex();
+  SimplexPtr sigma = st_->getRandomTopSimplex(*rng_);  // seeded rng (#262)
   if (!sigma) return false;
   const int dPlus1 = static_cast<int>(sigma->size());
   if (dPlus1 < 3) return false;  // need at least a triangle to subdivide
@@ -251,7 +251,7 @@ bool AddMove::apply() {
   // 4. Optional vertex relabeling.  Save the swap partner so rollback
   // can un-swap.
   if (relabelEnabled_) {
-    VertexPtr partner = st_->getRandomVertex();
+    VertexPtr partner = st_->getRandomVertex(*rng_);  // seeded rng (#262)
     if (partner && partner->getId() != newVert_->getId()) {
       st_->swapVertexLabels(newVert_, partner);
       swapPartner_ = partner;


### PR DESCRIPTION
## Summary
`AddMove` seeds its own `std::mt19937` from the `seed` argument, but its actual cell/vertex picks went through `Spacetime::getRandomTopSimplex()` / `getRandomVertex()`, which draw from the spacetime's **own** `rng` (seeded from `std::random_device`). So a seeded move made its random choices against the global generator → `growInterior(seed)` was nondeterministic (different result, intermittent throw, across runs with the same seed).

## Fix
- Add rng-parameterized overloads `getRandomVertex/getRandomSimplex/getRandomTopSimplex(std::mt19937&)` on `Spacetime`; the no-arg forms delegate to them with the member `rng` (existing callers unchanged).
- Route AddMove's three picks (N41 sigma, pre-geometric sigma, relabel partner) through its own seeded `rng_`.
- Disambiguate the existing `getRandom*` bindings to the no-arg overload.

## Verification
- `growInterior(seed)` is now **byte-deterministic** across runs (8× same seed → identical outcome; each seed independently reproducible).
- Pachner / moves-deterministic / CDT / build regression **green (95 passed)**.

## Out of scope — a separate follow-up
~half the seeds still *deterministically* throw `"cannot create an edge from a vertex to itself"` on small complexes. That's a **separate, pre-existing** AddMove pre-geometric-subdivision validity bug — it was the *symptom* that used to be nondeterministic, and is now reproducible. The determinism fix here doesn't address it (and shouldn't — it's a different defect). Happy to file it as its own issue.

Closes #262.