### PR TITLE
refactor(cobordism): complex builders in C++ — cells-to-Spacetime factory and degree-general prisms

### DIFF
--- a/examples/cobordism/l2_register_realizability.py
+++ b/examples/cobordism/l2_register_realizability.py
@@ -138,17 +138,7 @@ def _tet_facets(cell):
 def _bulk(cells, weight=1.0, phase=0.0):
     """A pre-geometric 3-complex (top cells = tetrahedra) from a tet list, all
     edges pinned to a uniform Hermitian weight -- the 3d twin of the 2d builder."""
-    sig = tessera.Signature(3, tessera.Lorentzian)
-    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
-                           tessera.PREFERRED, None)
-    vmap = {i: st.createVertex(i) for i in sorted({v for c in cells for v in c})}
-    for c in cells:
-        t = sorted(c)
-        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]], vmap[t[3]]])
-    for e in st.getEdgeList().toVector():
-        e.setSquaredLength(weight)
-        e.setPhase(phase)
-    return st
+    return tessera.Spacetime.fromCells(3, [list(c) for c in cells], weight, phase)
 
 
 # --------------------------------------------------------------------------- #

--- a/examples/cobordism/level1_fill_realizability.py
+++ b/examples/cobordism/level1_fill_realizability.py
@@ -142,22 +142,9 @@ def _prism_cells(faces=_W_FACES, layers=1, twist=None):
     rule, so the complex is consistent. *twist* (a vertex permutation of the
     register surface, e.g. _GAMMA) is applied cumulatively per layer, gluing
     the top end through the symmetry -- the mapping-torus-style twisted
-    product whose harmonics transport periods through the twist."""
-    twist = twist or _IDENT
-    phi = [_IDENT]
-    for _ in range(layers):
-        phi.append(_compose(twist, phi[-1]))
-    cells = []
-    for ell in range(layers):
-        lo, hi = phi[ell], phi[ell + 1]
-        for (a, b, c) in faces:
-            a0, b0, c0 = (lo[a] + 12 * ell, lo[b] + 12 * ell, lo[c] + 12 * ell)
-            a1, b1, c1 = (hi[a] + 12 * (ell + 1), hi[b] + 12 * (ell + 1),
-                          hi[c] + 12 * (ell + 1))
-            cells += [tuple(sorted((a0, b0, c0, c1))),
-                      tuple(sorted((a0, b0, b1, c1))),
-                      tuple(sorted((a0, a1, b1, c1)))]
-    return sorted(set(cells)), phi[layers]
+    product whose harmonics transport periods through the twist. The staircase
+    is the dimension-generic prism builder; this is its 3d face."""
+    return tessera.Spacetime.prismCells([list(f) for f in faces], layers, twist)
 
 
 def _hole_circles(shift, perm=None):
@@ -181,7 +168,7 @@ class Level1Fill:
     def __init__(self, faces=_W_FACES, layers=1, twist=None, extra_holes=(),
                  grow_vertices=0, grow_seed=0):
         self.layers = int(layers)
-        cells, _top_perm = _prism_cells(faces, self.layers, twist)
+        cells = _prism_cells(faces, self.layers, twist)
         self.seed_cells = cells
         # Each end is labeled by its OWN canonical register classes: the top
         # copy's hole set equals the canonical holes shifted into its layer

--- a/examples/cobordism/level1_mediated_selection.py
+++ b/examples/cobordism/level1_mediated_selection.py
@@ -103,17 +103,10 @@ def _layered_time_bulk(layers, twist=None):
     assignment): the tracked metric rule then makes intra-layer edges
     spacelike (equal times) and inter-layer edges timelike (time difference
     one). No unit re-pin -- this is the Lorentzian-native fill."""
-    cells, _ = L1._prism_cells(layers=layers, twist=twist)
-    sig = tessera.Signature(3, tessera.Lorentzian)
-    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
-                           tessera.PREFERRED, None)
-    vmap = {}
-    for i in sorted({v for c in cells for v in c}):
-        vmap[i] = st.createVertex(i, [float(i // 12)])   # time-only coordinate
-    for c in cells:
-        t = sorted(c)
-        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]], vmap[t[3]]])
-    return st
+    cells = L1._prism_cells(layers=layers, twist=twist)
+    n = max(v for c in cells for v in c) + 1
+    times = [float(i // 12) for i in range(n)]   # vertex i sits in layer i // 12
+    return tessera.Spacetime.fromCells(3, cells, vertexTimes=times)
 
 
 def _cut_variant(seed, n_cut):

--- a/examples/cobordism/level1_stabilizer_law.py
+++ b/examples/cobordism/level1_stabilizer_law.py
@@ -135,34 +135,14 @@ def _prism4_cells(cells=_W3_CELLS, twist=None):
     """The staircase triangulation of (holed S^3) x I: for each tetrahedron
     (a<b<c<d), the four 4-simplices (a0,b0,c0,d0,d1), (a0,b0,c0,c1,d1),
     (a0,b0,b1,c1,d1), (a0,a1,b1,c1,d1) with x1 = twist(x) + 12. Adjacent
