### PR TITLE
refactor(cobordism): the carried register in C++ — harmonic matrix, periods, residual-for-periods, sign covector

### DIFF
--- a/examples/cobordism/l2_register_realizability.py
+++ b/examples/cobordism/l2_register_realizability.py
@@ -237,27 +237,23 @@ class RegisterL2:
                 self.extra_opened.append(cs)
         self.dual_valid, self.dual_reason = register_dual_valid(self.es)
 
+        # The register core reads off the C++ layer (#286), exactly as the 2d
+        # Register: harmonic amplitude matrix, sphere-period rows with the
+        # boundary operator's signs, and the deterministic end sign covector
+        # from the surface's fundamental chain.
         self.cells = [tuple(int(v) for v in c) for c in self.es.cellSimplices()]
-        harmonics = cob.HodgeLaplacian(self.st).harmonics(2)
-        self.dim = len(harmonics)
-        if self.dim:
-            self.H_full = np.array(
-                [[complex(h.amplitudeFor(list(c))) for c in self.cells]
-                 for h in harmonics])
-        else:
-            self.H_full = np.zeros((0, len(self.cells)), dtype=complex)
+        self.H_full = np.asarray(
+            cob.HodgeLaplacian(self.st).harmonicMatrix(2),
+            dtype=complex).reshape(-1, len(self.cells))
+        self.dim = int(self.H_full.shape[0])
         self._reg_col = [self.cells.index(f) for f in self.reg_facets]
-        h_reg = self.H_full[:, self._reg_col]
-        self.P = np.array(
-            [[self._period(h_reg[r], hole) for hole in self.class_holes]
-             for r in range(self.dim)]).reshape(self.dim, len(self.class_holes))
-        if self.dim:
-            n_raw = np.linalg.svd(self.P)[2][-1].conj()
-            self.n = (n_raw / n_raw[np.argmax(np.abs(n_raw))]).real
-        else:
-            self.n = np.ones(len(self.class_holes))
-        self.sign = np.sign(self.n)
-        self.sign[self.sign == 0] = 1.0
+        self.P = np.asarray(
+            self.es.cyclePeriods([list(h) for h in self.class_holes]),
+            dtype=complex).reshape(self.dim, len(self.class_holes))
+        self.n = np.asarray(cob.ChainComplex.endSignCovector(
+            [[int(v) for v in c] for c in self.es.topCells()],
+            [list(h) for h in self.class_holes]), dtype=float)
+        self.sign = self.n.copy()
 
     def _stellar_grow(self, n, seed):
         """ADD up to *n* interior vertices by boundary-fixed stellar subdivision,
@@ -300,11 +296,6 @@ class RegisterL2:
                 e.setPhase(0.0)
         return grown
 
-    def _period(self, vec, hole):
-        """The induced (raw) oriented 2-sphere period of a hole: the signed sum of
-        the 2-form over the hole's four boundary triangles."""
-        return sum(s * vec[self.fidx[f]] for f, s in _tet_facets(hole))
-
     @property
     def rank(self):
         """The rank of the carried period space over the holonomy holes -- same
@@ -327,9 +318,11 @@ class RegisterL2:
     def spectral_residual(self, raw_periods):
         """The genuine Hodge residual ||(I-psi psi^dag) L_2 psi||^2 of the 2-form
         with the given raw periods -- the continuous spectral realizability score.
-        -> 0 iff the periods lie in the carried register V."""
-        psi = self.harmonic_form(raw_periods)
-        return float(self.es.residual([complex(z) for z in psi]))
+        -> 0 iff the periods lie in the carried register V.
+        One C++ call (the lstsq-project-leak-residual verdict primitive)."""
+        return float(self.es.residualForPeriods(
+            [list(h) for h in self.class_holes],
+            [complex(z) for z in np.asarray(raw_periods, dtype=complex)]))
 
 
 # --------------------------------------------------------------------------- #

--- a/examples/cobordism/level1_fill_realizability.py
+++ b/examples/cobordism/level1_fill_realizability.py
@@ -116,18 +116,15 @@ _GAMMA = {0: 3, 1: 7, 2: 8, 3: 4, 4: 0, 5: 2,
           6: 11, 7: 9, 8: 5, 9: 1, 10: 6, 11: 10}
 _IDENT = {v: v for v in range(_N_REG)}
 
-_REG_SIGN_CACHE = []
-
-
-def _reg_sign():
-    """The level-0 register's induced-orientation sign pattern (``reg.sign``).
-    It is a property of the end SURFACE, not of the fill: each end's three
-    circles bound that end's fundamental 2-chain, so every fill's harmonics
-    satisfy the same signed charge constraint at each end. Deterministic --
-    no per-fill null-vector normalization."""
-    if not _REG_SIGN_CACHE:
-        _REG_SIGN_CACHE.append(BASE.Register().sign.copy())
-    return _REG_SIGN_CACHE[0]
+def _end_sign(faces, circles):
+    """An end's induced-orientation sign pattern (the level-0 ``reg.sign``
+    analog). It is a property of the end SURFACE, not of the fill: each end's
+    three circles bound that end's fundamental 2-chain, so every fill's
+    harmonics satisfy the same signed charge constraint at each end.
+    Deterministic -- ``ChainComplex.endSignCovector`` reads it straight off
+    the fundamental chain, no per-fill null-vector normalization."""
+    return np.asarray(cob.ChainComplex.endSignCovector(
+        [list(f) for f in faces], [list(t) for t in circles]), dtype=float)
 
 
 def _compose(g, h):
@@ -193,6 +190,12 @@ class Level1Fill:
         self.reg_edges = [e for tri in (self.circles0 + self.circles1)
                           for e in BASE._cedges(tri)]
         self.eidx = {e: i for i, e in enumerate(self.reg_edges)}
+        # Each end's surface faces, for the sign covector: layer 0 carries the
+        # identity labeling, the top layer the shifted one (a twist permutes
+        # the face set among itself, so the set is labeling-equal either way).
+        self.end_faces0 = [tuple(sorted(f)) for f in faces]
+        self.end_faces1 = [tuple(sorted(v + 12 * self.layers for v in f))
+                           for f in faces]
 
         self.st = L2._bulk(cells)
         self.es = cob.EigenstateSynthesis(self.st, 1)
@@ -219,30 +222,17 @@ class Level1Fill:
         ok, why = self.es.dualComplexValid()
         self.dual_valid, self.dual_reason = bool(ok), str(why)
         self.cells = [tuple(int(v) for v in c) for c in self.es.cellSimplices()]
-        harmonics = cob.HodgeLaplacian(self.st).harmonics(1)
-        self.dim = len(harmonics)
-        if self.dim:
-            self.H_full = np.array(
-                [[complex(h.amplitudeFor(list(c))) for c in self.cells]
-                 for h in harmonics])
-        else:
-            self.H_full = np.zeros((0, len(self.cells)), dtype=complex)
+        self.H_full = np.asarray(
+            cob.HodgeLaplacian(self.st).harmonicMatrix(1),
+            dtype=complex).reshape(-1, len(self.cells))
+        self.dim = int(self.H_full.shape[0])
         self._reg_col = [self.cells.index(e) for e in self.reg_edges]
-        h_reg = self.H_full[:, self._reg_col] if self.dim else self.H_full
-        rows = []
-        for r in range(self.dim):
-            p0 = [self._period(h_reg[r], tri) for tri in self.circles0]
-            p1 = [self._period(h_reg[r], tri) for tri in self.circles1]
-            rows.append(p0 + p1)
-        self.P6 = np.array(rows).reshape(self.dim, 6)
-        self.sign0 = _reg_sign()
-        self.sign1 = _reg_sign()
+        self.P6 = np.asarray(
+            self.es.cyclePeriods([list(t) for t in (self.circles0 + self.circles1)]),
+            dtype=complex).reshape(self.dim, 6)
+        self.sign0 = _end_sign(self.end_faces0, self.circles0)
+        self.sign1 = _end_sign(self.end_faces1, self.circles1)
         return self
