### PR TITLE
refactor(cobordism): gated topology moves in C++ — checked cuts and the composed stellar move

### DIFF
--- a/examples/cobordism/l2_register_realizability.py
+++ b/examples/cobordism/l2_register_realizability.py
@@ -229,11 +229,10 @@ class RegisterL2:
             cs = tuple(sorted(cell))
             avail = {tuple(sorted(int(v) for v in c))
                      for c in self.es.interiorTopCells()}
-            if cs in avail and self.es.removeInteriorCell(list(cs)):
-                ok, _why = register_dual_valid(self.es)
-                if not ok:                  # accept moves only if the DUAL stays
-                    self.es.restoreLastRemoval()            # a valid complex
-                    continue
+            if cs not in avail:
+                continue
+            ok, _why = self.es.removeInteriorCellChecked(list(cs))   # gated cut
+            if ok:                          # accepted only if the DUAL stays valid
                 self.extra_opened.append(cs)
         self.dual_valid, self.dual_reason = register_dual_valid(self.es)
 
@@ -256,16 +255,16 @@ class RegisterL2:
         self.sign = self.n.copy()
 
     def _stellar_grow(self, n, seed):
-        """ADD up to *n* interior vertices by boundary-fixed stellar subdivision,
-        composed from the two surgery primitives exactly as in 2d: cone a fresh
-        vertex onto an interior tetrahedron's four faces (``attachInteriorVertex``
-        with the facet fan -- dW untouched), then remove the subdivided tet
-        (``removeInteriorCell`` -- its faces keep two cofaces, so dW stays
-        bit-exact). Each application adds ONE vertex and preserves ker L_2 (the
-        fan is homotopic to the tet it replaces); sites are drawn by the seeded
-        RNG from the current interior top cells. On seeds whose holes consume
-        every vertex (the canonical hexagon join) there is no interior site and
-        the budget is simply unused."""
+        """ADD up to *n* interior vertices by the boundary-fixed composed stellar
+        move (``EigenstateSynthesis.stellarSubdivideInterior``): attach a fresh
+        vertex onto an interior tetrahedron's facet fan, remove the subdivided
+        parent, gate on dual validity, and re-pin to the unit cochain metric --
+        one C++ implementation, shared with the 2d register and the level-1
+        fill. Each accepted move adds ONE vertex and preserves ker L_2 (the fan
+        is homotopic to the tet it replaces); sites are drawn by the seeded RNG
+        from the current interior top cells. On seeds whose holes consume every
+        vertex (the canonical hexagon join) there is no interior site and the
+        budget is simply unused."""
         rng = random.Random(int(seed))
         grown = 0
         for _ in range(int(n)):
@@ -273,27 +272,9 @@ class RegisterL2:
                            for c in self.es.interiorTopCells())
             if not sites:
                 break
-            cell = rng.choice(sites)
-            fan = [list(f) for f, _s in _tet_facets(cell)]
-            if not self.es.attachInteriorVertex(fan):
-                continue
-            if not self.es.removeInteriorCell(list(cell)):
-                self.es.detachLastInteriorVertex()
-                continue
-            ok, _why = register_dual_valid(self.es)
-            if not ok:                      # accept moves only if the DUAL stays
-                self.es.restoreLastRemoval()                # a valid complex
-                self.es.detachLastInteriorVertex()
-                continue
-            grown += 1
-        if grown:
-            # attachInteriorVertex wires the new cells through the endpoint
-            # TIME rule rather than a causal cone placement; re-pin the bulk
-            # uniform so the documented unit cochain metric holds by
-            # construction (the 2d register does the same).
-            for e in self.st.getEdgeList().toVector():
-                e.setSquaredLength(1.0)
-                e.setPhase(0.0)
+            ok, _why = self.es.stellarSubdivideInterior(list(rng.choice(sites)))
+            if ok:
+                grown += 1
         return grown
 
     @property

--- a/examples/cobordism/level1_fill_realizability.py
+++ b/examples/cobordism/level1_fill_realizability.py
@@ -205,11 +205,10 @@ class Level1Fill:
             cs = tuple(sorted(cell))
             avail = {tuple(sorted(int(v) for v in c))
                      for c in self.es.interiorTopCells()}
