### PR TITLE
fix(cobordism): CellsFill sign covector broken by the #291 rename

### DIFF
--- a/examples/cobordism/level1_value_reading.py
+++ b/examples/cobordism/level1_value_reading.py
@@ -155,6 +155,12 @@ class CellsFill:
     def __init__(self, cells, layers=1):
         self.circles0 = L1._hole_circles(0)
         self.circles1 = L1._hole_circles(12 * layers)
+        # the end register surfaces (the holed icosahedron at each end,
+        # shifted by 12*layers on the top) -- the faces _end_sign reads the
+        # induced-orientation charge covector off, mirroring Level1Fill
+        self.end_faces0 = [tuple(sorted(f)) for f in L1._W_FACES]
+        self.end_faces1 = [tuple(sorted(v + 12 * layers for v in f))
+                           for f in L1._W_FACES]
         self.reg_edges = [e for tri in (self.circles0 + self.circles1)
                           for e in BASE._cedges(tri)]
         self.eidx = {e: i for i, e in enumerate(self.reg_edges)}
@@ -178,8 +184,8 @@ class CellsFill:
             p1 = [self._period(h_reg[r], t) for t in self.circles1]
             rows.append(p0 + p1)
         self.P6 = np.array(rows).reshape(self.dim, 6)
-        self.sign0 = L1._reg_sign()
-        self.sign1 = L1._reg_sign()
+        self.sign0 = L1._end_sign(self.end_faces0, self.circles0)
+        self.sign1 = L1._end_sign(self.end_faces1, self.circles1)
 
     def _period(self, vec, tri):
         a, b, c = sorted(tri)


### PR DESCRIPTION
## Summary
#291's carried-register refactor renamed `_reg_sign()` → `_end_sign(faces, circles)` and updated `Level1Fill`, but missed `CellsFill` in `level1_value_reading.py` (#290), which still calls the removed `_reg_sign()`. That errors `test_level1_value_python.py` at import and **the entire `tests/cobordism` suite at collection** on `origin/main`. CI is build-only, so the green build hid it; the full-suite gate on the backreaction branch (#296) caught it.

Fix: give `CellsFill` the end register surfaces (holed icosahedron at each end, shifted by `12*layers` on the top — mirroring `Level1Fill`) and read the sign covector via `_end_sign`. Minimal; the #286-style fold of `CellsFill` into the C++ register stays the documented follow-up.

## Test plan
- [x] `test_level1_value_python.py` — 11 passed (was: import error)
- [ ] Full `tests/cobordism` suite collects + passes

Closes #297.