-
-    def _period(self, vec, tri):
-        a, b, c = sorted(tri)
-        return (vec[self.eidx[(a, b)]] + vec[self.eidx[(b, c)]]
-                - vec[self.eidx[(a, c)]])
 
     def _stellar_grow(self, n, seed):
         """ADD up to *n* interior vertices by the gated composed stellar move
@@ -304,9 +294,11 @@ class Level1Fill:
 
     def spectral_residual(self, pair6):
         """The genuine Hodge residual of the 1-form with the given six
-        periods on the fill -> 0 iff the pair (p_0, p_1) is carried by R."""
-        psi = self.harmonic_form(np.asarray(pair6, dtype=complex))
-        return float(self.es.residual([complex(z) for z in psi]))
+        periods on the fill -> 0 iff the pair (p_0, p_1) is carried by R.
+        One C++ call (the lstsq-project-leak-residual verdict primitive)."""
+        return float(self.es.residualForPeriods(
+            [list(t) for t in (self.circles0 + self.circles1)],
+            [complex(z) for z in np.asarray(pair6, dtype=complex)]))
 
     def emergent_gate(self):
         """The V-block u' with R = graph(u'), in the flat-orthonormal basis

--- a/examples/cobordism/level1_stabilizer_law.py
+++ b/examples/cobordism/level1_stabilizer_law.py
@@ -165,17 +165,14 @@ def _bulk4(cells):
     return st
 
 
-_REG_SIGN_CACHE = []
-
-
-def _reg_sign():
-    """The hexjoin L_2 register's induced-orientation sign pattern -- a
-    property of the end, applied deterministically at both ends (the level-1
-    icosahedron run showed per-fill null-vector normalization is
-    sign-unstable)."""
-    if not _REG_SIGN_CACHE:
-        _REG_SIGN_CACHE.append(L2.RegisterL2().sign.copy())
-    return _REG_SIGN_CACHE[0]
+def _end_sign(cells, holes):
+    """An end's induced-orientation sign pattern -- a property of the end,
+    applied deterministically at both ends (the level-1 icosahedron run
+    showed per-fill null-vector normalization is sign-unstable).
+    ``ChainComplex.endSignCovector`` reads it off the end's fundamental
+    chain."""
+    return np.asarray(cob.ChainComplex.endSignCovector(
+        [list(c) for c in cells], [list(h) for h in holes]), dtype=float)
 
 
 class Level1FillS3:
@@ -196,27 +193,17 @@ class Level1FillS3:
         self.st = _bulk4(self.cells4)
         self.es = cob.EigenstateSynthesis(self.st, 2)
         self.cells = [tuple(int(v) for v in c) for c in self.es.cellSimplices()]
-        harmonics = cob.HodgeLaplacian(self.st).harmonics(2)
-        self.dim = len(harmonics)
-        if self.dim:
-            self.H_full = np.array(
-                [[complex(h.amplitudeFor(list(c))) for c in self.cells]
-                 for h in harmonics])
-        else:
-            self.H_full = np.zeros((0, len(self.cells)), dtype=complex)
+        self.H_full = np.asarray(
+            cob.HodgeLaplacian(self.st).harmonicMatrix(2),
+            dtype=complex).reshape(-1, len(self.cells))
+        self.dim = int(self.H_full.shape[0])
         self._reg_col = [self.cells.index(f) for f in self.reg_facets]
-        h_reg = self.H_full[:, self._reg_col] if self.dim else self.H_full
-        rows = []
-        for r in range(self.dim):
-            p0 = [self._period(h_reg[r], hole) for hole in self.holes0]
-            p1 = [self._period(h_reg[r], hole) for hole in self.holes1]
-            rows.append(p0 + p1)
-        self.P6 = np.array(rows).reshape(self.dim, 6)
-        self.sign0 = _reg_sign()
-        self.sign1 = _reg_sign()
-
-    def _period(self, vec, hole):
-        return sum(s * vec[self.fidx[f]] for f, s in L2._tet_facets(hole))
+        self.P6 = np.asarray(
+            self.es.cyclePeriods([list(h) for h in (self.holes0 + self.holes1)]),
+            dtype=complex).reshape(self.dim, 6)
+        self.sign0 = _end_sign(_W3_CELLS, self.holes0)
+        self.sign1 = _end_sign([tuple(v + 12 for v in c) for c in _W3_CELLS],
+                               self.holes1)
 
     @property
     def rank(self):
@@ -238,8 +225,9 @@ class Level1FillS3:
         return full
 
     def spectral_residual(self, pair6):
-        psi = self.harmonic_form(np.asarray(pair6, dtype=complex))
-        return float(self.es.residual([complex(z) for z in psi]))
+        return float(self.es.residualForPeriods(
+            [list(h) for h in (self.holes0 + self.holes1)],
+            [complex(z) for z in np.asarray(pair6, dtype=complex)]))
 
     def emergent_gate(self):
         if self.dim != 2:

--- a/examples/cobordism/spectral_gate_realizability.py
+++ b/examples/cobordism/spectral_gate_realizability.py
@@ -275,14 +275,6 @@ _ICO = [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5), (0, 5, 1),
 # Three vertex-disjoint faces = the three holonomy-class holes [a], [b], [a+b].
 _CLASS_HOLES = [tuple(sorted(h)) for h in [(0, 1, 2), (3, 7, 8), (4, 9, 5)]]
 _REG_EDGES = [e for tri in _CLASS_HOLES for e in _cedges(tri)]   # the 9 register edges
-_EIDX = {e: i for i, e in enumerate(_REG_EDGES)}
-
-
-def _raw_period(vec, tri):
-    """The induced (raw) oriented loop sum of a 1-form (given on the register edges) on
-    circle `tri`'s edges."""
-    a, b, c = sorted(tri)
-    return vec[_EIDX[(a, b)]] + vec[_EIDX[(b, c)]] - vec[_EIDX[(a, c)]]
 
 
 def grow_register(faces=_ICO, class_holes=_CLASS_HOLES):
@@ -334,19 +326,25 @@ class Register:
                 self.es.removeInteriorCell(list(cs))
                 self.extra_opened.append(cs)
 
+        # The register core reads off the C++ layer (#286): the harmonic
+        # amplitude matrix in the bulk's cell order, the circle-period rows
+        # with the boundary operator's induced-orientation signs, and the end
+        # sign covector from the surface's fundamental chain — deterministic,
+        # where the old per-register SVD null-vector normalization was
+        # sign-unstable.
         self.cells = [tuple(int(v) for v in c) for c in self.es.cellSimplices()]
-        harmonics = cob.HodgeLaplacian(self.st).harmonics(1)
-        self.dim = len(harmonics)
-        self.H_full = np.array([[complex(h.amplitudeFor(list(c))) for c in self.cells]
-                                for h in harmonics])
+        self.H_full = np.asarray(
+            cob.HodgeLaplacian(self.st).harmonicMatrix(1),
+            dtype=complex).reshape(-1, len(self.cells))
+        self.dim = int(self.H_full.shape[0])
         self._reg_col = [self.cells.index(e) for e in self.reg_edges]
