### PR TITLE
feat(cobordism): L2 register on 3-bulks — the hexagon-join S3 substrate for Regge mediation

### DIFF
--- a/examples/cobordism/l2_register_realizability.py
+++ b/examples/cobordism/l2_register_realizability.py
@@ -65,8 +65,7 @@ import json
 import os
 import random
 import sys
-from collections import Counter, defaultdict
-from itertools import combinations
+from collections import Counter
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -156,11 +155,10 @@ def _bulk(cells, weight=1.0, phase=0.0):
 # Dual-complex validity. The mediated objective scores the DUAL complex
 # (ReggeSolver::dualReggeAction on W*), and the Poincare/Lefschetz dual block
 # decomposition is a valid cell complex iff the primal is a combinatorial
-# manifold(-with-boundary). For n <= 3 the classification of surfaces makes
-# this fully decidable: facet coface counts in {1,2}, no dangling facets,
-# ridge links single paths/cycles, and (n=3) vertex links spheres or disks.
-# Topology moves are accepted only if this condition survives -- validity in
-# the dual space, not merely scoreability on the primal lattice. (Metric
+# manifold(-with-boundary). The check itself lives in C++
+# (ChainComplex::dualComplexIsValid, EigenstateSynthesis::dualComplexValid)
+# so every layer -- the registers here, and the C++ growth/surgery paths --
+# can gate moves on it; these are thin delegating wrappers. (Metric
 # dual-validity -- non-degenerate circumcentric volumes -- is the mediation
 # layer's separate concern; on unit-metric register bulks circumcenters are
 # barycentric and fine automatically.)
@@ -170,120 +168,21 @@ def dual_complex_is_valid(top_cells, n, facet_cells=None):
     cell decomposition -- equivalently, is the primal a combinatorial manifold
     with boundary? *facet_cells*, when given (the complex's full (n-1)-cell
     list), also catches dangling facets: (n-1)-cells with zero cofaces that
