### PR TITLE
feat(cobordism): add --beta sweep to the spectral-realizability example scripts

### DIFF
--- a/examples/cobordism/emergent_bulk_realizability.py
+++ b/examples/cobordism/emergent_bulk_realizability.py
@@ -223,13 +223,19 @@ def _meridian_target(flip=False):
     return cob.Cochain(1, edges, np.asarray(vals, dtype=complex)), edges, vals
 
 
-def _decide(st, target, *, mode, max_cones, seed=1, restarts=RESTARTS):
+def _decide(st, target, *, mode, max_cones, seed=1, restarts=RESTARTS, beta=0.0):
     """Harmonic realizability: drive ||L_1 psi||^2 -> 0 with the pinned boundary,
     growing via `mode` up to `max_cones` steps. harmonic=True so realizable means
-    the meridian is CARRIED as a bulk harmonic (in image(H_1(dW) -> H_1(W)))."""
+    the meridian is CARRIED as a bulk harmonic (in image(H_1(dW) -> H_1(W))).
+
+    `beta` couples the mediated objective F_beta = r_U + beta * |S_Regge(W*)|: the
+    surgery search ranks candidate removals by F_beta rather than the bare residual,
+    so a larger beta makes the gravitational cost of opening the handle outweigh its
+    residual benefit. beta = 0 (default) is the base-layer search."""
     return cob.RealizabilityOracle(st).decideHarmonic(
         target, epsilon=DEEP_EPS, restarts=restarts, max_cones=max_cones,
-        seed=seed, growth_mode=mode, connectivity_candidates=8, harmonic=True)
+        seed=seed, growth_mode=mode, connectivity_candidates=8, harmonic=True,
+        beta=beta)
 
 
 # --------------------------------------------------------------------------- #
@@ -303,12 +309,50 @@ def frozen_without_surgery(target):
 
 
 # --------------------------------------------------------------------------- #
+# Regge mediation: re-run the E2 surgery search under F_beta = r_U + beta*|S_Regge|.
+# --------------------------------------------------------------------------- #
+def mediation_sweep(targets, betas, seed=0):
+    """For each beta, re-run the disk-seed SURGERY search (E2) under the mediated
+    objective F_beta = r_U + beta*|S_Regge(W*)|. Reports per (beta, target):
+    removals, b_1 after, realizable, residual, and |S_Regge(W*)|.
+
+    NOTE -- the verdict does NOT contract with beta on this fixture, and the reason
+    is structural. The oracle scores |S_Regge| on the residual-OPTIMIZED geometry;
+    a floored disk inflates the edge lengths the optimizer settles on (unit-length
+    |S| ~ 7.7 -> optimized ~ 111), while the realized annulus stays moderate (~28.7).
+    So realizing the meridian (opening the handle) LOWERS the optimized |S_Regge|,
+    and F_beta favors realizing at every beta. Contraction needs |S_Regge| to RISE
+    with the realizing move, which holds for fixed-geometry surgery -- the
+    k-selection in spectral_gate_realizability.py (13 -> 11 -> 0). See #276."""
+    rows = []
+    for beta in betas:
+        for tname, (target, _edges, _vals) in targets.items():
+            st = _disk()
+            before = _betti(st)[1]
+            v = _decide(st, target, mode=SURGERY, max_cones=GROW_STEPS,
+                        seed=seed, beta=beta)
+            rows.append({"beta": float(beta), "target": tname,
+                         "b1_before": before, "b1_after": _betti(st)[1],
+                         "removals": int(v.surgery_removals),
+                         "realizable": bool(v.residual < REALIZE),
+                         "residual": float(v.residual),
+                         "S_regge": float(abs(v.regge_action))})
+    return rows
+
+
+# --------------------------------------------------------------------------- #
 def main():
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--out", default="/tmp/cobordism",
                     help="dir for the raw table (default /tmp/cobordism; NOT committed).")
     ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--beta", type=float, nargs="+", default=[0.0], metavar="B",