-        h_reg = self.H_full[:, self._reg_col]
-        self.P = np.array([[self._period(h_reg[r], tri) for tri in self.class_holes]
-                           for r in range(self.dim)])
-        n_raw = np.linalg.svd(self.P)[2][-1].conj()
-        self.n = (n_raw / n_raw[np.argmax(np.abs(n_raw))]).real
-        self.sign = np.sign(self.n)
-        self.sign[self.sign == 0] = 1.0
+        self.P = np.asarray(
+            self.es.cyclePeriods([list(h) for h in self.class_holes]),
+            dtype=complex).reshape(self.dim, len(self.class_holes))
+        self.n = np.asarray(cob.ChainComplex.endSignCovector(
+            [[int(v) for v in c] for c in self.es.topCells()],
+            [list(h) for h in self.class_holes]), dtype=float)
+        self.sign = self.n.copy()
 
     def _stellar_grow(self, n, seed):
         """ADD up to *n* interior vertices by boundary-fixed stellar subdivision,
@@ -385,12 +383,6 @@ class Register:
                 e.setPhase(0.0)
         return grown
 
-    def _period(self, vec, tri):
-        """The induced (raw) oriented loop sum of a register-edge 1-form on `tri`."""
-        a, b, c = sorted(tri)
-        return (vec[self.eidx[(a, b)]] + vec[self.eidx[(b, c)]]
-                - vec[self.eidx[(a, c)]])
-
     @property
     def rank(self):
         """The rank of the carried period space over the holonomy holes. rank < #holes