-    the Hodge Laplacian still sees even though no top cell carries them."""
-    cells = [tuple(sorted(int(v) for v in c)) for c in top_cells]
-    if not cells:
-        return False, "no top cells"
-    if any(len(c) != n + 1 for c in cells):
-        return False, "mixed top-cell dimension"
-    if len(set(cells)) != len(cells):
-        return False, "duplicate top cell"
-
-    cofaces = Counter()
-    for c in cells:
-        for f in combinations(c, n):
-            cofaces[f] += 1
-    for f, k in cofaces.items():
-        if k > 2:
-            return False, f"facet {f} has {k} cofaces"
-    if facet_cells is not None:
-        for f in facet_cells:
-            fs = tuple(sorted(int(v) for v in f))
-            if cofaces.get(fs, 0) == 0:
-                return False, f"dangling facet {fs} (0 cofaces)"
-
-    # ridge links: the top cells around each (n-2)-simplex, glued along the
-    # facets that contain it, must form ONE path or cycle (no pinches).
-    at_ridge = defaultdict(list)
-    for ci, c in enumerate(cells):
-        for r in combinations(c, n - 1):
-            at_ridge[r].append(ci)
-    for r, cis in at_ridge.items():
-        if len(cis) == 1:
-            continue
-        by_facet = defaultdict(list)
-        for ci in cis:
-            for v in cells[ci]:
-                if v not in r:
-                    by_facet[tuple(sorted(r + (v,)))].append(ci)
-        adj = defaultdict(set)
-        for fc in by_facet.values():
-            if len(fc) == 2:
-                adj[fc[0]].add(fc[1])
-                adj[fc[1]].add(fc[0])
-        seen, stack = {cis[0]}, [cis[0]]
-        while stack:
-            for y in adj[stack.pop()]:
-                if y not in seen:
-                    seen.add(y)
-                    stack.append(y)
-        if len(seen) != len(cis):
-            return False, f"ridge {r}: link is disconnected (pinch)"
-    if n == 2:
-        return True, "ok"
-
-    # n == 3: vertex links must be 2-spheres (interior) or disks (boundary).
-    at_vertex = defaultdict(list)
-    for c in cells:
-        for v in c:
-            at_vertex[v].append(c)
-    for v, cs in at_vertex.items():
-        link_faces = [tuple(sorted(u for u in c if u != v)) for c in cs]
-        edge_faces = defaultdict(list)
-        for i, lf in enumerate(link_faces):
-            for le in combinations(lf, 2):
-                edge_faces[le].append(i)
-        boundary_edges = []
-        adj = defaultdict(set)
-        for le, fs in edge_faces.items():
-            if len(fs) == 2:
-                adj[fs[0]].add(fs[1])
-                adj[fs[1]].add(fs[0])
-            elif len(fs) == 1:
-                boundary_edges.append(le)
-            else:
-                return False, f"vertex {v}: link edge {le} in {len(fs)} faces"
-        seen, stack = {0}, [0]
-        while stack:
-            for y in adj[stack.pop()]:
-                if y not in seen:
-                    seen.add(y)
-                    stack.append(y)
-        if len(seen) != len(link_faces):
-            return False, f"vertex {v}: link is disconnected (pinch)"
-        n_lv = len({u for lf in link_faces for u in lf})
-        chi = n_lv - len(edge_faces) + len(link_faces)
-        if not boundary_edges:
-            if chi != 2:
-                return False, f"vertex {v}: closed link has chi={chi}, not S^2"
-        else:
-            if chi != 1:
-                return False, f"vertex {v}: bounded link has chi={chi}, not a disk"
-            badj = defaultdict(set)
-            for a, b in boundary_edges:
-                badj[a].add(b)
-                badj[b].add(a)
-            if any(len(s) != 2 for s in badj.values()):
-                return False, f"vertex {v}: link boundary is not a 1-manifold"
-            start = boundary_edges[0][0]
-            seen_b, stack_b = {start}, [start]
-            while stack_b:
-                for y in badj[stack_b.pop()]:
-                    if y not in seen_b:
-                        seen_b.add(y)
-                        stack_b.append(y)
-            if len(seen_b) != len(badj):
-                return False, f"vertex {v}: link boundary has several circles"
-    return True, "ok"
+    the Hodge Laplacian still sees even though no top cell carries them.
+    Delegates to ``ChainComplex.dualComplexIsValid``."""
+    ok, why = cob.ChainComplex.dualComplexIsValid(
+        [[int(v) for v in c] for c in top_cells], int(n),
+        [[int(v) for v in f] for f in (facet_cells or [])])
+    return bool(ok), str(why)
 
 
 def register_dual_valid(es, n=3):
     """The dual-validity verdict for a synthesis object's CURRENT complex: top
     cells from the surgery state, facet cells from the (n-1)-cell list the
-    Hodge Laplacian is built over."""
-    tops = [tuple(int(v) for v in c) for c in es.topCells()]
-    facets = [tuple(int(v) for v in c) for c in es.cellSimplices()]
-    return dual_complex_is_valid(tops, n, facet_cells=facets)
+    Hodge Laplacian is built over. Delegates to
+    ``EigenstateSynthesis.dualComplexValid``."""
+    ok, why = es.dualComplexValid()
+    return bool(ok), str(why)
 
 
 def _betti2(st):

--- a/examples/cobordism/l2_register_realizability.py
+++ b/examples/cobordism/l2_register_realizability.py
@@ -65,6 +65,8 @@ import json
 import os
 import random
 import sys
+from collections import Counter, defaultdict
+from itertools import combinations
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -150,6 +152,140 @@ def _bulk(cells, weight=1.0, phase=0.0):
     return st
 
 
+# --------------------------------------------------------------------------- #
+# Dual-complex validity. The mediated objective scores the DUAL complex
+# (ReggeSolver::dualReggeAction on W*), and the Poincare/Lefschetz dual block
+# decomposition is a valid cell complex iff the primal is a combinatorial
+# manifold(-with-boundary). For n <= 3 the classification of surfaces makes
+# this fully decidable: facet coface counts in {1,2}, no dangling facets,
+# ridge links single paths/cycles, and (n=3) vertex links spheres or disks.
+# Topology moves are accepted only if this condition survives -- validity in
+# the dual space, not merely scoreability on the primal lattice. (Metric
+# dual-validity -- non-degenerate circumcentric volumes -- is the mediation
+# layer's separate concern; on unit-metric register bulks circumcenters are
+# barycentric and fine automatically.)
+# --------------------------------------------------------------------------- #
+def dual_complex_is_valid(top_cells, n, facet_cells=None):
+    """(ok, reason): is the dual block complex of this pure n-complex a valid
+    cell decomposition -- equivalently, is the primal a combinatorial manifold
+    with boundary? *facet_cells*, when given (the complex's full (n-1)-cell
+    list), also catches dangling facets: (n-1)-cells with zero cofaces that
+    the Hodge Laplacian still sees even though no top cell carries them."""
+    cells = [tuple(sorted(int(v) for v in c)) for c in top_cells]
+    if not cells:
+        return False, "no top cells"
+    if any(len(c) != n + 1 for c in cells):
+        return False, "mixed top-cell dimension"
+    if len(set(cells)) != len(cells):
+        return False, "duplicate top cell"
+
+    cofaces = Counter()
+    for c in cells:
+        for f in combinations(c, n):
+            cofaces[f] += 1
+    for f, k in cofaces.items():
+        if k > 2:
+            return False, f"facet {f} has {k} cofaces"
+    if facet_cells is not None:
+        for f in facet_cells:
+            fs = tuple(sorted(int(v) for v in f))
+            if cofaces.get(fs, 0) == 0:
+                return False, f"dangling facet {fs} (0 cofaces)"
+
+    # ridge links: the top cells around each (n-2)-simplex, glued along the
+    # facets that contain it, must form ONE path or cycle (no pinches).
+    at_ridge = defaultdict(list)
+    for ci, c in enumerate(cells):
+        for r in combinations(c, n - 1):
+            at_ridge[r].append(ci)
+    for r, cis in at_ridge.items():
+        if len(cis) == 1:
+            continue
+        by_facet = defaultdict(list)
+        for ci in cis:
+            for v in cells[ci]:
+                if v not in r:
+                    by_facet[tuple(sorted(r + (v,)))].append(ci)
+        adj = defaultdict(set)
+        for fc in by_facet.values():
+            if len(fc) == 2:
+                adj[fc[0]].add(fc[1])
+                adj[fc[1]].add(fc[0])
+        seen, stack = {cis[0]}, [cis[0]]
+        while stack:
+            for y in adj[stack.pop()]:
+                if y not in seen:
+                    seen.add(y)
+                    stack.append(y)
+        if len(seen) != len(cis):
+            return False, f"ridge {r}: link is disconnected (pinch)"
+    if n == 2:
+        return True, "ok"
+
+    # n == 3: vertex links must be 2-spheres (interior) or disks (boundary).
+    at_vertex = defaultdict(list)
+    for c in cells:
+        for v in c:
+            at_vertex[v].append(c)
+    for v, cs in at_vertex.items():
+        link_faces = [tuple(sorted(u for u in c if u != v)) for c in cs]
+        edge_faces = defaultdict(list)
+        for i, lf in enumerate(link_faces):
+            for le in combinations(lf, 2):
+                edge_faces[le].append(i)
+        boundary_edges = []
+        adj = defaultdict(set)
+        for le, fs in edge_faces.items():
+            if len(fs) == 2:
+                adj[fs[0]].add(fs[1])
+                adj[fs[1]].add(fs[0])
+            elif len(fs) == 1:
+                boundary_edges.append(le)
+            else:
+                return False, f"vertex {v}: link edge {le} in {len(fs)} faces"
+        seen, stack = {0}, [0]
+        while stack:
+            for y in adj[stack.pop()]:
+                if y not in seen:
+                    seen.add(y)
+                    stack.append(y)
+        if len(seen) != len(link_faces):
+            return False, f"vertex {v}: link is disconnected (pinch)"
+        n_lv = len({u for lf in link_faces for u in lf})
+        chi = n_lv - len(edge_faces) + len(link_faces)
+        if not boundary_edges:
+            if chi != 2:
+                return False, f"vertex {v}: closed link has chi={chi}, not S^2"
+        else:
+            if chi != 1:
+                return False, f"vertex {v}: bounded link has chi={chi}, not a disk"
+            badj = defaultdict(set)
+            for a, b in boundary_edges:
+                badj[a].add(b)
+                badj[b].add(a)
+            if any(len(s) != 2 for s in badj.values()):
+                return False, f"vertex {v}: link boundary is not a 1-manifold"
+            start = boundary_edges[0][0]
+            seen_b, stack_b = {start}, [start]
+            while stack_b:
+                for y in badj[stack_b.pop()]:
+                    if y not in seen_b:
+                        seen_b.add(y)
+                        stack_b.append(y)
+            if len(seen_b) != len(badj):
+                return False, f"vertex {v}: link boundary has several circles"
+    return True, "ok"
+
+
+def register_dual_valid(es, n=3):
+    """The dual-validity verdict for a synthesis object's CURRENT complex: top
+    cells from the surgery state, facet cells from the (n-1)-cell list the
+    Hodge Laplacian is built over."""
+    tops = [tuple(int(v) for v in c) for c in es.topCells()]
+    facets = [tuple(int(v) for v in c) for c in es.cellSimplices()]
+    return dual_complex_is_valid(tops, n, facet_cells=facets)
+
+
 def _betti2(st):
     return [int(b) for b in cob.ChainComplex.fromSpacetime(st).bettiNumbers()][2]
 
@@ -195,7 +331,12 @@ class RegisterL2:
             avail = {tuple(sorted(int(v) for v in c))
                      for c in self.es.interiorTopCells()}
             if cs in avail and self.es.removeInteriorCell(list(cs)):
+                ok, _why = register_dual_valid(self.es)
+                if not ok:                  # accept moves only if the DUAL stays
+                    self.es.restoreLastRemoval()            # a valid complex
+                    continue
                 self.extra_opened.append(cs)
+        self.dual_valid, self.dual_reason = register_dual_valid(self.es)
 
         self.cells = [tuple(int(v) for v in c) for c in self.es.cellSimplices()]
         harmonics = cob.HodgeLaplacian(self.st).harmonics(2)
@@ -242,6 +383,11 @@ class RegisterL2:
             if not self.es.attachInteriorVertex(fan):
                 continue
             if not self.es.removeInteriorCell(list(cell)):
+                self.es.detachLastInteriorVertex()
+                continue
+            ok, _why = register_dual_valid(self.es)
+            if not ok:                      # accept moves only if the DUAL stays
+                self.es.restoreLastRemoval()                # a valid complex
                 self.es.detachLastInteriorVertex()
                 continue
             grown += 1
@@ -588,6 +734,7 @@ def score_variant(cells, holes, extra, grow=0, grow_seed=0):
     identity_ok = by_name.get("Identity", False)
     s3_all = all(by_name.get(n, False) for n in CANONICAL_SET[:6])
     genuine = bool(identity_ok and s3_all and rank < n_holes
+                   and reg.dual_valid
                    and len(realized) < len(BASE._gates()))
     extends = sorted(g for g in realized if g not in CANONICAL_SET) if genuine else []
     return {
@@ -595,6 +742,7 @@ def score_variant(cells, holes, extra, grow=0, grow_seed=0):
         "b2": _betti2(reg.st), "dim": reg.dim, "rank": rank,
         "n_holes": n_holes, "n_extra": len(reg.extra_opened),
         "n_grown": reg.grown,
+        "dual_valid": reg.dual_valid,
         "realized": realized, "n_realized": len(realized),
         "identity": identity_ok, "s3_all": s3_all,
         "saturated": bool(rank >= n_holes), "genuine": genuine, "extends": extends,
@@ -628,7 +776,6 @@ def surgery_search(retries, jobs, base_seed=12345, kmax=3, max_add=20,
                    on_progress=None):
     """Score *retries* randomized surgery-grown 3-topologies in parallel and
     aggregate -- the degree-2 twin of the 2d search."""
-    from collections import Counter
     tasks = [(i, base_seed, kmax, max_add) for i in range(retries)]
     results = [r for r in BASE._parallel_map(_retry_worker, tasks, jobs,
                                              on_progress=on_progress) if r]
@@ -642,6 +789,7 @@ def surgery_search(retries, jobs, base_seed=12345, kmax=3, max_add=20,
         "retries": retries, "scored": len(results),
         "n_genuine": len(genuine), "n_saturated": len(saturated),
         "n_invalid": len(invalid),
+        "n_dual_invalid": sum(1 for r in results if not r["dual_valid"]),
         "seeds": sorted(Counter(r["seed"] for r in results).items()),
         "max_b2": max((r["b2"] for r in results), default=0),
         "max_nV": max((r["nV"] for r in results), default=0),
@@ -677,6 +825,8 @@ def _emergence_and_anchor(reg, check):
     check("ker L_2 (the register) emerges 0->2 under surgery",
           [t["kerL2"] for t in trace] == [0, 0, 1, 2])
     check("carried register V is 2-dimensional", reg.dim == 2)
+    check("the dual complex is a valid cell complex (the primal is a "
+          "combinatorial manifold with boundary)", reg.dual_valid)
 
     cp_b = _CP_IN
     cp_a = np.asarray(BASE._gates()[1][1])[1:4, 1:4] @ _CP_IN  # psi_A = SWAP|psi_B>
@@ -815,10 +965,16 @@ def _print_search(search, check):
         print("        => NO genuine register carries any gate beyond the "
               "criterion set: the conservation law is dimension-free as well as "
               "topology-free.")
+    print(f"      dual-complex validity: every accepted move is gated on the "
+          f"dual staying a valid cell complex (combinatorial manifold with "
+          f"boundary); draws whose final state violates it: "
+          f"{search['n_dual_invalid']}")
     check("no genuine register carries a gate beyond the criterion set",
           not search["grows"])
     check("every genuine register realizes exactly the criterion set",
           all(n == len(CANONICAL_SET) for n, _c in search["genuine_sizes"]))
+    check("every scored draw keeps a valid dual complex",
+          search["n_dual_invalid"] == 0)
 
 
 def main():

--- a/examples/cobordism/l2_register_realizability.py
+++ b/examples/cobordism/l2_register_realizability.py
@@ -1,0 +1,937 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Spectral gate realizability on the L_2 register: the same staged synthesis as
+``spectral_gate_realizability.py``, one degree up.
+
+The carried register here is **ker L_2 of a surgery-opened triangulated S^3** --
+the 12-vertex join of two hexagons, with three pairwise vertex-disjoint
+tetrahedra removed by the boundary-fixed surgery. The register theorems are
+dimension-blind (sphere minus three balls with L_{n-1} in any n): opening the
+holes grows b_2 0 -> 2, ker L_2 emerges as the two-dimensional carried register,
+the harmonic periods over the three boundary 2-spheres conserve total charge,
+and the realizable gate set is exactly the charge-conservation criterion -- the
+same 13 named gates as the 2d register, decided by the same Hodge spectrum.
+
+What is genuinely new at this degree is the substrate, not the gate set: on
+3-complex bulks the Regge action has stationary points (vanishing interior
+deficit angles), so the mediated objective F_beta = r_U + beta*|S_Regge| can
+select among the bulks realizing a gate -- in two dimensions the Regge term is
+Gauss--Bonnet-topological and exerts no selection pressure.
+
+Everything battery-shaped is imported from ``spectral_gate_realizability.py``
+(the gates, thresholds, criterion, Choi reading, parallel pool); this module
+owns only the geometry layer: (p,q)-gon join seeds, tet holes, signed
+tet-facet periods, and the 3d composed stellar growth (cone a tetrahedron's
+four faces onto a fresh interior vertex, then remove the parent tet).
+
+A note on growth and extra cuts: a cell is "interior" to the synthesis only if
+it touches no boundary vertex, and the canonical hexagon join's three holes
+consume all 12 vertices -- so on the canonical bulk neither extra cuts nor
+additive growth can start. The topology search therefore draws larger
+(p,q)-join seeds (16+ vertices), where interior room exists; this is the same
+seed-laddering the 2d search does with geodesic subdivisions.
+
+Run:
+    python examples/cobordism/l2_register_realizability.py
+    python examples/cobordism/l2_register_realizability.py --h3
+    python examples/cobordism/l2_register_realizability.py --retries 300 --jobs 10
+    python examples/cobordism/l2_register_realizability.py --gate sqrt-SWAP
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import random
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_base():
+    """Load the 2d example as a module and register it in sys.modules so the
+    spawn-based parallel pool can re-resolve its functions in worker processes."""
+    name = "spectral_gate_realizability"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_HERE, "spectral_gate_realizability.py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = _load_base()                       # sets the 10-CPU thread caps on import
+np = BASE.np
+tessera = BASE.tessera
+cob = tessera.cobordism
+
+REALIZE = BASE.REALIZE
+CERT_FLOOR = BASE.CERT_FLOOR
+CANONICAL_SET = BASE.CANONICAL_SET
+_CP_IN = BASE._CP_IN
+
+
+# --------------------------------------------------------------------------- #
+# The (p,q)-gon join family of triangulated S^3 seeds. S^3 = S^1 * S^1: every
+# tetrahedron is (an edge of the p-gon) x (an edge of the q-gon), so a p-gon
+# joined with a q-gon gives p+q vertices and p*q tets. Vertex-disjoint hole
+# triples need three pairwise disjoint edges in EACH factor (p, q >= 6).
+# --------------------------------------------------------------------------- #
+def _join_cells(p, q):
+    """The tetrahedra of the p-gon * q-gon join (vertices 0..p-1, then p..p+q-1)."""
+    ae = [(i, (i + 1) % p) for i in range(p)]
+    be = [(p + j, p + (j + 1) % q) for j in range(q)]
+    return sorted(tuple(sorted((*ea, *eb))) for ea in ae for eb in be)
+
+
+def _diag_holes(p, q, k=3):
+    """The canonical C_3-orbit hole triple: the first k even edges of each factor,
+    diagonally matched -- cyclically permuted by the shift (i,j) -> (i+2, j+2)
+    (for p = q = 6 this is the verified hexagon-join triple; for p = q = 9 use
+    stride 3 via _stride_holes)."""
+    return [tuple(sorted((2 * t, (2 * t + 1) % p,
+                          p + 2 * t, p + (2 * t + 1) % q))) for t in range(k)]
+
+
+def _stride_holes(p, q, stride, k=3):
+    """k diagonally-matched holes at the given edge stride in each factor."""
+    return [tuple(sorted((stride * t, (stride * t + 1) % p,
+                          p + stride * t, p + (stride * t + 1) % q)))
+            for t in range(k)]
+
+
+_HEXJOIN = _join_cells(6, 6)
+_HEXJOIN_HOLES = _diag_holes(6, 6)        # the verified canonical triple
+
+
+def _tet_facets(cell):
+    """The four oriented boundary triangles of a sorted tetrahedron (a,b,c,d),
+    with the (-1)^j induced-orientation signs of the boundary operator."""
+    a, b, c, d = sorted(cell)
+    return [((b, c, d), +1), ((a, c, d), -1), ((a, b, d), +1), ((a, b, c), -1)]
+
+
+def _bulk(cells, weight=1.0, phase=0.0):
+    """A pre-geometric 3-complex (top cells = tetrahedra) from a tet list, all
+    edges pinned to a uniform Hermitian weight -- the 3d twin of the 2d builder."""
+    sig = tessera.Signature(3, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {i: st.createVertex(i) for i in sorted({v for c in cells for v in c})}
+    for c in cells:
+        t = sorted(c)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]], vmap[t[3]]])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(weight)
+        e.setPhase(phase)
+    return st
+
+
+def _betti2(st):
+    return [int(b) for b in cob.ChainComplex.fromSpacetime(st).bettiNumbers()][2]
+
+
+def _ker_l2_dim(st):
+    return len(cob.HodgeLaplacian(st).harmonics(2))
+
+
+# --------------------------------------------------------------------------- #
+# The L_2 register: ker L_2 of the surgery-grown S^3, read by eigendecomposition.
+# The structural mirror of the 2d Register, with circle periods over hole edges
+# replaced by signed 2-sphere periods over hole facets.
+# --------------------------------------------------------------------------- #
+class RegisterL2:
+    """The carried register V = ker L_2 of the surgery-grown S^3. Holds the grown
+    bulk, its degree-2 ``EigenstateSynthesis`` (the genuine L_2 residual core),
+    the harmonic 2-forms in the bulk's cell order, their hole-facet restriction
+    and period rows, and the orientation signs that symmetrize the
+    boundary-period constraint to Sigma = 0. All OUTPUTS read off the grown bulk.
+
+    The default ``RegisterL2()`` is the verified hexagon-join / 3-canonical-hole
+    register. ``cells`` / ``class_holes`` / ``extra_holes`` / ``grow_vertices``
+    drive the surgery-topology search exactly as in the 2d Register: a different
+    (p,q)-join seed, a different vertex-disjoint tet triple, extra
+    ``removeInteriorCell`` surgeries, and seeded additive stellar growth."""
+
+    def __init__(self, cells=_HEXJOIN, class_holes=_HEXJOIN_HOLES, extra_holes=(),
+                 grow_vertices=0, grow_seed=0):
+        self.seed_cells = list(cells)
+        self.class_holes = [tuple(sorted(h)) for h in class_holes]
+        self.reg_facets = [f for hole in self.class_holes
+                           for f, _s in _tet_facets(hole)]
+        self.fidx = {f: i for i, f in enumerate(self.reg_facets)}
+
+        self.st = _bulk(self.seed_cells)
+        self.es = cob.EigenstateSynthesis(self.st, 2)
+        for hole in self.class_holes:                       # the holonomy holes
+            self.es.removeInteriorCell(list(hole))
+        self.grown = self._stellar_grow(grow_vertices, grow_seed)
+        self.extra_opened = []                              # extra surgery (b_2 growth)
+        for cell in extra_holes:
+            cs = tuple(sorted(cell))
+            avail = {tuple(sorted(int(v) for v in c))
+                     for c in self.es.interiorTopCells()}
+            if cs in avail and self.es.removeInteriorCell(list(cs)):
+                self.extra_opened.append(cs)
+
+        self.cells = [tuple(int(v) for v in c) for c in self.es.cellSimplices()]
+        harmonics = cob.HodgeLaplacian(self.st).harmonics(2)
+        self.dim = len(harmonics)
+        if self.dim:
+            self.H_full = np.array(
+                [[complex(h.amplitudeFor(list(c))) for c in self.cells]
+                 for h in harmonics])
+        else:
+            self.H_full = np.zeros((0, len(self.cells)), dtype=complex)
+        self._reg_col = [self.cells.index(f) for f in self.reg_facets]
+        h_reg = self.H_full[:, self._reg_col]
+        self.P = np.array(
+            [[self._period(h_reg[r], hole) for hole in self.class_holes]
+             for r in range(self.dim)]).reshape(self.dim, len(self.class_holes))
+        if self.dim:
+            n_raw = np.linalg.svd(self.P)[2][-1].conj()
+            self.n = (n_raw / n_raw[np.argmax(np.abs(n_raw))]).real
+        else:
+            self.n = np.ones(len(self.class_holes))
+        self.sign = np.sign(self.n)
+        self.sign[self.sign == 0] = 1.0
+
+    def _stellar_grow(self, n, seed):
+        """ADD up to *n* interior vertices by boundary-fixed stellar subdivision,
+        composed from the two surgery primitives exactly as in 2d: cone a fresh
+        vertex onto an interior tetrahedron's four faces (``attachInteriorVertex``
+        with the facet fan -- dW untouched), then remove the subdivided tet
+        (``removeInteriorCell`` -- its faces keep two cofaces, so dW stays
+        bit-exact). Each application adds ONE vertex and preserves ker L_2 (the
+        fan is homotopic to the tet it replaces); sites are drawn by the seeded
+        RNG from the current interior top cells. On seeds whose holes consume
+        every vertex (the canonical hexagon join) there is no interior site and
+        the budget is simply unused."""
+        rng = random.Random(int(seed))
+        grown = 0
+        for _ in range(int(n)):
+            sites = sorted(tuple(sorted(int(v) for v in c))
+                           for c in self.es.interiorTopCells())
+            if not sites:
+                break
+            cell = rng.choice(sites)
+            fan = [list(f) for f, _s in _tet_facets(cell)]
+            if not self.es.attachInteriorVertex(fan):
+                continue
+            if not self.es.removeInteriorCell(list(cell)):
+                self.es.detachLastInteriorVertex()
+                continue
+            grown += 1
+        if grown:
+            # attachInteriorVertex wires the new cells through the endpoint
+            # TIME rule rather than a causal cone placement; re-pin the bulk
+            # uniform so the documented unit cochain metric holds by
+            # construction (the 2d register does the same).
+            for e in self.st.getEdgeList().toVector():
+                e.setSquaredLength(1.0)
+                e.setPhase(0.0)
+        return grown
+
+    def _period(self, vec, hole):
+        """The induced (raw) oriented 2-sphere period of a hole: the signed sum of
+        the 2-form over the hole's four boundary triangles."""
+        return sum(s * vec[self.fidx[f]] for f, s in _tet_facets(hole))
+
+    @property
+    def rank(self):
+        """The rank of the carried period space over the holonomy holes -- same
+        genuine (rank < #holes) vs saturated (rank == #holes) semantics as 2d."""
+        return int(np.linalg.matrix_rank(self.P, tol=1e-9)) if self.dim else 0
+
+    def harmonic_form(self, raw_periods):
+        """The carried harmonic 2-form whose three sphere-periods are the
+        projection of *raw_periods* onto the carried period space, plus a minimal
+        leak 2-form on one facet per hole so the cochain's periods are EXACTLY
+        *raw_periods* -- the L_2 twin of the 2d leak construction."""
+        coeffs, *_ = np.linalg.lstsq(self.P.T, raw_periods, rcond=None)
+        full = (coeffs @ self.H_full).astype(complex)
+        leak = raw_periods - coeffs @ self.P
+        for k, hole in enumerate(self.class_holes):
+            first_facet = _tet_facets(hole)[0][0]           # sign +1 by convention
+            full[self._reg_col[self.fidx[first_facet]]] += leak[k]
+        return full
+
+    def spectral_residual(self, raw_periods):
+        """The genuine Hodge residual ||(I-psi psi^dag) L_2 psi||^2 of the 2-form
+        with the given raw periods -- the continuous spectral realizability score.
+        -> 0 iff the periods lie in the carried register V."""
+        psi = self.harmonic_form(raw_periods)
+        return float(self.es.residual([complex(z) for z in psi]))
+
+
+# --------------------------------------------------------------------------- #
+# STAGE 3 emergence and the identity anchor, on the hexagon join.
+# --------------------------------------------------------------------------- #
+def register_emergence():
+    """Surgery opens the three tet holes one at a time; b_2 and ker L_2 emerge
+    0 -> 2 from the spectrum (the closed S^3 carries nothing)."""
+    st = _bulk(_HEXJOIN)
+    es = cob.EigenstateSynthesis(st, 2)
+    interior = {tuple(sorted(int(v) for v in c)) for c in es.interiorTopCells()}
+    trace = [{"step": "closed S^3 seed", "b2": _betti2(st), "kerL2": _ker_l2_dim(st)}]
+    for hole in _HEXJOIN_HOLES:
+        assert hole in interior, "holonomy hole must be a genuine interior cell"
+        es.removeInteriorCell(list(hole))
+        trace.append({"step": f"open {hole}", "b2": _betti2(st),
+                      "kerL2": _ker_l2_dim(st)})
+    return trace
+
+
+def synthesize_state(reg, raw_periods):
+    """STAGE 1 for one register state at degree 2: confirm the state is carried as
+    a harmonic of the grown bulk by the genuine metric Hodge residual."""
+    res = reg.spectral_residual(raw_periods)
+    return res, int(reg.st.getVertexList().size()), int(reg.es.order())
+
+
+def identity_anchor(reg):
+    """The falsifiable core at degree 2: the identity post-interaction state is
+    carried ONLY once surgery has grown the full register (b_2 = 2, ker L_2 = 2);
+    on the closed S^3, the one-hole ball, and the two-hole shell it floors."""
+    raw = reg.sign * _CP_IN
+    psi_full = reg.harmonic_form(raw)
+    by_cell = {reg.cells[i]: psi_full[i] for i in range(len(reg.cells))}
+    rows = []
+    for k in range(len(_HEXJOIN_HOLES) + 1):
+        st = _bulk(_HEXJOIN)
+        es = cob.EigenstateSynthesis(st, 2)
+        for hole in _HEXJOIN_HOLES[:k]:
+            es.removeInteriorCell(list(hole))
+        cells = [tuple(int(v) for v in c) for c in es.cellSimplices()]
+        psi = np.array([by_cell.get(c, 0.0) for c in cells], dtype=complex)
+        res = float(es.residual([complex(z) for z in psi]))
+        rows.append({"holes_open": k, "b2": _betti2(st), "kerL2": _ker_l2_dim(st),
+                     "residual": res, "realizable": bool(res < REALIZE)})
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# STAGE 3 gate scoring -- identical decision, one degree up.
+# --------------------------------------------------------------------------- #
+def post_interaction(reg, U):
+    """The post-interaction state U|psi_B> on the carried register: the spectral
+    residual of the 2-form with raw periods sign * (U_reg cp_in) -> 0 iff carried
+    by ker L_2. Returns (residual, b_2, leakage |Sigma|)."""
+    u_reg = np.asarray(U, dtype=complex)[1:4, 1:4]
+    cp_out = u_reg @ _CP_IN.astype(complex)
+    res = reg.spectral_residual(reg.sign * cp_out)
+    return res, _betti2(reg.st), float(abs(cp_out.sum()))
+
+
+def gate_sweep(reg, on_progress=None):
+    """The full battery on the L_2 register (serial; each gate is one residual)."""
+    rows = []
+    for name, U, fam in BASE._gates():
+        res, b2, leak = post_interaction(reg, U)
+        rows.append({"gate": name, "family": fam, "residual": res, "b2": b2,
+                     "leak": leak, "realizable": bool(res < REALIZE)})
+        if on_progress is not None:
+            on_progress()
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# --h3: the value level at degree 2 -- anchor, Gram, Z_spec vs the amplitude,
+# bulk independence across join seeds. Mirrors the 2d implementation exactly.
+# --------------------------------------------------------------------------- #
+def _carried_form(reg, raw_periods):
+    """The pure ker-L_2 representative (least squares, NO leak correction) and the
+    norm of the un-carried period remainder."""
+    raw = np.asarray(raw_periods, dtype=complex)
+    coeffs, *_ = np.linalg.lstsq(reg.P.T, raw, rcond=None)
+    full = (coeffs @ reg.H_full).astype(complex)
+    leak = raw - coeffs @ reg.P
+    return full, float(np.linalg.norm(leak))
+
+
+def register_gram(reg, scale):
+    """The register Gram in period coordinates on a flat-orthonormal basis of the
+    Sigma = 0 subspace. G = I is the period-map isometry; the hexagon join's hole
+    triple is a full S_3 orbit of its automorphism group, so the isometric-chart
+    proposition applies (a fortiori: a cyclic symmetry plus the real metric
+    already suffices)."""
+    e1 = np.array([1.0, -1.0, 0.0]) / np.sqrt(2.0)
+    e2 = np.array([1.0, 1.0, -2.0]) / np.sqrt(6.0)
+    forms = [_carried_form(reg, reg.sign * e.astype(complex))[0] for e in (e1, e2)]
+    return scale * np.array([[complex(np.vdot(a, b)) for b in forms] for a in forms])
+
+
+def h3_value_sweep(reg, n_states=8, seed=2026, on_progress=None):
+    """H3 on the L_2 spectral data: Z_spec = scale * <h(psi_A), h(U psi_B)> against
+    the flat register amplitude and the independent Choi reading, for every gate
+    the construction realizes. One scale from the T1 anchor; then predictions."""
+    hodge = cob.HodgeLaplacian(reg.st)
+    w2 = np.asarray(hodge.weights(2), dtype=float)
+    # At degree 2 the cochain weights are simplex AREAS, so the unit-edge pin
+    # gives the uniform equilateral metric w_2 = sqrt(3)/4 -- a single scalar,
+    # absorbed by the T1 anchor. Uniformity (not unit value) is what the
+    # plain-contraction pairing and the isometric-chart proposition require.
+    info = {"metric_mean": float(w2.mean()),
+            "metric_uniform_dev": float(np.max(np.abs(w2 - w2.mean())))}
+
+    cp_b = (_CP_IN / np.linalg.norm(_CP_IN)).astype(complex)
+    h_b, leak_b = _carried_form(reg, reg.sign * cp_b)
+    info["psi_b_leak"] = leak_b
+    scale = 1.0 / float(np.vdot(h_b, h_b).real)           # the T1 anchor
+    info["scale"] = scale
+    info["gram"] = register_gram(reg, scale)
+    info["gram_dev"] = float(np.max(np.abs(info["gram"] - np.eye(2))))
+
+    states = [cp_b] + BASE.random_carried_states(n_states, seed)
+    forms_a = [_carried_form(reg, reg.sign * cp)[0] for cp in states]
+
+    rows = []
+    for name, U, fam in BASE._gates():
+        u_reg = np.asarray(U, dtype=complex)[1:4, 1:4]
+        cp_out = u_reg @ cp_b
+        res, _b2, leak = post_interaction(reg, U)
+        realized = bool(res < REALIZE)
+        if not realized:
+            rows.append({"gate": name, "family": fam, "realizable": False,
+                         "residual": res, "leak": leak,
+                         "max_dev": None, "choi_dev": None, "n_pairs": 0})
+            if on_progress is not None:
+                on_progress()
+            continue
+        h_out, _ = _carried_form(reg, reg.sign * cp_out)
+        devs, choi_devs = [], []
+        for cp_a, h_a in zip(states, forms_a):
+            amp = complex(np.vdot(cp_a, cp_out))
+            z = scale * complex(np.vdot(h_a, h_out))
+            devs.append(abs(z - amp))
+            choi_devs.append(abs(BASE._amp_choi(U, cp_a, cp_out, cp_b) - amp))
+        rows.append({"gate": name, "family": fam, "realizable": True,
+                     "residual": res, "leak": leak,
+                     "max_dev": float(max(devs)), "choi_dev": float(max(choi_devs)),
+                     "n_pairs": len(states)})
+        if on_progress is not None:
+            on_progress()
+    return rows, info
+
+
+def _equivariant_variant():
+    """The symmetry-preserving bulk variant: the (9,9)-gon join with the hole
+    triple at edge stride 3 -- cyclically permuted by the shift (i,j) -> (i+3,
+    j+3), so the isometric-chart proposition applies and the value must carry
+    over exactly. The holes are still tetrahedra, so the boundary pair is the
+    same three triangulated 2-spheres as the canonical register's."""
+    return RegisterL2(cells=_join_cells(9, 9), class_holes=_stride_holes(9, 9, 3))
+
+
+def _vertex_disjoint_tets(cells, k, rng, tries=600):
+    """k pairwise vertex-disjoint tetrahedra drawn at random from a seed."""
+    cl = [tuple(sorted(c)) for c in cells]
+    for _ in range(tries):
+        pick = rng.sample(cl, k)
+        verts = [v for c in pick for v in c]
+        if len(set(verts)) == 4 * k:
+            return pick
+    return None
+
+
+def _anisotropic_variant_registers(n_variants, seed):
+    """Re-grown GENUINE registers with generic (seeded, vertex-disjoint) tet
+    triples on the (8,8) join -- carried, but with no symmetry to enforce an
+    isometric chart. Their Gram defect is the control the equivariant witness is
+    read against."""
+    rng = random.Random(seed)
+    out, tries = [], 0
+    cells = _join_cells(8, 8)
+    while len(out) < n_variants and tries < 60:
+        tries += 1
+        holes = _vertex_disjoint_tets(cells, 3, rng)
+        if holes is None:
+            continue
+        reg = RegisterL2(cells=cells, class_holes=holes)
+        if reg.dim != 2 or reg.rank >= len(reg.class_holes):
+            continue                                      # saturated / degenerate
+        if post_interaction(reg, BASE._gates()[0][1])[0] >= REALIZE:
+            continue                                      # identity anchor must hold
+        out.append(reg)
+    return out
+
+
+def h3_invariance(n_variants=2, n_states=4, seed=2026, on_progress=None):
+    """Bulk independence of the value at degree 2, and what it turns on: the H3
+    table re-run on re-grown registers with the SAME state battery. On the
+    symmetric (9,9)-join variant the value carries over exactly; on generic
+    (8,8) hole draws the chart is anisotropic and the deviation from the
+    amplitude equals the Gram-defect prediction a^dag (G - I) b exactly."""
+    cp_b = (_CP_IN / np.linalg.norm(_CP_IN)).astype(complex)
+    states = [cp_b] + BASE.random_carried_states(n_states, seed)
+    realized = [(name, np.asarray(U, dtype=complex)[1:4, 1:4])
+                for name, U, _f in BASE._gates() if BASE.conserves_charge(U)]
+    e_basis = np.array([[1.0, -1.0, 0.0] / np.sqrt(2.0),
+                        [1.0, 1.0, -2.0] / np.sqrt(6.0)])
+
+    def survey(reg):
+        h_b, _ = _carried_form(reg, reg.sign * cp_b)
+        scale = 1.0 / float(np.vdot(h_b, h_b).real)
+        gram = register_gram(reg, scale)
+        forms_a = [_carried_form(reg, reg.sign * cp)[0] for cp in states]
+        vals, defect = {}, 0.0
+        for name, u_reg in realized:
+            cp_out = u_reg @ cp_b
+            h_out, _ = _carried_form(reg, reg.sign * cp_out)
+            b = e_basis @ cp_out
+            zs = []
+            for cp_a, h_a in zip(states, forms_a):
+                z = scale * complex(np.vdot(h_a, h_out))
+                amp = complex(np.vdot(cp_a, cp_out))
+                a = e_basis @ cp_a
+                predicted = complex(np.conj(a) @ (gram - np.eye(2)) @ b)
+                defect = max(defect, abs((z - amp) - predicted))
+                zs.append(z)
+            vals[name] = zs
+        return vals, float(np.max(np.abs(gram - np.eye(2)))), defect
+
+    base_vals, _gd, _dd = survey(RegisterL2())
+    if on_progress is not None:
+        on_progress()
+
+    def drift_vs_base(vals):
+        return float(max(abs(vals[name][k] - base_vals[name][k])
+                         for name in vals for k in range(len(states))))
+
+    eq = _equivariant_variant()
+    eq_vals, eq_gram_dev, eq_defect = survey(eq)
+    equivariant = {"nV": int(eq.st.getVertexList().size()), "rank": eq.rank,
+                   "gram_dev": eq_gram_dev, "drift": drift_vs_base(eq_vals),
+                   "defect_residual": eq_defect}
+    if on_progress is not None:
+        on_progress()
+
+    anisotropic = []
+    for reg in _anisotropic_variant_registers(n_variants, seed):
+        vals, gram_dev, defect = survey(reg)
+        anisotropic.append({"nV": int(reg.st.getVertexList().size()),
+                            "rank": reg.rank, "gram_dev": gram_dev,
+                            "drift": drift_vs_base(vals),
+                            "defect_residual": defect})
+        if on_progress is not None:
+            on_progress()
+    return {"equivariant": equivariant, "anisotropic": anisotropic,
+            "n_gates": len(realized), "n_pairs": len(states)}
+
+
+# --------------------------------------------------------------------------- #
+# The surgery-topology search at degree 2: randomized (p,q)-join seeds, random
+# vertex-disjoint tet triples, extra cuts, additive stellar growth -- then the
+# full battery re-decided by the same L_2 spectrum.
+# --------------------------------------------------------------------------- #
+_SEEDS = [(6, 6), (8, 8), (6, 8), (8, 6), (10, 10)]
+_SEED_WEIGHTS = [3, 3, 2, 2, 1]
+
+
+def _extra_tets(cells, holes, n, rng):
+    """Up to *n* extra tets, pairwise vertex-disjoint and disjoint from the
+    holonomy holes (the Register opens the genuinely removable subset)."""
+    if n <= 0:
+        return []
+    used = {v for h in holes for v in h}
+    cand = [tuple(sorted(c)) for c in cells
+            if not (set(c) & used) and tuple(sorted(c)) not in holes]
+    rng.shuffle(cand)
+    out, chosen = [], set()
+    for c in cand:
+        if len(out) >= n:
+            break
+        if set(c) & chosen:
+            continue
+        out.append(c)
+        chosen |= set(c)
+    return out
+
+
+def score_variant(cells, holes, extra, grow=0, grow_seed=0):
+    """Build the L_2 register on one surgery-grown 3-topology and re-decide the
+    full battery. Same compact summary and genuine/saturated semantics as 2d."""
+    reg = RegisterL2(cells=cells, class_holes=holes, extra_holes=extra,
+                     grow_vertices=grow, grow_seed=grow_seed)
+    realized, by_name = [], {}
+    for name, U, _fam in BASE._gates():
+        res, _b2, _leak = post_interaction(reg, U)
+        ok = bool(res < REALIZE)
+        by_name[name] = ok
+        if ok:
+            realized.append(name)
+    rank = reg.rank
+    n_holes = len(reg.class_holes)
+    identity_ok = by_name.get("Identity", False)
+    s3_all = all(by_name.get(n, False) for n in CANONICAL_SET[:6])
+    genuine = bool(identity_ok and s3_all and rank < n_holes
+                   and len(realized) < len(BASE._gates()))
+    extends = sorted(g for g in realized if g not in CANONICAL_SET) if genuine else []
+    return {
+        "seed": None, "nV": int(reg.st.getVertexList().size()),
+        "b2": _betti2(reg.st), "dim": reg.dim, "rank": rank,
+        "n_holes": n_holes, "n_extra": len(reg.extra_opened),
+        "n_grown": reg.grown,
+        "realized": realized, "n_realized": len(realized),
+        "identity": identity_ok, "s3_all": s3_all,
+        "saturated": bool(rank >= n_holes), "genuine": genuine, "extends": extends,
+    }
+
+
+def _retry_worker(task):
+    """One surgery-topology retry at degree 2: pick a (p,q)-join seed, a
+    vertex-disjoint tet triple, extra cuts, and an additive-growth count by the
+    retry's RNG, then score the variant."""
+    idx, base_seed, kmax, max_add = task
+    rng = random.Random(base_seed * 1_000_003 + idx)
+    p, q = rng.choices(_SEEDS, weights=_SEED_WEIGHTS)[0]
+    cells = _join_cells(p, q)
+    holes = _vertex_disjoint_tets(cells, 3, rng)
+    if holes is None:
+        return None
+    n_extra = rng.randint(0, kmax)
+    extra = _extra_tets(cells, holes, n_extra, rng)
+    n_grow = rng.randint(0, max(int(max_add), 0))
+    grow_seed = rng.randrange(1, 2**31)
+    try:
+        out = score_variant(cells, holes, extra, grow=n_grow, grow_seed=grow_seed)
+    except Exception:                                       # a degenerate draw
+        return None
+    out["seed"] = f"{p}x{q}"
+    return out
+
+
+def surgery_search(retries, jobs, base_seed=12345, kmax=3, max_add=20,
+                   on_progress=None):
+    """Score *retries* randomized surgery-grown 3-topologies in parallel and
+    aggregate -- the degree-2 twin of the 2d search."""
+    from collections import Counter
+    tasks = [(i, base_seed, kmax, max_add) for i in range(retries)]
+    results = [r for r in BASE._parallel_map(_retry_worker, tasks, jobs,
+                                             on_progress=on_progress) if r]
+    genuine = [r for r in results if r["genuine"]]
+    saturated = [r for r in results if r["saturated"]]
+    invalid = [r for r in results if not r["genuine"] and not r["saturated"]]
+    extensions = [r for r in genuine if r["extends"]]
+    genuine_sizes = Counter(r["n_realized"] for r in genuine)
+    new_gates = sorted({g for r in extensions for g in r["extends"]})
+    return {
+        "retries": retries, "scored": len(results),
+        "n_genuine": len(genuine), "n_saturated": len(saturated),
+        "n_invalid": len(invalid),
+        "seeds": sorted(Counter(r["seed"] for r in results).items()),
+        "max_b2": max((r["b2"] for r in results), default=0),
+        "max_nV": max((r["nV"] for r in results), default=0),
+        "max_grown": max((r.get("n_grown", 0) for r in results), default=0),
+        "max_add": max_add,
+        "genuine_sizes": sorted(genuine_sizes.items()),
+        "extensions": extensions, "new_gates": new_gates,
+        "grows": bool(new_gates),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Report rendering + main.
+# --------------------------------------------------------------------------- #
+def _print_header():
+    print("Spectral gate realizability on the L_2 register (S^3 hexagon-join, "
+          "surgery)\n  (the staged synthesis one degree up: tet holes open b_2 "
+          "0 -> 2, ker L_2 carries the register, the same Hodge spectrum "
+          "decides; the substrate the Regge-mediated objective selects on)\n")
+
+
+def _emergence_and_anchor(reg, check):
+    trace = register_emergence()
+    print("  STAGE 3 register emergence (removeInteriorCell opens the three tet "
+          "holes; ker L_2 emerges from the spectrum, boundary bit-exact):")
+    print("      " + "  ->  ".join(
+        f"{t['step']}: b_2={t['b2']}, ker L_2={t['kerL2']}" for t in trace))
+    print(f"        => surgery grows b_2 0 -> {trace[-1]['b2']} and ker L_2 0 -> "
+          f"{trace[-1]['kerL2']}; boundary-period constraint n ~ "
+          f"{np.round(reg.n, 2)} (orientation signs {reg.sign}; symmetrized to "
+          f"Sigma=0).")
+    check("surgery grows b_2 0->2 on its own", trace[-1]["b2"] == 2)
+    check("ker L_2 (the register) emerges 0->2 under surgery",
+          [t["kerL2"] for t in trace] == [0, 0, 1, 2])
+    check("carried register V is 2-dimensional", reg.dim == 2)
+
+    cp_b = _CP_IN
+    cp_a = np.asarray(BASE._gates()[1][1])[1:4, 1:4] @ _CP_IN  # psi_A = SWAP|psi_B>
+    res_b, nv_b, nc_b = synthesize_state(reg, reg.sign * cp_b)
+    res_a, nv_a, nc_a = synthesize_state(reg, reg.sign * cp_a)
+    print("\n  STAGE 1 boundary synthesis (geo(psi) carried as a harmonic of "
+          "ker L_2 on the grown S^3):")
+    print(f"      geo(psi_B): |V|={nv_b} |C_2|={nc_b}  ||(I-PP)L_2 psi_B||^2 = "
+          f"{res_b:.2e}  (carried)")
+    print(f"      geo(psi_A): |V|={nv_a} |C_2|={nc_a}  ||(I-PP)L_2 psi_A||^2 = "
+          f"{res_a:.2e}  (carried)")
+    check("stage-1 geo(psi_B) carries psi_B as a harmonic", res_b < REALIZE)
+    check("stage-1 geo(psi_A) carries psi_A as a harmonic", res_a < REALIZE)
+
+    anchor = identity_anchor(reg)
+    print("\n  Identity sanity check (the falsifiable core, decided spectrally):")
+    for r in anchor:
+        print(f"      {r['holes_open']} holes open: b_2={r['b2']} "
+              f"ker L_2={r['kerL2']}  r={r['residual']:.2e}  "
+              f"{'REALIZES' if r['realizable'] else 'floors'}")
+    print("        => the identity FLOORS on every seed with ker L_2 < 2 and "
+          "REALIZES only once surgery opens b_2 0 -> 2. Surgery is load-bearing "
+          "at this degree exactly as at degree 1.")
+    check("identity floors on every under-grown seed (ker L_2 < 2)",
+          all((not r["realizable"]) and r["residual"] > CERT_FLOOR
+              for r in anchor[:-1]))
+    check("identity realizes once surgery grows the full register (b_2=2)",
+          anchor[-1]["realizable"] and anchor[-1]["b2"] == 2)
+    return trace, anchor, {"geo_psi_B": [res_b, nv_b, nc_b],
+                           "geo_psi_A": [res_a, nv_a, nc_a]}
+
+
+def _print_sweep(rows, check):
+    realized = [r for r in rows if r["realizable"]]
+    floored = [r for r in rows if not r["realizable"]]
+    print(f"\n  STAGE 3 battery ({len(rows)} gates, the same battery as the 2d "
+          f"register, scored by the L_2 spectrum):")
+    print(f"      realized ({len(realized)}): "
+          + ", ".join(r["gate"] for r in realized))
+    lo = min(r["residual"] for r in floored)
+    hi = max(r["residual"] for r in floored)
+    lo_r = max(r["residual"] for r in realized)
+    print(f"      floored ({len(floored)}): residuals in {lo:.2f}..{hi:.2f}; "
+          f"worst realized residual {lo_r:.1e}")
+    agree = all(r["realizable"] == BASE.conserves_charge(U)
+                for r, (_n, U, _f) in zip(rows, BASE._gates()))
+    check("the realizable set is EXACTLY the charge-conservation criterion "
+          "(spectral == closed form on every gate)", agree)
+    check("the realizable set matches the canonical 13 named gates",
+          sorted(r["gate"] for r in realized) == sorted(CANONICAL_SET))
+    check("every floored gate is certified by a nonzero leak",
+          all(r["leak"] > 1e-6 for r in floored))
+    return realized, floored
+
+
+def _print_h3(rows, info, inv, check):
+    realized = [r for r in rows if r["realizable"]]
+    floored = [r for r in rows if not r["realizable"]]
+    print("\n  H3 at the VALUE level on the L_2 register (one scale from the T1 "
+          "anchor, then every number is a prediction):")
+    print(f"      uniform cochain metric: w_2 = {info['metric_mean']:.6f} "
+          f"(= sqrt(3)/4, the unit-edge triangle area; the anchor absorbs the "
+          f"scale), max deviation {info['metric_uniform_dev']:.1e}")
+    g = info["gram"]
+    print(f"      register Gram on V: [[{g[0, 0]:.6f}, {g[0, 1]:.6f}], "
+          f"[{g[1, 0]:.6f}, {g[1, 1]:.6f}]]  max|G - I| = {info['gram_dev']:.2e}")
+    print("        (the hexagon join's hole triple is a full S_3 orbit of its "
+          "automorphism group -- the isometric-chart proposition applies.)")
+    header = (f"      {'gate':16} {'family':16} {'r(U)':>10} "
+              f"{'max|Z_spec - amp|':>18} {'choi dev':>10} {'pairs':>6}")
+    print(header)
+    print("      " + "-" * (len(header) - 6))
+    for r in realized:
+        print(f"      {r['gate']:16} {r['family']:16} {r['residual']:>10.1e} "
+              f"{r['max_dev']:>18.2e} {r['choi_dev']:>10.1e} {r['n_pairs']:>6}")
+    lo = min(r["leak"] for r in floored)
+    hi = max(r["leak"] for r in floored)
+    print(f"      ({len(floored)} floored gates: no carried post-state -- leak "
+          f"|Sigma| in {lo:.2f}..{hi:.2f} -- so no spectral value exists.)")
+    eq = inv["equivariant"]
+    print(f"      bulk independence ({inv['n_gates']} gates x {inv['n_pairs']} "
+          f"pairs): the symmetric (9,9)-join variant (|V|={eq['nV']}) carries "
+          f"the value EXACTLY -- Gram dev {eq['gram_dev']:.1e}, drift "
+          f"{eq['drift']:.2e}.")
+    for v in inv["anisotropic"]:
+        print(f"        generic (8,8) hole draw (|V|={v['nV']}): Gram dev "
+              f"{v['gram_dev']:.2e}, value deviation {v['drift']:.2e} -- equal "
+              f"to the Gram-defect prediction a*(G-I)b to "
+              f"{v['defect_residual']:.1e}.")
+    worst = max(r["max_dev"] for r in realized)
+    worst_choi = max(r["choi_dev"] for r in realized)
+    print(f"        => Z_spec = <psi_A|U|psi_B> on every realized gate (worst "
+          f"{worst:.2e}); the Choi/operator reading agrees (worst "
+          f"{worst_choi:.2e}).")
+    check("the register bulk has a uniform cochain metric (anchor absorbs the "
+          "scale)", info["metric_uniform_dev"] < 1e-12)
+    check("psi_B is carried (its periods lie in V)", info["psi_b_leak"] < 1e-9)
+    check("the register Gram is the identity (period map is a scaled isometry)",
+          info["gram_dev"] < 1e-9)
+    check("T1 anchor: the identity's spectral value is <psi_A|psi_B> on every "
+          "pair", realized[0]["gate"] == "Identity"
+          and realized[0]["max_dev"] < 1e-9)
+    check("H3: Z_spec = <psi_A|U|psi_B> for EVERY realized gate, on every pair",
+          worst < 1e-9)
+    check("the Choi/operator reading agrees with the flat amplitude",
+          worst_choi < 1e-9)
+    check("every floored gate has no carried post-state (leak != 0)",
+          all(r["leak"] > 1e-6 for r in floored))
+    check("the value carries over exactly to the symmetric (9,9)-join variant "
+          "(bulk independence)", eq["gram_dev"] < 1e-9 and eq["drift"] < 1e-9)
+    check("a generic hole draw's value deviation equals its register Gram "
+          "defect", len(inv["anisotropic"]) >= 1
+          and all(v["defect_residual"] < 1e-9 for v in inv["anisotropic"]))
+    return worst
+
+
+def _print_search(search, check):
+    print(f"\n  Surgery-topology search at degree 2 ({search['scored']}/"
+          f"{search['retries']} randomized surgery-grown S^3 topologies; seeds = "
+          f"(p,q)-gon joins {dict(search['seeds'])}, max |V|={search['max_nV']}, "
+          f"max b_2 grown = {search['max_b2']}; cuts AND additions -- up to "
+          f"{search['max_add']} added vertices allowed, {search['max_grown']} "
+          f"actually added in one draw):")
+    print(f"      genuine registers (rank < #holes, S_3 anchor intact): "
+          f"{search['n_genuine']}")
+    print(f"      saturated registers (rank == #holes -- the register dissolves): "
+          f"{search['n_saturated']}")
+    if search["n_invalid"]:
+        print(f"      invalid draws (S_3 anchor not met): {search['n_invalid']}")
+    sizes = ", ".join(f"{n} gates x{c}" for n, c in search["genuine_sizes"])
+    print(f"      genuine realizable-set sizes: {sizes or '(none)'}")
+    if search["grows"]:
+        print(f"        => the search GROWS the set beyond the criterion: "
+              f"{', '.join(search['new_gates'])}.")
+    else:
+        print("        => NO genuine register carries any gate beyond the "
+              "criterion set: the conservation law is dimension-free as well as "
+              "topology-free.")
+    check("no genuine register carries a gate beyond the criterion set",
+          not search["grows"])
+    check("every genuine register realizes exactly the criterion set",
+          all(n == len(CANONICAL_SET) for n, _c in search["genuine_sizes"]))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--gate", default=None,
+                    help="score ONE gate by name ('--gate help' lists them)")
+    ap.add_argument("--h3", action="store_true",
+                    help="validate H3 at the value level on the L_2 register")
+    ap.add_argument("--retries", type=int, default=0,
+                    help="randomized surgery-topology search draws (0 = skip)")
+    ap.add_argument("--max-additional-vertices", type=int, default=20,
+                    help="additive-growth cap per search draw (default 20)")
+    ap.add_argument("--jobs", type=int, default=min(10, os.cpu_count() or 1),
+                    help="parallel workers for the search (procs x threads <= 10)")
+    ap.add_argument("--seed", type=int, default=12345)
+    ap.add_argument("--out", default="/tmp/cobordism",
+                    help="directory for the raw JSON table")
+    args = ap.parse_args()
+    jobs = max(1, min(args.jobs, 10))
+
+    checks = []
+
+    def check(label, passed):
+        checks.append((label, bool(passed)))
+        return bool(passed)
+
+    _print_header()
+    prog = BASE._progress()
+    prog.phase("growing the L_2 register + synthesizing states")
+    reg = RegisterL2()
+    trace, anchor, stage1 = _emergence_and_anchor(reg, check)
+    prog.finish("register ready")
+
+    if args.gate is not None:
+        resolved = BASE.resolve_gate(args.gate)
+        if args.gate.lower() == "help" or resolved is None:
+            if args.gate.lower() != "help":
+                print(f"  unknown gate '{args.gate}'.\n")
+            print("  Available gates (--gate <name>, slug-insensitive):")
+            for name, _U, fam in BASE._gates():
+                print(f"      {name:16} [{fam}]")
+            raise SystemExit(0 if args.gate.lower() == "help" else 2)
+        name, U, fam = resolved
+        res, b2, leak = post_interaction(reg, U)
+        realized = bool(res < REALIZE)
+        print(f"\n  Single-gate solve -- {name} [{fam}] on the L_2 register:")
+        print(f"      residual r(U) = {res:.3e}   leak |Sigma| = {leak:.3f}   "
+              f"emergent b_2 = {b2}")
+        print(f"        => {name} {'REALIZES' if realized else 'FLOORS'}.")
+        check(f"{name} verdict matches the charge-conservation criterion",
+              realized == BASE.conserves_charge(U))
+        ok = all(passed for _l, passed in checks)
+        print("\n  Verdict: " + ("SUPPORTED" if ok else "NOT SUPPORTED"))
+        raise SystemExit(0 if ok else 1)
+
+    prog.phase("battery sweep", total=len(BASE._gates()))
+    rows = gate_sweep(reg, on_progress=prog.on_tick)
+    prog.finish("battery scored")
+    realized, floored = _print_sweep(rows, check)
+
+    h3_payload = None
+    if args.h3:
+        prog.phase("H3 value sweep", total=len(BASE._gates()))
+        h3_rows, info = h3_value_sweep(reg, on_progress=prog.on_tick)
+        prog.finish("values read")
+        prog.phase("bulk independence", total=4)
+        inv = h3_invariance(on_progress=prog.on_tick)
+        prog.finish("variants surveyed")
+        worst = _print_h3(h3_rows, info, inv, check)
+        h3_payload = {"rows": h3_rows,
+                      "gram_dev": info["gram_dev"],
+                      "metric_mean": info["metric_mean"],
+                      "metric_uniform_dev": info["metric_uniform_dev"],
+                      "worst_dev": worst, "invariance": inv}
+
+    search = None
+    if args.retries > 0:
+        prog.phase("surgery-topology search", total=args.retries)
+        search = surgery_search(args.retries, jobs, base_seed=args.seed,
+                                max_add=args.max_additional_vertices,
+                                on_progress=prog.on_tick)
+        prog.finish("search scored")
+        _print_search(search, check)
+
+    if not args.no_write:
+        os.makedirs(args.out, exist_ok=True)
+        path = os.path.join(args.out, "l2_register_realizability.json")
+        with open(path, "w") as handle:
+            json.dump({"register_trace": trace,
+                       "register_constraint": reg.n.tolist(),
+                       "identity_anchor": anchor, "stage1": stage1,
+                       "gate_sweep": rows, "h3": h3_payload,
+                       "surgery_search": search}, handle, indent=2)
+        print(f"\n  raw table (PR artifact, not committed): {path}")
+
+    ok = all(passed for _label, passed in checks)
+    if not ok:
+        print("\n  FAILED checks:")
+        for label, passed in checks:
+            if not passed:
+                print(f"      - {label}")
+    print("\n  Verdict: " + (
+        "SUPPORTED -- the staged spectral synthesis on the S^3 hexagon-join "
+        "register realizes exactly the charge-conservation criterion set, one "
+        "degree up: tet surgery grows ker L_2 0 -> 2, the same 13 named gates "
+        "realize at machine zero, and the spectral test agrees with the closed "
+        "form on every gate. The register theorems are dimension-free, and this "
+        "bulk is the substrate the Regge-mediated objective selects on."
+        if ok else
+        "NOT SUPPORTED -- a claim failed; inspect the FAILED checks above."))
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/include/cobordism/ChainComplex.h
+++ b/include/cobordism/ChainComplex.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 // === tessera subsystem ns fwd-decls ===
@@ -69,6 +70,25 @@ class ChainComplex {
 
     /// Check ∂_{k-1} ∘ ∂_k = 0 for all k (chain-complex axiom / V3 sanity check).
     [[nodiscard]] bool boundaryComposesToZero() const;
+
+    /// Whether the Poincaré/Lefschetz **dual block decomposition** of a pure
+    /// \f$ n \f$-complex is a valid cell complex — equivalently, whether the
+    /// primal is a combinatorial manifold-with-boundary. Decidable for
+    /// \f$ n \le 3 \f$ by the classification of surfaces; checked as: facet
+    /// coface counts in \f$ \{1, 2\} \f$; no dangling facets (when
+    /// `facetCells` is non-empty it is the full \f$ (n-1) \f$-cell universe —
+    /// e.g. the cells a Hodge Laplacian is built over — and every entry must
+    /// be carried by at least one top cell); ridge links single paths/cycles
+    /// (no pinches); and, at \f$ n = 3 \f$, vertex links that are 2-spheres
+    /// (interior) or disks (boundary), decided by connectivity, Euler
+    /// characteristic, and a single boundary circle. Returns (ok, reason)
+    /// with the first violation named. Pure combinatorics on sorted
+    /// vertex-id tuples — no geometry required. Topology-changing moves
+    /// should be accepted only if this survives: validity in the dual space,
+    /// not merely scoreability on the primal lattice.
+    [[nodiscard]] static std::pair<bool, std::string> dualComplexIsValid(
+        const std::vector<std::vector<std::uint64_t>> &topCells, int dim,
+        const std::vector<std::vector<std::uint64_t>> &facetCells = {});
 
     /// Betti numbers b_0..b_n over ℚ (free ranks of H_k):
     /// b_k = |C_k| − rank ∂_k − rank ∂_{k+1}.

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -287,6 +287,15 @@ class EigenstateSynthesis {
     /// these cells' vertices, reproducing `growInterior`'s 1-skeleton.
     [[nodiscard]] std::vector<std::vector<std::uint64_t>> topCells() const;
 
+    /// The dual-complex validity verdict (`ChainComplex::dualComplexIsValid`)
+    /// for the synthesizer's **current** complex: top cells from the surgery
+    /// state and, when the degree sits at \f$ k = n - 1 \f$ (the register
+    /// layers), the \f$ k \f$-cell universe (`cellSimplices()`) checked for
+    /// dangling facets. Topology-changing moves should be accepted only while
+    /// this stays true — validity in the dual space, not merely scoreability
+    /// on the primal lattice.
+    [[nodiscard]] std::pair<bool, std::string> dualComplexValid() const;
+
     // === Surgery: the topology-changing interior remove move (#196) ===
 
     /// The interior top cells eligible for surgery removal: top cells whose

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -94,6 +94,19 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
            "Flat row-major ∂_k (rows=|C_{k-1}|, cols=|C_k|), entries in {-1,0,1}.")
       .def("boundaryComposesToZero", &ChainComplex::boundaryComposesToZero,
            "True iff ∂_{k-1}∘∂_k = 0 for all k.")
+      .def_static(
+          "dualComplexIsValid", &ChainComplex::dualComplexIsValid,
+          py::arg("top_cells"), py::arg("dim"),
+          py::arg("facet_cells") = std::vector<std::vector<std::uint64_t>>{},
+          "(ok, reason): is the dual block decomposition of this pure "
+          "n-complex a valid cell complex -- equivalently, is the primal a "
+          "combinatorial manifold with boundary? Facet coface counts in "
+          "{1,2}; no dangling facets against the optional (n-1)-cell "
+          "universe; ridge links single paths/cycles; at n=3, vertex links "
+          "2-spheres or disks. Pure combinatorics on sorted vertex-id "
+          "tuples; rigorous for n <= 3. Accept topology moves only while "
+          "this holds: validity in the DUAL space, not merely scoreability "
+          "on the primal lattice.")
       .def("bettiNumbers", &ChainComplex::bettiNumbers, "Betti numbers b_0..b_n over Q.")
       .def("bettiNumbersGF2", &ChainComplex::bettiNumbersGF2, "Betti numbers over GF(2).")
       .def("torsion", &ChainComplex::torsion, py::arg("k"),
@@ -450,6 +463,11 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
       .def("topCells", &EigenstateSynthesis::topCells,
            "The top cells as sorted vertex-id tuples (the d+1-vertex simplices); "
            "wiring the new vertex to one reproduces growInterior's 1-skeleton.")
+      .def("dualComplexValid", &EigenstateSynthesis::dualComplexValid,
+           "(ok, reason): ChainComplex.dualComplexIsValid for the CURRENT "
+           "complex -- top cells from the surgery state, with the k-cell "
+           "universe checked for dangling facets when k = n-1 (the register "
+           "layers). Accept topology moves only while this stays true.")
       // ----- Surgery: the topology-changing interior remove move (#196) -----
       .def("interiorTopCells", &EigenstateSynthesis::interiorTopCells,
            "The interior top cells (all-interior vertices, on no dW face) as "

--- a/src/cobordism/ChainComplex.cpp
+++ b/src/cobordism/ChainComplex.cpp
@@ -756,4 +756,184 @@ std::map<std::string, int> ChainComplex::stiefelWhitneyNumbers() const {
   return numbers;
 }
 
+std::pair<bool, std::string> ChainComplex::dualComplexIsValid(
+    const std::vector<std::vector<std::uint64_t>> &topCells, int dim,
+    const std::vector<std::vector<std::uint64_t>> &facetCells) {
+  using Cell = std::vector<std::uint64_t>;
+  const auto joinIds = [](const Cell &c) {
+    std::string out = "(";
+    for (std::size_t i = 0; i < c.size(); ++i) {
+      if (i) out += ",";
+      out += std::to_string(c[i]);
+    }
+    return out + ")";
+  };
+  const auto connectedFrom = [](int start, int count,
+                                const std::map<int, std::vector<int>> &adj) {
+    std::vector<int> stack{start};
+    std::map<int, bool> seen{{start, true}};
+    while (!stack.empty()) {
+      const int x = stack.back();
+      stack.pop_back();
+      const auto it = adj.find(x);
+      if (it == adj.end()) continue;
+      for (const int y : it->second)
+        if (!seen.count(y)) {
+          seen[y] = true;
+          stack.push_back(y);
+        }
+    }
+    return static_cast<int>(seen.size()) == count;
+  };
+
+  if (topCells.empty()) return {false, "no top cells"};
+  const std::size_t nv = static_cast<std::size_t>(dim) + 1;
+  std::vector<Cell> cells;
+  cells.reserve(topCells.size());
+  for (const auto &raw : topCells) {
+    if (raw.size() != nv) return {false, "mixed top-cell dimension"};
+    Cell c = raw;
+    std::sort(c.begin(), c.end());
+    cells.push_back(std::move(c));
+  }
+  {
+    auto dedup = cells;
+    std::sort(dedup.begin(), dedup.end());
+    if (std::adjacent_find(dedup.begin(), dedup.end()) != dedup.end())
+      return {false, "duplicate top cell"};
+  }
+
+  // Facet coface counts in {1, 2}; the dangling-facet check against the
+  // supplied (n-1)-cell universe.
+  std::map<Cell, int> cofaces;
+  for (const auto &c : cells)
+    for (std::size_t j = 0; j < nv; ++j) {
+      Cell f;
+      f.reserve(nv - 1);
+      for (std::size_t i = 0; i < nv; ++i)
+        if (i != j) f.push_back(c[i]);
+      ++cofaces[f];
+    }
+  for (const auto &[f, count] : cofaces)
+    if (count > 2)
+      return {false,
+              "facet " + joinIds(f) + " has " + std::to_string(count) + " cofaces"};
+  for (const auto &raw : facetCells) {
+    Cell f = raw;
+    std::sort(f.begin(), f.end());
+    if (!cofaces.count(f))
+      return {false, "dangling facet " + joinIds(f) + " (0 cofaces)"};
+  }
+
+  // Ridge links: the top cells around each (n-2)-simplex, glued along the
+  // facets containing it, must form ONE path or cycle (no pinches).
+  std::map<Cell, std::vector<int>> atRidge;
+  for (std::size_t ci = 0; ci < cells.size(); ++ci) {
+    const Cell &c = cells[ci];
+    for (std::size_t a = 0; a < nv; ++a)
+      for (std::size_t b = a + 1; b < nv; ++b) {
+        Cell r;
+        r.reserve(nv - 2);
+        for (std::size_t i = 0; i < nv; ++i)
+          if (i != a && i != b) r.push_back(c[i]);
+        atRidge[r].push_back(static_cast<int>(ci));
+      }
+  }
+  for (const auto &[r, cis] : atRidge) {
+    if (cis.size() < 2) continue;
+    std::map<Cell, std::vector<int>> byFacet;
+    for (const int ci : cis)
+      for (const std::uint64_t v : cells[static_cast<std::size_t>(ci)])
+        if (!std::binary_search(r.begin(), r.end(), v)) {
+          Cell f = r;
+          f.insert(std::upper_bound(f.begin(), f.end(), v), v);
+          byFacet[f].push_back(ci);
+        }
+    std::map<int, std::vector<int>> adj;
+    for (const auto &[f, fc] : byFacet)
+      if (fc.size() == 2) {
+        adj[fc[0]].push_back(fc[1]);
+        adj[fc[1]].push_back(fc[0]);
+      }
+    if (!connectedFrom(cis.front(), static_cast<int>(cis.size()), adj))
+      return {false, "ridge " + joinIds(r) + ": link is disconnected (pinch)"};
+  }
+  if (dim == 2) return {true, "ok"};
+
+  // n == 3: vertex links must be 2-spheres (interior) or disks (boundary).
+  std::map<std::uint64_t, std::vector<Cell>> atVertex;
+  for (const auto &c : cells)
+    for (const std::uint64_t v : c) {
+      Cell lf;
+      lf.reserve(nv - 1);
+      for (const std::uint64_t u : c)
+        if (u != v) lf.push_back(u);
+      atVertex[v].push_back(lf);
+    }
+  for (const auto &[v, linkFaces] : atVertex) {
+    std::map<std::pair<std::uint64_t, std::uint64_t>, std::vector<int>> edgeFaces;
+    for (std::size_t i = 0; i < linkFaces.size(); ++i) {
+      const Cell &lf = linkFaces[i];
+      for (std::size_t a = 0; a < lf.size(); ++a)
+        for (std::size_t b = a + 1; b < lf.size(); ++b)
+          edgeFaces[{lf[a], lf[b]}].push_back(static_cast<int>(i));
+    }
+    std::map<int, std::vector<int>> adj;
+    std::vector<std::pair<std::uint64_t, std::uint64_t>> boundaryEdges;
+    for (const auto &[le, fs] : edgeFaces) {
+      if (fs.size() == 2) {
+        adj[fs[0]].push_back(fs[1]);
+        adj[fs[1]].push_back(fs[0]);
+      } else if (fs.size() == 1) {
+        boundaryEdges.push_back(le);
+      } else {
+        return {false, "vertex " + std::to_string(v) + ": link edge in " +
+                           std::to_string(fs.size()) + " faces"};
+      }
+    }
+    if (!connectedFrom(0, static_cast<int>(linkFaces.size()), adj))
+      return {false,
+              "vertex " + std::to_string(v) + ": link is disconnected (pinch)"};
+    std::map<std::uint64_t, int> linkVertexDegree;
+    for (const auto &lf : linkFaces)
+      for (const std::uint64_t u : lf) linkVertexDegree[u] = 0;
+    const int chi = static_cast<int>(linkVertexDegree.size()) -
+                    static_cast<int>(edgeFaces.size()) +
+                    static_cast<int>(linkFaces.size());
+    if (boundaryEdges.empty()) {
+      if (chi != 2)
+        return {false, "vertex " + std::to_string(v) + ": closed link has chi=" +
+                           std::to_string(chi) + ", not S^2"};
+    } else {
+      if (chi != 1)
+        return {false, "vertex " + std::to_string(v) + ": bounded link has chi=" +
+                           std::to_string(chi) + ", not a disk"};
+      std::map<std::uint64_t, std::vector<std::uint64_t>> badj;
+      for (const auto &[a, b] : boundaryEdges) {
+        badj[a].push_back(b);
+        badj[b].push_back(a);
+      }
+      for (const auto &[u, nbrs] : badj)
+        if (nbrs.size() != 2)
+          return {false, "vertex " + std::to_string(v) +
+                             ": link boundary is not a 1-manifold"};
+      std::vector<std::uint64_t> stack{boundaryEdges.front().first};
+      std::map<std::uint64_t, bool> seen{{boundaryEdges.front().first, true}};
+      while (!stack.empty()) {
+        const std::uint64_t x = stack.back();
+        stack.pop_back();
+        for (const std::uint64_t y : badj[x])
+          if (!seen.count(y)) {
+            seen[y] = true;
+            stack.push_back(y);
+          }
+      }
+      if (seen.size() != badj.size())
+        return {false, "vertex " + std::to_string(v) +
+                           ": link boundary has several circles"};
+    }
+  }
+  return {true, "ok"};
+}
+
 }  // namespace tessera::cobordism

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -734,4 +734,19 @@ std::vector<std::vector<std::uint64_t>> EigenstateSynthesis::topCells() const {
   return cells;
 }
 
+std::pair<bool, std::string> EigenstateSynthesis::dualComplexValid() const {
+  const auto tops = topCells();
+  if (tops.empty()) return {false, "no top cells"};
+  const int dim = static_cast<int>(tops.front().size()) - 1;
+  // The dangling-facet check needs the (n-1)-cell universe; cellSimplices()
+  // is exactly that when the synthesis degree sits one below the top
+  // dimension (the register layers). At other degrees the facet universe is
+  // not tracked here, so only the top-cell conditions are checked.
+  const bool facetDegree = (k_ == dim - 1);
+  return ChainComplex::dualComplexIsValid(
+      tops, dim,
+      facetDegree ? cellSimplices()
+                  : std::vector<std::vector<std::uint64_t>>{});
+}
+
 }  // namespace tessera::cobordism

--- a/tests/cobordism/test_l2_register_python.py
+++ b/tests/cobordism/test_l2_register_python.py
@@ -1,0 +1,222 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The L_2 register on the hexagon-join S^3
+(``examples/cobordism/l2_register_realizability.py``).
+
+The register theorems are dimension-free, and these tests pin the degree-2
+instance through the real pipeline (Spacetime construction, degree-2
+EigenstateSynthesis surgery, HodgeLaplacian.harmonics(2)):
+
+  1. **Emergence.** Opening the three vertex-disjoint tetrahedra grows b_2 and
+     ker L_2 0 -> 2 (the staircase [0, 0, 1, 2]); the boundary-period
+     constraint symmetrizes to Sigma = 0 (the all-ones covector).
+  2. **The gate set is the conservation law, one degree up.** The 52-gate
+     battery splits 13/39 with membership identical to the 2d register, and
+     the spectral verdict agrees with the closed-form column-sum criterion on
+     every gate.
+  3. **H3 at the value level.** The anchor-normalized Gram is the identity
+     (the hole triple is a full S_3 orbit of the join's automorphism group),
+     Z_spec equals the operator amplitude at machine precision with the
+     independent Choi reading agreeing, the value carries over exactly to the
+     symmetric (9,9)-join variant, and a generic (8,8) draw deviates by
+     exactly its Gram defect.
+  4. **Additive growth.** The 3d composed stellar move (cone a tet's four
+     faces, remove the parent) adds interior vertices on seeds with interior
+     room, preserving ker L_2, the identity anchor, and the uniform metric.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "l2_register_realizability.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("l2_register_realizability",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["l2_register_realizability"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+L2 = _load_example()
+
+# One register, one battery sweep, and one H3 sweep shared by every test below
+# (the construction is deterministic; building once keeps the suite fast).
+_REG = L2.RegisterL2()
+_TRACE = L2.register_emergence()
+_ROWS = L2.gate_sweep(_REG)
+_H3_ROWS, _INFO = L2.h3_value_sweep(_REG, n_states=4, seed=7)
+_REALIZED = [r for r in _H3_ROWS if r["realizable"]]
+_FLOORED = [r for r in _H3_ROWS if not r["realizable"]]
+
+
+class RegisterEmergenceTest(unittest.TestCase):
+    """1: surgery grows the degree-2 register out of the closed S^3."""
+
+    def test_hexagon_join_counts(self):
+        self.assertEqual(int(_REG.st.getVertexList().size()), 12)
+        self.assertEqual(len(_REG.cells), 72)
+
+    def test_ker_l2_emerges_0_to_2(self):
+        self.assertEqual([t["kerL2"] for t in _TRACE], [0, 0, 1, 2])
+
+    def test_b2_grows_0_to_2(self):
+        self.assertEqual(_TRACE[0]["b2"], 0)
+        self.assertEqual(_TRACE[-1]["b2"], 2)
+
+    def test_register_is_two_dimensional_with_full_period_rank(self):
+        self.assertEqual(_REG.dim, 2)
+        self.assertEqual(_REG.rank, 2)
+
+    def test_charge_constraint_is_the_all_ones_covector(self):
+        self.assertTrue(np.allclose(np.abs(_REG.n), 1.0, atol=1e-9))
+
+    def test_identity_floors_until_the_register_is_grown(self):
+        anchor = L2.identity_anchor(_REG)
+        for row in anchor[:-1]:
+            self.assertFalse(row["realizable"])
+            self.assertGreater(row["residual"], L2.CERT_FLOOR)
+        self.assertTrue(anchor[-1]["realizable"])
+        self.assertEqual(anchor[-1]["b2"], 2)
+
+
+class GateSetIsTheConservationLawTest(unittest.TestCase):
+    """2: the battery splits 13/39 exactly as at degree 1."""
+
+    def test_realized_set_matches_the_canonical_thirteen(self):
+        realized = sorted(r["gate"] for r in _ROWS if r["realizable"])
+        self.assertEqual(realized, sorted(L2.CANONICAL_SET))
+
+    def test_spectral_verdict_matches_the_criterion_on_every_gate(self):
+        for row, (_name, U, _fam) in zip(_ROWS, L2.BASE._gates()):
+            self.assertEqual(row["realizable"], L2.BASE.conserves_charge(U),
+                             msg=row["gate"])
+
+    def test_realized_residuals_are_machine_zero(self):
+        for row in _ROWS:
+            if row["realizable"]:
+                self.assertLess(row["residual"], L2.REALIZE, msg=row["gate"])
+
+    def test_floored_gates_sit_above_the_certificate_floor(self):
+        for row in _ROWS:
+            if not row["realizable"]:
+                self.assertGreater(row["residual"], L2.CERT_FLOOR,
+                                   msg=row["gate"])
+
+    def test_every_floored_gate_is_certified_by_a_nonzero_leak(self):
+        for row in _ROWS:
+            if not row["realizable"]:
+                self.assertGreater(row["leak"], 1e-6, msg=row["gate"])
+
+
+class H3ValueLevelTest(unittest.TestCase):
+    """3: the value identities, realized by the implementation at degree 2."""
+
+    def test_metric_is_uniform_at_the_equilateral_area(self):
+        self.assertLess(_INFO["metric_uniform_dev"], 1e-12)
+        self.assertAlmostEqual(_INFO["metric_mean"], np.sqrt(3.0) / 4.0,
+                               places=12)
+
+    def test_generic_input_is_carried(self):
+        self.assertLess(_INFO["psi_b_leak"], 1e-9)
+
+    def test_register_gram_is_the_identity(self):
+        self.assertLess(_INFO["gram_dev"], 1e-12)
+
+    def test_value_equals_amplitude_on_every_realized_gate(self):
+        self.assertEqual(len(_REALIZED), len(L2.CANONICAL_SET))
+        for row in _REALIZED:
+            self.assertLess(row["max_dev"], 1e-9, msg=row["gate"])
+
+    def test_choi_reading_agrees(self):
+        for row in _REALIZED:
+            self.assertLess(row["choi_dev"], 1e-9, msg=row["gate"])
+
+    def test_floored_gates_have_no_value(self):
+        self.assertEqual(len(_FLOORED), 39)
+        for row in _FLOORED:
+            self.assertIsNone(row["max_dev"], msg=row["gate"])
+
+
+class BulkIndependenceTest(unittest.TestCase):
+    """3 (continued): exact carry-over on the symmetric variant, exact
+    Gram-defect law on a generic draw."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inv = L2.h3_invariance(n_variants=1, n_states=2, seed=11)
+
+    def test_symmetric_join_variant_carries_the_value_exactly(self):
+        eq = self.inv["equivariant"]
+        self.assertLess(eq["gram_dev"], 1e-9)
+        self.assertLess(eq["drift"], 1e-9)
+
+    def test_generic_draw_deviates_by_exactly_its_gram_defect(self):
+        self.assertGreaterEqual(len(self.inv["anisotropic"]), 1)
+        for v in self.inv["anisotropic"]:
+            self.assertLess(v["defect_residual"], 1e-9)
+
+
+class AdditiveGrowthTest(unittest.TestCase):
+    """4: the 3d composed stellar move grows interior vertices and preserves
+    the register."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reg = L2.RegisterL2(cells=L2._join_cells(8, 8),
+                                class_holes=L2._stride_holes(8, 8, 2),
+                                grow_vertices=3, grow_seed=7)
+
+    def test_growth_adds_interior_vertices(self):
+        self.assertGreaterEqual(self.reg.grown, 1)
+        self.assertGreater(int(self.reg.st.getVertexList().size()), 16)
+
+    def test_register_survives_growth(self):
+        self.assertEqual(self.reg.dim, 2)
+        self.assertEqual(self.reg.rank, 2)
+        res, b2, _leak = L2.post_interaction(self.reg, L2.BASE._gates()[0][1])
+        self.assertLess(res, L2.REALIZE)
+        self.assertEqual(b2, 2)
+
+    def test_metric_stays_uniform_after_the_re_pin(self):
+        hodge = L2.cob.HodgeLaplacian(self.reg.st)
+        w2 = np.asarray(hodge.weights(2), dtype=float)
+        self.assertLess(float(np.max(np.abs(w2 - w2.mean()))), 1e-12)
+
+    def test_canonical_hexjoin_has_no_interior_room(self):
+        # The three canonical holes consume all 12 vertices, so the additive
+        # budget is unused on the canonical bulk -- documented behavior.
+        reg = L2.RegisterL2(grow_vertices=5, grow_seed=3)
+        self.assertEqual(reg.grown, 0)
+        self.assertEqual(reg.dim, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_l2_register_python.py
+++ b/tests/cobordism/test_l2_register_python.py
@@ -184,6 +184,82 @@ class BulkIndependenceTest(unittest.TestCase):
             self.assertLess(v["defect_residual"], 1e-9)
 
 
+class DualComplexValidityTest(unittest.TestCase):
+    """The mediated objective scores the DUAL complex, so topology moves are
+    accepted only if the dual stays a valid cell complex -- equivalently the
+    primal stays a combinatorial manifold with boundary. These tests pin the
+    invariant on every register the suite builds, prove the checker has teeth
+    on hand-built violations, and document why the condition cannot currently
+    fail through the surgery API (the vertex-based interiority guard)."""
+
+    def test_canonical_register_keeps_a_valid_dual(self):
+        self.assertTrue(_REG.dual_valid, _REG.dual_reason)
+        ok, why = L2.register_dual_valid(_REG.es)
+        self.assertTrue(ok, why)
+
+    def test_symmetric_variant_keeps_a_valid_dual(self):
+        eq = L2._equivariant_variant()
+        self.assertTrue(eq.dual_valid, eq.dual_reason)
+
+    def test_grown_register_keeps_a_valid_dual(self):
+        reg = L2.RegisterL2(cells=L2._join_cells(8, 8),
+                            class_holes=L2._stride_holes(8, 8, 2),
+                            grow_vertices=2, grow_seed=5)
+        self.assertGreaterEqual(reg.grown, 1)
+        self.assertTrue(reg.dual_valid, reg.dual_reason)
+
+    def test_2d_canonical_register_keeps_a_valid_dual(self):
+        # the same checker at n=2: the icosahedron minus the three holonomy
+        # holes, with the full edge list as the facet universe
+        holes = set(L2.BASE._CLASS_HOLES)
+        faces = [f for f in (tuple(sorted(t)) for t in L2.BASE._ICO)
+                 if f not in holes]
+        edges = {e for t in L2.BASE._ICO for e in L2.BASE._cedges(tuple(sorted(t)))}
+        ok, why = L2.dual_complex_is_valid(faces, 2, facet_cells=sorted(edges))
+        self.assertTrue(ok, why)
+
+    def test_checker_rejects_a_facet_sharing_double_cut(self):
+        # removing two tets that share a triangle leaves that triangle with
+        # zero cofaces -- a dangling facet the Hodge Laplacian still sees, and
+        # a pinched (non-manifold) dual
+        t1 = tuple(sorted((0, 1, 6, 7)))
+        t2 = tuple(sorted((1, 2, 6, 7)))
+        remaining = [c for c in L2._HEXJOIN if c not in (t1, t2)]
+        all_facets = sorted({f for c in L2._HEXJOIN
+                             for f, _s in L2._tet_facets(c)})
+        ok, why = L2.dual_complex_is_valid(remaining, 3,
+                                           facet_cells=all_facets)
+        self.assertFalse(ok)
+        self.assertIn("dangling", why)
+
+    def test_checker_rejects_pinched_complexes(self):
+        # two tets glued at exactly one vertex: the link of that vertex is
+        # disconnected, so the dual block at it is not a cell
+        ok, why = L2.dual_complex_is_valid([(0, 1, 2, 3), (0, 4, 5, 6)], 3)
+        self.assertFalse(ok)
+        self.assertIn("disconnected", why)
+        # the 2d bowtie fails the same way
+        ok2, why2 = L2.dual_complex_is_valid([(0, 1, 2), (0, 3, 4)], 2)
+        self.assertFalse(ok2)
+        self.assertIn("disconnected", why2)
+
+    def test_checker_accepts_the_closed_seeds(self):
+        self.assertTrue(L2.dual_complex_is_valid(L2._HEXJOIN, 3)[0])
+        self.assertTrue(L2.dual_complex_is_valid(
+            [tuple(sorted(t)) for t in L2.BASE._ICO], 2)[0])
+
+    def test_api_already_refuses_the_facet_sharing_cut(self):
+        # why the condition cannot currently fail through this API: opening a
+        # hole puts its vertices on the boundary, and the vertex-based
+        # interiority guard then refuses every facet-adjacent removal
+        st = L2._bulk(L2._HEXJOIN)
+        es = L2.cob.EigenstateSynthesis(st, 2)
+        self.assertTrue(es.removeInteriorCell([0, 1, 6, 7]))
+        self.assertFalse(es.removeInteriorCell([1, 2, 6, 7]))
+        ok, why = L2.register_dual_valid(es)
+        self.assertTrue(ok, why)
+
+
 class AdditiveGrowthTest(unittest.TestCase):
     """4: the 3d composed stellar move grows interior vertices and preserves
     the register."""


### PR DESCRIPTION
## Summary
Implements #272: the carried register one degree up — **ker L₂ of a surgery-opened triangulated S³** (the 12-vertex hexagon join), scored by the same staged spectral synthesis as the 2d icosahedral register. The sibling example `examples/cobordism/l2_register_realizability.py` imports the gate battery, thresholds, criterion, Choi reading, and parallel pool from `spectral_gate_realizability.py` (no duplication) and owns only the geometry layer: (p,q)-gon join seeds, tet holes, signed tet-facet sphere periods, and 3d composed stellar growth. Python-only — spike-verified that `EigenstateSynthesis(st, 2)`, `removeInteriorCell` on tets, `harmonics(2)`, and `es.residual` on 2-cochains all work through the existing C++ unchanged.

## Results (full runs, seeded)
- **Emergence**: ker L₂ and b₂ grow 0 → 2 with the staircase [0,0,1,2]; the charge covector is exactly all-ones (no sign normalization needed on the join).
- **Battery**: 13/39 split with membership **identical to the 2d register**; spectral verdict = column-sum criterion on all 52 gates; realized residuals ~1e-27, floored 2.3–57.4.
- **H3**: Gram = I to 3.5e-16; worst |Z_spec − amp| = **1.08e-15** over 13 gates × 9 pairs; Choi reading agrees to 1.6e-16; floored leaks 0.21–2.60 (bulk-independent — same certificates as 2d).
- **Bulk independence**: exact on the symmetric (9,9)-join variant (Gram dev 5.6e-16, drift 9.0e-16); two generic (8,8) draws have Gram defects 0.066/0.102 and deviate by exactly a†(G−I)b to ~5e-16.
- **Search** (`--retries 300 --jobs 10`): 281 scored over five join-seed families (|V| ≤ 39, b₂ ≤ 3, up to 19 vertices added), **273 genuine — every one realizing exactly the criterion set** — 8 saturated, none beyond.
- At degree 2 the cochain weights are simplex areas: the unit-edge pin gives the **uniform** equilateral metric √3/4, absorbed by the anchor — uniformity is the invariant the value reading needs.
- Known geometry fact, documented: the canonical hexjoin's holes consume all 12 vertices, so additive growth and extra cuts only engage on larger join seeds (16+ vertices) — hence the search's seed ladder.

- **Dual-validity gate** (#274): topology moves are accepted only if the **dual** stays a valid cell complex — `dual_complex_is_valid()` checks the primal is a combinatorial manifold-with-boundary (facet cofaces in {1,2}, no dangling facets, ridge links paths/cycles, vertex links spheres/disks), the stellar/cut moves roll back via `restoreLastRemoval` on violation, and the search counts dual-invalid draws (0 observed — the vertex-based interiority guard already refuses facet-adjacent cuts; the gate makes that an enforced invariant). Negative controls prove the checker detects facet-sharing double cuts and pinched links.

- **Dual-validity check moved to C++** (#275): `ChainComplex::dualComplexIsValid(top_cells, dim, facet_cells)` (static, pure combinatorics) + `EigenstateSynthesis::dualComplexValid()` (current-complex verdict, facet universe applied automatically at k = n−1), both bound; the example's functions are now thin delegating wrappers with unchanged signatures, so the register layers AND future C++ callers (oracle growth modes, the mediated search) can gate moves on the same check.

## Test plan
- [x] `pytest tests/cobordism/test_l2_register_python.py` — 23 passed (shared env)
- [x] Full `tests/cobordism` suite in a throwaway venv built from this branch: **579 passed, 1 skipped, 0 failures** (the 17 shared-env failures were env skew; all pass on this branch.s build)
- [x] Full example runs: battery, `--h3`, `--retries 300` — all SUPPORTED

Closes #272. Closes #274. Closes #275.