-    prisms split shared walls by the same vertex-order rule."""
-    twist = twist or _IDENT
-    out = []
-    for c in cells:
-        a, b, cc, d = sorted(c)
-        a1, b1, c1, d1 = (twist[a] + 12, twist[b] + 12,
-                          twist[cc] + 12, twist[d] + 12)
-        out += [tuple(sorted((a, b, cc, d, d1))),
-                tuple(sorted((a, b, cc, c1, d1))),
-                tuple(sorted((a, b, b1, c1, d1))),
-                tuple(sorted((a, a1, b1, c1, d1)))]
-    return sorted(set(out))
+    prisms split shared walls by the same vertex-order rule. The staircase is
+    the dimension-generic prism builder; this is its 4d (single-layer) face."""
+    return tessera.Spacetime.prismCells([list(c) for c in cells], 1, twist)
 
 
 def _bulk4(cells):
     """A pre-geometric 4-complex (top cells = 4-simplices), unit edge pin."""
-    sig = tessera.Signature(4, tessera.Lorentzian)
-    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
-                           tessera.PREFERRED, None)
-    vmap = {i: st.createVertex(i)
-            for i in sorted({v for c in cells for v in c})}
-    for c in cells:
-        t = sorted(c)
-        st.createSimplex([vmap[v] for v in t])
-    for e in st.getEdgeList().toVector():
-        e.setSquaredLength(1.0)
-        e.setPhase(0.0)
-    return st
+    return tessera.Spacetime.fromCells(4, [list(c) for c in cells])
 
 
 _REG_SIGN_CACHE = []

--- a/examples/cobordism/spectral_gate_realizability.py
+++ b/examples/cobordism/spectral_gate_realizability.py
@@ -229,17 +229,7 @@ def _progress():
 def _surface(faces, weight=1.0, phase=0.0):
     """A pre-geometric 2-complex (top cells = triangles) from a face list, all edges
     pinned to a uniform Hermitian weight. No topology object is used."""