@@ -417,9 +409,11 @@ class Register:
     def spectral_residual(self, raw_periods):
         """The genuine Hodge residual ||(I-psi psi^dag) L_1 psi||^2 of the 1-form with
         the given raw periods, on the surgery-grown bulk -- the continuous spectral
-        realizability score. -> 0 iff the periods lie in the carried register V."""
-        psi = self.harmonic_form(raw_periods)
-        return float(self.es.residual([complex(z) for z in psi]))
+        realizability score. -> 0 iff the periods lie in the carried register V.
+        One C++ call (the lstsq-project-leak-residual verdict primitive)."""
+        return float(self.es.residualForPeriods(
+            [list(h) for h in self.class_holes],
+            [complex(z) for z in np.asarray(raw_periods, dtype=complex)]))
 
 
 def register_emergence():

--- a/include/cobordism/ChainComplex.h
+++ b/include/cobordism/ChainComplex.h
@@ -133,6 +133,33 @@ class ChainComplex {
     ///   \neq 1 \f$) — or \f$ d < 1 \f$.
     [[nodiscard]] std::vector<int> fundamentalClass() const;
 
+    /// The **end sign covector**: the induced-orientation charge pattern
+    /// \f$ \sigma \in \{\pm 1\}^{|\text{holes}|} \f$ of an end surface, read off
+    /// its fundamental chain. `surfaceCells` are the end's top cells (sorted
+    /// vertex-id tuples, all of one dimension) and `holes` the removed cells
+    /// whose boundary cycles carry the periods; the union is oriented by sign
+    /// propagation across shared facets (facet \f$ j \f$ of a sorted cell is the
+    /// drop-\f$ v_j \f$ tuple with boundary sign \f$ (-1)^j \f$), each connected
+    /// component normalized so its lexicographically smallest cell carries
+    /// \f$ +1 \f$, and \f$ \sigma_k \f$ is the coefficient the orientation
+    /// \f$ \varepsilon \f$ assigns to `holes[k]`. Since
+    /// \f$ \partial\big(\sum_{\text{kept}} \varepsilon_c\, c\big) =
+    /// -\sum_k \varepsilon_{H_k}\, \partial H_k \f$ on the hole cycles, every
+    /// closed form's signed periods obey \f$ \sum_k \sigma_k p_k = 0 \f$ end by
+    /// end — the symmetrized charge constraint the register layers apply — for
+    /// **either** global sign; this normalization is the deterministic one
+    /// (a property of the end surface, not of any fill or spectrum: no
+    /// per-fill null-vector normalization, which is sign-unstable). Each
+    /// entry is independent of the others, so reordering `holes` permutes
+    /// \f$ \sigma \f$ without flips, and relabeling the vertices by any
+    /// order-preserving map (e.g. a layer shift) leaves it unchanged.
+    /// @throws std::runtime_error if the cells are not all of one dimension,
+    ///   a facet has more than two cofaces (not a pseudomanifold), or the
+    ///   orientation propagation contradicts itself (non-orientable).
+    [[nodiscard]] static std::vector<int> endSignCovector(
+        const std::vector<std::vector<std::uint64_t>> &surfaceCells,
+        const std::vector<std::vector<std::uint64_t>> &holes);
+
     /// The symmetric intersection form \f$ Q_{ij} = \langle \alpha_i \cup
     /// \alpha_j, [K] \rangle \f$ on a basis \f$ \{\alpha_i\} \f$ of the free
     /// part of \f$ H^2 \f$, as a flat row-major \f$ b_2 \times b_2 \f$ matrix.

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -296,6 +296,49 @@ class EigenstateSynthesis {
     /// on the primal lattice.
     [[nodiscard]] std::pair<bool, std::string> dualComplexValid() const;
 
+    // === The carried register read-outs (#286) ===
+
+    /// The **period matrix** of the current harmonics over the boundary cycles
+    /// of the given (removed) cells: a flat row-major
+    /// \f$ \dim\ker L_k \times |\text{holes}| \f$ complex array whose entry
+    /// \f$ [\,r\,|\text{holes}| + q\,] \f$ is harmonic \f$ r \f$ summed over
+    /// hole \f$ q \f$'s facets with the induced-orientation signs of the
+    /// boundary operator — facet \f$ j \f$ of the sorted hole drops vertex
+    /// \f$ v_j \f$ and carries \f$ (-1)^j \f$, so a circle (a triangle hole at
+    /// \f$ k = 1 \f$) contributes \f$ +(a,b) + (b,c) - (a,c) \f$ and a sphere
+    /// (a tetrahedron hole at \f$ k = 2 \f$) its four \f$ (-1)^j \f$-signed
+    /// triangles: degree-general. Each hole is a \f$ (k\!+\!2) \f$-vertex
+    /// tuple (sorted internally) whose facets must all be \f$ k \f$-cells of
+    /// the **current** complex — the cycles surgery (`removeInteriorCell`)
+    /// leaves behind. Harmonics are read fresh from the live complex
+    /// (`HodgeLaplacian::harmonicMatrix`, \f$ |\lambda| < 10^{-9} \f$, metric
+    /// weights), rows in ascending-eigenvalue order. Empty when
+    /// \f$ \ker L_k = 0 \f$.
+    /// @throws std::runtime_error if a hole has the wrong vertex count or one
+    ///   of its facets is not a \f$ k \f$-cell of the complex.
+    [[nodiscard]] std::vector<std::complex<double>> cyclePeriods(
+        const std::vector<std::vector<std::uint64_t>> &holes) const;
+
+    /// The **verdict primitive** every realizability experiment flows through,
+    /// in one call: the genuine residual of the carried representative of
+    /// `targetPeriods` over the `holes` cycles. Builds the period matrix
+    /// \f$ P \f$ (`cyclePeriods`), solves the least-squares projection
+    /// \f$ \min_c \|P^{\top} c - \text{target}\| \f$ (minimum-norm, so a
+    /// rank-deficient carried space matches `numpy.linalg.lstsq`), forms the
+    /// harmonic combination \f$ \psi = \sum_r c_r h_r \f$, attaches the
+    /// uncarried remainder (the **minimal leak**) to one facet per hole so the
+    /// cochain's periods are exactly `targetPeriods` — the hole's first facet
+    /// in the degree's established walk order, both of boundary sign
+    /// \f$ +1 \f$: the \f$ (a,b) \f$ edge of a circle at \f$ k = 1 \f$, the
+    /// drop-\f$ v_0 \f$ facet at every other degree — and returns
+    /// `residual(psi)`: \f$ \to 0 \f$ iff the targets lie in the carried
+    /// period space, floored otherwise, with the leak the certificate.
+    /// @throws std::runtime_error if `targetPeriods.size() != holes.size()`
+    ///   or a hole is malformed (see `cyclePeriods`).
+    [[nodiscard]] double residualForPeriods(
+        const std::vector<std::vector<std::uint64_t>> &holes,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
     // === Surgery: the topology-changing interior remove move (#196) ===
 
     /// The interior top cells eligible for surgery removal: top cells whose
@@ -379,6 +422,21 @@ class EigenstateSynthesis {
           removedEdges{};
     };
     std::vector<Removal> removals_{};
+
+    // The shared register read-out assembly (#286): the fresh harmonic matrix
+    // H (flat row-major dim × order(), HodgeLaplacian::harmonicMatrix on the
+    // live complex), the period matrix P (flat row-major dim × |holes|, the
+    // boundary-operator-signed facet sums), and each hole's leak column (the
+    // cochain index its uncarried remainder attaches to). Backs cyclePeriods
+    // and residualForPeriods.
+    struct RegisterReadout {
+      std::vector<std::complex<double>> H{};
+      std::vector<std::complex<double>> P{};
+      std::vector<std::size_t> leakColumns{};
+      std::size_t dim{0};
+    };
+    [[nodiscard]] RegisterReadout assembleRegisterReadout(
+        const std::vector<std::vector<std::uint64_t>> &holes) const;
 
     // Re-create the top cell of a Removal (createSimplexTracked rebuilds its
     // missing edges = the orphaned ones) and restore those edges' weights/phases.

--- a/include/cobordism/HodgeLaplacian.h
+++ b/include/cobordism/HodgeLaplacian.h
@@ -191,6 +191,23 @@ class HodgeLaplacian {
     [[nodiscard]] std::vector<Cochain> harmonics(int k = 0, double tol = 1e-9,
                                                  bool metric = true) const;
 
+    /// The harmonic amplitude matrix: the same representatives as
+    /// `harmonics(k, tol, metric)` — the eigenvectors with
+    /// \f$ |\lambda| < \text{tol} \f$, in ascending-eigenvalue order — stacked
+    /// as the **rows** of a flat row-major \f$ \dim\ker L_k \times M \f$
+    /// complex array (\f$ M = N \f$ at \f$ k = 0 \f$, else \f$ |C_k| \f$),
+    /// columns in the same sorted-vertex / canonical `ChainComplex`
+    /// \f$ k \f$-cell order the `Cochain`s index. One call replaces the
+    /// per-cell `amplitudeFor` round-trips a register layer makes to read its
+    /// harmonics; entry \f$ [\,r\,M + c\,] \f$ equals
+    /// `harmonics(k, tol, metric)[r].amplitude(c)` exactly. Empty when the
+    /// kernel is empty (\f$ b_k = 0 \f$) or \f$ k \f$ is above the top
+    /// dimension. For \f$ k \geq 1 \f$, `metric` selects volume vs. unit
+    /// weights (ignored at \f$ k = 0 \f$).
+    /// @throws std::runtime_error for \f$ k < 0 \f$.
+    [[nodiscard]] std::vector<std::complex<double>> harmonicMatrix(
+        int k = 0, double tol = 1e-9, bool metric = true) const;
+
     /// === Lorentzian (signed-weight) d'Alembertian, \f$ k \geq 1 \f$ (§5.6) ===
     ///
     /// The eigendecomposition of the signed-weight \f$ L_k \f$ (the

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -126,6 +126,21 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
            "cycle (d_d applied to the signed top chain is 0). Sign-normalized so "
            "the first nonzero entry is +1. Raises if the complex is not a closed "
            "connected oriented manifold (dim ker d_d != 1) or dimension < 1.")
+      .def_static(
+          "endSignCovector", &ChainComplex::endSignCovector,
+          py::arg("surface_cells"), py::arg("holes"),
+          "The end sign covector sigma in {+/-1}^len(holes): the induced-"
+          "orientation charge pattern of an end surface, from its fundamental "
+          "chain. surface_cells are the end's top cells, holes the removed "
+          "cells whose boundary cycles carry the periods; the union is "
+          "oriented by sign propagation (component roots = lex-smallest "
+          "cells, +1) and sigma_k is the orientation coefficient of "
+          "holes[k], so every closed form's signed periods obey "
+          "sum_k sigma_k p_k = 0 end by end. Deterministic -- a property of "
+          "the end surface, not of any fill or spectrum -- and equivariant "
+          "under order-preserving relabelings (e.g. a layer shift). Raises "
+          "on mixed-dimension cells, a facet with > 2 cofaces, or a "
+          "non-orientable surface.")
       .def("intersectionForm", &ChainComplex::intersectionForm,
            "Symmetric intersection form on free H^2 (flat b2 x b2), for a closed "
            "oriented 4-manifold; empty if n != 4 or b2 == 0.")
@@ -289,6 +304,16 @@ Euclidean spectrum/kernel.)doc")
            "of Cochains spanning ker L_k ~= H_k (the count is b_k). metric selects "
            "volume vs. unit weights for k>=1. Raises for k<0; empty above the top "
            "dimension.")
+      .def("harmonicMatrix", &HodgeLaplacian::harmonicMatrix, py::arg("k") = 0,
+           py::arg("tol") = 1e-9, py::arg("metric") = true,
+           "The harmonic amplitude matrix: the harmonics(k, tol, metric) "
+           "representatives stacked as the ROWS of a flat row-major "
+           "(dim ker L_k) x M complex array (M = |V| at k=0, else |C_k|), "
+           "columns in the canonical cell order (cellSimplices / "
+           "kSimplexVertices). Entry [r*M + c] equals "
+           "harmonics(k)[r].amplitude(c) exactly -- one call instead of one "
+           "amplitudeFor round-trip per cell per harmonic. Raises for k<0; "
+           "empty when the kernel is empty or k is above the top dimension.")
       // ----- Lorentzian (signed-weight) d'Alembertian (#105, spec §5.6) -----
       .def("lorentzianSpectrum", &HodgeLaplacian::lorentzianSpectrum,
            py::arg("k"), py::arg("metric") = true,
@@ -468,6 +493,29 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "complex -- top cells from the surgery state, with the k-cell "
            "universe checked for dangling facets when k = n-1 (the register "
            "layers). Accept topology moves only while this stays true.")
+      // ----- The carried register read-outs (#286) -----
+      .def("cyclePeriods", &EigenstateSynthesis::cyclePeriods, py::arg("holes"),
+           "The period matrix of the current harmonics over the boundary "
+           "cycles of the given (removed) cells: flat row-major "
+           "(dim ker L_k) x len(holes), complex. Entry [r*m + q] sums "
+           "harmonic r over hole q's facets with the boundary operator's "
+           "induced-orientation signs (facet j of the sorted hole drops v_j, "
+           "sign (-1)^j) -- degree-general: circles at k=1, spheres at k=2. "
+           "Harmonics are read fresh from the live complex, rows ascending "
+           "by eigenvalue. Raises if a hole is not a (k+2)-vertex tuple "
+           "whose facets are all current k-cells.")
+      .def("residualForPeriods", &EigenstateSynthesis::residualForPeriods,
+           py::arg("holes"), py::arg("target_periods"),
+           "The verdict primitive in one call: the genuine residual of the "
+           "carried representative of target_periods over the holes' cycles. "
+           "Least-squares-projects the targets onto the carried period rows "
+           "(minimum-norm, as numpy.linalg.lstsq), forms the harmonic "
+           "combination, attaches each hole's uncarried remainder (the "
+           "minimal leak) to the hole's first walk-order facet (the (a,b) "
+           "edge of a circle at k=1, the drop-v0 facet otherwise; boundary "
+           "sign +1), and returns residual(psi): -> 0 iff the targets lie "
+           "in the carried register, floored otherwise. Raises on a "
+           "hole/target length mismatch or a malformed hole.")
       // ----- Surgery: the topology-changing interior remove move (#196) -----
       .def("interiorTopCells", &EigenstateSynthesis::interiorTopCells,
            "The interior top cells (all-interior vertices, on no dW face) as "

--- a/src/cobordism/ChainComplex.cpp
+++ b/src/cobordism/ChainComplex.cpp
@@ -30,10 +30,12 @@
 #include <cstdlib>
 #include <functional>
 #include <map>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "cobordism/IntegerLinalg.h"
@@ -934,6 +936,101 @@ std::pair<bool, std::string> ChainComplex::dualComplexIsValid(
     }
   }
   return {true, "ok"};
+}
+
+std::vector<int> ChainComplex::endSignCovector(
+    const std::vector<std::vector<std::uint64_t>> &surfaceCells,
+    const std::vector<std::vector<std::uint64_t>> &holes) {
+  using Cell = std::vector<std::uint64_t>;
+  const auto joinIds = [](const Cell &c) {
+    std::string out = "(";
+    for (std::size_t i = 0; i < c.size(); ++i) {
+      if (i) out += ",";
+      out += std::to_string(c[i]);
+    }
+    return out + ")";
+  };
+  if (holes.empty()) return {};
+
+  // The oriented complex is the union surface ∪ holes (the capped end), as
+  // sorted-unique sorted tuples — the lexicographic order makes the component
+  // roots, and with them the whole covector, deterministic.
+  std::set<Cell> uniq;
+  const std::size_t nv = holes.front().size();
+  const auto addCell = [&](const Cell &raw) {
+    if (raw.size() != nv)
+      throw std::runtime_error(
+          "ChainComplex::endSignCovector: cell " + joinIds(raw) + " has " +
+          std::to_string(raw.size()) + " vertices, expected " +
+          std::to_string(nv) + " (one dimension throughout)");
+    Cell c = raw;
+    std::sort(c.begin(), c.end());
+    uniq.insert(std::move(c));
+  };
+  for (const auto &raw : holes) addCell(raw);
+  for (const auto &raw : surfaceCells) addCell(raw);
+  const std::vector<Cell> cells(uniq.begin(), uniq.end());
+
+  // facet -> its cofaces as (cell index, boundary sign of the facet in that
+  // cell): facet j of a sorted cell drops vertex j and carries (-1)^j.
+  std::map<Cell, std::vector<std::pair<std::size_t, int>>> cofaces;
+  for (std::size_t ci = 0; ci < cells.size(); ++ci)
+    for (std::size_t j = 0; j < nv; ++j) {
+      Cell f;
+      f.reserve(nv - 1);
+      for (std::size_t i = 0; i < nv; ++i)
+        if (i != j) f.push_back(cells[ci][i]);
+      cofaces[f].emplace_back(ci, (j % 2 == 0) ? 1 : -1);
+    }
+  for (const auto &[f, at] : cofaces)
+    if (at.size() > 2)
+      throw std::runtime_error(
+          "ChainComplex::endSignCovector: facet " + joinIds(f) + " has " +
+          std::to_string(at.size()) + " cofaces (not a pseudomanifold)");
+
+  // Orient by propagation: across an interior facet the two induced signs must
+  // cancel (eps_b = -eps_a * s_a * s_b); boundary facets (one coface) impose
+  // nothing. Component roots are the lex-smallest unvisited cells, eps = +1.
+  std::vector<int> eps(cells.size(), 0);
+  for (std::size_t root = 0; root < cells.size(); ++root) {
+    if (eps[root] != 0) continue;
+    eps[root] = 1;
+    std::vector<std::size_t> stack{root};
+    while (!stack.empty()) {
+      const std::size_t a = stack.back();
+      stack.pop_back();
+      for (std::size_t j = 0; j < nv; ++j) {
+        Cell f;
+        f.reserve(nv - 1);
+        for (std::size_t i = 0; i < nv; ++i)
+          if (i != j) f.push_back(cells[a][i]);
+        const int sa = (j % 2 == 0) ? 1 : -1;
+        for (const auto &[b, sb] : cofaces.at(f)) {
+          if (b == a) continue;
+          const int want = -eps[a] * sa * sb;
+          if (eps[b] == 0) {
+            eps[b] = want;
+            stack.push_back(b);
+          } else if (eps[b] != want) {
+            throw std::runtime_error(
+                "ChainComplex::endSignCovector: orientation propagation "
+                "contradicts itself at facet " + joinIds(f) +
+                " (the end surface is non-orientable)");
+          }
+        }
+      }
+    }
+  }
+
+  std::vector<int> sigma;
+  sigma.reserve(holes.size());
+  for (const auto &raw : holes) {
+    Cell h = raw;
+    std::sort(h.begin(), h.end());
+    const auto it = std::lower_bound(cells.begin(), cells.end(), h);
+    sigma.push_back(eps[static_cast<std::size_t>(it - cells.begin())]);
+  }
+  return sigma;
 }
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -21,6 +21,8 @@
 
 #include "cobordism/EigenstateSynthesis.h"
 
+#include <Eigen/Dense>
+
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -747,6 +749,137 @@ std::pair<bool, std::string> EigenstateSynthesis::dualComplexValid() const {
       tops, dim,
       facetDegree ? cellSimplices()
                   : std::vector<std::vector<std::uint64_t>>{});
+}
+
+EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleRegisterReadout(
+    const std::vector<std::vector<std::uint64_t>> &holes) const {
+  const auto joinIds = [](const std::vector<std::uint64_t> &c) {
+    std::string out = "(";
+    for (std::size_t i = 0; i < c.size(); ++i) {
+      if (i) out += ",";
+      out += std::to_string(c[i]);
+    }
+    return out + ")";
+  };
+
+  RegisterReadout out;
+  const std::size_t n = order_;
+  // Harmonics fresh from the live complex — surgery between calls moves them,
+  // and the operator's own spectral cache is keyed to construction time.
+  out.H = HodgeLaplacian(st_).harmonicMatrix(k_, 1e-9, /*metric=*/true);
+  if (n == 0) {
+    if (!holes.empty())
+      throw std::runtime_error(
+          "EigenstateSynthesis::assembleRegisterReadout: the complex has no "
+          "k-cells to carry periods");
+    return out;
+  }
+  if (out.H.size() % n != 0)
+    throw std::runtime_error(
+        "EigenstateSynthesis::assembleRegisterReadout: the harmonic matrix "
+        "width " + std::to_string(out.H.size()) +
+        " is not a multiple of the captured operator dimension " +
+        std::to_string(n) + " (the complex changed behind the synthesizer)");
+  out.dim = out.H.size() / n;
+
+  std::map<std::vector<std::uint64_t>, std::size_t> col;
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i) col[cellOrdering_[i]] = i;
+
+  const std::size_t m = holes.size();
+  const std::size_t hv = static_cast<std::size_t>(k_) + 2;
+  out.P.assign(out.dim * m, cd(0.0, 0.0));
+  out.leakColumns.reserve(m);
+  for (std::size_t q = 0; q < m; ++q) {
+    std::vector<std::uint64_t> h = holes[q];
+    std::sort(h.begin(), h.end());
+    if (h.size() != hv)
+      throw std::runtime_error(
+          "EigenstateSynthesis::assembleRegisterReadout: hole " + joinIds(h) +
+          " has " + std::to_string(h.size()) + " vertices; a degree-" +
+          std::to_string(k_) + " period needs a removed (k+1)-cell of " +
+          std::to_string(hv));
+    // Facets are visited in the degree's established walk order — the
+    // (a,b),(b,c),(a,c) edge walk of a circle at k = 1 (so the period
+    // accumulates in exactly the register layers' summation order, bit for
+    // bit), the canonical drop-v_j order otherwise. The hole's leak facet is
+    // the first of the walk — the (a,b) edge / the drop-v_0 facet — which
+    // carries boundary sign +1 in both conventions, so adding the leak there
+    // moves that hole's period by exactly the leak.
+    std::vector<std::size_t> walk(hv);
+    for (std::size_t i = 0; i < hv; ++i) walk[i] = i;
+    if (k_ == 1) std::rotate(walk.begin(), walk.end() - 1, walk.end());
+    for (std::size_t w = 0; w < hv; ++w) {
+      const std::size_t j = walk[w];
+      std::vector<std::uint64_t> f;
+      f.reserve(hv - 1);
+      for (std::size_t i = 0; i < hv; ++i)
+        if (i != j) f.push_back(h[i]);
+      const auto it = col.find(f);
+      if (it == col.end())
+        throw std::runtime_error(
+            "EigenstateSynthesis::assembleRegisterReadout: facet " +
+            joinIds(f) + " of hole " + joinIds(h) +
+            " is not a k-cell of the complex (not a boundary cycle here)");
+      if (w == 0) out.leakColumns.push_back(it->second);
+      // The induced-orientation boundary sign: facet j of the sorted hole
+      // drops vertex v_j and carries (-1)^j.
+      const double s = (j % 2 == 0) ? 1.0 : -1.0;
+      for (std::size_t r = 0; r < out.dim; ++r)
+        out.P[r * m + q] += s * out.H[r * n + it->second];
+    }
+  }
+  return out;
+}
+
+std::vector<cd> EigenstateSynthesis::cyclePeriods(
+    const std::vector<std::vector<std::uint64_t>> &holes) const {
+  return assembleRegisterReadout(holes).P;
+}
+
+double EigenstateSynthesis::residualForPeriods(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+  if (targetPeriods.size() != holes.size())
+    throw std::runtime_error(
+        "EigenstateSynthesis::residualForPeriods: " +
+        std::to_string(targetPeriods.size()) + " target periods for " +
+        std::to_string(holes.size()) + " holes");
+  const RegisterReadout ro = assembleRegisterReadout(holes);
+  const std::size_t n = order_;
+  const std::size_t m = holes.size();
+  if (n == 0) return 0.0;
+
+  // The minimum-norm least-squares projection onto the carried period rows
+  // (what numpy.linalg.lstsq returns): c = (P^T)^+ target via the SVD.
+  Eigen::VectorXcd t(static_cast<Eigen::Index>(m));
+  for (std::size_t q = 0; q < m; ++q)
+    t[static_cast<Eigen::Index>(q)] = targetPeriods[q];
+  Eigen::VectorXcd c(static_cast<Eigen::Index>(ro.dim));
+  if (ro.dim > 0) {
+    Eigen::MatrixXcd Pt(static_cast<Eigen::Index>(m),
+                        static_cast<Eigen::Index>(ro.dim));
+    for (std::size_t q = 0; q < m; ++q)
+      for (std::size_t r = 0; r < ro.dim; ++r)
+        Pt(static_cast<Eigen::Index>(q), static_cast<Eigen::Index>(r)) =
+            ro.P[r * m + q];
+    c = Pt.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(t);
+  }
+
+  // The carried representative plus the minimal leak: psi = sum_r c_r h_r,
+  // then each hole's uncarried remainder lands on its leak column, so the
+  // cochain's periods are exactly the targets.
+  std::vector<cd> psi(n, cd(0.0, 0.0));
+  for (std::size_t r = 0; r < ro.dim; ++r) {
+    const cd cr = c[static_cast<Eigen::Index>(r)];
+    for (std::size_t i = 0; i < n; ++i) psi[i] += cr * ro.H[r * n + i];
+  }
+  for (std::size_t q = 0; q < m; ++q) {
+    cd carried(0.0, 0.0);
+    for (std::size_t r = 0; r < ro.dim; ++r)
+      carried += c[static_cast<Eigen::Index>(r)] * ro.P[r * m + q];
+    psi[ro.leakColumns[q]] += targetPeriods[q] - carried;
+  }
+  return residual(psi);
 }
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/HodgeLaplacian.cpp
+++ b/src/cobordism/HodgeLaplacian.cpp
@@ -544,6 +544,34 @@ std::vector<Cochain> HodgeLaplacian::harmonics(int k, double tol,
   return spectrum(k, metric).harmonics(tol);
 }
 
+std::vector<cd> HodgeLaplacian::harmonicMatrix(int k, double tol,
+                                               bool metric) const {
+  requireNonNegativeDegree(k);
+  // The same cached eigendecompositions harmonics() reads, emitted column-by-
+  // selected-column so no Cochain objects are materialized.
+  const std::vector<double> *evals = nullptr;
+  const std::vector<cd> *evecs = nullptr;
+  int dim = 0;
+  if (k == 0) {
+    ensureDecomposition();
+    evals = &evals_;
+    evecs = &evecs_;
+    dim = static_cast<int>(order_);
+  } else {
+    const MetricSpectrum &sp = ensureMetricSpectrum(k, metric);
+    evals = &sp.evals;
+    evecs = &sp.evecs;
+    dim = sp.dim;
+  }
+  std::vector<cd> rows;
+  for (int j = 0; j < dim; ++j) {
+    if (std::abs((*evals)[static_cast<std::size_t>(j)]) >= tol) continue;
+    for (int i = 0; i < dim; ++i)
+      rows.push_back((*evecs)[static_cast<std::size_t>(i) * dim + j]);
+  }
+  return rows;
+}
+
 Spectrum HodgeLaplacian::lorentzianSpectrum(int k, bool metric) const {
   requireNonNegativeDegree(k);
   const LorentzianSpectrum &sp = ensureLorentzianSpectrum(k, metric);

--- a/tests/cobordism/test_carried_register_python.py
+++ b/tests/cobordism/test_carried_register_python.py
@@ -1,0 +1,276 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The carried register core in C++ (#286): ``HodgeLaplacian.harmonicMatrix``,
+``EigenstateSynthesis.cyclePeriods`` / ``residualForPeriods``, and
+``ChainComplex.endSignCovector``, each checked against an independent numpy
+recomputation through the real pipeline — the same construction the register
+layers (``Register``, ``RegisterL2``, ``Level1Fill``, ``Level1FillS3``) now
+delegate to:
+
+  1. **The harmonic matrix is the amplitude loop.** Row r, column c of
+     ``harmonicMatrix(k)`` equals ``harmonics(k)[r].amplitudeFor(cells[c])``
+     entry for entry, at k = 1 on the holed icosahedron and k = 2 on the
+     holed hexagon join.
+  2. **Periods carry the boundary operator's signs.** ``cyclePeriods`` equals
+     the hand-rolled signed facet sums — the (a,b)+(b,c)-(a,c) circle walk at
+     k = 1, the (-1)^j tetrahedron facets at k = 2 — bit for bit, and raises
+     on a malformed hole or a facet that is not a current k-cell.
+  3. **The verdict primitive is the lstsq-project-leak-residual pipeline.**
+     ``residualForPeriods`` matches the numpy construction (minimum-norm
+     least squares onto the period rows, the leak on each hole's first
+     walk-order facet, the genuine residual) for carried, floored, and
+     complex targets; zero iff the target lies in the carried period space.
+  4. **The end sign covector is the fundamental chain's charge pattern.**
+     ``endSignCovector`` annihilates every harmonic's signed periods on the
+     canonical 2d and 3d registers, is independent of hole order, equivariant
+     under a layer shift, and raises on non-orientable (RP^2) or pinched
+     (three-coface) input.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_example(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                           name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+GATE = _load_example("spectral_gate_realizability")
+L2 = _load_example("l2_register_realizability")
+
+
+def _holed_icosahedron():
+    """The canonical 2d register bulk: the icosahedron with the three
+    holonomy holes opened by surgery (k = 1, dim ker L_1 = 2)."""
+    st = GATE._surface(GATE._ICO)
+    es = cob.EigenstateSynthesis(st, 1)
+    for hole in GATE._CLASS_HOLES:
+        es.removeInteriorCell(list(hole))
+    return st, es, [tuple(h) for h in GATE._CLASS_HOLES]
+
+
+def _holed_hexjoin():
+    """The canonical 3d register bulk: the hexagon-join S^3 with the three
+    canonical tetrahedra removed (k = 2, dim ker L_2 = 2)."""
+    st = L2._bulk(L2._HEXJOIN)
+    es = cob.EigenstateSynthesis(st, 2)
+    for hole in L2._HEXJOIN_HOLES:
+        es.removeInteriorCell(list(hole))
+    return st, es, [tuple(h) for h in L2._HEXJOIN_HOLES]
+
+
+def _harmonic_matrix_by_loop(st, es, k):
+    """The independent reading: the nested amplitudeFor loop the register
+    layers used before #286."""
+    cells = [tuple(int(v) for v in c) for c in es.cellSimplices()]
+    harmonics = cob.HodgeLaplacian(st).harmonics(k)
+    return cells, np.array(
+        [[complex(h.amplitudeFor(list(c))) for c in cells] for h in harmonics],
+        dtype=complex).reshape(len(harmonics), len(cells))
+
+
+class HarmonicMatrixIsTheAmplitudeLoopTest(unittest.TestCase):
+    def test_k1_holed_icosahedron(self):
+        st, es, _holes = _holed_icosahedron()
+        cells, by_loop = _harmonic_matrix_by_loop(st, es, 1)
+        flat = cob.HodgeLaplacian(st).harmonicMatrix(1)
+        matrix = np.asarray(flat, dtype=complex).reshape(-1, len(cells))
+        self.assertEqual(matrix.shape, by_loop.shape)
+        self.assertTrue(np.array_equal(matrix, by_loop))
+
+    def test_k2_holed_hexjoin(self):
+        st, es, _holes = _holed_hexjoin()
+        cells, by_loop = _harmonic_matrix_by_loop(st, es, 2)
+        matrix = np.asarray(cob.HodgeLaplacian(st).harmonicMatrix(2),
+                            dtype=complex).reshape(-1, len(cells))
+        self.assertEqual(matrix.shape, by_loop.shape)
+        self.assertTrue(np.array_equal(matrix, by_loop))
+
+    def test_closed_seed_has_an_empty_matrix(self):
+        st = GATE._surface(GATE._ICO)          # closed S^2: b_1 = 0
+        self.assertEqual(len(cob.HodgeLaplacian(st).harmonicMatrix(1)), 0)
+
+
+class CyclePeriodsCarryBoundarySignsTest(unittest.TestCase):
+    def test_k1_circle_walk(self):
+        st, es, holes = _holed_icosahedron()
+        cells, H = _harmonic_matrix_by_loop(st, es, 1)
+        idx = {c: i for i, c in enumerate(cells)}
+        expected = np.array(
+            [[H[r, idx[(a, b)]] + H[r, idx[(b, c)]] - H[r, idx[(a, c)]]
+              for (a, b, c) in (tuple(sorted(h)) for h in holes)]
+             for r in range(H.shape[0])], dtype=complex)
+        periods = np.asarray(es.cyclePeriods([list(h) for h in holes]),
+                             dtype=complex).reshape(-1, len(holes))
+        self.assertTrue(np.array_equal(periods, expected))
+
+    def test_k2_signed_tet_facets(self):
+        st, es, holes = _holed_hexjoin()
+        cells, H = _harmonic_matrix_by_loop(st, es, 2)
+        idx = {c: i for i, c in enumerate(cells)}
+        expected = np.array(
+            [[sum(s * H[r, idx[f]] for f, s in L2._tet_facets(h)) for h in holes]
+             for r in range(H.shape[0])], dtype=complex)
+        periods = np.asarray(es.cyclePeriods([list(h) for h in holes]),
+                             dtype=complex).reshape(-1, len(holes))
+        self.assertTrue(np.array_equal(periods, expected))
+
+    def test_malformed_hole_raises(self):
+        _st, es, _holes = _holed_icosahedron()
+        with self.assertRaises(RuntimeError):
+            es.cyclePeriods([[0, 1]])          # an edge is not a (k+1)-cell
+
+    def test_unopened_cell_raises(self):
+        # A face still present in the complex: its (a,b,c) facets are edges of
+        # the complex, but the hole itself was never removed -- the period is
+        # still defined by the cycle, so what must raise is a facet that is
+        # not a k-cell at all (made-up vertices).
+        _st, es, _holes = _holed_icosahedron()
+        with self.assertRaises(RuntimeError):
+            es.cyclePeriods([[100, 101, 102]])
+
+
+class ResidualForPeriodsIsTheVerdictPipelineTest(unittest.TestCase):
+    def _numpy_pipeline(self, es, holes, cells, H, P, target, leak_edges):
+        coeffs, *_ = np.linalg.lstsq(P.T, target, rcond=None)
+        psi = (coeffs @ H).astype(complex)
+        leak = target - coeffs @ P
+        idx = {c: i for i, c in enumerate(cells)}
+        for q, edge in enumerate(leak_edges):
+            psi[idx[edge]] += leak[q]
+        return float(es.residual([complex(z) for z in psi]))
+
+    def test_k1_carried_floored_and_complex_targets(self):
+        st, es, holes = _holed_icosahedron()
+        cells, H = _harmonic_matrix_by_loop(st, es, 1)
+        P = np.asarray(es.cyclePeriods([list(h) for h in holes]),
+                       dtype=complex).reshape(-1, len(holes))
+        # the k = 1 leak edge is the hole's (a,b) -- the first of the walk
+        leak_edges = [tuple(sorted(h))[:2] for h in holes]
+        carried = P[0] + 0.25 * P[1]
+        rng = np.random.default_rng(2862861)
+        for target in (carried, np.array([1.0, 1.0, 1.0], dtype=complex),
+                       rng.normal(size=3) + 1j * rng.normal(size=3)):
+            with self.subTest(target=target):
+                want = self._numpy_pipeline(es, holes, cells, H, P,
+                                            np.asarray(target, dtype=complex),
+                                            leak_edges)
+                got = es.residualForPeriods([list(h) for h in holes],
+                                            [complex(z) for z in target])
+                self.assertLessEqual(abs(got - want),
+                                     1e-9 * max(1.0, abs(want)))
+        self.assertLess(
+            es.residualForPeriods([list(h) for h in holes],
+                                  [complex(z) for z in carried]), 1e-18)
+
+    def test_k2_matches_and_floors(self):
+        st, es, holes = _holed_hexjoin()
+        cells, H = _harmonic_matrix_by_loop(st, es, 2)
+        P = np.asarray(es.cyclePeriods([list(h) for h in holes]),
+                       dtype=complex).reshape(-1, len(holes))
+        # the k = 2 leak facet is the hole's (b,c,d) -- drop-v0, walk-first
+        leak_facets = [tuple(sorted(h))[1:] for h in holes]
+        carried = 0.5 * P[0] - P[1]
+        floored = np.array([1.0, 1.0, 1.0], dtype=complex)
+        for target in (carried, floored):
+            with self.subTest(target=target):
+                want = self._numpy_pipeline(es, holes, cells, H, P, target,
+                                            leak_facets)
+                got = es.residualForPeriods([list(h) for h in holes],
+                                            [complex(z) for z in target])
+                self.assertLessEqual(abs(got - want),
+                                     1e-9 * max(1.0, abs(want)))
+        self.assertGreater(
+            es.residualForPeriods([list(h) for h in holes],
+                                  [complex(z) for z in floored]), 1e-2)
+
+    def test_length_mismatch_raises(self):
+        _st, es, holes = _holed_icosahedron()
+        with self.assertRaises(RuntimeError):
+            es.residualForPeriods([list(h) for h in holes], [1.0 + 0j])
+
+
+class EndSignCovectorTest(unittest.TestCase):
+    def test_annihilates_the_carried_periods_2d_and_3d(self):
+        for build in (_holed_icosahedron, _holed_hexjoin):
+            with self.subTest(build=build.__name__):
+                _st, es, holes = build()
+                sigma = cob.ChainComplex.endSignCovector(
+                    [[int(v) for v in c] for c in es.topCells()],
+                    [list(h) for h in holes])
+                self.assertEqual(sorted(set(abs(s) for s in sigma)), [1])
+                P = np.asarray(es.cyclePeriods([list(h) for h in holes]),
+                               dtype=complex).reshape(-1, len(holes))
+                self.assertTrue(
+                    np.allclose(P @ np.asarray(sigma, dtype=float), 0.0,
+                                atol=1e-9))
+
+    def test_hole_order_independence_and_shift_equivariance(self):
+        _st, es, holes = _holed_icosahedron()
+        tops = [[int(v) for v in c] for c in es.topCells()]
+        sigma = cob.ChainComplex.endSignCovector(tops, [list(h) for h in holes])
+        reordered = cob.ChainComplex.endSignCovector(
+            tops, [list(h) for h in holes[::-1]])
+        self.assertEqual(reordered, sigma[::-1])
+        shifted = cob.ChainComplex.endSignCovector(
+            [[v + 12 for v in c] for c in tops],
+            [[v + 12 for v in h] for h in holes])
+        self.assertEqual(shifted, sigma)
+
+    def test_non_orientable_raises(self):
+        # the minimal 6-vertex RP^2 (test_characteristic_python.py)
+        rp2 = [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5), (0, 1, 5),
+               (1, 2, 4), (2, 3, 5), (1, 3, 4), (1, 3, 5), (2, 4, 5)]
+        with self.assertRaises(RuntimeError):
+            cob.ChainComplex.endSignCovector(
+                [list(c) for c in rp2[1:]], [list(rp2[0])])
+
+    def test_pinched_facet_raises(self):
+        with self.assertRaises(RuntimeError):
+            cob.ChainComplex.endSignCovector(
+                [[0, 1, 2], [0, 1, 3], [0, 1, 4]], [[0, 1, 2]])
+
+    def test_mixed_dimension_raises(self):
+        with self.assertRaises(RuntimeError):
+            cob.ChainComplex.endSignCovector([[0, 1, 2, 3]], [[0, 1, 2]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Moves the register core that `Register` (2d), `RegisterL2` (3d), `Level1Fill`, and `Level1FillS3` each hand-roll (~150 lines apiece) into C++, so every layer — the example registers, the level-1 fills, and any future C++ caller (e.g. the mediated search) — shares one implementation:

- `HodgeLaplacian::harmonicMatrix(k)` — the dim × |C_k| complex amplitude matrix, flat row-major, canonical cell order; replaces the nested `amplitudeFor` loop (one pybind round-trip per cell per harmonic — the hottest repeated loop in every experiment), entry-for-entry identical.
- `EigenstateSynthesis::cyclePeriods(holes)` — harmonic periods over the boundary cycles of the given removed cells, induced-orientation signs from the boundary operator, degree-general (circles at k=1, spheres at k=2). Facets are visited in the degree's established walk order, so the sums accumulate bit-for-bit as the register layers'.
- `EigenstateSynthesis::residualForPeriods(holes, targetPeriods)` — the verdict primitive in one call: minimum-norm least-squares projection onto the carried period rows, minimal leak attached to each hole's first walk-order facet, genuine residual. Like `residual()`, it reads the live complex on every call, so it tracks in-place weight perturbations honestly.
- `ChainComplex::endSignCovector(surfaceCells, holes)` — the deterministic induced-orientation charge pattern of an end surface from its fundamental chain (a property of the end, not the fill), replacing the sign-unstable per-fill SVD normalization that caused two debugging rounds in #279. Reproduces the canonical 2d/3d register signs and both fill ends exactly; hole-order independent; equivariant under order-preserving relabelings (layer shifts). The fills no longer construct a whole level-0 register just to read its sign.

The four Python classes are now thin shells with unchanged public signatures (`H_full`, `P`/`P6`, `n`, `sign`/`sign0`/`sign1`, `rank`, `harmonic_form`, `spectral_residual` all preserved); `harmonic_form` stays in numpy for its standalone consumers (`identity_anchor`, `mediated_gate_battery`, `_carried_form`).

Two scope notes:
- The single-harmonic restriction reads in `dw_spectral_bridge` / `loosened_gate_retest` / `correspondence_retest_k1` / `emergent_bulk_realizability` (a handful of `amplitudeFor` lookups against short explicit edge lists, not the dim × |C_k| matrix) are left as is — `harmonicMatrix` is not a drop-in there and they are not hot.
- For non-canonical search registers whose carried period space is rank-deficient by more than one, the old SVD picked an arbitrary null vector where the covector is now the genuine fundamental-chain pattern; canonical numbers are unaffected (pinned by tests), and such candidates score as floored either way.

## Test plan
- [x] Ground-truth capture on unmodified main (signs, `n`, `P`, carried + floored residuals, the 13-gate battery per class, twisted-fill gates, diag/end-charge leaks)
- [x] Parity vs the unmodified pipeline: `harmonicMatrix` and `cyclePeriods` **bit-exact** on all four canonical fixtures; `residualForPeriods` ≤ 2e-15 relative (LAPACK gelsd vs Eigen JacobiSVD); `endSignCovector` equals every current sign vector exactly
- [x] Ground truth reproduces after the conversion: floored residuals 6.540173471 (k=1) / 48.254978421 (k=2) to all digits, batteries worst relative drift 2e-15, signs/P exact, emergent gates and realized sets identical
- [x] New `tests/cobordism/test_carried_register_python.py`: each primitive vs an independent numpy recomputation + error paths (15 tests)
- [x] Full local cobordism suite (CI is build-only): **635 passed, 1 skipped, 726 subtests** in 12m13s
- [x] Headline runs exit 0, verdicts SUPPORTED: `level1_fill_realizability.py` (anchor, twists, 40-draw catalog) and `level1_stabilizer_law.py` (the S_3 law table)
- [x] Wall-clock: register paths unchanged; the 3-layer fill battery 0.04s → 0.22s (fresh harmonics per verdict call — the honest live-weights semantic), catalog ~10s

Closes #286.
