### PR TITLE
feat(cobordism): the level-1 stabilizer law + mediated selection over fills

### DIFF
--- a/examples/cobordism/level1_fill_realizability.py
+++ b/examples/cobordism/level1_fill_realizability.py
@@ -1,0 +1,617 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Hierarchical synthesis, level 1: a bulk between two realized registers.
+
+The recursion that makes several interactions interpretable as time: a
+completed level-0 interaction is itself a carrier -- the register bulk
+W_AB holds its post-interaction state as a harmonic, so W_AB *is*
+geo(Psi_AB) by the framework's own definition. This example treats two
+copies of the canonical (icosahedral, three-holed) register as the pinned
+boundary pair of a NEW three-dimensional bulk and runs the same staged
+procedure one level up: hand-calculate the level-1 post-interaction state,
+drive the genuine L_1 residual of the fill to zero, certify floors
+otherwise. Time is the nesting level; the level-0 holonomy holes sweep
+worldtubes through the level-1 bulk.
+
+Semantics (the level-1 register). The level-1 state space is the pair of
+boundary period vectors (p_0, p_1) in V (+) V -- each end's three
+circle-periods, individually charge-zero. A level-1 gate u' is a map
+V -> V between the ends; a fill realizes u' iff (a, u'a) is carried by
+ker L_1 of the fill for carried inputs a -- iff graph(u') lies in R, the
+restriction of ker L_1 to boundary periods. The controls and predictions,
+all hand-derivable and all falsifiable:
+
+  * NO bulk (the disjoint union of the two registers): ker L_1 = V (+) V,
+    R is everything -- every u' "carried" trivially. No interaction
+    without a bulk: the saturated case.
+  * The TRIVIAL fill (the prism W x I): homotopy-equivalent to W, so
+    ker L_1 stays 2-dimensional and R is the DIAGONAL -- the graph of the
+    identity. The cylinder carries exactly u' = 1 (the level-1 T1 anchor)
+    and floors every other gate.
+  * A TWISTED fill (the prism glued through the icosahedron's order-3
+    hole symmetry): the pullback harmonics transport periods through the
+    twist, so R is the graph of the corresponding hole 3-cycle -- the
+    twist realizes exactly that gate. The hole triple's setwise
+    stabilizer is the bare C_3 (no transpositions), so prism-class fills
+    are predicted to realize exactly the C_3 subgroup of the canonical
+    thirteen: holonomy transport by mapping classes.
+  * Interior surgery and gated stellar growth (multi-layer fills only:
+    every prism tet spans adjacent layers, so vertex-interior tets first
+    exist at three layers) deform R; the EMERGENT GATE of a fill is read
+    off as the V-block u' with R = graph(u') whenever R is a graph.
+
+Everything battery-shaped is imported from spectral_gate_realizability.py;
+the 3-complex builder is imported from l2_register_realizability.py; all
+topology moves are gated on the C++ dual-complex validity check (#275).
+
+Run:
+    python examples/cobordism/level1_fill_realizability.py
+    python examples/cobordism/level1_fill_realizability.py --draws 60 --jobs 10
+    python examples/cobordism/level1_fill_realizability.py --layers 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import random
+import sys
+from collections import Counter
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_HERE, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = _load("spectral_gate_realizability")   # sets the 10-CPU caps on import
+L2 = _load("l2_register_realizability")
+np = BASE.np
+tessera = BASE.tessera
+cob = tessera.cobordism
+
+REALIZE = BASE.REALIZE
+CERT_FLOOR = BASE.CERT_FLOOR
+_CP_IN = BASE._CP_IN
+
+# The level-0 register surface W: the icosahedron minus the three canonical
+# holonomy holes (the pair of pants whose ker L_1 carries the register).
+_W_FACES = [f for f in (tuple(sorted(t)) for t in BASE._ICO)
+            if f not in set(BASE._CLASS_HOLES)]
+_N_REG = max(v for f in BASE._ICO for v in f) + 1      # 12 vertices per layer
+
+# The icosahedron's order-3 hole symmetry (the full setwise stabilizer of the
+# canonical triple; see the register paper's isometric-chart remark). Twisted
+# prisms glue the top layer through gamma -- the mapping-class transport.
+_GAMMA = {0: 3, 1: 7, 2: 8, 3: 4, 4: 0, 5: 2,
+          6: 11, 7: 9, 8: 5, 9: 1, 10: 6, 11: 10}
+_IDENT = {v: v for v in range(_N_REG)}
+
+_REG_SIGN_CACHE = []
+
+
+def _reg_sign():
+    """The level-0 register's induced-orientation sign pattern (``reg.sign``).
+    It is a property of the end SURFACE, not of the fill: each end's three
+    circles bound that end's fundamental 2-chain, so every fill's harmonics
+    satisfy the same signed charge constraint at each end. Deterministic --
+    no per-fill null-vector normalization."""
+    if not _REG_SIGN_CACHE:
+        _REG_SIGN_CACHE.append(BASE.Register().sign.copy())
+    return _REG_SIGN_CACHE[0]
+
+
+def _compose(g, h):
+    return {v: g[h[v]] for v in h}
+
+
+def _prism_cells(faces=_W_FACES, layers=1, twist=None):
+    """The staircase triangulation of W x [0, layers]: for each face
+    (a<b<c) and layer l, the three tets (a0,b0,c0,c1), (a0,b0,b1,c1),
+    (a0,a1,b1,c1) with x0 = phi_l(x) + 12*l and x1 = phi_{l+1}(x) + 12*(l+1).
+    Adjacent prisms split their shared quad walls by the same vertex-order
+    rule, so the complex is consistent. *twist* (a vertex permutation of the
+    register surface, e.g. _GAMMA) is applied cumulatively per layer, gluing
+    the top end through the symmetry -- the mapping-torus-style twisted
+    product whose harmonics transport periods through the twist."""
+    twist = twist or _IDENT
+    phi = [_IDENT]
+    for _ in range(layers):
+        phi.append(_compose(twist, phi[-1]))
+    cells = []
+    for ell in range(layers):
+        lo, hi = phi[ell], phi[ell + 1]
+        for (a, b, c) in faces:
+            a0, b0, c0 = (lo[a] + 12 * ell, lo[b] + 12 * ell, lo[c] + 12 * ell)
+            a1, b1, c1 = (hi[a] + 12 * (ell + 1), hi[b] + 12 * (ell + 1),
+                          hi[c] + 12 * (ell + 1))
+            cells += [tuple(sorted((a0, b0, c0, c1))),
+                      tuple(sorted((a0, b0, b1, c1))),
+                      tuple(sorted((a0, a1, b1, c1)))]
+    return sorted(set(cells)), phi[layers]
+
+
+def _hole_circles(shift, perm=None):
+    """The three register circles of one end: the canonical hole triangles,
+    relabeled through *perm* and shifted into the end's layer."""
+    perm = perm or _IDENT
+    return [tuple(sorted(perm[v] + shift for v in h))
+            for h in BASE._CLASS_HOLES]
+
+
+class Level1Fill:
+    """The level-1 register: ker L_1 of a 3-dimensional fill whose boundary
+    pair is two copies of the canonical level-0 register surface. Holds the
+    fill, its degree-1 EigenstateSynthesis (the genuine L_1 residual core),
+    the harmonic 1-forms, and the six-circle period matrix split into the two
+    ends -- the restriction space R whose graphs are the realizable level-1
+    gates. Surgery (`extra_holes`, interior tets) and gated stellar growth
+    deform R; every move is accepted only while the dual complex stays valid.
+    """
+
+    def __init__(self, faces=_W_FACES, layers=1, twist=None, extra_holes=(),
+                 grow_vertices=0, grow_seed=0):
+        self.layers = int(layers)
+        cells, _top_perm = _prism_cells(faces, self.layers, twist)
+        self.seed_cells = cells
+        # Each end is labeled by its OWN canonical register classes: the top
+        # copy's hole set equals the canonical holes shifted into its layer
+        # (a twist permutes the holes among themselves), so the twist shows
+        # up where it belongs -- in the transported periods -- not in the
+        # bookkeeping.
+        self.circles0 = _hole_circles(0)
+        self.circles1 = _hole_circles(12 * self.layers)
+        self.reg_edges = [e for tri in (self.circles0 + self.circles1)
+                          for e in BASE._cedges(tri)]
+        self.eidx = {e: i for i, e in enumerate(self.reg_edges)}
+
+        self.st = L2._bulk(cells)
+        self.es = cob.EigenstateSynthesis(self.st, 1)
+        self.grown = self._stellar_grow(grow_vertices, grow_seed)
+        self.extra_opened = []
+        for cell in extra_holes:
+            cs = tuple(sorted(cell))
+            avail = {tuple(sorted(int(v) for v in c))
+                     for c in self.es.interiorTopCells()}
+            if cs in avail and self.es.removeInteriorCell(list(cs)):
+                ok, _why = self.es.dualComplexValid()
+                if not ok:
+                    self.es.restoreLastRemoval()
+                    continue
+                self.extra_opened.append(cs)
+        self.read_spectral()
+
+    def read_spectral(self):
+        """(Re)read the spectral state of the CURRENT complex: dual verdict,
+        harmonics, the six-circle period matrix, and each end's induced-
+        orientation sign covector (the level-0 ``reg.sign`` analog, computed
+        per end so twisted tops stay consistent). Call after any in-place
+        surgery beyond the constructor's."""
+        ok, why = self.es.dualComplexValid()
+        self.dual_valid, self.dual_reason = bool(ok), str(why)
+        self.cells = [tuple(int(v) for v in c) for c in self.es.cellSimplices()]
+        harmonics = cob.HodgeLaplacian(self.st).harmonics(1)
+        self.dim = len(harmonics)
+        if self.dim:
+            self.H_full = np.array(
+                [[complex(h.amplitudeFor(list(c))) for c in self.cells]
+                 for h in harmonics])
+        else:
+            self.H_full = np.zeros((0, len(self.cells)), dtype=complex)
+        self._reg_col = [self.cells.index(e) for e in self.reg_edges]
+        h_reg = self.H_full[:, self._reg_col] if self.dim else self.H_full
+        rows = []
+        for r in range(self.dim):
+            p0 = [self._period(h_reg[r], tri) for tri in self.circles0]
+            p1 = [self._period(h_reg[r], tri) for tri in self.circles1]
+            rows.append(p0 + p1)
+        self.P6 = np.array(rows).reshape(self.dim, 6)
+        self.sign0 = _reg_sign()
+        self.sign1 = _reg_sign()
+        return self
+
+    def _period(self, vec, tri):
+        a, b, c = sorted(tri)
+        return (vec[self.eidx[(a, b)]] + vec[self.eidx[(b, c)]]
+                - vec[self.eidx[(a, c)]])
+
+    def _stellar_grow(self, n, seed):
+        """ADD up to *n* interior vertices by the gated composed stellar move
+        (cone a vertex onto an interior tet's four faces, then remove the
+        parent), exactly as the L_2 register does. Pure prisms have interior
+        tets only at three or more layers (every tet spans adjacent layers),
+        so the budget is unused on thin fills -- documented geometry."""
+        rng = random.Random(int(seed))
+        grown = 0
+        for _ in range(int(n)):
+            sites = sorted(tuple(sorted(int(v) for v in c))
+                           for c in self.es.interiorTopCells())
+            if not sites:
+                break
+            cell = rng.choice(sites)
+            fan = [list(f) for f, _s in L2._tet_facets(cell)]
+            if not self.es.attachInteriorVertex(fan):
+                continue
+            if not self.es.removeInteriorCell(list(cell)):
+                self.es.detachLastInteriorVertex()
+                continue
+            ok, _why = self.es.dualComplexValid()
+            if not ok:
+                self.es.restoreLastRemoval()
+                self.es.detachLastInteriorVertex()
+                continue
+            grown += 1
+        if grown:
+            for e in self.st.getEdgeList().toVector():
+                e.setSquaredLength(1.0)
+                e.setPhase(0.0)
+        return grown
+
+    # ---- the level-1 register read-outs ---------------------------------- #
+    @property
+    def rank(self):
+        return int(np.linalg.matrix_rank(self.P6, tol=1e-9)) if self.dim else 0
+
+    def end_charge_leak(self):
+        """max |sign-weighted charge| over the two ends and all harmonics:
+        each end's periods must individually conserve the (induced-
+        orientation signed) charge -- Proposition-1 structure end by end."""
+        if not self.dim:
+            return 0.0
+        return float(max(np.max(np.abs(self.P6[:, 0:3] @ self.sign0)),
+                         np.max(np.abs(self.P6[:, 3:6] @ self.sign1))))
+
+
+    def harmonic_form(self, pair6):
+        """The carried representative of a six-period target (p_0, p_1), plus
+        the minimal leak attached to one edge per circle so the cochain's
+        periods are exact -- the level-1 twin of the register construction."""
+        coeffs, *_ = np.linalg.lstsq(self.P6.T, pair6, rcond=None)
+        full = (coeffs @ self.H_full).astype(complex)
+        leak = pair6 - coeffs @ self.P6
+        for k, tri in enumerate(self.circles0 + self.circles1):
+            full[self._reg_col[self.eidx[BASE._cedges(tri)[0]]]] += leak[k]
+        return full
+
+    def spectral_residual(self, pair6):
+        """The genuine Hodge residual of the 1-form with the given six
+        periods on the fill -> 0 iff the pair (p_0, p_1) is carried by R."""
+        psi = self.harmonic_form(np.asarray(pair6, dtype=complex))
+        return float(self.es.residual([complex(z) for z in psi]))
+
+    def emergent_gate(self):
+        """The V-block u' with R = graph(u'), in the flat-orthonormal basis
+        of each end's symmetrized (sign-corrected) charge-zero plane -- or
+        None when R is not a graph (the end-0 block is singular). The
+        cylinder must emit the identity; a gamma-twisted fill must emit the
+        corresponding hole 3-cycle."""
+        if self.dim != 2:
+            return None
+        e_basis = np.array([[1.0, -1.0, 0.0] / np.sqrt(2.0),
+                            [1.0, 1.0, -2.0] / np.sqrt(6.0)])
+        A = (self.P6[:, 0:3] * self.sign0) @ e_basis.T   # dim x 2, end 0
+        B = (self.P6[:, 3:6] * self.sign1) @ e_basis.T   # dim x 2, end 1
+        if np.linalg.matrix_rank(A, tol=1e-9) < 2:
+            return None
+        return np.linalg.solve(A, B).T                   # u2 with B = A u2^T
+
+
+# --------------------------------------------------------------------------- #
+# The disconnected-union control: two register surfaces, no fill. ker L_1 is
+# the direct sum, R is all of V (+) V -- every gate trivially "carried".
+# --------------------------------------------------------------------------- #
+def union_control():
+    faces = list(_W_FACES) + [tuple(v + 12 for v in f) for f in _W_FACES]
+    st = BASE._surface(faces)
+    dim = len(cob.HodgeLaplacian(st).harmonics(1))
+    return {"dim": dim, "saturated": bool(dim == 4)}
+
+
+# --------------------------------------------------------------------------- #
+# The level-1 battery: the thirteen canonical level-0 gates' holonomy blocks
+# as candidate transports u' : V -> V, plus leak controls. A candidate is
+# scored by the genuine residual of the hand-calculated pair (a, u'a).
+# --------------------------------------------------------------------------- #
+def _v_candidates():
+    """(name, 3x3 block) for the canonical thirteen -- the V-preserving
+    blocks, the only well-typed level-1 transports -- in battery order."""
+    out = []
+    for name, U, _fam in BASE._gates():
+        if name in BASE.CANONICAL_SET:
+            out.append((name, np.asarray(U, dtype=complex)[1:4, 1:4]))
+    return out
+
+
+def level1_battery(fill, on_progress=None):
+    """Score every canonical candidate u' on *fill*: the input a is the
+    V-generic level-0 post-interaction periods (the carried state of W_AB),
+    the target is the hand-calculated pair (a, u'a) -- converted to raw
+    periods through each end's induced-orientation signs, exactly as the
+    level-0 scripts apply ``reg.sign``."""
+    a = _CP_IN.astype(complex)
+    rows = []
+    for name, u in _v_candidates():
+        b = u @ a
+        pair = np.concatenate([fill.sign0 * a, fill.sign1 * b])
+        res = fill.spectral_residual(pair)
+        coeffs, *_ = np.linalg.lstsq(fill.P6.T, pair, rcond=None)
+        leak = float(np.linalg.norm(pair - coeffs @ fill.P6))
+        rows.append({"gate": name, "residual": res, "leak": leak,
+                     "realizable": bool(res < REALIZE)})
+        if on_progress is not None:
+            on_progress()
+    return rows
+
+
+def match_gate(u2, tol=1e-6):
+    """Name the canonical candidate whose V-block equals *u2*, if any."""
+    if u2 is None:
+        return None
+    e_basis = np.array([[1.0, -1.0, 0.0] / np.sqrt(2.0),
+                        [1.0, 1.0, -2.0] / np.sqrt(6.0)])
+    for name, u in _v_candidates():
+        cand = e_basis @ u @ e_basis.T
+        if np.max(np.abs(cand - u2)) < tol:
+            return name
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# The surgery catalog: seeded interior cuts + growth on a thick fill; record
+# how R deforms and which gates the variants carry.
+# --------------------------------------------------------------------------- #
+def _catalog_worker(task):
+    idx, base_seed, layers, max_cut, max_add = task
+    rng = random.Random(base_seed * 1_000_003 + idx)
+    grow = rng.randint(0, max_add)
+    fill = Level1Fill(layers=layers, grow_vertices=grow,
+                      grow_seed=rng.randrange(1, 2**31))
+    sites = sorted(tuple(sorted(int(v) for v in c))
+                   for c in fill.es.interiorTopCells())
+    rng.shuffle(sites)
+    cut = []
+    for cell in sites[:rng.randint(0, max_cut)]:
+        if fill.es.removeInteriorCell(list(cell)):
+            ok, _why = fill.es.dualComplexValid()
+            if not ok:
+                fill.es.restoreLastRemoval()
+                continue
+            cut.append(cell)
+    # re-read the spectral state after the catalog's own cuts
+    try:
+        fill.read_spectral()
+    except Exception:
+        return None
+    if not fill.dim:
+        return None
+    realized = [r["gate"] for r in level1_battery(fill) if r["realizable"]]
+    u2 = fill.emergent_gate()
+    return {"dim": fill.dim, "rank": fill.rank, "n_cut": len(cut),
+            "n_grown": fill.grown, "dual_valid": fill.dual_valid,
+            "is_graph": bool(u2 is not None),
+            "emergent": match_gate(u2),
+            "realized": realized, "n_realized": len(realized),
+            "end_leak": fill.end_charge_leak()}
+
+
+def surgery_catalog(draws, jobs, layers=3, base_seed=12345, max_cut=3,
+                    max_add=6, on_progress=None):
+    tasks = [(i, base_seed, layers, max_cut, max_add) for i in range(draws)]
+    results = [r for r in BASE._parallel_map(_catalog_worker, tasks, jobs,
+                                             on_progress=on_progress) if r]
+    carried = Counter(g for r in results for g in r["realized"])
+    return {
+        "draws": draws, "scored": len(results),
+        "n_dual_invalid": sum(1 for r in results if not r["dual_valid"]),
+        "dims": sorted(Counter(r["dim"] for r in results).items()),
+        "graphs": sum(1 for r in results if r["is_graph"]),
+        "emergent": sorted(Counter(r["emergent"] for r in results
+                                   if r["emergent"]).items()),
+        "carried_counts": sorted(carried.items()),
+        "max_realized": max((r["n_realized"] for r in results), default=0),
+        "beyond_c3": sorted({g for r in results for g in r["realized"]
+                             if g not in ("Identity", "3-cycle (0231)",
+                                          "3-cycle (0312)")}),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Report + main.
+# --------------------------------------------------------------------------- #
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--layers", type=int, default=1,
+                    help="prism layers of the anchor fill (default 1)")
+    ap.add_argument("--draws", type=int, default=40,
+                    help="surgery-catalog draws on the 3-layer fill (0 = skip)")
+    ap.add_argument("--jobs", type=int, default=min(10, os.cpu_count() or 1))
+    ap.add_argument("--seed", type=int, default=12345)
+    ap.add_argument("--out", default="/tmp/cobordism")
+    args = ap.parse_args()
+    jobs = max(1, min(args.jobs, 10))
+
+    checks = []
+
+    def check(label, passed):
+        checks.append((label, bool(passed)))
+        return bool(passed)
+
+    print("Hierarchical synthesis, level 1: a 3-bulk between two realized "
+          "registers\n  (the level-0 bulks are the boundary carriers; the "
+          "level-1 state space is the pair of end periods V (+) V; a fill "
+          "realizes u' iff graph(u') lies in its restriction space R)\n")
+    prog = BASE._progress()
+
+    # -- the no-bulk control ------------------------------------------------ #
+    uc = union_control()
+    print(f"  No-bulk control (disjoint union of the two registers): "
+          f"ker L_1 dim = {uc['dim']} -- R is ALL of V(+)V, every transport "
+          f"trivially 'carried'. No interaction without a bulk.")
+    check("the disconnected union is saturated (dim 4)", uc["saturated"])
+
+    # -- the trivial fill: the level-1 anchor ------------------------------- #
+    prog.phase("building the trivial fill")
+    cyl = Level1Fill(layers=args.layers)
+    prog.finish("fill ready")
+    print(f"\n  Trivial fill (the {args.layers}-layer prism W x I, "
+          f"|V|={int(cyl.st.getVertexList().size())}, "
+          f"|C_3|={len(cyl.seed_cells)}): dim ker L_1 = {cyl.dim}, "
+          f"rank R = {cyl.rank}, end-charge leak = {cyl.end_charge_leak():.1e}, "
+          f"dual valid = {cyl.dual_valid}")
+    diag_dev = (float(np.max(np.abs(cyl.P6[:, 0:3] * cyl.sign0
+                                    - cyl.P6[:, 3:6] * cyl.sign1)))
+                if cyl.dim else float("inf"))
+    print(f"      R vs the diagonal (graph of the identity): "
+          f"max|p_0 - p_1| = {diag_dev:.2e}")
+    u2 = cyl.emergent_gate()
+    print(f"      emergent gate: {match_gate(u2) or 'NOT A GRAPH'}")
+    check("the fill keeps a valid dual complex", cyl.dual_valid)
+    check("ker L_1 of the trivial fill is 2-dimensional (homotopy with W)",
+          cyl.dim == 2)
+    check("both ends conserve signed charge harmonic-by-harmonic",
+          cyl.end_charge_leak() < 1e-9)
+    check("R of the trivial fill is the diagonal (graph of the identity)",
+          diag_dev < 1e-9)
+    check("the emergent gate of the trivial fill is the identity",
+          match_gate(u2) == "Identity")
+
+    prog.phase("level-1 battery on the trivial fill", total=13)
+    rows = level1_battery(cyl, on_progress=prog.on_tick)
+    prog.finish("battery scored")
+    realized = [r for r in rows if r["realizable"]]
+    floored = [r for r in rows if not r["realizable"]]
+    print(f"\n  Level-1 battery on the trivial fill (the 13 canonical blocks "
+          f"as transports, hand-calculated targets (a, u'a)):")
+    print(f"      realized ({len(realized)}): "
+          + ", ".join(r["gate"] for r in realized))
+    if floored:
+        print(f"      floored ({len(floored)}): residuals in "
+              f"{min(r['residual'] for r in floored):.2f}.."
+              f"{max(r['residual'] for r in floored):.2f}, leaks in "
+              f"{min(r['leak'] for r in floored):.2f}.."
+              f"{max(r['leak'] for r in floored):.2f}")
+    check("T1 at level 1: the identity transports across the trivial fill",
+          any(r["gate"] == "Identity" and r["realizable"] for r in rows))
+    check("ONLY the identity transports across the trivial fill",
+          [r["gate"] for r in realized] == ["Identity"])
+    check("every floored transport is certified by a nonzero leak",
+          all(r["leak"] > 1e-6 for r in floored))
+
+    # -- twisted fills: mapping-class transport ----------------------------- #
+    print("\n  Twisted fills (top layer glued through the C_3 hole symmetry):")
+    twist_ok = True
+    for twist, label in ((_GAMMA, "gamma"),
+                         (_compose(_GAMMA, _GAMMA), "gamma^2")):
+        tw = Level1Fill(layers=1, twist=twist)
+        em = match_gate(tw.emergent_gate())
+        t_rows = level1_battery(tw)
+        t_real = [r["gate"] for r in t_rows if r["realizable"]]
+        print(f"      {label}: dim = {tw.dim}, emergent gate = {em}, "
+              f"realizes = {t_real}")
+        twist_ok &= (tw.dim == 2 and em is not None
+                     and em.startswith("3-cycle") and t_real == [em]
+                     and tw.dual_valid)
+    check("each twisted fill realizes exactly its hole 3-cycle "
+          "(mapping-class transport)", twist_ok)
+
+    # -- interior room and the surgery catalog ------------------------------ #
+    thin_sites = len(list(cyl.es.interiorTopCells()))
+    thick = Level1Fill(layers=3)
+    thick_sites = len(list(thick.es.interiorTopCells()))
+    print(f"\n  Interior room: {args.layers}-layer fill has {thin_sites} "
+          f"interior tets; the 3-layer fill has {thick_sites} (every prism "
+          f"tet spans adjacent layers, so surgery first becomes possible at "
+          f"three layers).")
+    check("the thin fill has no interior tets (documented geometry)",
+          thin_sites == 0 if args.layers <= 2 else True)
+    check("the 3-layer fill has interior tets (surgery room)",
+          thick_sites > 0)
+
+    catalog = None
+    if args.draws > 0:
+        prog.phase("surgery catalog on the 3-layer fill", total=args.draws)
+        catalog = surgery_catalog(args.draws, jobs, base_seed=args.seed,
+                                  on_progress=prog.on_tick)
+        prog.finish("catalog scored")
+        print(f"\n  Surgery catalog ({catalog['scored']}/{catalog['draws']} "
+              f"gated draws; cuts + growth on the 3-layer fill):")
+        print(f"      dual-invalid final states: {catalog['n_dual_invalid']}")
+        print(f"      dim ker L_1 distribution: {dict(catalog['dims'])}")
+        print(f"      graph-like R: {catalog['graphs']}; emergent gates: "
+              f"{dict(catalog['emergent']) or '(none)'}")
+        print(f"      transports carried across variants: "
+              f"{dict(catalog['carried_counts']) or '(none)'}")
+        if catalog["beyond_c3"]:
+            print(f"        => a variant carries a transport beyond the C_3 "
+                  f"prediction: {catalog['beyond_c3']} -- the level-1 "
+                  f"criterion is richer than mapping-class transport.")
+        else:
+            print("        => NO variant carries a transport beyond "
+                  "{identity, the two 3-cycles}: on prism-class fills the "
+                  "level-1 realizable set is the C_3 of mapping-class "
+                  "transport, exactly as the twist construction predicts.")
+        check("every catalog draw keeps a valid dual complex",
+              catalog["n_dual_invalid"] == 0)
+
+    if not args.no_write:
+        os.makedirs(args.out, exist_ok=True)
+        path = os.path.join(args.out, "level1_fill_realizability.json")
+        with open(path, "w") as handle:
+            json.dump({"union": uc, "trivial_fill": {
+                           "dim": cyl.dim, "rank": cyl.rank,
+                           "diag_dev": diag_dev,
+                           "battery": rows},
+                       "catalog": catalog}, handle, indent=2)
+        print(f"\n  raw table (PR artifact, not committed): {path}")
+
+    ok = all(passed for _label, passed in checks)
+    if not ok:
+        print("\n  FAILED checks:")
+        for label, passed in checks:
+            if not passed:
+                print(f"      - {label}")
+    print("\n  Verdict: " + (
+        "SUPPORTED -- the hierarchical step closes: completed level-0 "
+        "registers serve as boundary carriers, the level-1 anchor holds "
+        "(the trivial fill transports exactly the identity, at machine "
+        "zero), twisted fills realize exactly their hole 3-cycles "
+        "(mapping-class transport), every floored transport is certified "
+        "by a period leak, and every topology move keeps a valid dual "
+        "complex. Time enters as the nesting level."
+        if ok else
+        "NOT SUPPORTED -- a claim failed; inspect the FAILED checks above."))
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/level1_mediated_selection.py
+++ b/examples/cobordism/level1_mediated_selection.py
@@ -1,0 +1,323 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Mediated selection over the level-1 fill ensemble.
+
+The mediation objective F_beta = r_U(W) + beta * |S_Regge(W*)| (#248) was
+built to choose among the many bulks realizing one operation -- and #279
+produced exactly that degenerate ensemble: level-1 fills (straight prisms
+of several thicknesses, twisted prisms, gated cut and growth variants) all
+realizing the identity transport at machine zero. The spectral layer cannot
+tell them apart; this example asks what the gravitational term selects.
+
+Every ensemble member is verified to realize the identity (the residual
+side of F_beta ties at machine zero), then scored by the magnitude of the
+dual Lorentzian Regge action (ReggeSolver.dualReggeAction, #247) on the
+unit-pinned complex, with a Lorentzian-native comparison column: the same
+prisms rebuilt with vertex times = layer, letting the tracked metric rule
+assign timelike inter-layer edges (the CDT-natural fill; no nulls arise --
+intra-layer edges have time difference 0, inter-layer exactly 1).
+
+The selection questions charted (not assumed):
+  * thickness: does F_beta prefer the thinnest fill between the two events?
+  * twists: gluing through a symmetry is a relabeling -- the action must be
+    blind to it (an isometry of the complex).
+  * cuts vs growth at fixed thickness: the #281 spike showed cuts RAISE the
+    action and stellar growth LOWERS it -- the catalog quantifies both.
+
+Run:
+    python examples/cobordism/level1_mediated_selection.py
+    python examples/cobordism/level1_mediated_selection.py --variants 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import random
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_HERE, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = _load("spectral_gate_realizability")
+L1 = _load("level1_fill_realizability")
+np = BASE.np
+tessera = BASE.tessera
+
+REALIZE = BASE.REALIZE
+_CP_IN = BASE._CP_IN
+
+BETAS = [0.0, 0.1, 0.3, 0.5, 1.0, 2.0, 5.0, 10.0]
+
+
+def _regge_magnitude(st):
+    """|S_Regge(W*)| -- the modulus of the dual Lorentzian Regge action on the
+    circumcentric dual (the same reading mediated_gate_battery.py uses for the
+    level-0 stages). The Sorkin action is complex in general; the mediation
+    objective consumes the magnitude (#258)."""
+    s = tessera.ReggeSolver(st, tessera.MatterConfiguration()).dualReggeAction()
+    return float(abs(s))
+
+
+def _identity_residual(fill):
+    """The r_U side of F_beta for the identity transport on *fill*."""
+    a = _CP_IN.astype(complex)
+    pair = np.concatenate([fill.sign0 * a, fill.sign1 * a])
+    return fill.spectral_residual(pair)
+
+
+def _layered_time_bulk(layers, twist=None):
+    """The same prism complex with vertex times = layer (the CDT-natural
+    assignment): the tracked metric rule then makes intra-layer edges
+    spacelike (equal times) and inter-layer edges timelike (time difference
+    one). No unit re-pin -- this is the Lorentzian-native fill."""
+    cells, _ = L1._prism_cells(layers=layers, twist=twist)
+    sig = tessera.Signature(3, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {}
+    for i in sorted({v for c in cells for v in c}):
+        vmap[i] = st.createVertex(i, [float(i // 12)])   # time-only coordinate
+    for c in cells:
+        t = sorted(c)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]], vmap[t[3]]])
+    return st
+
+
+def _cut_variant(seed, n_cut):
+    """A gated cut variant of the 3-layer fill (the #279 catalog flow,
+    deterministic): remove up to *n_cut* interior tets, dual-validity gated,
+    then re-read the spectral state."""
+    fill = L1.Level1Fill(layers=3)
+    rng = random.Random(seed)
+    sites = sorted(tuple(sorted(int(v) for v in c))
+                   for c in fill.es.interiorTopCells())
+    rng.shuffle(sites)
+    cut = 0
+    for cell in sites[:n_cut]:
+        if fill.es.removeInteriorCell(list(cell)):
+            ok, _why = fill.es.dualComplexValid()
+            if not ok:
+                fill.es.restoreLastRemoval()
+                continue
+            cut += 1
+    fill.read_spectral()
+    return fill, cut
+
+
+def build_ensemble(n_variants=8, base_seed=12345):
+    """The level-1 identity-realizing ensemble: straight prisms (1, 2, 3
+    layers), the two twisted prisms, and gated cut / growth variants of the
+    3-layer fill. Returns rows of (label, fill, meta)."""
+    members = []
+    for layers in (1, 2, 3):
+        members.append((f"straight L={layers}", L1.Level1Fill(layers=layers),
+                        {"layers": layers, "n_cut": 0, "n_grown": 0,
+                         "twist": None}))
+    members.append(("gamma twist L=1", L1.Level1Fill(layers=1, twist=L1._GAMMA),
+                    {"layers": 1, "n_cut": 0, "n_grown": 0, "twist": "gamma"}))
+    members.append(("gamma^2 twist L=1",
+                    L1.Level1Fill(layers=1,
+                                  twist=L1._compose(L1._GAMMA, L1._GAMMA)),
+                    {"layers": 1, "n_cut": 0, "n_grown": 0,
+                     "twist": "gamma^2"}))
+    rng = random.Random(base_seed)
+    for i in range(n_variants):
+        if i % 2 == 0:
+            fill, cut = _cut_variant(base_seed * 7 + i, n_cut=1 + (i // 2) % 3)
+            members.append((f"cut x{cut} (draw {i})", fill,
+                            {"layers": 3, "n_cut": cut, "n_grown": 0,
+                             "twist": None}))
+        else:
+            grow = 1 + (i // 2) % 4
+            fill = L1.Level1Fill(layers=3, grow_vertices=grow,
+                                 grow_seed=rng.randrange(1, 2**31))
+            members.append((f"grown +{fill.grown} (draw {i})", fill,
+                            {"layers": 3, "n_cut": 0, "n_grown": fill.grown,
+                             "twist": None}))
+    return members
+
+
+def score_ensemble(members, on_progress=None):
+    rows = []
+    for label, fill, meta in members:
+        res = _identity_residual(fill)
+        emergent = L1.match_gate(fill.emergent_gate())
+        # twisted fills carry their own mapping class; the identity-residual
+        # tie holds within the untwisted family -- twists are scored for the
+        # action-neutrality claim, with their own transport noted.
+        realizes_identity = bool(res < REALIZE)
+        s_mag = _regge_magnitude(fill.st)
+        n_tets = len([c for c in fill.es.topCells()])
+        rows.append({"label": label, **meta,
+                     "dim": fill.dim, "dual_valid": fill.dual_valid,
+                     "identity_residual": res,
+                     "realizes_identity": realizes_identity,
+                     "emergent": emergent,
+                     "S": s_mag, "n_tets": int(n_tets),
+                     "S_per_tet": s_mag / max(int(n_tets), 1)})
+        if on_progress is not None:
+            on_progress()
+    return rows
+
+
+def f_beta_table(rows, betas=BETAS):
+    """F_beta = identity residual + beta * |S| per member; the argmin per
+    beta over the identity-realizing members (the transport-degenerate
+    family the mediation objective was built to break ties in)."""
+    family = [r for r in rows if r["realizes_identity"]]
+    table = []
+    for beta in betas:
+        scored = sorted(family,
+                        key=lambda r: r["identity_residual"] + beta * r["S"])
+        table.append({"beta": beta, "winner": scored[0]["label"],
+                      "F": scored[0]["identity_residual"]
+                           + beta * scored[0]["S"]})
+    return table
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--variants", type=int, default=8,
+                    help="cut/growth variants of the 3-layer fill (default 8)")
+    ap.add_argument("--seed", type=int, default=12345)
+    ap.add_argument("--out", default="/tmp/cobordism")
+    args = ap.parse_args()
+
+    checks = []
+
+    def check(label, passed):
+        checks.append((label, bool(passed)))
+        return bool(passed)
+
+    print("Mediated selection over the level-1 fill ensemble\n"
+          "  (every member realizes the same transport at machine zero --\n"
+          "  the spectral layer cannot tell them apart; the dual Lorentzian\n"
+          "  Regge action is what selects)\n")
+    prog = BASE._progress()
+    prog.phase("building the ensemble")
+    members = build_ensemble(n_variants=args.variants, base_seed=args.seed)
+    prog.finish(f"{len(members)} fills")
+    prog.phase("scoring", total=len(members))
+    rows = score_ensemble(members, on_progress=prog.on_tick)
+    prog.finish("scored")
+
+    print(f"  {'fill':24} {'tets':>5} {'r(identity)':>12} {'|S_Regge|':>10} "
+          f"{'|S|/tet':>8}  transport")
+    for r in rows:
+        print(f"  {r['label']:24} {r['n_tets']:>5} "
+              f"{r['identity_residual']:>12.1e} {r['S']:>10.4f} "
+              f"{r['S_per_tet']:>8.4f}  {r['emergent']}")
+
+    by = {r["label"]: r for r in rows}
+    s1 = by["straight L=1"]
+    s3 = by["straight L=3"]
+    check("every fill keeps a valid dual complex",
+          all(r["dual_valid"] for r in rows))
+    check("every untwisted fill realizes the identity at machine zero "
+          "(the spectral tie F_beta breaks)",
+          all(r["realizes_identity"] for r in rows if not r["twist"]))
+    check("twists are action-neutral (gluing through a symmetry is an "
+          "isometry of the complex)",
+          abs(by["gamma twist L=1"]["S"] - s1["S"]) < 1e-9
+          and abs(by["gamma^2 twist L=1"]["S"] - s1["S"]) < 1e-9)
+    cuts = [r for r in rows if r["n_cut"] > 0]
+    grown = [r for r in rows if r["n_grown"] > 0]
+    check("every gated cut RAISES the action above the straight 3-layer fill",
+          all(r["S"] > s3["S"] for r in cuts))
+    growth_lowers = all(r["S"] < s3["S"] for r in grown)
+    print(f"\n  growth vs the straight 3-layer fill: "
+          f"{'LOWERS' if growth_lowers else 'mixed'} the action "
+          f"({', '.join(f'{r[chr(83)]:.2f}' for r in grown)} vs {s3['S']:.2f})")
+
+    table = f_beta_table(rows)
+    print("\n  F_beta selection (argmin over the identity-realizing family):")
+    for t in table:
+        print(f"      beta = {t['beta']:>5}: {t['winner']}  "
+              f"(F = {t['F']:.4f})")
+    sel = {t["winner"] for t in table if t["beta"] > 0}
+    check("a positive beta selects a single consistent winner",
+          len(sel) == 1)
+    winner = next(iter(sel)) if len(sel) == 1 else None
+    min_s = min(r["S"] for r in rows if r["realizes_identity"])
+    check("the winner is the minimal-action fill",
+          winner is not None and abs(by[winner]["S"] - min_s) < 1e-12)
+    check("the minimal-action fill is the THINNEST straight prism "
+          "(mediation selects the smallest interpolating geometry)",
+          winner == "straight L=1")
+
+    # ---- the Lorentzian-native column ------------------------------------ #
+    print("\n  Lorentzian-native fills (vertex times = layer; tracked metric "
+          "rule assigns timelike inter-layer edges):")
+    lorentz = []
+    for layers in (1, 2, 3):
+        st = _layered_time_bulk(layers)
+        s = _regge_magnitude(st)
+        lorentz.append({"layers": layers, "S": s})
+        print(f"      L={layers}: |S_Regge| = {s:.4f}")
+    check("the Lorentzian-native actions are finite (no null/degenerate "
+          "dual cells -- intra-layer dt=0, inter-layer dt=1)",
+          all(np.isfinite(r["S"]) for r in lorentz))
+    check("Lorentzian-native selection agrees: thinner is smaller",
+          lorentz[0]["S"] < lorentz[1]["S"] < lorentz[2]["S"])
+
+    if not args.no_write:
+        os.makedirs(args.out, exist_ok=True)
+        path = os.path.join(args.out, "level1_mediated_selection.json")
+        with open(path, "w") as handle:
+            json.dump({"ensemble": rows, "f_beta": table,
+                       "lorentzian": lorentz}, handle, indent=2)
+        print(f"\n  raw table (PR artifact, not committed): {path}")
+
+    ok = all(passed for _label, passed in checks)
+    if not ok:
+        print("\n  FAILED checks:")
+        for label, passed in checks:
+            if not passed:
+                print(f"      - {label}")
+    print("\n  Verdict: " + (
+        "SUPPORTED -- the mediation objective does real work on the level-1 "
+        "ensemble: among fills the spectral layer cannot distinguish, "
+        "F_beta is blind to twists (isometries), penalizes cuts, and "
+        "selects the thinnest straight prism -- the minimal interpolating "
+        "geometry between the two interaction events."
+        if ok else
+        "NOT SUPPORTED -- a claim failed; inspect the FAILED checks above."))
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/level1_stabilizer_law.py
+++ b/examples/cobordism/level1_stabilizer_law.py
@@ -1,0 +1,412 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The level-1 stabilizer law: S_3 transport on hexagon-join ends.
+
+#279 charted the level-1 transports on icosahedron-end prism fills: exactly
+C_3 -- the setwise stabilizer of the end's hole triple in its automorphism
+group (the icosahedron has no hole-transposing automorphism, and the
+randomized interior catalog could not enlarge the set). This example tests
+the law it suggests --
+
+    the level-1 realizable transports are the END's mapping classes:
+    the image of the hole-triple stabilizer in Sym(holes) --
+
+on the second seed the framework already owns: the hexagon-join L_2
+register, whose stabilizer is the FULL S_3 (order 12 inside the 288-element
+automorphism group, all six hole permutations induced). The fills are
+4-dimensional staircase prisms (each tetrahedron x interval -> four
+4-simplices) between two copies of the holed S^3; transport is read at
+k = 2 from each end's three tet-boundary sphere periods. Predictions, all
+falsifiable:
+
+  * the straight fill transports exactly the identity (the level-1 anchor,
+    b_2 of the fill = 2 by homotopy with the end);
+  * each twisted fill (top end glued through a stabilizer element)
+    transports exactly its induced hole permutation -- including the
+    TRANSPOSITIONS the icosahedron ends provably cannot transport;
+  * the factor swap (a_i <-> b_i), a nontrivial twist inducing the
+    identity on holes, transports the identity -- mapping classes, not
+    vertex maps, are what transport;
+  * everything outside the six S_3 permutation gates floors with a
+    certified period leak.
+
+A note on gating: `dualComplexIsValid` is rigorous for n <= 3 only, and no
+gated topology moves are used at dimension 4 in this example -- the fills
+here are explicit constructions, not search outputs.
+
+Run:
+    python examples/cobordism/level1_stabilizer_law.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_HERE, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = _load("spectral_gate_realizability")   # thread caps + the gate battery
+L2 = _load("l2_register_realizability")       # hexjoin cells + tet facets
+L1 = _load("level1_fill_realizability")       # transport semantics + matching
+np = BASE.np
+tessera = BASE.tessera
+cob = tessera.cobordism
+
+REALIZE = BASE.REALIZE
+CERT_FLOOR = BASE.CERT_FLOOR
+_CP_IN = BASE._CP_IN
+
+# The level-0 end: the hexagon join minus its three canonical tet holes (the
+# holed S^3 whose ker L_2 carries the register).
+_W3_CELLS = [c for c in L2._HEXJOIN if c not in set(L2._HEXJOIN_HOLES)]
+_HOLES = list(L2._HEXJOIN_HOLES)
+_N_END = 12                                    # vertices per layer
+
+# --------------------------------------------------------------------------- #
+# The hole-triple stabilizer of the hexagon join (order 12; image = full S_3).
+# Vertex labels: a_i = i, b_j = 6 + j. Generators:
+#   shift  sigma: (a_i, b_j) -> (a_{i+2}, b_{j+2})   -- a hole 3-cycle
+#   reflect  rho: (a_i, b_j) -> (a_{1-i}, b_{1-j})   -- a hole transposition
+#   swap     tau: a_i <-> b_i                        -- fixes every hole
+# --------------------------------------------------------------------------- #
+def _vmap(fa, fb):
+    return {**{i: fa(i) % 6 for i in range(6)},
+            **{6 + j: 6 + (fb(j) % 6) for j in range(6)}}
+
+
+_SIGMA = _vmap(lambda i: i + 2, lambda j: j + 2)
+_RHO = _vmap(lambda i: 1 - i, lambda j: 1 - j)
+_TAU = {**{i: 6 + i for i in range(6)}, **{6 + j: j for j in range(6)}}
+_IDENT = {v: v for v in range(_N_END)}
+
+TWISTS = [
+    ("straight", _IDENT),
+    ("sigma", _SIGMA),
+    ("sigma^2", L1._compose(_SIGMA, _SIGMA)),
+    ("rho", _RHO),
+    ("sigma.rho", L1._compose(_SIGMA, _RHO)),
+    ("rho.sigma", L1._compose(_RHO, _SIGMA)),
+    ("tau (factor swap)", _TAU),
+]
+
+
+def _is_end_automorphism(perm):
+    """*perm* preserves the holed join's tet set and its hole set."""
+    cells = {tuple(sorted(perm[v] for v in c)) for c in _W3_CELLS}
+    holes = {tuple(sorted(perm[v] for v in h)) for h in _HOLES}
+    return cells == set(_W3_CELLS) and holes == set(_HOLES)
+
+
+def _prism4_cells(cells=_W3_CELLS, twist=None):
+    """The staircase triangulation of (holed S^3) x I: for each tetrahedron
+    (a<b<c<d), the four 4-simplices (a0,b0,c0,d0,d1), (a0,b0,c0,c1,d1),
+    (a0,b0,b1,c1,d1), (a0,a1,b1,c1,d1) with x1 = twist(x) + 12. Adjacent
+    prisms split shared walls by the same vertex-order rule."""
+    twist = twist or _IDENT
+    out = []
+    for c in cells:
+        a, b, cc, d = sorted(c)
+        a1, b1, c1, d1 = (twist[a] + 12, twist[b] + 12,
+                          twist[cc] + 12, twist[d] + 12)
+        out += [tuple(sorted((a, b, cc, d, d1))),
+                tuple(sorted((a, b, cc, c1, d1))),
+                tuple(sorted((a, b, b1, c1, d1))),
+                tuple(sorted((a, a1, b1, c1, d1)))]
+    return sorted(set(out))
+
+
+def _bulk4(cells):
+    """A pre-geometric 4-complex (top cells = 4-simplices), unit edge pin."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {i: st.createVertex(i)
+            for i in sorted({v for c in cells for v in c})}
+    for c in cells:
+        t = sorted(c)
+        st.createSimplex([vmap[v] for v in t])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+        e.setPhase(0.0)
+    return st
+
+
+_REG_SIGN_CACHE = []
+
+
+def _reg_sign():
+    """The hexjoin L_2 register's induced-orientation sign pattern -- a
+    property of the end, applied deterministically at both ends (the level-1
+    icosahedron run showed per-fill null-vector normalization is
+    sign-unstable)."""
+    if not _REG_SIGN_CACHE:
+        _REG_SIGN_CACHE.append(L2.RegisterL2().sign.copy())
+    return _REG_SIGN_CACHE[0]
+
+
+class Level1FillS3:
+    """The level-1 register over hexagon-join ends: ker L_2 of a 4-dimensional
+    fill whose boundary pair is two copies of the holed S^3. Transport is the
+    pair of end sphere-period vectors; a fill realizes u' iff graph(u') lies
+    in the restriction R -- the same semantics as the icosahedron-end fills
+    of #279, one dimension up."""
+
+    def __init__(self, twist=None):
+        self.cells4 = _prism4_cells(twist=twist)
+        self.holes0 = [tuple(sorted(h)) for h in _HOLES]
+        self.holes1 = [tuple(sorted(v + 12 for v in h)) for h in _HOLES]
+        self.reg_facets = [f for hole in (self.holes0 + self.holes1)
+                           for f, _s in L2._tet_facets(hole)]
+        self.fidx = {f: i for i, f in enumerate(self.reg_facets)}
+
+        self.st = _bulk4(self.cells4)
+        self.es = cob.EigenstateSynthesis(self.st, 2)
+        self.cells = [tuple(int(v) for v in c) for c in self.es.cellSimplices()]
+        harmonics = cob.HodgeLaplacian(self.st).harmonics(2)
+        self.dim = len(harmonics)
+        if self.dim:
+            self.H_full = np.array(
+                [[complex(h.amplitudeFor(list(c))) for c in self.cells]
+                 for h in harmonics])
+        else:
+            self.H_full = np.zeros((0, len(self.cells)), dtype=complex)
+        self._reg_col = [self.cells.index(f) for f in self.reg_facets]
+        h_reg = self.H_full[:, self._reg_col] if self.dim else self.H_full
+        rows = []
+        for r in range(self.dim):
+            p0 = [self._period(h_reg[r], hole) for hole in self.holes0]
+            p1 = [self._period(h_reg[r], hole) for hole in self.holes1]
+            rows.append(p0 + p1)
+        self.P6 = np.array(rows).reshape(self.dim, 6)
+        self.sign0 = _reg_sign()
+        self.sign1 = _reg_sign()
+
+    def _period(self, vec, hole):
+        return sum(s * vec[self.fidx[f]] for f, s in L2._tet_facets(hole))
+
+    @property
+    def rank(self):
+        return int(np.linalg.matrix_rank(self.P6, tol=1e-9)) if self.dim else 0
+
+    def end_charge_leak(self):
+        if not self.dim:
+            return 0.0
+        return float(max(np.max(np.abs(self.P6[:, 0:3] @ self.sign0)),
+                         np.max(np.abs(self.P6[:, 3:6] @ self.sign1))))
+
+    def harmonic_form(self, pair6):
+        coeffs, *_ = np.linalg.lstsq(self.P6.T, pair6, rcond=None)
+        full = (coeffs @ self.H_full).astype(complex)
+        leak = pair6 - coeffs @ self.P6
+        for k, hole in enumerate(self.holes0 + self.holes1):
+            first_facet = L2._tet_facets(hole)[0][0]      # sign +1 by convention
+            full[self._reg_col[self.fidx[first_facet]]] += leak[k]
+        return full
+
+    def spectral_residual(self, pair6):
+        psi = self.harmonic_form(np.asarray(pair6, dtype=complex))
+        return float(self.es.residual([complex(z) for z in psi]))
+
+    def emergent_gate(self):
+        if self.dim != 2:
+            return None
+        e_basis = np.array([[1.0, -1.0, 0.0] / np.sqrt(2.0),
+                            [1.0, 1.0, -2.0] / np.sqrt(6.0)])
+        A = (self.P6[:, 0:3] * self.sign0) @ e_basis.T
+        B = (self.P6[:, 3:6] * self.sign1) @ e_basis.T
+        if np.linalg.matrix_rank(A, tol=1e-9) < 2:
+            return None
+        return np.linalg.solve(A, B).T
+
+
+def battery(fill, on_progress=None):
+    """The 13 canonical blocks as candidate transports, hand-calculated
+    targets (a, u'a) in each end's signed conventions."""
+    a = _CP_IN.astype(complex)
+    rows = []
+    for name, u in L1._v_candidates():
+        b = u @ a
+        pair = np.concatenate([fill.sign0 * a, fill.sign1 * b])
+        res = fill.spectral_residual(pair)
+        coeffs, *_ = np.linalg.lstsq(fill.P6.T, pair, rcond=None)
+        leak = float(np.linalg.norm(pair - coeffs @ fill.P6))
+        rows.append({"gate": name, "residual": res, "leak": leak,
+                     "realizable": bool(res < REALIZE)})
+        if on_progress is not None:
+            on_progress()
+    return rows
+
+
+_S3_GATES = ("Identity", "SWAP", "CNOT", "reversed-CNOT",
+             "3-cycle (0231)", "3-cycle (0312)")
+
+
+def _v_classes():
+    """Group the 13 canonical candidates by their ACTION ON V: transport can
+    only see the V-block, so gates equal on the charge-zero plane co-realize
+    on any fill. (Discovered by this experiment: H(x)H = SWAP - J/2 with J
+    the all-ones matrix, and J annihilates V -- on the carried register,
+    double-Hadamard IS the swap of the holonomy generators.) Returns
+    {gate name: sorted tuple of class member names}."""
+    e_basis = np.array([[1.0, -1.0, 0.0] / np.sqrt(2.0),
+                        [1.0, 1.0, -2.0] / np.sqrt(6.0)])
+    cands = L1._v_candidates()
+    classes = {}
+    for name, u in cands:
+        members = sorted(n2 for n2, u2 in cands
+                         if np.max(np.abs((u2 - u) @ e_basis.T)) < 1e-9)
+        classes[name] = tuple(members)
+    return classes
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--out", default="/tmp/cobordism")
+    args = ap.parse_args()
+
+    checks = []
+
+    def check(label, passed):
+        checks.append((label, bool(passed)))
+        return bool(passed)
+
+    print("The level-1 stabilizer law: S_3 transport on hexagon-join ends\n"
+          "  (4-dimensional prism fills between two holed-S^3 registers; the\n"
+          "  end's hole-triple stabilizer is the FULL S_3, so all six hole\n"
+          "  permutations -- including transpositions -- should transport)\n")
+    prog = BASE._progress()
+
+    for name, perm in TWISTS:
+        check(f"{name} is an automorphism of the holed join",
+              _is_end_automorphism(perm))
+
+    results = []
+    for name, perm in TWISTS:
+        prog.phase(f"fill: {name}")
+        fill = Level1FillS3(twist=perm)
+        rows = battery(fill)
+        prog.finish(f"{name} scored")
+        realized = [r["gate"] for r in rows if r["realizable"]]
+        floored = [r for r in rows if not r["realizable"]]
+        emergent = L1.match_gate(fill.emergent_gate())
+        results.append({"twist": name, "dim": fill.dim, "rank": fill.rank,
+                        "emergent": emergent, "realized": realized,
+                        "end_leak": fill.end_charge_leak(),
+                        "floor_lo": min((r["residual"] for r in floored),
+                                        default=None),
+                        "leak_lo": min((r["leak"] for r in floored),
+                                       default=None)})
+        print(f"  {name:18} dim={fill.dim} rank={fill.rank} "
+              f"end-leak={fill.end_charge_leak():.1e} "
+              f"emergent={emergent or 'NOT A GRAPH'} realizes={realized}")
+
+    classes = _v_classes()
+    nontrivial_classes = {n: m for n, m in classes.items() if len(m) > 1}
+    print(f"\n  V-action classes among the 13 candidates (gates equal on the "
+          f"charge-zero plane co-transport): "
+          f"{sorted(set(nontrivial_classes.values())) or 'all distinct'}")
+
+    by_twist = {r["twist"]: r for r in results}
+    straight = by_twist["straight"]
+    check("the straight fill carries a 2-dim register (b_2 by homotopy)",
+          straight["dim"] == 2)
+    check("level-1 anchor: the straight fill transports exactly the "
+          "identity's V-class",
+          tuple(sorted(straight["realized"])) == classes["Identity"]
+          and straight["emergent"] == "Identity")
+    check("the factor swap (nontrivial twist, trivial hole action) "
+          "transports the identity",
+          tuple(sorted(by_twist["tau (factor swap)"]["realized"]))
+          == classes["Identity"])
+    twist_names = ["sigma", "sigma^2", "rho", "sigma.rho", "rho.sigma"]
+    nontrivial = sorted({g for t in twist_names
+                         for g in by_twist[t]["realized"]})
+    check("each nontrivial twist transports exactly ONE V-class: its own "
+          "mapping class",
+          all(by_twist[t]["emergent"] is not None
+              and tuple(sorted(by_twist[t]["realized"]))
+              == classes[by_twist[t]["emergent"]]
+              for t in twist_names))
+    transported = sorted({g for r in results for g in r["realized"]})
+    expected = sorted({m for g in _S3_GATES for m in classes[g]})
+    check("the transported set is exactly the S_3 permutation gates' "
+          "V-classes (the law: stabilizer image, as actions on V)",
+          transported == expected)
+    check("transpositions transport on hexjoin ends (impossible on "
+          "icosahedron ends, #279)",
+          any(g in ("SWAP", "CNOT", "reversed-CNOT") for g in nontrivial))
+    check("every floored transport is leak-certified",
+          all((r["leak_lo"] or 1.0) > 1e-6 for r in results))
+    check("both ends conserve signed charge on every fill",
+          all(r["end_leak"] < 1e-9 for r in results))
+
+    print("\n  The law table (level-1 realizable transports = the end's "
+          "hole-triple stabilizer image, as V-actions):")
+    print("      icosahedron ends (#279):  stabilizer C_3  ->  "
+          "{Identity, 3-cycle (0231), 3-cycle (0312)}")
+    print(f"      hexagon-join ends (here): stabilizer S_3  ->  "
+          f"{transported}")
+    print("      (H(x)H rides with SWAP: H(x)H = SWAP - J/2 and J kills V, "
+          "so they are the SAME action on the carried register.)")
+
+    if not args.no_write:
+        os.makedirs(args.out, exist_ok=True)
+        path = os.path.join(args.out, "level1_stabilizer_law.json")
+        with open(path, "w") as handle:
+            json.dump({"results": results, "transported": transported},
+                      handle, indent=2)
+        print(f"\n  raw table (PR artifact, not committed): {path}")
+
+    ok = all(passed for _label, passed in checks)
+    if not ok:
+        print("\n  FAILED checks:")
+        for label, passed in checks:
+            if not passed:
+                print(f"      - {label}")
+    print("\n  Verdict: " + (
+        "SUPPORTED -- the level-1 conservation law holds on both seeds: the "
+        "realizable transports are exactly the end's mapping classes (the "
+        "hole-triple stabilizer image), C_3 on icosahedron ends and the "
+        "full S_3 -- transpositions included -- on hexagon-join ends."
+        if ok else
+        "NOT SUPPORTED -- a claim failed; inspect the FAILED checks above."))
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cobordism/test_level1_fill_python.py
+++ b/tests/cobordism/test_level1_fill_python.py
@@ -1,0 +1,180 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Hierarchical synthesis, level 1
+(``examples/cobordism/level1_fill_realizability.py``).
+
+Two completed level-0 registers serve as the boundary carriers of a new
+3-dimensional fill; the level-1 state space is the pair of end periods
+V (+) V, and a fill realizes the transport u' iff graph(u') lies in the
+restriction R of its ker L_1. These tests pin the hand-derivable structure:
+
+  1. **No bulk, no interaction.** The disjoint union is saturated
+     (ker L_1 = V (+) V): every transport trivially "carried".
+  2. **The level-1 anchor.** The trivial fill (prism W x I) keeps
+     ker L_1 two-dimensional, conserves each end's signed charge, has
+     R = the diagonal -- the graph of the identity -- and its battery
+     realizes EXACTLY the identity, with every floored transport
+     certified by a period leak.
+  3. **Mapping-class transport.** The gamma- and gamma^2-twisted fills
+     realize exactly their hole 3-cycles: the C_3 (the hole triple's full
+     setwise stabilizer) is transported by twisting, and nothing else is.
+  4. **Rigidity under interior topology change.** Gated interior surgery
+     and stellar growth on the 3-layer fill (thin prisms have no interior
+     tets -- every tet spans adjacent layers) leave the transport at the
+     identity: the level-1 realizable set on prism-class fills is the C_3
+     of mapping-class transport.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "level1_fill_realizability.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("level1_fill_realizability",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["level1_fill_realizability"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+L1 = _load_example()
+
+# Shared fixtures: the trivial fill and its battery (deterministic builds).
+_CYL = L1.Level1Fill(layers=1)
+_ROWS = L1.level1_battery(_CYL)
+
+
+class NoBulkNoInteractionTest(unittest.TestCase):
+    """1: the disconnected union is the saturated control."""
+
+    def test_union_is_saturated(self):
+        uc = L1.union_control()
+        self.assertEqual(uc["dim"], 4)
+        self.assertTrue(uc["saturated"])
+
+
+class TrivialFillAnchorTest(unittest.TestCase):
+    """2: the level-1 T1 anchor on the prism W x I."""
+
+    def test_fill_keeps_a_valid_dual_complex(self):
+        self.assertTrue(_CYL.dual_valid, _CYL.dual_reason)
+
+    def test_ker_l1_is_two_dimensional(self):
+        self.assertEqual(_CYL.dim, 2)
+        self.assertEqual(_CYL.rank, 2)
+
+    def test_both_ends_conserve_signed_charge(self):
+        self.assertLess(_CYL.end_charge_leak(), 1e-9)
+
+    def test_restriction_is_the_diagonal(self):
+        dev = float(np.max(np.abs(_CYL.P6[:, 0:3] * _CYL.sign0
+                                  - _CYL.P6[:, 3:6] * _CYL.sign1)))
+        self.assertLess(dev, 1e-9)
+
+    def test_emergent_gate_is_the_identity(self):
+        self.assertEqual(L1.match_gate(_CYL.emergent_gate()), "Identity")
+
+    def test_battery_realizes_exactly_the_identity(self):
+        realized = [r["gate"] for r in _ROWS if r["realizable"]]
+        self.assertEqual(realized, ["Identity"])
+
+    def test_identity_residual_is_machine_zero(self):
+        row = next(r for r in _ROWS if r["gate"] == "Identity")
+        self.assertLess(row["residual"], L1.REALIZE)
+
+    def test_floored_transports_sit_above_the_floor_with_leaks(self):
+        for row in _ROWS:
+            if row["realizable"]:
+                continue
+            self.assertGreater(row["residual"], L1.CERT_FLOOR, msg=row["gate"])
+            self.assertGreater(row["leak"], 1e-6, msg=row["gate"])
+
+
+class MappingClassTransportTest(unittest.TestCase):
+    """3: twisted fills realize exactly their hole 3-cycles."""
+
+    def _twist_case(self, twist, expected):
+        fill = L1.Level1Fill(layers=1, twist=twist)
+        self.assertTrue(fill.dual_valid, fill.dual_reason)
+        self.assertEqual(fill.dim, 2)
+        self.assertEqual(L1.match_gate(fill.emergent_gate()), expected)
+        realized = [r["gate"] for r in L1.level1_battery(fill)
+                    if r["realizable"]]
+        self.assertEqual(realized, [expected])
+
+    def test_gamma_twist_realizes_its_three_cycle(self):
+        self._twist_case(L1._GAMMA, "3-cycle (0312)")
+
+    def test_gamma_squared_twist_realizes_the_other_three_cycle(self):
+        self._twist_case(L1._compose(L1._GAMMA, L1._GAMMA), "3-cycle (0231)")
+
+
+class InteriorTopologyRigidityTest(unittest.TestCase):
+    """4: interior room exists only at three layers, and gated cuts/growth
+    leave the transport at the identity."""
+
+    def test_thin_fills_have_no_interior_tets(self):
+        self.assertEqual(len(list(_CYL.es.interiorTopCells())), 0)
+        two = L1.Level1Fill(layers=2)
+        self.assertEqual(len(list(two.es.interiorTopCells())), 0)
+
+    def test_three_layer_fill_has_interior_room(self):
+        thick = L1.Level1Fill(layers=3)
+        self.assertGreaterEqual(len(list(thick.es.interiorTopCells())), 3)
+
+    def test_gated_cuts_preserve_the_identity_transport(self):
+        fill = L1.Level1Fill(layers=3)
+        sites = sorted(tuple(sorted(int(v) for v in c))
+                       for c in fill.es.interiorTopCells())
+        cut = 0
+        for cell in sites[:2]:
+            if fill.es.removeInteriorCell(list(cell)):
+                ok, _why = fill.es.dualComplexValid()
+                if not ok:
+                    fill.es.restoreLastRemoval()
+                    continue
+                cut += 1
+        fill.read_spectral()
+        self.assertGreaterEqual(cut, 1)
+        self.assertTrue(fill.dual_valid, fill.dual_reason)
+        self.assertEqual(fill.dim, 2)
+        self.assertEqual(L1.match_gate(fill.emergent_gate()), "Identity")
+
+    def test_gated_growth_preserves_the_identity_transport(self):
+        fill = L1.Level1Fill(layers=3, grow_vertices=2, grow_seed=7)
+        self.assertGreaterEqual(fill.grown, 1)
+        self.assertTrue(fill.dual_valid, fill.dual_reason)
+        self.assertEqual(fill.dim, 2)
+        self.assertEqual(L1.match_gate(fill.emergent_gate()), "Identity")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_level1_mediation_python.py
+++ b/tests/cobordism/test_level1_mediation_python.py
@@ -1,0 +1,142 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Mediated selection over the level-1 fill ensemble
+(``examples/cobordism/level1_mediated_selection.py``).
+
+Among fills that all realize the identity transport at machine zero -- the
+spectral tie the mediation objective was built to break -- these tests pin
+what the dual Lorentzian Regge action selects:
+
+  1. Twists are action-neutral: gluing through a symmetry is an isometry of
+     the complex, so |S_Regge| is bit-identical to the straight prism's.
+  2. Gated interior cuts RAISE the action above the straight fill of the
+     same thickness; stellar growth is scored, not assumed.
+  3. For every beta > 0, F_beta selects the minimal-action member -- the
+     thinnest straight prism, the minimal interpolating geometry between
+     the two interaction events.
+  4. The Lorentzian-native fills (vertex times = layer, timelike inter-layer
+     edges by the tracked metric rule) have finite actions with the same
+     thinner-is-smaller ordering, and keep the 2-dimensional ker L_1 (the
+     transport space is topological, so the metric cannot move it).
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "level1_mediated_selection.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("level1_mediated_selection",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["level1_mediated_selection"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SEL = _load_example()
+
+# One small deterministic ensemble shared by the tests below.
+_MEMBERS = SEL.build_ensemble(n_variants=4, base_seed=12345)
+_ROWS = SEL.score_ensemble(_MEMBERS)
+_BY = {r["label"]: r for r in _ROWS}
+
+
+class EnsembleIsDegenerateTest(unittest.TestCase):
+    """The family F_beta breaks ties in: every untwisted member realizes the
+    identity at machine zero with a valid dual complex."""
+
+    def test_every_member_keeps_a_valid_dual(self):
+        for r in _ROWS:
+            self.assertTrue(r["dual_valid"], msg=r["label"])
+
+    def test_untwisted_members_realize_the_identity(self):
+        for r in _ROWS:
+            if r["twist"] is None:
+                self.assertTrue(r["realizes_identity"], msg=r["label"])
+                self.assertLess(r["identity_residual"], SEL.REALIZE,
+                                msg=r["label"])
+
+
+class ActionStructureTest(unittest.TestCase):
+    """1 + 2: what the action sees."""
+
+    def test_twists_are_action_neutral(self):
+        s1 = _BY["straight L=1"]["S"]
+        self.assertLess(abs(_BY["gamma twist L=1"]["S"] - s1), 1e-9)
+        self.assertLess(abs(_BY["gamma^2 twist L=1"]["S"] - s1), 1e-9)
+
+    def test_cuts_raise_the_action(self):
+        s3 = _BY["straight L=3"]["S"]
+        cuts = [r for r in _ROWS if r["n_cut"] > 0]
+        self.assertGreaterEqual(len(cuts), 1)
+        for r in cuts:
+            self.assertGreater(r["S"], s3, msg=r["label"])
+
+    def test_thinner_straight_prisms_have_smaller_action(self):
+        self.assertLess(_BY["straight L=1"]["S"], _BY["straight L=2"]["S"])
+        self.assertLess(_BY["straight L=2"]["S"], _BY["straight L=3"]["S"])
+
+
+class FBetaSelectionTest(unittest.TestCase):
+    """3: the selection verdict."""
+
+    def test_positive_beta_selects_the_thinnest_straight_prism(self):
+        table = SEL.f_beta_table(_ROWS)
+        winners = {t["winner"] for t in table if t["beta"] > 0}
+        self.assertEqual(winners, {"straight L=1"})
+
+    def test_the_winner_is_the_minimal_action_member(self):
+        family = [r for r in _ROWS if r["realizes_identity"]]
+        min_s = min(r["S"] for r in family)
+        self.assertLess(abs(_BY["straight L=1"]["S"] - min_s), 1e-12)
+
+
+class LorentzianNativeTest(unittest.TestCase):
+    """4: the CDT-natural fills."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fills = {layers: SEL._layered_time_bulk(layers)
+                     for layers in (1, 2, 3)}
+        cls.actions = {layers: SEL._regge_magnitude(st)
+                       for layers, st in cls.fills.items()}
+
+    def test_actions_are_finite_and_ordered(self):
+        for layers, s in self.actions.items():
+            self.assertTrue(SEL.np.isfinite(s), msg=f"L={layers}")
+        self.assertLess(self.actions[1], self.actions[2])
+        self.assertLess(self.actions[2], self.actions[3])
+
+    def test_transport_space_survives_the_lorentzian_metric(self):
+        cob = SEL.tessera.cobordism
+        harm = cob.HodgeLaplacian(self.fills[1]).harmonics(1)
+        self.assertEqual(len(harm), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_level1_stabilizer_python.py
+++ b/tests/cobordism/test_level1_stabilizer_python.py
@@ -1,0 +1,138 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The level-1 stabilizer law
+(``examples/cobordism/level1_stabilizer_law.py``).
+
+The law: the level-1 realizable transports are the END's mapping classes --
+the image of its hole-triple stabilizer in Sym(holes), read as actions on
+the carried plane V. Icosahedron ends give C_3 (#279); hexagon-join ends,
+whose stabilizer is the full S_3, transport all six hole permutations --
+including the transpositions the icosahedron provably cannot. These tests
+pin the 4-dimensional instance:
+
+  1. Every twist used is verified to be an automorphism of the holed join
+     preserving the hole set.
+  2. The straight 4d fill carries a 2-dim register (b_2 by homotopy) and
+     transports exactly the identity's V-class.
+  3. A transposition twist (rho) transports exactly CNOT -- impossible on
+     icosahedron ends.
+  4. The V-class structure: gates equal on the charge-zero plane
+     co-transport, and the only nontrivial class among the 13 candidates is
+     {H(x)H, SWAP} (H(x)H = SWAP - J/2 with J the all-ones matrix, and J
+     annihilates V).
+  5. The factor swap -- a nontrivial twist inducing the identity on holes --
+     transports the identity: mapping classes, not vertex maps, transport.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "level1_stabilizer_law.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("level1_stabilizer_law",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["level1_stabilizer_law"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+LAW = _load_example()
+
+
+class TwistsAreEndAutomorphismsTest(unittest.TestCase):
+    """1: the twist family is the hole-triple stabilizer, verifiably."""
+
+    def test_every_twist_preserves_cells_and_holes(self):
+        for name, perm in LAW.TWISTS:
+            self.assertTrue(LAW._is_end_automorphism(perm), msg=name)
+
+
+class VClassStructureTest(unittest.TestCase):
+    """4: transport sees only the action on V."""
+
+    def test_the_only_nontrivial_class_is_hxh_swap(self):
+        classes = LAW._v_classes()
+        nontrivial = {m for m in classes.values() if len(m) > 1}
+        self.assertEqual(nontrivial, {("H(x)H", "SWAP")})
+
+
+class StraightFillAnchorTest(unittest.TestCase):
+    """2: the 4d level-1 anchor."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fill = LAW.Level1FillS3()
+        cls.rows = LAW.battery(cls.fill)
+
+    def test_register_is_two_dimensional(self):
+        self.assertEqual(self.fill.dim, 2)
+        self.assertEqual(self.fill.rank, 2)
+
+    def test_ends_conserve_signed_charge(self):
+        self.assertLess(self.fill.end_charge_leak(), 1e-9)
+
+    def test_transports_exactly_the_identity(self):
+        realized = sorted(r["gate"] for r in self.rows if r["realizable"])
+        self.assertEqual(realized, ["Identity"])
+        self.assertEqual(LAW.L1.match_gate(self.fill.emergent_gate()),
+                         "Identity")
+
+    def test_floored_transports_are_leak_certified(self):
+        for row in self.rows:
+            if not row["realizable"]:
+                self.assertGreater(row["leak"], 1e-6, msg=row["gate"])
+
+
+class TranspositionTransportTest(unittest.TestCase):
+    """3 + 5: the transposition twist and the factor-swap control."""
+
+    def test_rho_transports_exactly_cnot(self):
+        fill = LAW.Level1FillS3(twist=LAW._RHO)
+        self.assertEqual(fill.dim, 2)
+        self.assertEqual(LAW.L1.match_gate(fill.emergent_gate()), "CNOT")
+        realized = sorted(r["gate"] for r in LAW.battery(fill)
+                          if r["realizable"])
+        self.assertEqual(realized, ["CNOT"])
+
+    def test_sigma_rho_transports_the_swap_v_class(self):
+        fill = LAW.Level1FillS3(twist=LAW.L1._compose(LAW._SIGMA, LAW._RHO))
+        self.assertEqual(LAW.L1.match_gate(fill.emergent_gate()), "SWAP")
+        realized = sorted(r["gate"] for r in LAW.battery(fill)
+                          if r["realizable"])
+        self.assertEqual(realized, ["H(x)H", "SWAP"])
+
+    def test_factor_swap_transports_the_identity(self):
+        fill = LAW.Level1FillS3(twist=LAW._TAU)
+        realized = sorted(r["gate"] for r in LAW.battery(fill)
+                          if r["realizable"])
+        self.assertEqual(realized, ["Identity"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Two results on the level-1 substrate (milestone: Mediated Cobordism Validation and Testing). Stacked on #279 — will retarget automatically when it merges.

**The stabilizer law (#280).** The level-1 realizable transports are the *end's mapping classes*: the image of its hole-triple stabilizer in Sym(holes), as actions on the carried plane V. Second seed confirmed: 4-dimensional prisms between two hexagon-join L₂ registers (tet × I → four 4-simplices, transport read at k=2) carry the **full S₃** — identity (straight), 3-cycles (σ twists), and the **transpositions** (ρ twists → CNOT, SWAP, reversed-CNOT) that icosahedron ends provably cannot transport; the factor swap (nontrivial twist, trivial hole action) transports the identity. The law table: icosahedron → C₃ (#279), hexagon join → S₃ (here). Discovered en route: **transport sees only the V-action** — H⊗H = SWAP − J/2 and J annihilates the charge-zero plane, so H⊗H and SWAP are the same action on the carried register and co-transport; the law is stated in V-classes (the only nontrivial class among the 13 candidates).

**Mediated selection (#281).** Among fills that all realize the identity at machine zero — the degenerate family F_β was built to break ties in — the dual Lorentzian Regge action (#247/#258) does real work: twists are exactly action-neutral (|S| bit-identical: isometries), every gated cut **raises** the action above the same-thickness straight fill, stellar growth lowers it within the 3-layer family, and for every β > 0 **F_β selects the thinnest straight prism** — the minimal interpolating geometry between the two interaction events. A Lorentzian-native column (vertex times = layer, timelike inter-layer edges via the tracked metric rule; no nulls by construction) gives finite actions with the same thinner-is-smaller ordering, and ker L₁ stays 2-dimensional under the metric change (the transport space is topological).

## Test plan
- [x] `pytest tests/cobordism/test_level1_stabilizer_python.py tests/cobordism/test_level1_mediation_python.py` — 18 passed
- [x] Full `tests/cobordism` suite in the worktree venv: **620 passed, 1 skipped (pre-existing), 0 failures** (11:40)
- [x] Full example runs: `level1_stabilizer_law.py` and `level1_mediated_selection.py` — both SUPPORTED

Closes #280. Closes #281.