-    sig = tessera.Signature(2, tessera.Lorentzian)
-    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
-                           tessera.PREFERRED, None)
-    vmap = {i: st.createVertex(i) for i in sorted({v for f in faces for v in f})}
-    for f in faces:
-        t = sorted(f)
-        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]]])
-    for e in st.getEdgeList().toVector():
-        e.setSquaredLength(weight)
-        e.setPhase(phase)
-    return st
+    return tessera.Spacetime.fromCells(2, [list(f) for f in faces], weight, phase)
 
 
 def _betti(st):

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -277,6 +277,80 @@ class Spacetime {
     /// @param numSimplices The number of simplices to add to the initial complex
     void build(int numSimplices=3);
 
+    /// Factory: build a pre-geometric simplicial complex from an explicit list
+    /// of top \p cells (each a vertex-id tuple) — the cells-to-Spacetime
+    /// builder the register/fill examples share. Creates a coordinate-free
+    /// Lorentzian \f$ d \f$-dimensional CDT Spacetime, one vertex per distinct
+    /// id, one top simplex per cell (auto-wiring the edges via
+    /// :func:`createSimplex`), and sets the edge geometry by one of two
+    /// explicit rules:
+    ///
+    ///   - **Uniform Hermitian pin** (when \p vertexTimes is absent): every
+    ///     edge is pinned to squared length \p weight and phase \p phase. The
+    ///     pre-geometric register/bulk surfaces use this.
+    ///   - **Tracked metric** (when \p vertexTimes is present): each vertex
+    ///     \f$ v \f$ is created carrying the single time coordinate
+    ///     \f$ \text{vertexTimes}[v] \f$, so the tracked metric rule assigns
+    ///     spacelike (equal-time) and timelike (differing-time) edges
+    ///     automatically — the CDT-natural layered fill. \p weight and \p phase
+    ///     are ignored.
+    ///
+    /// The time coordinate is always arity one: a vertex carries \f$ \{t\} \f$
+    /// or no coordinate at all, never the length-2/3 vector that makes
+    /// @ref Vertex::getTime throw (the coordinate-arity trap).
+    ///
+    /// @param dimensions The metric/signature dimension \f$ d \f$; cells should
+    ///   be \f$ (d{+}1) \f$-vertex tuples to register as top simplices.
+    /// @param cells Top cells as vertex-id tuples (order within a cell does not
+    ///   matter; it is sorted).
+    /// @param weight Uniform-pin squared length (ignored when \p vertexTimes is
+    ///   given).
+    /// @param phase Uniform-pin Hermitian phase (ignored when \p vertexTimes is
+    ///   given).
+    /// @param vertexTimes Optional per-vertex time, indexed by vertex id; its
+    ///   presence selects the tracked-metric rule. Must be long enough to index
+    ///   every vertex id appearing in \p cells.
+    /// @return The freshly built Spacetime.
+    [[nodiscard]] static std::shared_ptr<Spacetime> fromCells(
+        int dimensions,
+        const std::vector<std::vector<std::uint64_t>> &cells,
+        double weight = 1.0,
+        double phase = 0.0,
+        const std::optional<std::vector<double>> &vertexTimes = std::nullopt);
+
+    /// The dimension-generic staircase ("prism") triangulation of
+    /// \f$ K \times [0, \text{layers}] \f$ from the top cells of a base
+    /// complex \f$ K \f$. For each base cell \f$ (v_0 < \dots < v_{m-1}) \f$
+    /// (an \f$ (m{-}1) \f$-simplex) and each layer, emits the \f$ m \f$ cells
+    /// \f[
+    ///   S_j = \{\mathrm{lo}[v_0], \dots, \mathrm{lo}[v_j]\} \cup
+    ///         \{\mathrm{hi}[v_j], \dots, \mathrm{hi}[v_{m-1}]\},
+    ///   \quad j = 0 \dots m-1,
+    /// \f]
+    /// where the lower copy in layer \f$ \ell \f$ is
+    /// \f$ \mathrm{lo}[x] = \varphi^{\ell}(x) + s\,\ell \f$ and the upper copy
+    /// is \f$ \mathrm{hi}[x] = \varphi^{\ell+1}(x) + s\,(\ell{+}1) \f$, with
+    /// \f$ s \f$ the per-layer vertex stride (one past the largest base id).
+    /// Adjacent prisms split shared walls by the same vertex-order rule, so the
+    /// result is a consistent complex. This is the single source of the
+    /// staircase the register fills carried as separate 3d and 4d copies; the
+    /// rule is identical in every dimension (\f$ m = 3 \f$ gives tetrahedra
+    /// over triangles, \f$ m = 4 \f$ gives 4-simplices over tetrahedra, …).
+    ///
+    /// @param cells Base top cells as vertex-id tuples.
+    /// @param layers Number of product layers (\f$ \ge 1 \f$).
+    /// @param twist Optional vertex permutation \f$ \varphi \f$ of the base,
+    ///   applied cumulatively per layer (gluing the top end through a symmetry —
+    ///   the mapping-torus-style twisted product). Identity when absent; keys
+    ///   are base vertex ids and a missing id maps to itself.
+    /// @return The prism's top cells as sorted vertex-id tuples, uniqued and
+    ///   sorted.
+    [[nodiscard]] static std::vector<std::vector<std::uint64_t>> prismCells(
+        const std::vector<std::vector<std::uint64_t>> &cells,
+        int layers = 1,
+        const std::optional<std::unordered_map<std::uint64_t, std::uint64_t>>
+            &twist = std::nullopt);
+
     // ========================================
     // Query Methods
     // ========================================

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -367,6 +367,58 @@ probability. Sits next to ``modularityOnSkeleton``.
 Uses the topology's builder (e.g. Toroid staircase triangulation) to
 create the initial simplicial complex.  The actual number of simplices
 may differ slightly due to slab quantization.)doc")