-            if cs in avail and self.es.removeInteriorCell(list(cs)):
-                ok, _why = self.es.dualComplexValid()
-                if not ok:
-                    self.es.restoreLastRemoval()
-                    continue
+            if cs not in avail:
+                continue
+            ok, _why = self.es.removeInteriorCellChecked(list(cs))
+            if ok:
                 self.extra_opened.append(cs)
         self.read_spectral()
 
@@ -235,11 +234,13 @@ class Level1Fill:
         return self
 
     def _stellar_grow(self, n, seed):
-        """ADD up to *n* interior vertices by the gated composed stellar move
-        (cone a vertex onto an interior tet's four faces, then remove the
-        parent), exactly as the L_2 register does. Pure prisms have interior
-        tets only at three or more layers (every tet spans adjacent layers),
-        so the budget is unused on thin fills -- documented geometry."""
+        """ADD up to *n* interior vertices by the boundary-fixed composed stellar
+        move (``EigenstateSynthesis.stellarSubdivideInterior``: attach a vertex
+        onto an interior tet's facet fan, remove the parent, gate on dual
+        validity, re-pin to the unit cochain metric) -- the same C++
+        implementation the L_2 register uses. Pure prisms have interior tets
+        only at three or more layers (every tet spans adjacent layers), so the
+        budget is unused on thin fills -- documented geometry."""
         rng = random.Random(int(seed))
         grown = 0
         for _ in range(int(n)):
@@ -247,23 +248,9 @@ class Level1Fill:
                            for c in self.es.interiorTopCells())
             if not sites:
                 break
-            cell = rng.choice(sites)
-            fan = [list(f) for f, _s in L2._tet_facets(cell)]
-            if not self.es.attachInteriorVertex(fan):
-                continue
-            if not self.es.removeInteriorCell(list(cell)):
-                self.es.detachLastInteriorVertex()
-                continue
-            ok, _why = self.es.dualComplexValid()
-            if not ok:
-                self.es.restoreLastRemoval()
-                self.es.detachLastInteriorVertex()
-                continue
-            grown += 1
-        if grown:
-            for e in self.st.getEdgeList().toVector():
-                e.setSquaredLength(1.0)
-                e.setPhase(0.0)
+            ok, _why = self.es.stellarSubdivideInterior(list(rng.choice(sites)))
+            if ok:
+                grown += 1
         return grown
 
     # ---- the level-1 register read-outs ---------------------------------- #
@@ -392,11 +379,8 @@ def _catalog_worker(task):
     rng.shuffle(sites)
     cut = []
     for cell in sites[:rng.randint(0, max_cut)]:
-        if fill.es.removeInteriorCell(list(cell)):
-            ok, _why = fill.es.dualComplexValid()
-            if not ok:
-                fill.es.restoreLastRemoval()
-                continue
+        ok, _why = fill.es.removeInteriorCellChecked(list(cell))
+        if ok:
             cut.append(cell)
     # re-read the spectral state after the catalog's own cuts
     try:

--- a/examples/cobordism/level1_mediated_selection.py
+++ b/examples/cobordism/level1_mediated_selection.py
@@ -127,11 +127,8 @@ def _cut_variant(seed, n_cut):
     rng.shuffle(sites)
     cut = 0
     for cell in sites[:n_cut]:
-        if fill.es.removeInteriorCell(list(cell)):
-            ok, _why = fill.es.dualComplexValid()
-            if not ok:
-                fill.es.restoreLastRemoval()
-                continue
+        ok, _why = fill.es.removeInteriorCellChecked(list(cell))
+        if ok:
             cut += 1
     fill.read_spectral()
     return fill, cut

--- a/examples/cobordism/level1_value_reading.py
+++ b/examples/cobordism/level1_value_reading.py
@@ -310,10 +310,7 @@ def _cut_variant(seed, n_cut=2):
                    for c in fill.es.interiorTopCells())
     rng.shuffle(sites)
     for cell in sites[:n_cut]:
-        if fill.es.removeInteriorCell(list(cell)):
-            ok, _why = fill.es.dualComplexValid()
-            if not ok:
-                fill.es.restoreLastRemoval()
+        fill.es.removeInteriorCellChecked(list(cell))   # gated cut, dual-validity
     fill.read_spectral()
     return fill
 

--- a/examples/cobordism/spectral_gate_realizability.py
+++ b/examples/cobordism/spectral_gate_realizability.py
@@ -347,12 +347,12 @@ class Register:
         self.sign = self.n.copy()
 
     def _stellar_grow(self, n, seed):
