### PR TITLE
fix(spacetime): createVertex() skips used ids — fixes growInterior self-edge (#267)

### DIFF
--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -412,7 +412,7 @@ class Spacetime {
     /// inserting a vertex with this id (otherwise the id is
     /// simply unused).
     [[nodiscard]] std::uint64_t reserveVertexId() noexcept {
-      return vertexIdCounter++;
+      return nextFreeVertexId();
     }
 
     /// The boundary surface of the complex: the codimension-one faces — one
@@ -653,6 +653,12 @@ class Spacetime {
     void unregisterSimplex(const SimplexPtr &simplex);
 
   private:
+    // The next vertex id not already in use: advances vertexIdCounter past any
+    // explicitly-assigned ids so a no-arg/reserved id never aliases an existing
+    // vertex (VertexList::add returns the existing vertex on a duplicate id;
+    // coning that alias makes a self-edge — #267).
+    [[nodiscard]] std::uint64_t nextFreeVertexId() noexcept;
+
     std::shared_ptr<EdgeList> edgeList = std::make_shared<EdgeList>();
     std::shared_ptr<VertexList> vertexList = std::make_shared<VertexList>();
 

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -256,8 +256,17 @@ std::pair<SimplexPtr, bool> Spacetime::createSimplex(std::size_t k) {
   return createSimplex(vertices, edges);
 }
 
+std::uint64_t Spacetime::nextFreeVertexId() noexcept {
+  // Advance past any id already in use (explicit createVertex(id) or a topology
+  // builder) so a no-arg / reserved id never collides with an existing vertex.
+  // VertexList::add on a duplicate id returns the EXISTING vertex — a silent
+  // alias that, when coned, makes a self-edge (#267).
+  while (vertexList->contains(vertexIdCounter)) ++vertexIdCounter;
+  return vertexIdCounter++;
+}
+
 VertexPtr Spacetime::createVertex() noexcept {
-  return vertexList->add(vertexIdCounter++);
+  return vertexList->add(nextFreeVertexId());
 }
 
 VertexPtr Spacetime::createVertex(const std::uint64_t id) const noexcept {
@@ -269,7 +278,7 @@ VertexPtr Spacetime::createVertex(const std::uint64_t id, const std::vector<doub
 }
 
 VertexPtr Spacetime::createVertex(const std::vector<double> &coords) noexcept {
-  return vertexList->add(vertexIdCounter++, coords);
+  return vertexList->add(nextFreeVertexId(), coords);
 }
 
 EdgePtr Spacetime::createEdge(

--- a/tests/test_addmove_selfedge_python.py
+++ b/tests/test_addmove_selfedge_python.py
@@ -1,0 +1,82 @@
+"""growInterior / AddMove must never propose a self-edge (#267).
+
+`Spacetime::createVertex()` (no-arg) drew its id from a counter that ignored
+explicitly-assigned ids. On a complex built with explicit ids — `build()` plus
+`createVertex(id)` — the counter was stale, so the no-arg create returned an id
+already in use; `VertexList::add` on a duplicate id returns the **existing**
+vertex, and coning that aliased vertex in the 1→(d+1) stellar subdivision made an
+edge from a vertex to itself (`growInterior` threw for the seeds that picked a
+cell containing the aliased id). The fix skips used ids.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import pytest
+
+try:
+    import tessera
+    cob = tessera.cobordism
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+
+def _bipyramid():
+    """Two triangles 012, 013 sharing edge 01 — built with EXPLICIT ids
+    (build() creates 0,1,2; createVertex(3) adds 3), the configuration that
+    desynced the no-arg id counter."""
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.SolidSimplex(2))
+    st.build()
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    v3 = st.createVertex(3)
+    st.createSimplex([v[0], v[1], v3])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+        e.setPhase(0.0)
+    return st
+
+
+class GrowInteriorSelfEdge(unittest.TestCase):
+    def test_grow_never_self_edges_across_seeds(self):
+        # Every seed must grow the interior by exactly one fresh vertex — no
+        # "cannot create an edge from a vertex to itself", for any seed.
+        for seed in range(32):
+            st = _bipyramid()
+            n0 = st.getVertexList().size()
+            es = cob.EigenstateSynthesis(st)
+            grew = es.growInterior(seed)            # must not raise
+            self.assertTrue(grew, f"seed {seed} failed to grow")
+            self.assertEqual(st.getVertexList().size(), n0 + 1,
+                             f"seed {seed} did not add exactly one vertex")
+
+    def test_new_vertex_id_is_fresh(self):
+        # The coned-in vertex must carry a brand-new id, never an alias of an
+        # existing one.
+        st = _bipyramid()
+        before = {v.getId() for v in st.getVertexList().toVector()}
+        cob.EigenstateSynthesis(st).growInterior(0)
+        after = {v.getId() for v in st.getVertexList().toVector()}
+        new_ids = after - before
+        self.assertEqual(len(new_ids), 1)            # exactly one new vertex
+        self.assertTrue(new_ids.isdisjoint(before))  # and it didn't alias
+
+    def test_repeated_growth_keeps_adding_fresh_vertices(self):
+        # Coning repeatedly (each step calls the no-arg createVertex) keeps
+        # producing fresh ids — never aliasing back onto the growing complex.
+        st = _bipyramid()
+        es = cob.EigenstateSynthesis(st)
+        n = st.getVertexList().size()
+        for step in range(3):
+            self.assertTrue(es.growInterior(step + 1))
+            n += 1
+            self.assertEqual(st.getVertexList().size(), n)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
`Spacetime::createVertex()` (no-arg) returned `vertexList->add(vertexIdCounter++)`, but the explicit-id `createVertex(id)` is `const` and never advanced `vertexIdCounter`. On a complex built with explicit ids — `build()` (0,1,2) + `createVertex(3)` — the counter was stale, so the no-arg create returned an id **already in use**. `VertexList::add` on a duplicate id returns the **existing** vertex (a silent alias), and AddMove's 1→(d+1) stellar subdivision then coned that aliased vertex → an edge from a vertex to itself. `growInterior(seed)` threw for every seed that picked a cell containing the aliased id (~half; seed-dependent — #262 made it deterministic but didn't remove it).

## Fix
Add a private `nextFreeVertexId()` that advances past any id already in `vertexList->contains()`, and route the no-arg `createVertex()`, `createVertex(coords)`, and `reserveVertexId()` through it. Counter-built complexes (CDT) are unchanged (no used ids to skip); only the explicit-id case is fixed.

## Root cause (verified with instrumentation)
build → 0,1,2 (counter→3); `createVertex(3)` → counter stays 3; `growInterior`'s `createVertex()` → `add(3)` → returns the **existing** vertex 3; coning cell (0,1,3) makes `[0,1,3]` with the apex == 3 → self-edge. Cell (0,1,2) (no 3) cones fine — hence seed-dependence.

## Verification
- `growInterior` on the bipyramid now succeeds for **all 16 sampled seeds** (was 7/16), no throw; the coned vertex always carries a fresh, non-aliasing id.
- Regression green: pachner / moves / cdt / build / spacetime / simplex / vertex (**106 passed**); cobordism — realizability oracle / eigenstate synthesis / surgery / emergent-bulk / mediated gate battery / mesh (**100 passed**).

Test: `tests/test_addmove_selfedge_python.py`.

Closes #267.