### PR TITLE
feat(cobordism): stationary phase over the fill ensemble — damping selects the classical geometry

### DIFF
--- a/examples/cobordism/level1_stationary_phase.py
+++ b/examples/cobordism/level1_stationary_phase.py
@@ -1,0 +1,372 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Stationary phase over the level-1 fill ensemble: is the F_beta winner the
+classical geometry?
+
+The mediated objective consumes |S| and OPTIMIZES; a sum over geometries
+consumes e^{i lambda S} and INTERFERES. This example keeps the complex
+Sorkin action per ensemble member (#284 took its modulus) and asks whether
+the optimizer's winner is also the geometry a phase sum localizes on -- the
+saddle-point question, posed honestly on a finite, discrete family.
+
+Conventions and what is measured:
+
+  * The measure. The catalog is a seeded sample, not a defined measure over
+    fills. Two draws producing isometric complexes are the SAME geometry, so
+    the sum runs over ISOMETRY CLASSES (members grouped by exactly equal
+    complex action), each counted once -- the dedup is itself a finding: the
+    twisted prisms are bit-exact phase degenerates of their straight twins
+    (gluing through a symmetry is an isometry), and the gated single-cut
+    variants collapse to one class (the three interior tets of the 3-layer
+    fill are a symmetry orbit, and after one cut the interiority guard
+    forbids a second -- every cut draw is the same geometry).
+  * The move table. Discrete "directions" through the ensemble: thickness
+    (the action is monotone -- the winner is an ENDPOINT extremum, the
+    discrete analog of a boundary saddle), cuts (raise S), and growth at
+    fixed thickness (an INTERIOR dip: S falls to the +3 growth variant and
+    rises again -- a genuine discrete stationary candidate, and exactly the
+    geometry fixed-thickness F_beta selects).
+  * The phase sum, and the honest negative. Z(lambda) = sum over classes
+    of e^{i lambda S} with UNIFORM weights. On a finite family of unit
+    phasors there is no measure factor to suppress the bulk, so the sum
+    does NOT localize on the minimal action: the tail phase velocity
+    d(arg Z)/d lambda sits inside the family's action range, well above
+    S_min. That non-localization is itself asserted as a check: continuum
+    stationary-phase intuition does not transfer to a uniform discrete
+    measure.
+  * Where stationarity IS well-posed, the optimizer sits on it. The one
+    interior extremum the move graph supports -- the action dip in the
+    growth direction at fixed thickness -- is exactly the geometry the
+    fixed-thickness F_beta selects.
+  * The Lorentzian-native family localizes by SORKIN DAMPING. The
+    layered-time fills' actions are genuinely complex, with |Im S|
+    extensive in thickness. In the damped branch of the sum-over-
+    geometries convention the weights e^{-lambda |Im S|} suppress thicker
+    fills EXPONENTIALLY; the thinnest fill's weight share is ~1 already at
+    lambda = 1, and the least-damped geometry is the global F_beta winner:
+    the classical geometry emerges through damping, not uniform-phase
+    cancellation.
+  * The beta bridge. argmin(r + beta |S|) over the identity-realizing family
+    for every beta > 0, globally and at fixed thickness, compared with the
+    phase analysis: both select the same geometries (global: the thinnest
+    straight prism; fixed L=3: the +3 growth variant at the interior dip).
+  * The Lorentzian-native column. The layered-time fills' complex actions
+    are recorded; an imaginary part would act as Sorkin damping
+    (|e^{iS}| = e^{-Im S}) and is reported per fill.
+  * Robustness. The full analysis is repeated with the variant count
+    doubled; every verdict must agree (the class structure is stable under
+    resampling -- the seeded draws only add members to existing classes).
+
+Run:
+    python examples/cobordism/level1_stationary_phase.py
+    python examples/cobordism/level1_stationary_phase.py --variants 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_HERE, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = _load("spectral_gate_realizability")
+L1 = _load("level1_fill_realizability")
+SEL = _load("level1_mediated_selection")
+np = BASE.np
+tessera = BASE.tessera
+
+REALIZE = BASE.REALIZE
+BETAS = SEL.BETAS
+
+
+def _regge_complex(st):
+    """The dual Lorentzian Regge action, kept COMPLEX (Sorkin): the phase is
+    what a sum over geometries interferes with; #284 consumed only |S|."""
+    return complex(tessera.ReggeSolver(st, tessera.MatterConfiguration())
+                   .dualReggeAction())
+
+
+def score_complex(members):
+    """Per-member rows with the complex action and the spectral meta."""
+    rows = []
+    for label, fill, meta in members:
+        s = _regge_complex(fill.st)
+        rows.append({"label": label, **meta,
+                     "dim": fill.dim, "dual_valid": fill.dual_valid,
+                     "identity_residual": SEL._identity_residual(fill),
+                     "emergent": L1.match_gate(fill.emergent_gate()),
+                     "S_re": s.real, "S_im": s.imag, "S_abs": abs(s)})
+    return rows
+
+
+def isometry_classes(rows, tol=1e-9):
+    """Group members by exactly equal complex action -- the sum-over-
+    GEOMETRIES measure convention. Returns one row per class with the member
+    labels attached, sorted by |S|."""
+    classes = []
+    for r in rows:
+        s = complex(r["S_re"], r["S_im"])
+        for c in classes:
+            if abs(s - c["S"]) < tol:
+                c["members"].append(r["label"])
+                c["in_family"] = c["in_family"] or (r["twist"] is None)
+                break
+        else:
+            classes.append({"S": s, "members": [r["label"]],
+                            "rep": r["label"],
+                            "in_family": r["twist"] is None})
+    return sorted(classes, key=lambda c: abs(c["S"]))
+
+
+def phase_sum(actions, lam_max=50.0, n=2000):
+    """Z(lambda) = sum_k e^{i lambda S_k} over the class actions, on a grid
+    dense enough to unwrap (delta(lambda) * max|S| < pi). Returns the grid,
+    |Z|, the unwrapped phase, and the tail phase velocity d(arg Z)/d lambda
+    estimated by regression over the last fifth of the sweep."""
+    lam = np.linspace(0.01, lam_max, n)
+    z = np.exp(1j * np.outer(lam, np.asarray(actions))).sum(axis=1)
+    phase = np.unwrap(np.angle(z))
+    tail = lam > 0.8 * lam_max
+    slope = float(np.polyfit(lam[tail], phase[tail], 1)[0])
+    return lam, np.abs(z), phase, slope
+
+
+def f_beta_winners(rows, betas=BETAS):
+    """argmin(r + beta |S|) over the identity-realizing family, per beta."""
+    family = [r for r in rows
+              if r["twist"] is None and r["identity_residual"] < REALIZE]
+    out = {}
+    for beta in betas:
+        if beta <= 0:
+            continue
+        out[beta] = min(family,
+                        key=lambda r: r["identity_residual"]
+                        + beta * r["S_abs"])["label"]
+    return out
+
+
+def analyze(n_variants, seed):
+    """The full analysis pass at one ensemble size (built twice for the
+    robustness check)."""
+    members = SEL.build_ensemble(n_variants=n_variants, base_seed=seed)
+    rows = score_complex(members)
+    by = {r["label"]: r for r in rows}
+
+    twins = [("gamma twist L=1", "straight L=1"),
+             ("gamma^2 twist L=1", "straight L=1")]
+    twist_degenerate = all(
+        abs(complex(by[a]["S_re"], by[a]["S_im"])
+            - complex(by[b]["S_re"], by[b]["S_im"])) < 1e-9
+        for a, b in twins)
+
+    classes = isometry_classes(rows)
+    family_classes = [c for c in classes if c["in_family"]]
+    actions = [c["S"] for c in family_classes]
+    s_min_class = family_classes[0]
+    max_im = max(abs(c["S"].imag) for c in family_classes)
+
+    lam, zabs, _phase, slope = phase_sum([c["S"].real for c in family_classes])
+    s_min = abs(s_min_class["S"])
+    s_max = max(abs(c["S"]) for c in family_classes)
+    non_localized = bool(1.05 * s_min < slope < s_max)
+
+    winners = f_beta_winners(rows)
+    global_agree = all(w in s_min_class["members"] for w in winners.values())
+
+    fixed = [r for r in rows
+             if r["twist"] is None and r["layers"] == 3
+             and r["identity_residual"] < REALIZE]
+    dip = min(fixed, key=lambda r: r["S_abs"])
+    fixed_winner = min(fixed, key=lambda r: r["identity_residual"]
+                       + 1.0 * r["S_abs"])
+    grown = sorted((r for r in fixed if r["n_grown"] > 0),
+                   key=lambda r: r["n_grown"])
+    interior_dip = (len(grown) >= 3
+                    and any(grown[i]["S_abs"] < grown[i - 1]["S_abs"]
+                            and grown[i]["S_abs"] < grown[i + 1]["S_abs"]
+                            for i in range(1, len(grown) - 1)))
+
+    return {"rows": rows, "classes": classes,
+            "family_classes": family_classes,
+            "twist_degenerate": twist_degenerate,
+            "n_actions": len(actions), "max_im": max_im,
+            "slope": slope, "s_min": s_min, "s_max": s_max,
+            "non_localized": non_localized,
+            "zabs_final": float(zabs[-1]),
+            "winners": winners, "global_agree": global_agree,
+            "dip_label": dip["label"], "fixed_winner": fixed_winner["label"],
+            "fixed_agree": dip["label"] == fixed_winner["label"],
+            "interior_dip": interior_dip}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--variants", type=int, default=8)
+    ap.add_argument("--seed", type=int, default=12345)
+    ap.add_argument("--out", default="/tmp/cobordism")
+    args = ap.parse_args()
+
+    checks = []
+
+    def check(label, passed):
+        checks.append((label, bool(passed)))
+        return bool(passed)
+
+    print("Stationary phase over the level-1 fill ensemble\n"
+          "  (the optimizer consumed |S|; the phase sum interferes with "
+          "e^{i lambda S} --\n  is the F_beta winner where the sum "
+          "oscillates from?)\n")
+    prog = BASE._progress()
+    prog.phase("ensemble + complex actions")
+    res = analyze(args.variants, args.seed)
+    prog.finish("analyzed")
+
+    print(f"  {'fill':24} {'Re S':>10} {'Im S':>9} {'|S|':>10} "
+          f"{'transport':>16}")
+    for r in res["rows"]:
+        print(f"  {r['label']:24} {r['S_re']:>10.4f} {r['S_im']:>9.1e} "
+              f"{r['S_abs']:>10.4f} {r['emergent']:>16}")
+
+    print("\n  Isometry classes (the sum-over-geometries measure: members "
+          "with bit-equal complex action):")
+    for c in res["classes"]:
+        fam = "in family" if c["in_family"] else "twist (other transport)"
+        print(f"      |S| = {abs(c['S']):>9.4f}  x{len(c['members'])}  "
+              f"[{fam}]  {c['members']}")
+    check("twisted fills are bit-exact phase degenerates of their straight "
+          "twins (isometry consistency)", res["twist_degenerate"])
+    check("the gated cut draws collapse to one isometry class (the interior "
+          "tets are a symmetry orbit; the guard forbids a second cut)",
+          any(len(c["members"]) >= 2 and "cut" in c["members"][0]
+              for c in res["classes"]))
+    check("the actions are real (no Sorkin damping on the unit-pin "
+          "ensemble)", res["max_im"] < 1e-9)
+
+    print(f"\n  Phase sum over {res['n_actions']} family classes (uniform "
+          f"weights): tail phase velocity d(arg Z)/d lambda = "
+          f"{res['slope']:.4f}, family action range [{res['s_min']:.4f}, "
+          f"{res['s_max']:.4f}]; final |Z| = {res['zabs_final']:.3f}")
+    check("the honest negative: a UNIFORM discrete sum does not localize "
+          "on the minimal action (the velocity sits in the family's bulk)",
+          res["non_localized"])
+
+    print(f"\n  The beta bridge: F_beta winners (beta > 0) = "
+          f"{sorted(set(res['winners'].values()))}; minimal class = "
+          f"{res['classes'][0]['members']}")
+    check("every positive beta selects a member of the minimal-action "
+          "isometry class (the phase sum and the optimizer agree globally)",
+          res["global_agree"])
+    print(f"      fixed thickness (L=3): action dip at "
+          f"'{res['dip_label']}', fixed-thickness F_beta winner "
+          f"'{res['fixed_winner']}'")
+    check("at fixed thickness the interior action dip exists in the growth "
+          "direction (a discrete stationary candidate)",
+          res["interior_dip"])
+    check("the fixed-thickness F_beta winner sits AT the dip (the "
+          "fixed-thickness saddle = the fixed-thickness optimizer)",
+          res["fixed_agree"])
+
+    # ---- the Lorentzian-native column -------------------------------------- #
+    prog.phase("Lorentzian-native actions")
+    lorentz = []
+    for layers in (1, 2, 3):
+        s = _regge_complex(SEL._layered_time_bulk(layers))
+        lorentz.append({"layers": layers, "S_re": s.real, "S_im": s.imag})
+        print(f"      Lorentzian L={layers}: S = {s.real:.4f} "
+              f"{'+' if s.imag >= 0 else '-'} {abs(s.imag):.1e} i")
+    prog.finish("scored")
+    check("the Lorentzian-native actions are finite",
+          all(np.isfinite(r["S_re"]) and np.isfinite(r["S_im"])
+              for r in lorentz))
+
+    # ---- robustness: double the variants ----------------------------------- #
+    prog.phase("robustness (doubled ensemble)")
+    res2 = analyze(2 * args.variants, args.seed)
+    prog.finish("re-analyzed")
+    print(f"\n  Robustness at {2 * args.variants} variants: "
+          f"non-localized = {res2['non_localized']}, global agree = "
+          f"{res2['global_agree']}, fixed-thickness agree = "
+          f"{res2['fixed_agree']}")
+    check("every verdict survives doubling the ensemble (the class "
+          "structure is stable under resampling)",
+          res2["twist_degenerate"] and res2["non_localized"]
+          and res2["global_agree"] and res2["fixed_agree"]
+          and res2["interior_dip"])
+
+    if not args.no_write:
+        os.makedirs(args.out, exist_ok=True)
+        path = os.path.join(args.out, "level1_stationary_phase.json")
+        with open(path, "w") as handle:
+            json.dump({"rows": res["rows"],
+                       "classes": [{"S_abs": abs(c["S"]),
+                                    "members": c["members"],
+                                    "in_family": c["in_family"]}
+                                   for c in res["classes"]],
+                       "slope": res["slope"], "s_min": res["s_min"],
+                       "s_max": res["s_max"],
+                       "non_localized": res["non_localized"],
+                       "winners": {str(k): v
+                                   for k, v in res["winners"].items()},
+                       "lorentzian": lorentz},
+                      handle, indent=2)
+        print(f"\n  raw table (PR artifact, not committed): {path}")
+
+    ok = all(passed for _label, passed in checks)
+    if not ok:
+        print("\n  FAILED checks:")
+        for label, passed in checks:
+            if not passed:
+                print(f"      - {label}")
+    print("\n  Verdict: " + (
+        "SUPPORTED -- phases see geometry (isometry classes are bit-exact "
+        "phase degenerates); a UNIFORM discrete sum does NOT localize on "
+        "the minimal action (the asserted honest negative); where "
+        "discrete stationarity is well-posed -- the interior dip in the "
+        "growth direction -- the fixed-thickness optimizer sits exactly "
+        "on it; and the Lorentzian-native family LOCALIZES on the global "
+        "F_beta winner through Sorkin damping (|Im S| extensive in "
+        "thickness, the thinnest fill least damped). The optimizer's "
+        "winner is the classical geometry -- selected by damping, not by "
+        "uniform-phase cancellation."
+        if ok else
+        "NOT SUPPORTED -- a claim failed; inspect the FAILED checks above."))
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cobordism/test_level1_stationary_phase_python.py
+++ b/tests/cobordism/test_level1_stationary_phase_python.py
@@ -1,0 +1,142 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Stationary phase over the level-1 fill ensemble
+(``examples/cobordism/level1_stationary_phase.py``).
+
+The optimizer consumes |S|; a sum over geometries interferes with
+e^{i lambda S}. These tests pin what the complex Sorkin action establishes
+on the level-1 ensemble:
+
+  1. **Phases see geometry.** Isometry classes are bit-exact phase
+     degenerates: the twisted prisms carry the same complex action as their
+     straight twins, and the gated single-cut draws collapse to one class
+     (the interior tets are a symmetry orbit; the interiority guard forbids
+     a second cut).
+  2. **The honest negative.** With uniform weights over classes, the
+     discrete phase sum does NOT localize on the minimal action -- the tail
+     phase velocity sits in the family's bulk. Continuum stationary-phase
+     intuition does not transfer to a uniform discrete measure, and the
+     example asserts that rather than hiding it.
+  3. **Where stationarity is well-posed, the optimizer sits on it.** The
+     interior action dip in the growth direction at fixed thickness is
+     exactly the fixed-thickness F_beta winner; globally, every positive
+     beta selects a member of the minimal-action class.
+  4. **Sorkin damping localizes the Lorentzian family on the F_beta
+     winner.** The layered-time fills' actions are genuinely complex with
+     |Im S| extensive in thickness, so the damped branch suppresses thicker
+     fills exponentially and the thinnest fill -- the global optimizer's
+     winner -- carries essentially all the weight.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "level1_stationary_phase.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("level1_stationary_phase",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["level1_stationary_phase"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SP = _load_example()
+
+# One deterministic analysis pass shared by the tests below.
+_RES = SP.analyze(n_variants=8, seed=12345)
+_BY = {r["label"]: r for r in _RES["rows"]}
+
+
+class PhasesSeeGeometryTest(unittest.TestCase):
+    """1: isometry classes are exact phase degeneracies."""
+
+    def test_twists_carry_the_same_complex_action(self):
+        self.assertTrue(_RES["twist_degenerate"])
+
+    def test_cut_draws_collapse_to_one_class(self):
+        cut_classes = [c for c in _RES["classes"]
+                       if any("cut" in m for m in c["members"])]
+        self.assertEqual(len(cut_classes), 1)
+        self.assertGreaterEqual(len(cut_classes[0]["members"]), 2)
+
+    def test_unit_pin_actions_are_real(self):
+        self.assertLess(_RES["max_im"], 1e-9)
+
+
+class UniformSumDoesNotLocalizeTest(unittest.TestCase):
+    """2: the asserted honest negative."""
+
+    def test_phase_velocity_sits_in_the_bulk(self):
+        self.assertTrue(_RES["non_localized"])
+        self.assertGreater(_RES["slope"], 1.05 * _RES["s_min"])
+        self.assertLess(_RES["slope"], _RES["s_max"])
+
+
+class OptimizerSitsOnStationarityTest(unittest.TestCase):
+    """3: the beta bridge, globally and at fixed thickness."""
+
+    def test_global_winners_are_the_minimal_class(self):
+        self.assertTrue(_RES["global_agree"])
+        minimal = _RES["classes"][0]
+        self.assertIn("straight L=1", minimal["members"])
+
+    def test_interior_dip_exists_and_is_the_fixed_thickness_winner(self):
+        self.assertTrue(_RES["interior_dip"])
+        self.assertTrue(_RES["fixed_agree"])
+        self.assertEqual(_RES["dip_label"], _RES["fixed_winner"])
+
+
+class SorkinDampingLocalizesTest(unittest.TestCase):
+    """4: the Lorentzian-native family."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.actions = [SP._regge_complex(SP.SEL._layered_time_bulk(layers))
+                       for layers in (1, 2, 3)]
+
+    def test_actions_are_genuinely_complex(self):
+        for s in self.actions:
+            self.assertGreater(abs(s.imag), 1e-6)
+
+    def test_damping_is_extensive_in_thickness(self):
+        ims = [abs(s.imag) for s in self.actions]
+        self.assertLess(ims[0], ims[1])
+        self.assertLess(ims[1], ims[2])
+
+    def test_damped_sum_localizes_on_the_thinnest_fill(self):
+        ims = np.array([abs(s.imag) for s in self.actions])
+        weights = np.exp(-ims)
+        share = float(weights[0] / weights.sum())
+        self.assertGreater(share, 1.0 - 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements #285 (milestone: Mediated Cobordism Validation and Testing). Keeps the complex Sorkin action per level-1 ensemble member (#284 consumed only |S|) and asks whether the F_β winner is the geometry a sum over fills localizes on. The answer is yes — but by a different mechanism than the naive stationary-phase story, and the corrections are the substance:

- **Phases see geometry.** Isometry classes are bit-exact phase degenerates: twisted prisms ≡ their straight twins, and the gated single-cut draws collapse to **one** class (the interior tets are a symmetry orbit; the interiority guard forbids a second cut — every cut draw is the same geometry). The sum-over-geometries measure is uniform over classes, dedup checked.
- **The honest negative, asserted as a check.** With uniform weights, the discrete phase sum does **not** localize on the minimal action — the tail phase velocity sits in the family's bulk (48.2 in [34.4, 57.7]). A finite family of unit phasors has no measure factor to suppress the bulk; continuum stationary-phase intuition does not transfer, and the example asserts that rather than hiding it.
- **Where discrete stationarity is well-posed, the optimizer sits on it.** The interior action dip in the growth direction at fixed thickness (grown +3, non-monotone on both sides) is exactly the fixed-thickness F_β winner; globally every β > 0 selects the minimal-action class.
- **Sorkin damping localizes the Lorentzian family on the F_β winner.** The layered-time fills' actions are genuinely complex with |Im S| extensive in thickness (13 < 37 < 60): the damped branch suppresses thicker fills exponentially, and the thinnest fill — the global optimizer's winner — carries weight share ~1−1e−10 at λ=1. **The classical geometry emerges through damping, not uniform-phase cancellation.**
- Robustness: every verdict survives doubling the ensemble. The F_β machinery is untouched (optimizer-not-sampler preserved — this is a diagnostic comparison).

## Test plan
- [x] `pytest tests/cobordism/test_level1_stationary_phase_python.py` — 9 passed (fresh venv from main tip)
- [x] Full `tests/cobordism` suite in the same venv: **640 passed, 1 skipped, 719 subtests passed**, 0 failures
- [x] Full example run (`--variants 8`, robustness at 16) — verdict SUPPORTED

Closes #285.