-        """ADD up to *n* interior vertices by boundary-fixed stellar subdivision,
-        composed from the two documented surgery primitives: cone a fresh vertex
-        onto an interior top cell's three edges (`attachInteriorVertex` with the
-        triangle fan — dW untouched, the new edges interior), then remove the
-        subdivided face (`removeInteriorCell` — its edges keep two faces, so dW
-        stays bit-exact). Each application adds exactly ONE vertex and preserves
+        """ADD up to *n* interior vertices by the boundary-fixed composed stellar
+        move (``EigenstateSynthesis.stellarSubdivideInterior``): attach a fresh
+        vertex onto an interior top cell's facet fan, remove the subdivided
+        parent, gate on dual validity, and re-pin the bulk to the unit cochain
+        metric -- one C++ implementation, shared with the 3d registers and the
+        level-1 fill. Each accepted move adds exactly ONE vertex and preserves
         ker L_1 (the fan is homotopic to the face it replaces); sites are drawn
         by the seeded RNG from the current interior top cells."""
         rng = random.Random(int(seed))
@@ -362,25 +362,9 @@ class Register:
                            for c in self.es.interiorTopCells())
             if not cells:
                 break
-            a, b, c = rng.choice(cells)
-            if not self.es.attachInteriorVertex([[a, b], [b, c], [a, c]]):
-                continue
-            if not self.es.removeInteriorCell([a, b, c]):
-                self.es.detachLastInteriorVertex()
-                continue
-            grown += 1
-        if grown:
-            # attachInteriorVertex wires the new edges through
-            # createSimplexTracked, whose metric follows the endpoints' TIME
-            # rule (timelike l^2 = -alpha*a on a time difference) rather than
-            # Simplex::cone's causal vertex placement. On the all-same-time
-            # register seeds that already yields spacelike unit edges, but the
-            # documented unit cochain metric should hold by construction, not
-            # by the default-time coincidence: re-pin the bulk uniform exactly
-            # as _surface does at build.
-            for e in self.st.getEdgeList().toVector():
-                e.setSquaredLength(1.0)
-                e.setPhase(0.0)
+            ok, _why = self.es.stellarSubdivideInterior(list(rng.choice(cells)))
+            if ok:
+                grown += 1
         return grown
 
     @property

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -373,6 +373,45 @@ class EigenstateSynthesis {
     /// The surgery analogue of `detachLastInteriorVertex`.
     bool restoreLastRemoval();
 
+    // === Gated topology moves: the checked cut and the composed stellar move ===
+
+    /// The gated surgery cut: `removeInteriorCell(cell)`, then the dual-validity
+    /// gate (`dualComplexValid`), rolled back via `restoreLastRemoval` when the
+    /// cut violates the dual — the accept-a-move-only-while-the-dual-stays-valid
+    /// composition the register / fill layers apply, as one move. Returns
+    /// `{true, "ok"}` with the cut applied, or `{false, reason}` with the
+    /// complex unchanged: either the cell is not a removable interior top cell
+    /// (`removeInteriorCell` rejected it) or the gate verdict names the dual
+    /// violation. The gate is rigorous for \f$ n \leq 3 \f$
+    /// (`ChainComplex::dualComplexIsValid`); dimension-4 callers use explicit
+    /// constructions, not gated moves.
+    [[nodiscard]] std::pair<bool, std::string> removeInteriorCellChecked(
+        const std::vector<std::uint64_t> &cell);
+
+    /// The composed gated stellar move — the boundary-fixed interior
+    /// \f$ 1 \to (d+1) \f$ subdivision built from the two surgery primitives:
+    /// attach a fresh interior vertex onto `cell`'s facet fan
+    /// (`attachInteriorVertex` with the \f$ d+1 \f$ codim-one facets —
+    /// \f$ \partial W \f$ untouched, the new edges interior), remove the
+    /// subdivided parent (`removeInteriorCell` — its facets keep two cofaces, so
+    /// \f$ \partial W \f$ stays bit-exact), then gate on `dualComplexValid`,
+    /// rolling back **both** in LIFO order (`restoreLastRemoval`, then
+    /// `detachLastInteriorVertex`) on violation. Each accepted move adds exactly
+    /// one interior vertex and preserves \f$ \ker L_k \f$ (the fan is homotopic
+    /// to the cell it replaces).
+    ///
+    /// On acceptance the bulk's edges are re-pinned uniform — squared length 1,
+    /// phase 0, the unit cochain metric the register / fill seeds are built
+    /// with: the attach wires the fan edges through `createSimplexTracked`,
+    /// whose tracked metric follows the endpoints' TIME rule (timelike
+    /// \f$ l^2 \f$ on a time difference) rather than a causal cone placement.
+    /// On all-same-time seeds that already yields spacelike unit edges, but the
+    /// documented unit metric holds by construction, not by the default-time
+    /// coincidence. Returns `{true, "ok"}` on acceptance, or `{false, reason}`
+    /// with the complex unchanged (and no re-pin).
+    [[nodiscard]] std::pair<bool, std::string> stellarSubdivideInterior(
+        const std::vector<std::uint64_t> &cell);
+
   private:
     std::shared_ptr<Spacetime> st_;
     int k_{0};  // the Hodge degree of L_k that apply()/residual() score against

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -537,7 +537,32 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "Undo the most recent removeInteriorCell (LIFO): re-create the removed "
            "top cell and the edges it orphaned, restoring their weights/phases bit-"
            "exactly, and re-capture. Returns False if there is no removal to undo. "
-           "Lets a surgery search try a removal, score it, and roll back.");
+           "Lets a surgery search try a removal, score it, and roll back.")
+      // ----- Gated moves: the checked cut and the composed stellar move -----
+      .def("removeInteriorCellChecked",
+           &EigenstateSynthesis::removeInteriorCellChecked, py::arg("cell"),
+           "(ok, reason): the gated surgery cut — removeInteriorCell(cell), then "
+           "the dual-validity gate (dualComplexValid), rolled back via "
+           "restoreLastRemoval when the cut violates the dual. (True, 'ok') means "
+           "the cut is applied and the dual complex stayed valid; (False, reason) "
+           "means the complex is unchanged — the cell was not a removable interior "
+           "top cell, or the reason names the dual violation. The gate is rigorous "
+           "for n <= 3; dimension-4 callers use explicit constructions, not gated "
+           "moves.")
+      .def("stellarSubdivideInterior",
+           &EigenstateSynthesis::stellarSubdivideInterior, py::arg("cell"),
+           "(ok, reason): the composed gated stellar move — attach a fresh "
+           "interior vertex onto `cell`'s facet fan (attachInteriorVertex with "
+           "the d+1 codim-one facets; dW untouched), remove the subdivided parent "
+           "(removeInteriorCell; its facets keep two cofaces, so dW stays "
+           "bit-exact), gate on dualComplexValid, and roll back BOTH in LIFO "
+           "order (restoreLastRemoval, then detachLastInteriorVertex) on "
+           "violation. Each accepted move adds exactly ONE interior vertex and "
+           "preserves ker L_k (the fan is homotopic to the cell it replaces). On "
+           "acceptance the bulk's edges are re-pinned uniform (squaredLength 1, "
+           "phase 0) — the unit cochain metric the register/fill seeds are built "
+           "with, held by construction rather than by the createSimplexTracked "
+           "time-rule coincidence on all-same-time seeds.");
 
   // ----- §4b cone-and-retry synthesis loop → geo(ψ) (#134) -----
   py::class_<GeometrySynthesizer> gs(m, "GeometrySynthesizer",

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -714,6 +714,69 @@ bool EigenstateSynthesis::restoreLastRemoval() {
   return true;
 }
 
+// === Gated topology moves: the checked cut and the composed stellar move ===
+
+std::pair<bool, std::string> EigenstateSynthesis::removeInteriorCellChecked(
+    const std::vector<std::uint64_t> &cell) {
+  if (!removeInteriorCell(cell))
+    return {false,
+            "not an interior top cell (or the removal would touch dW)"};
+  const auto verdict = dualComplexValid();  // {true, "ok"} when the dual holds
+  if (!verdict.first) restoreLastRemoval();
+  return verdict;
+}
+
+std::pair<bool, std::string> EigenstateSynthesis::stellarSubdivideInterior(
+    const std::vector<std::uint64_t> &cell) {
+  if (!st_) return {false, "no spacetime"};
+  const int d = st_->getMetric()->getSignature()->getDimensions();
+  const std::size_t topVerts = (d >= 0) ? static_cast<std::size_t>(d) + 1 : 0;
+  if (topVerts < 2 || cell.size() != topVerts)
+    return {false, "cell is not a top cell (" + std::to_string(cell.size()) +
+                       " vertices, expected " + std::to_string(topVerts) + ")"};
+
+  // The facet fan: `cell` with each vertex dropped in turn (its d+1 codim-one
+  // facets). The attach cones the fresh vertex onto every facet, so the parent
+  // cell's 1-skeleton survives its removal (each parent edge keeps a fan
+  // coface) and the subdivision is exactly 1 -> (d+1).
+  std::vector<std::uint64_t> want(cell.begin(), cell.end());
+  std::sort(want.begin(), want.end());
+  std::vector<std::vector<std::uint64_t>> fan;
+  fan.reserve(want.size());
+  for (std::size_t skip = 0; skip < want.size(); ++skip) {
+    std::vector<std::uint64_t> facet;
+    facet.reserve(want.size() - 1);
+    for (std::size_t i = 0; i < want.size(); ++i)
+      if (i != skip) facet.push_back(want[i]);
+    fan.push_back(std::move(facet));
+  }
+
+  if (!attachInteriorVertex(fan))
+    return {false, "attach rejected (invalid fan spec, or dW perturbed)"};
+  if (!removeInteriorCell(want)) {
+    detachLastInteriorVertex();
+    return {false,
+            "not an interior top cell (or the removal would touch dW)"};
+  }
+  const auto verdict = dualComplexValid();
+  if (!verdict.first) {
+    // LIFO rollback: the removal happened after the attach.
+    restoreLastRemoval();
+    detachLastInteriorVertex();
+    return verdict;
+  }
+
+  // The uniform re-pin: the seeds are built with every edge at squared length 1
+  // and phase 0 (the unit cochain metric), and the move must hold that by
+  // construction, not by the time-rule coincidence on all-same-time seeds.
+  for (const auto e : st_->getEdgeList()->toVector()) {
+    if (e == nullptr) continue;
+    e->setSquaredLength(1.0);
+    e->setPhase(0.0);
+  }
+  return verdict;  // {true, "ok"}
+}
+
 std::vector<std::vector<std::uint64_t>> EigenstateSynthesis::topCells() const {
   std::vector<std::vector<std::uint64_t>> cells;
   if (!st_) return cells;


### PR DESCRIPTION
## Summary
#275 moved the dual-validity gate into C++; the gated moves were still hand-assembled around it in Python — the cut-with-rollback pattern in several places and the composed stellar move in three copies, with subtly divergent rollback paths (one of which cost a level-1 debugging round) and the re-pin subtlety re-documented in each. This PR moves both compositions onto `EigenstateSynthesis`: one implementation, one rollback semantics, one re-pin policy.

- `removeInteriorCellChecked(cell)` — the gated surgery cut: `removeInteriorCell`, the `dualComplexValid` gate, `restoreLastRemoval` on violation; returns `(ok, reason)`.
- `stellarSubdivideInterior(cell)` — the composed stellar move: attach the facet fan onto a fresh interior vertex, remove the parent, gate, roll back both the removal and the attach (LIFO) on failure, then apply the uniform unit-metric re-pin.
- Bindings; the three `_stellar_grow` copies and the gated-cut sites rewired to the new calls. The 2d `Register`'s stellar grow previously lacked the dual gate — it now shares the gated C++ move.

The dimensional contract is preserved: the gate stays rigorous for n ≤ 3, and dimension-4 callers (the stabilizer-law fills) keep using explicit constructions, not gated moves.

Rebased onto current `main`; the migration picked up a fifth gated-cut copy — the `_cut_variant` in `level1_value_reading.py` added by #290 — and migrated that too, so no divergent copy is left behind.

## Test plan
- [x] Local cobordism suite (the migration gate, tests unchanged): **668 passed, 1 skipped, 726 subtests passed**. The seeded growth tests — `test_surgery_and_cone` (2d, asserts `grown == 3` and every edge at `1.0`/`0.0`), `test_l2_register` (3d), `test_level1_fill`, and `test_level1_mediation` (exercises `_cut_variant`) — pin the RNG draw sequence and accept/reject behavior; all green.
- [x] `test_pachner_pregeometric` + `test_addmove_selfedge` (the shared move machinery): 24 passed.
- [ ] `test_level1_value_python.py` is **blocked by a pre-existing `main` regression, not by this change** — see #299 (`level1_value_reading` calls the renamed `_reg_sign`, a #290/#291 merge-order miss). This PR migrates that file's `_cut_variant` but deliberately does not touch the broken `_reg_sign` call sites.
- [ ] After merge: branch teardown.

Closes #287.