+      .def_static("fromCells", &Spacetime::fromCells,
+           py::arg("dimensions"), py::arg("cells"),
+           py::arg("weight") = 1.0, py::arg("phase") = 0.0,
+           py::arg("vertexTimes") = std::optional<std::vector<double>>{},
+           R"doc(Build a pre-geometric complex from an explicit list of top cells.
+
+The cells-to-Spacetime factory the register/fill builders share. Creates a
+coordinate-free Lorentzian ``dimensions``-D CDT spacetime, one vertex per
+distinct id, one top simplex per cell (edges auto-wired), and sets the edge
+geometry by one of two explicit rules:
+
+  - Uniform Hermitian pin (vertexTimes=None): every edge is pinned to squared
+    length ``weight`` and phase ``phase``.
+  - Tracked metric (vertexTimes given): each vertex ``v`` carries the single
+    time coordinate ``vertexTimes[v]``, so the tracked metric rule assigns
+    spacelike (equal-time) and timelike (differing-time) edges automatically.
+    ``weight`` and ``phase`` are ignored.
+
+The time coordinate is always arity one — a vertex carries ``[t]`` or no
+coordinate, never the length-2/3 vector that makes ``Vertex.getTime`` throw.
+
+Args:
+    dimensions: Metric/signature dimension d; pass (d+1)-vertex cells so they
+        register as top simplices.
+    cells: Top cells as vertex-id tuples (sorted internally).
+    weight: Uniform-pin squared length (ignored when vertexTimes is given).
+    phase: Uniform-pin Hermitian phase (ignored when vertexTimes is given).
+    vertexTimes: Optional per-vertex time indexed by vertex id; its presence
+        selects the tracked-metric rule. Must index every vertex id in cells.)doc")
+      .def_static("prismCells", &Spacetime::prismCells,
+           py::arg("cells"), py::arg("layers") = 1,
+           py::arg("twist") =
+               std::optional<std::unordered_map<std::uint64_t, std::uint64_t>>{},
+           R"doc(The dimension-generic staircase (prism) triangulation of K x [0, layers].
+
+For each base cell (v_0 < ... < v_{m-1}) and each layer, emits the m cells
+S_j = {lo[v_0..v_j]} u {hi[v_j..v_{m-1}]}, with lo[x] = phi^l(x) + s*l and
+hi[x] = phi^{l+1}(x) + s*(l+1), where s is the per-layer vertex stride (one
+past the largest base id). The same rule in every dimension: m=3 gives
+tetrahedra over triangles, m=4 gives 4-simplices over tetrahedra, and so on —
+the single source replacing the separate 3d and 4d copies.
+
+Args:
+    cells: Base top cells as vertex-id tuples.
+    layers: Number of product layers (>= 1).
+    twist: Optional vertex permutation phi of the base (a dict {id: id}),
+        applied cumulatively per layer to glue the top end through a symmetry
+        (the mapping-torus twisted product). Identity when None; a missing key
+        maps to itself.
+
+Returns:
+    The prism's top cells as sorted vertex-id tuples, uniqued and sorted.)doc")
       // The returned Simplex handles point into this Spacetime's storage, so
       // each one must keep the Spacetime alive — otherwise
       // `Spacetime(...).getSimplices()` on a temporary frees the storage before

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -315,6 +315,120 @@ void Spacetime::build(int numSimplices) {
   return topology->build(this, numSimplices);
 }
 
+std::shared_ptr<Spacetime> Spacetime::fromCells(
+  int dimensions,
+  const std::vector<std::vector<std::uint64_t>> &cells,
+  double weight,
+  double phase,
+  const std::optional<std::vector<double>> &vertexTimes
+) {
+  auto metric = std::make_shared<Metric>(
+    true, Signature(dimensions, SignatureType::Lorentzian));
+  auto st = std::make_shared<Spacetime>(
+    metric, SpacetimeType::CDT, 1.0, 1.0, Foliation::PREFERRED, std::nullopt);
+
+  // One vertex per distinct id, created in ascending id order so the labels are
+  // deterministic. Under the tracked-metric rule each vertex carries its single
+  // time coordinate (arity one — never the length-2/3 vector getTime() rejects).
+  std::set<std::uint64_t> ids;
+  for (const auto &cell : cells)
+    for (auto v : cell) ids.insert(v);
+  std::unordered_map<std::uint64_t, VertexPtr> vmap;
+  vmap.reserve(ids.size());
+  for (auto id : ids) {
+    if (vertexTimes) {
+      if (id >= vertexTimes->size())
+        throw std::out_of_range(
+          "Spacetime::fromCells: vertexTimes too short to index vertex id "
+          + std::to_string(id));
+      vmap[id] = st->createVertex(id, {(*vertexTimes)[id]});
+    } else {
+      vmap[id] = st->createVertex(id);
+    }
+  }
+
+  // One top simplex per cell; createSimplex auto-wires the edges, assigning
+  // spacelike (+a) / timelike (-alpha*a) lengths from the vertex times under the
+  // tracked rule, or all-spacelike when the vertices are coordinate-free.
+  for (const auto &cell : cells) {
+    std::vector<std::uint64_t> sortedIds(cell.begin(), cell.end());
+    std::sort(sortedIds.begin(), sortedIds.end());
+    VertexPtrs verts;
+    verts.reserve(sortedIds.size());
+    for (auto v : sortedIds) verts.push_back(vmap[v]);
+    st->createSimplex(verts);
+  }
+
+  // Uniform Hermitian pin: overwrite every edge's geometry. Skipped under the
+  // tracked-metric rule, where the auto-wired causal lengths are the geometry.
+  if (!vertexTimes) {
+    for (const auto &edge : st->getEdgeList()->toVector()) {
+      edge->setSquaredLength(weight);
+      edge->setPhase(phase);
+    }
+  }
+  return st;
+}
+
+std::vector<std::vector<std::uint64_t>> Spacetime::prismCells(
+  const std::vector<std::vector<std::uint64_t>> &cells,
+  int layers,
+  const std::optional<std::unordered_map<std::uint64_t, std::uint64_t>> &twist
+) {
+  // Per-layer vertex stride: one past the largest base id. Each layer l offsets
+  // its vertices by stride*l, so the layers occupy disjoint id ranges.
+  std::uint64_t stride = 0;
+  for (const auto &cell : cells)
+    for (auto v : cell) stride = std::max(stride, v + 1);
+
+  // The base permutation phi (identity unless a twist is supplied), indexed by
+  // id. A missing twist key maps to itself.
+  std::vector<std::uint64_t> phi1(stride);
+  for (std::uint64_t v = 0; v < stride; ++v) {
+    phi1[v] = v;
+    if (twist) {
+      auto it = twist->find(v);
+      if (it != twist->end()) phi1[v] = it->second;
+    }
+  }
+
+  // phi[ell] = phi1 composed with itself ell times (phi[0] = identity), so the
+  // twist is applied cumulatively as the layers climb.
+  std::vector<std::vector<std::uint64_t>> phi;
+  phi.reserve(static_cast<std::size_t>(layers) + 1);
+  std::vector<std::uint64_t> ident(stride);
+  for (std::uint64_t v = 0; v < stride; ++v) ident[v] = v;
+  phi.push_back(std::move(ident));
+  for (int l = 0; l < layers; ++l) {
+    const auto &prev = phi.back();
+    std::vector<std::uint64_t> next(stride);
+    for (std::uint64_t v = 0; v < stride; ++v) next[v] = phi1[prev[v]];
+    phi.push_back(std::move(next));
+  }
+
+  std::set<std::vector<std::uint64_t>> out;
+  for (int ell = 0; ell < layers; ++ell) {
+    const auto &lo = phi[ell];
+    const auto &hi = phi[ell + 1];
+    const std::uint64_t loOff = stride * static_cast<std::uint64_t>(ell);
+    const std::uint64_t hiOff = stride * static_cast<std::uint64_t>(ell + 1);
+    for (const auto &cell : cells) {
+      std::vector<std::uint64_t> base(cell.begin(), cell.end());
+      std::sort(base.begin(), base.end());
+      const std::size_t m = base.size();
+      for (std::size_t j = 0; j < m; ++j) {
+        std::vector<std::uint64_t> s;
+        s.reserve(m + 1);
+        for (std::size_t i = 0; i <= j; ++i) s.push_back(lo[base[i]] + loOff);
+        for (std::size_t i = j; i < m; ++i) s.push_back(hi[base[i]] + hiOff);
+        std::sort(s.begin(), s.end());
+        out.insert(std::move(s));
+      }
+    }
+  }
+  return {out.begin(), out.end()};
+}
+
 // ========================================
 // Query Methods
 // ========================================

--- a/tests/cobordism/test_complex_builders_python.py
+++ b/tests/cobordism/test_complex_builders_python.py
@@ -1,0 +1,320 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The C++ complex builders: Spacetime.fromCells + Spacetime.prismCells (#288).
+
+The register/fill examples hand-rolled a "Signature(n) -> createVertex ->
+createSimplex(sorted) -> uniform pin" builder in a dozen files, plus a 3d copy
+and a 4d copy of the staircase prism rule. Both conventions now live once, as
+statics on Spacetime. These tests pin the factory against verbatim
+reimplementations of the pre-refactor hand-rolled logic, so any drift in the
+conventions (vertex labels, the uniform pin, the tracked-metric causal signs,
+the staircase) is caught -- and check the degree-generality the 3d/4d copies
+could not express (5d, for level 2).
+"""
+
+import unittest
+
+import tessera
+
+
+# --------------------------------------------------------------------------- #
+# Verbatim reimplementations of the pre-refactor hand-rolled builders, the
+# reference the factory must reproduce exactly.
+# --------------------------------------------------------------------------- #
+def _old_surface(faces, weight=1.0, phase=0.0):
+    """The pre-refactor _surface (2-complex, uniform Hermitian pin)."""
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {i: st.createVertex(i) for i in sorted({v for f in faces for v in f})}
+    for f in faces:
+        t = sorted(f)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]]])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(weight)
+        e.setPhase(phase)
+    return st
+
+
+def _old_bulk(cells, weight=1.0, phase=0.0):
+    """The pre-refactor _bulk (3-complex, uniform Hermitian pin)."""
+    sig = tessera.Signature(3, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {i: st.createVertex(i) for i in sorted({v for c in cells for v in c})}
+    for c in cells:
+        t = sorted(c)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]], vmap[t[3]]])
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(weight)
+        e.setPhase(phase)
+    return st
+
+
+def _old_layered_bulk(cells, stride=12):
+    """The pre-refactor _layered_time_bulk (tracked metric, time = id // stride)."""
+    sig = tessera.Signature(3, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {}
+    for i in sorted({v for c in cells for v in c}):
+        vmap[i] = st.createVertex(i, [float(i // stride)])
+    for c in cells:
+        t = sorted(c)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]], vmap[t[3]]])
+    return st
+
+
+def _old_prism(cells, layers=1, twist=None, stride=None):
+    """The pre-refactor staircase (the 3d _prism_cells / 4d _prism4_cells rule),
+    generalized over the base-cell arity. Base cells are taken sorted."""
+    cells = [tuple(sorted(c)) for c in cells]
+    if stride is None:
+        stride = max(v for c in cells for v in c) + 1
+    ident = {v: v for v in range(stride)}
+    twist = dict(twist) if twist else ident
+
+    def compose(g, h):
+        return {v: g[h[v]] for v in h}
+
+    phi = [ident]
+    for _ in range(layers):
+        phi.append(compose(twist, phi[-1]))
+    out = []
+    for ell in range(layers):
+        lo, hi = phi[ell], phi[ell + 1]
+        for base in cells:
+            m = len(base)
+            for j in range(m):
+                s = [lo[base[i]] + stride * ell for i in range(j + 1)]
+                s += [hi[base[i]] + stride * (ell + 1) for i in range(j, m)]
+                out.append(tuple(sorted(s)))
+    return sorted(set(out))
+
+
+def _snapshot(st):
+    """The geometry-bearing fingerprint of a complex: every edge keyed by its
+    sorted endpoints to (squared length, phase), and the sorted set of simplex
+    vertex tuples."""
+    edges = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        edges[(min(a, b), max(a, b))] = (round(e.getSquaredLength(), 12),
+                                         round(e.getPhase(), 12))
+    simplices = sorted(tuple(sorted(v.getId() for v in s.getVertices()))
+                       for s in st.getSimplices())
+    return edges, simplices
+
+
+def _vertices_by_id(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        for v in (e.getSource(), e.getTarget()):
+            out[v.getId()] = v
+    return out
+
+
+# An octahedron-style 6-vertex surface (sorted faces) and a 12-vertex triangle
+# base whose prism is a tet bulk (the shape of the real 3D layered fill).
+_OCTA = [tuple(sorted(f)) for f in
+         [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 1, 4),
+          (1, 2, 5), (2, 3, 5), (3, 4, 5), (1, 4, 5)]]
+_TRI12 = [tuple(sorted(t)) for t in
+          [(0, 1, 2), (3, 4, 5), (6, 7, 8), (9, 10, 11),
+           (0, 3, 6), (1, 4, 7), (2, 5, 8), (0, 9, 3),
+           (1, 10, 4), (2, 11, 5)]]
+# A 6-vertex tetrahedral 3-complex (the join-style seed) for the 4d prism.
+_TETS6 = [tuple(sorted(t)) for t in
+          [(0, 1, 2, 3), (1, 2, 3, 4), (2, 3, 4, 5), (0, 1, 4, 5)]]
+# An order-6 twist (a permutation of 0..5) for the twisted-prism checks.
+_TWIST6 = {0: 1, 1: 2, 2: 0, 3: 4, 4: 5, 5: 3}
+
+
+class TestPrismCells(unittest.TestCase):
+    """Spacetime.prismCells reproduces the staircase rule the register fills
+    carried as separate 3d and 4d copies, in every dimension."""
+
+    def test_reproduces_3d_staircase(self):
+        # Triangles -> tetrahedra, the _prism_cells rule. Identity + twisted,
+        # single + multi-layer.
+        for layers in (1, 2, 3):
+            for twist in (None, _TWIST6):
+                with self.subTest(layers=layers, twisted=twist is not None):
+                    got = [tuple(c) for c in tessera.Spacetime.prismCells(
+                        [list(f) for f in _OCTA], layers, twist)]
+                    want = _old_prism(_OCTA, layers, twist)
+                    self.assertEqual(got, want)
+
+    def test_reproduces_4d_staircase(self):
+        # Tetrahedra -> 4-simplices, the _prism4_cells rule (single layer, the
+        # only arity the 4d copy supported), identity + twisted.
+        for twist in (None, _TWIST6):
+            with self.subTest(twisted=twist is not None):
+                got = [tuple(c) for c in tessera.Spacetime.prismCells(
+                    [list(t) for t in _TETS6], 1, twist)]
+                want = _old_prism(_TETS6, 1, twist)
+                self.assertEqual(got, want)
+
+    def test_cell_arity_and_count(self):
+        # A base m-vertex cell yields m prism cells per layer, each on m+1
+        # vertices. The same rule at every dimension -- 5d included (the level-2
+        # case the 3d/4d copies could not reach).
+        for base, m in ((_OCTA, 3), (_TETS6, 4),
+                        ([tuple(range(5)), tuple(range(1, 6))], 5)):
+            with self.subTest(m=m):
+                layers = 2
+                cells = tessera.Spacetime.prismCells(
+                    [list(c) for c in base], layers, None)
+                self.assertTrue(all(len(c) == m + 1 for c in cells))
+                # Per layer, per base cell, exactly m staircase simplices (before
+                # the cross-cell dedup at shared walls) -- so the unique count is
+                # at most layers * |base| * m and positive.
+                self.assertGreater(len(cells), 0)
+                self.assertLessEqual(len(cells), layers * len(base) * m)
+
+    def test_twist_is_cumulative_across_layers(self):
+        # phi^2 over one transition equals phi over two transitions of phi:
+        # composing the twist into the layer offsets, not re-applying it raw.
+        twosq = {v: _TWIST6[_TWIST6[v]] for v in _TWIST6}
+        a = _old_prism(_OCTA, 2, _TWIST6)
+        b = [tuple(c) for c in tessera.Spacetime.prismCells(
+            [list(f) for f in _OCTA], 2, _TWIST6)]
+        self.assertEqual(b, a)
+        # the second layer's top end is glued through phi^2, by construction
+        self.assertEqual(twosq, {v: _TWIST6[_TWIST6[v]] for v in range(6)})
+
+    def test_identity_twist_matches_no_twist(self):
+        ident = {v: v for v in range(6)}
+        with_id = [tuple(c) for c in tessera.Spacetime.prismCells(
+            [list(f) for f in _OCTA], 2, ident)]
+        without = [tuple(c) for c in tessera.Spacetime.prismCells(
+            [list(f) for f in _OCTA], 2, None)]
+        self.assertEqual(with_id, without)
+
+
+class TestFromCellsUniformPin(unittest.TestCase):
+    """Spacetime.fromCells with no vertexTimes reproduces the uniform Hermitian
+    pin of _surface / _bulk / _bulk4 exactly."""
+
+    def test_surface_pin_matches(self):
+        for weight, phase in ((1.0, 0.0), (2.5, 0.3), (0.7, -1.2)):
+            with self.subTest(weight=weight, phase=phase):
+                got = _snapshot(tessera.Spacetime.fromCells(
+                    2, [list(f) for f in _OCTA], weight, phase))
+                want = _snapshot(_old_surface(_OCTA, weight, phase))
+                self.assertEqual(got, want)
+
+    def test_bulk_pin_matches(self):
+        for weight, phase in ((1.0, 0.0), (3.0, 0.5)):
+            with self.subTest(weight=weight, phase=phase):
+                got = _snapshot(tessera.Spacetime.fromCells(
+                    3, [list(c) for c in _TETS6], weight, phase))
+                want = _snapshot(_old_bulk(_TETS6, weight, phase))
+                self.assertEqual(got, want)
+
+    def test_every_edge_carries_the_pin(self):
+        st = tessera.Spacetime.fromCells(2, [list(f) for f in _OCTA], 1.7, -0.4)
+        edges, _ = _snapshot(st)
+        self.assertTrue(edges)
+        for sq, ph in edges.values():
+            self.assertAlmostEqual(sq, 1.7)
+            self.assertAlmostEqual(ph, -0.4)
+
+    def test_vertices_are_coordinate_free(self):
+        # The uniform-pin vertices carry no coordinates (getTime() == 0; the
+        # coordinate vector is absent), so the length-2/3 getTime() trap never
+        # arises.
+        st = tessera.Spacetime.fromCells(2, [list(f) for f in _OCTA])
+        for v in _vertices_by_id(st).values():
+            self.assertEqual(v.getTime(), 0.0)
+            with self.assertRaises(Exception):
+                v.getCoordinates()
+
+    def test_one_simplex_per_cell_distinct_vertices(self):
+        st = tessera.Spacetime.fromCells(3, [list(c) for c in _TETS6])
+        _, simplices = _snapshot(st)
+        self.assertEqual(simplices, sorted(tuple(c) for c in _TETS6))
+        ids = {v for c in _TETS6 for v in c}
+        self.assertEqual(st.getVertexCount(), len(ids))
+
+
+class TestFromCellsTrackedMetric(unittest.TestCase):
+    """Spacetime.fromCells with a per-vertex time vector reproduces the tracked
+    metric rule of _layered_time_bulk: spacelike intra-layer, timelike
+    inter-layer edges, no uniform re-pin."""
+
+    def _prism_and_times(self, layers, stride=12):
+        prism = tessera.Spacetime.prismCells(
+            [list(c) for c in _TRI12], layers, None)
+        n = max(v for c in prism for v in c) + 1
+        times = [float(i // stride) for i in range(n)]
+        return prism, times
+
+    def test_matches_old_layered_builder(self):
+        for layers in (1, 2, 3):
+            with self.subTest(layers=layers):
+                prism, times = self._prism_and_times(layers)
+                got = _snapshot(tessera.Spacetime.fromCells(
+                    3, prism, vertexTimes=times))
+                want = _snapshot(_old_layered_bulk([tuple(c) for c in prism]))
+                self.assertEqual(got, want)
+
+    def test_causal_edge_signs(self):
+        # Intra-layer (equal time) edges are spacelike (+a = +1); inter-layer
+        # (time difference one) edges are timelike (-alpha*a = -1).
+        prism, times = self._prism_and_times(2)
+        edges, _ = _snapshot(tessera.Spacetime.fromCells(
+            3, prism, vertexTimes=times))
+        intra = [(i, j) for (i, j) in edges if i // 12 == j // 12]
+        inter = [(i, j) for (i, j) in edges if i // 12 != j // 12]
+        self.assertTrue(intra and inter)
+        for ij in intra:
+            self.assertAlmostEqual(edges[ij][0], 1.0)
+        for ij in inter:
+            self.assertAlmostEqual(edges[ij][0], -1.0)
+
+    def test_tracked_vertices_carry_arity_one_time(self):
+        # The time coordinate is arity one -- {t} -- never the length-2/3 vector
+        # that makes Vertex.getTime() throw.
+        prism, times = self._prism_and_times(2)
+        st = tessera.Spacetime.fromCells(3, prism, vertexTimes=times)
+        for vid, v in _vertices_by_id(st).items():
+            self.assertEqual(list(v.getCoordinates()), [float(vid // 12)])
+            self.assertEqual(v.getTime(), float(vid // 12))
+
+    def test_weight_and_phase_ignored_when_tracked(self):
+        # Under the tracked rule the auto-wired causal lengths are the geometry;
+        # weight/phase do not overwrite them.
+        prism, times = self._prism_and_times(2)
+        pinned = tessera.Spacetime.fromCells(
+            3, prism, weight=99.0, phase=7.0, vertexTimes=times)
+        plain = tessera.Spacetime.fromCells(3, prism, vertexTimes=times)
+        self.assertEqual(_snapshot(pinned), _snapshot(plain))
+
+    def test_short_vertex_times_raises(self):
+        cells = [list(c) for c in _TETS6]  # ids up to 5
+        with self.assertRaises(Exception):
+            tessera.Spacetime.fromCells(3, cells, vertexTimes=[0.0, 0.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The "Signature(n) → createVertex → createSimplex(sorted) → uniform pin" complex builder was hand-rolled across the active register/fill examples (16 `createVertex` sites, 19 `setSquaredLength` sites, 23 `Signature` sites), and the degree-specific staircase prism rule had a 3d copy (`_prism_cells`) and a 4d copy (`_prism4_cells`). This PR moves both conventions into C++ as statics on `Spacetime`:

- **`Spacetime.fromCells(dim, cells, weight=1.0, phase=0.0, vertexTimes=None)`** — the cells-to-Spacetime factory. With no `vertexTimes` it reproduces the uniform Hermitian pin (every edge `squaredLength=weight`, `phase=phase`); with a per-vertex time vector it builds coordinate-carrying vertices and lets the tracked metric rule assign spacelike (intra-layer) vs. timelike (inter-layer) edges. The pin-vs-tracked choice is an explicit argument, not an artifact of construction order. Owns the coordinate-arity convention (arity-1 time coords, never the length-2/3 vectors that make `Vertex::getTime()` throw — the trap that bit during #281).
- **`Spacetime.prismCells(cells, layers=1, twist=None)`** — the dimension-generic staircase: for a base m-vertex cell `(v_0<…<v_{m-1})` and layer transition, the m simplices `S_j = {lo[v_0..v_j]} ∪ {hi[v_j..v_{m-1}]}`. Reproduces both the 3d and 4d copies exactly, and extends to 5d for level-2 with no new code. `twist` is applied cumulatively per layer (the mapping-torus glue).

Both are placed as statics on `Spacetime` ("next to the factory" per the issue; `ChainComplex` was the sanctioned alternative — flagging for review). The five active register/fill modules now delegate to the factory through their thin module-local wrappers (which keep only their seed defaults), so every hand-rolled builder body is gone while call sites are untouched.

## Test plan
- [ ] `tests/cobordism/test_complex_builders_python.py` — `fromCells`/`prismCells` reproduce the old hand-rolled builders exactly (vertex ids, edge set with squared lengths + phases, simplex set, twisted + multi-layer prisms, tracked-metric causal edge signs).
- [ ] The five migrated examples run green (`spectral_gate_realizability`, `l2_register_realizability`, `level1_fill_realizability`, `level1_stabilizer_law`, `level1_mediated_selection`).
- [ ] After merge: docs/site unaffected (no API removed).

Closes #288.