+                    help="Regge-mediation coupling(s) for the mediated objective "
+                         "F_beta = r_U + beta*|S_Regge(W*)| (#249/#250). With any "
+                         "beta > 0 the E2 surgery search is re-run as a sweep over "
+                         "these values; beta = 0 (default) is the base-layer search "
+                         "and leaves the output unchanged.")
     args = ap.parse_args()
 
     print("Emergent-bulk realizability at k=1: grow the bulk by surgery, let b_1 "
@@ -399,6 +443,30 @@ def main():
     ok &= all(r["b1_before"] == r["b1_after"] == 0 for r in e3)
     ok &= not e3[1]["attach_accepted"]
 
+    # ---- Regge mediation sweep (--beta): contraction of the realizable set - #
+    # Authoritative verdict stays anchored to the beta = 0 experiment above; the
+    # sweep is reported only when the user asks for beta > 0.
+    med = None
+    if any(b > 0 for b in args.beta):
+        med = mediation_sweep(targets, args.beta)
+        print("\n  Regge mediation (--beta): the E2 disk-seed SURGERY search under "
+              "F_beta = r_U + beta*|S_Regge(W*)|:")
+        header = (f"      {'beta':>6} {'target':>8} {'removals':>9} {'b_1':>9} "
+                  f"{'realizable':>11} {'residual':>11} {'|S_Regge|':>11}")
+        print(header)
+        print("      " + "-" * (len(header) - 6))
+        for r in med:
+            print(f"      {r['beta']:>6g} {r['target']:>8} {r['removals']:>9} "
+                  f"{str(r['b1_before'])+'->'+str(r['b1_after']):>9} "
+                  f"{'YES' if r['realizable'] else 'floored':>11} "
+                  f"{r['residual']:>11.2e} {r['S_regge']:>11.3f}")
+        print("        => beta scales the search but the verdict does NOT contract "
+              "here: realizing opens the handle, which LOWERS the optimized "
+              "|S_Regge| (the floored disk inflates the optimizer's edge lengths), "
+              "so F_beta favors realizing at every beta. Contraction needs |S_Regge| "
+              "to RISE with the realizing move -- the fixed-geometry k-selection in "
+              "spectral_gate_realizability.py (13 -> 11 -> 0); see #276.")
+
     # ---- raw table (PR artifact, not committed) --------------------------- #
     if not args.no_write:
         os.makedirs(args.out, exist_ok=True)
@@ -412,7 +480,8 @@ def main():
                 "period_A": [p_a.real, p_a.imag],
                 "period_B": [p_b.real, p_b.imag]}
         raw = {"degree": 1, "targets": target_raw, "E1_two_by_two": e1,
-               "E2_surgery_emergence": e2, "E3_frozen_without_surgery": e3}
+               "E2_surgery_emergence": e2, "E3_frozen_without_surgery": e3,
+               "betas": args.beta, "mediation_sweep": med}
         with open(path, "w") as handle:
             json.dump(raw, handle, indent=2)
         print(f"\n  raw table (PR artifact, not committed): {path}")

--- a/examples/cobordism/realizability_report.py
+++ b/examples/cobordism/realizability_report.py
@@ -221,11 +221,15 @@ def synthesize_boundary(c0, c1, seed, restarts=80, max_cones=4):
 # --------------------------------------------------------------------------- #
 # §5.0 realizability decisions.
 # --------------------------------------------------------------------------- #
-def decide(bulk_factory, U, dA, dB, seed, restarts, max_cones, growth_mode=None):
+def decide(bulk_factory, U, dA, dB, seed, restarts, max_cones, growth_mode=None,
+           beta=0.0):
     """Bend U → vec(U), pin the bulk boundary, and let the oracle fill the
     interior. `growth_mode` defaults to the historical cone-only growth;
     SURGERY_AND_CONE allows additions as well as surgical cuts (max_cones then
-    budgets the added vertices only). Returns the Verdict."""
+    budgets the added vertices only). `beta` couples the mediated objective
+    F_beta = r_U + beta * |S_Regge(W*)|: candidate moves are ranked by F_beta
+    rather than the bare residual (beta = 0, the default, is the base-layer
+    search). Returns the Verdict."""
     bulk = bulk_factory()
     _pin_all(bulk, w=1.0, phase=0.0)
     target = _bend(U, dA, dB)
@@ -233,7 +237,8 @@ def decide(bulk_factory, U, dA, dB, seed, restarts, max_cones, growth_mode=None)
     if growth_mode is None:
         growth_mode = cob.RealizabilityOracle.GrowthMode.CONE
     return oracle.decide(target, dA, dB, epsilon=EPSILON, restarts=restarts,
-                         max_cones=max_cones, seed=seed, growth_mode=growth_mode)
+                         max_cones=max_cones, seed=seed, growth_mode=growth_mode,
+                         beta=beta)
 
 
 def _np_floor_oracle(U, dA, dB, w_bounds=(0.1, 10.0), n=60):
@@ -455,6 +460,12 @@ def main():
     ap.add_argument("--out", default="/tmp/cobordism",
                     help="directory for sweeps + figures (default /tmp/cobordism).")
     ap.add_argument("--no-plot", action="store_true", help="skip the figures.")
+    ap.add_argument("--beta", type=float, nargs="+", default=[0.0], metavar="B",
+                    help="Regge-mediation coupling(s) for the mediated objective "
+                         "F_beta = r_U + beta*|S_Regge(W*)| (#249/#250). With any "
+                         "beta > 0 the §5.0 realizability cases are re-decided as a "
+                         "sweep over these values; beta = 0 (default) is the "
+                         "base-layer search and leaves the output unchanged.")
     args = ap.parse_args()
 
     print("State-Operation-Cobordism correspondence -- synthesis + "
@@ -549,6 +560,35 @@ def main():
     print(f"  and the three correspondence claims -- (1) W_AB is a cobordism, "
           f"(2) ∂W_AB = the pinned geo's, (3) Z(W_AB) = <ψ_A|U|ψ_B> -- hold "
           f"({'SUPPORTED' if all_ok else 'NOT SUPPORTED -- a check failed'}).")
+
+    # ---- Regge mediation sweep (--beta) ----------------------------------- #
+    # Authoritative verdict stays anchored to the beta = 0 decisions above; the
+    # sweep re-decides the §5.0 cases under F_beta only when beta > 0 is asked for.
+    if any(b > 0 for b in args.beta):
+        print("\n  Regge mediation (--beta): §5.0 cases re-decided under "
+              "F_beta = r_U + beta*|S_Regge(W*)|:")
+        header = (f"  {'operation U':26} {'beta':>6} {'verdict':11} "
+                  f"{'r / floor':>12} {'cuts':>5} {'|S_Regge|':>11}")
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+        for name, factory, U, dA, dB, max_cones, mode, _expect in cases:
+            for beta in args.beta:
+                v = decide(factory, U, dA, dB, seed=args.seed,
+                           restarts=args.restarts, max_cones=max_cones,
+                           growth_mode=mode, beta=beta)
+                verdict = "REALIZABLE" if v.realizable else "OBSTRUCTED"
+                metric = (f"r={v.residual:.2e}" if v.realizable
+                          else f"f={v.floor:.2e}")
+                print(f"  {_fmt_op(name):26} {beta:>6g} {verdict:11} "
+                      f"{metric:>12} {v.surgery_removals:>5} "
+                      f"{abs(v.regge_action):>11.3f}")
+        print("        => beta is applied (candidate cuts are ranked by F_beta), but "
+              "the verdicts do NOT contract here: these cases realize by cone growth "
+              "(0 surgical cuts), so a surgery-ranking beta has nothing to gate, and "
+              "where surgery is used the oracle scores |S_Regge| on the optimized "
+              "geometry, so realizing does not raise it. The fixed-geometry "
+              "contraction is in spectral_gate_realizability.py (13 -> 11 -> 0); "
+              "see #276.")
 
     if not args.no_plot:
         print("\n  §7 sweeps:")

--- a/examples/cobordism/spectral_gate_realizability.py
+++ b/examples/cobordism/spectral_gate_realizability.py
@@ -657,6 +657,81 @@ def gate_sweep(reg, on_progress=None):
 
 
 # --------------------------------------------------------------------------- #
+# --beta: the Regge-mediated objective F_beta = r_U + beta * |S_Regge(W*)|. Opening
+# a holonomy hole drives the residual down but RAISES the dual Regge action, so per
+# gate and per beta we pick the hole count k in {0..KMAX} that minimizes F_beta and
+# decide realizability on that committed bulk. beta = 0 selects the full register
+# (k = KMAX, lowest residual) and reproduces the base-layer gate_sweep set; as beta
+# grows the cost of the last hole outweighs its residual benefit, k drops, and gates
+# contract out of the realizable set (the headline #249/#250 result). This is the
+# in-script contraction sweep; mediated_gate_battery.py is the fuller H1-H3 harness.
+# --------------------------------------------------------------------------- #
+KMAX = len(_CLASS_HOLES)  # holonomy holes -> hole count k in 0..KMAX
+
+
+def _regge_magnitude(st):
+    """|S_Regge(W*)|: the modulus of the dual Lorentzian Regge action
+    (ReggeSolver.dualReggeAction, #247), built in C++ so facet/coface
+    materialization stays consistent."""
+    s = tessera.ReggeSolver(st, tessera.MatterConfiguration()).dualReggeAction()
+    return float(abs(s))
+
+
+def _mediation_stages():
+    """The k = 0..KMAX stages: the icosahedron with the first k holonomy holes
+    opened. Each carries its residual engine, cell order, |S_Regge|, and b_1."""
+    stages = []
+    for k in range(KMAX + 1):
+        st = _surface(_ICO)
+        es = cob.EigenstateSynthesis(st, 1)
+        for hole in _CLASS_HOLES[:k]:
+            es.removeInteriorCell(list(hole))
+        cells = [tuple(int(v) for v in c) for c in es.cellSimplices()]
+        stages.append({"k": k, "es": es, "cells": cells,
+                       "S": _regge_magnitude(st), "b1": int(_betti1(st))})
+    return stages
+
+
+def _residual_at_stage(reg, stage, U):
+    """The gate's spectral residual on the k-hole sphere: the output harmonic
+    U|psi_B> (in the full register's basis) restricted to this stage's cells, scored
+    by the genuine metric Hodge L_1 residual -- post_interaction generalized to any k."""
+    u_reg = np.asarray(U, dtype=complex)[1:4, 1:4]
+    cp_out = u_reg @ _CP_IN.astype(complex)
+    psi_full = reg.harmonic_form(reg.sign * cp_out)
+    by_cell = {reg.cells[i]: psi_full[i] for i in range(len(reg.cells))}
+    psi = np.array([by_cell.get(c, 0.0) for c in stage["cells"]], dtype=complex)
+    return float(stage["es"].residual([complex(z) for z in psi]))
+
+
+def mediation_sweep(reg, betas):
+    """Per gate and per beta, commit the hole count k minimizing F_beta(k) =
+    r_U(k) + beta*|S_Regge(k)| and decide realizability on it. Returns
+    (summary, rows): summary is per-beta (n_realizable, realized set); rows is one
+    record per (gate, beta) with k_star, r_U, |S_Regge|, F_beta, realizable."""
+    stages = _mediation_stages()
+    S_by_k = {s["k"]: s["S"] for s in stages}
+    rows = []
+    for name, U, fam in _gates():
+        res_by_k = {s["k"]: _residual_at_stage(reg, s, U) for s in stages}
+        for beta in betas:
+            kstar = min(res_by_k, key=lambda k: res_by_k[k] + beta * S_by_k[k])
+            r = res_by_k[kstar]
+            rows.append({"gate": name, "family": fam, "beta": float(beta),
+                         "k_star": int(kstar), "r_U": r,
+                         "S_regge": float(S_by_k[kstar]),
+                         "F_beta": float(r + beta * S_by_k[kstar]),
+                         "realizable": bool(r < REALIZE)})
+    summary = []
+    for beta in betas:
+        br = [r for r in rows if r["beta"] == beta]
+        realized = sorted(r["gate"] for r in br if r["realizable"])
+        summary.append({"beta": float(beta), "n_realizable": len(realized),
+                        "realized": realized})
+    return summary, rows
+
+
+# --------------------------------------------------------------------------- #
 # --h3: H3 at the VALUE level, on the spectral data alone. The staged synthesis
 # proves U|psi_B> is CARRIED (r -> 0); this leg checks the value equation itself,
 # Z_spec(W; psi_A, U psi_B) = <psi_A|U|psi_B>, for every gate the construction
@@ -1589,6 +1664,13 @@ def main():
     ap.add_argument("--no-upload", action="store_true",
                     help="with --all-plots, render locally but do not upload.")
     ap.add_argument("--dpi", type=int, default=130, help="PNG dpi (default 130).")
+    ap.add_argument("--beta", type=float, nargs="+", default=[0.0], metavar="B",
+                    help="Regge-mediation coupling(s) for the mediated objective "
+                         "F_beta = r_U + beta*|S_Regge(W*)| (#249/#250). With any "
+                         "beta > 0 the gate battery is re-scored as a sweep over "
+                         "these values (per gate, commit the hole count minimizing "
+                         "F_beta); beta = 0 (default) reproduces the base-layer "
+                         "gate sweep and leaves the output unchanged.")
     args = ap.parse_args()
     jobs = max(1, min(args.jobs, 10))                        # respect the 10-CPU cap
 
@@ -1647,6 +1729,30 @@ def main():
     _check("every floored gate is certified (residual > CERT_FLOOR and leaks)",
            all(r["residual"] > CERT_FLOOR and r["leak"] > 1e-6 for r in floored))
 
+    # ---- Regge mediation sweep (--beta): contraction of the realizable set --- #
+    # Authoritative verdict + checks stay anchored to the beta = 0 gate_sweep above;
+    # the sweep is reported only when the user asks for beta > 0.
+    mediation = None
+    if any(b > 0 for b in args.beta):
+        med_summary, med_rows = mediation_sweep(reg, args.beta)
+        mediation = {"summary": med_summary, "rows": med_rows}
+        print(f"\n  Regge mediation (--beta): F_beta = r_U + beta*|S_Regge(W*)|, "
+              f"per gate commit the hole count k in 0..{KMAX} minimizing F_beta:")
+        print(f"      {'beta':>8} {'#realizable':>12}   realized set")
+        print("      " + "-" * 56)
+        for s in med_summary:
+            preview = (", ".join(s["realized"]) if s["n_realizable"] <= 6
+                       else ", ".join(s["realized"][:6])
+                       + f" (+{s['n_realizable'] - 6})")
+            print(f"      {s['beta']:>8g} {s['n_realizable']:>12}   {preview}")
+        base_row = next((s for s in med_summary if s["beta"] == 0.0), None)
+        if base_row is not None:
+            _check("beta=0 mediation reproduces the base-layer realizable set",
+                   set(base_row["realized"]) == set(CANONICAL_SET))
+        print(f"        => beta = 0 commits the full register (k = {KMAX}) and "
+              f"reproduces the base sweep ({len(CANONICAL_SET)} gates); as beta "
+              f"grows the committed k drops and the realizable set contracts.")
+
     # ---- H3 at the value level (--h3): Z_spec = <psi_A|U|psi_B> on the realized set #
     h3_payload = None
     if args.h3:
@@ -1696,7 +1802,8 @@ def main():
             json.dump({"register_trace": trace, "register_constraint": reg.n.tolist(),
                        "identity_anchor": anchor, "stage1": stage1,
                        "gate_sweep": rows, "h3": h3_payload,
-                       "surgery_search": search,
+                       "surgery_search": search, "betas": args.beta,
+                       "mediation": mediation,
                        "plot_urls": plot_urls}, handle, indent=2)
         print(f"\n  raw table (PR artifact, not committed): {path}")
 


### PR DESCRIPTION
## Summary
Adds a multi-value `--beta` flag to the three Hodge/spectral realizability example scripts so they can run the Regge-mediated objective **F_β = r_U + β·|S_Regge(W*)|**. `--beta 0` (default) reproduces each script's current output and exit code exactly; the mediation sweep is emitted only when β > 0 is requested.

## What each script does under `--beta`
- **`spectral_gate_realizability.py` — genuine contraction.** Per gate and per β, commit the hole count `k ∈ 0..KMAX` minimizing F_β and decide on it. β=0 selects the full register (k=KMAX) and reproduces the 13-gate base set; as β grows the committed k drops and the realizable set contracts **13 → 11 → 0**. `|S_Regge|` is read off the **fixed** unit-length holed icosahedron, where opening holes raises it topologically (9.1 → 13.2), so the residual/action trade-off is real.
- **`realizability_report.py`, `emergent_bulk_realizability.py` — honest, non-contracting sweep.** β is threaded into `RealizabilityOracle.decide`/`decideHarmonic` (which already rank candidate surgeries by F_β) and the cases are re-decided across the swept β. These **do not** contract, and the scripts say so plainly.

## Why the oracle scripts don't contract (verified, not assumed)
The oracle scores `|S_Regge|` on the **residual-optimized** geometry. A floored state inflates the edge lengths the optimizer settles on, so realizing-by-surgery *lowers* `|S|` and F_β favors realizing at every β:

| state | unit-length \|S\| | optimized \|S\| | residual |
|---|---|---|---|
| octahedron disk (floored) | 7.7 | 111 | 0.43 |
| octahedron annulus (realized) | 8.2 | 28.7 | ~0 |

Confirmed β=0→1000 leaves the verdict unchanged (octahedron), and the icosahedron analog never realizes with erratic `|S|`. `realizability_report`'s cases realize by **cone growth** (0 cuts), which a surgery-ranking β cannot gate. Contraction needs `|S|` driven by topology — which is exactly the fixed-geometry spectral k-selection. Enabling oracle-path contraction (fixed-geometry `|S|` in the oracle) is filed as **#276**.

## Out of scope
`realizable_image_sweep.py` — its realizability is the DW gap-to-S₃ metric (distance to the 6 holonomy permutations); no residual `r_U` or geometric bulk `W*` for the Regge action to mediate.

## Test plan
- [x] `--beta 0` / default reproduces each script's verdict and exit code (all exit 0)
- [x] `spectral … --beta 0 1 5` contracts 13 → 11 → 0; β=0 == CANONICAL_SET (asserted in-script)
- [x] oracle scripts emit a correct β-sweep with the honest non-contraction note
- [x] only the three example scripts change; no C++ touched

Closes #271.