### PR TITLE
feat(cobordism): backreaction — the matter stress-energy sources the emergent dual

### DIFF
--- a/examples/cobordism/backreaction_emergent_dual.py
+++ b/examples/cobordism/backreaction_emergent_dual.py
@@ -1,0 +1,304 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Backreaction: matter sources the emergent dual on the merge substrate.
+
+The framework's two halves couple, in the only well-posed way: the carried
+state's stress-energy **shifts the action-selected, damping-regulated emergent
+dual**. We do NOT solve a discrete Einstein equation from scratch — the bulk
+is intrinsically curved (no flat vacuum), and the Lorentzian Regge action has
+a conformal mode that runs away. Instead, following the stationary-phase /
+Sorkin-damping selection (the merged `level1_stationary_phase` result): the
+emergent dual is the carrier the damped action concentrates on, and the matter
+re-ranks the carriers.
+
+The substrate is the **merge** cobordism (two co-incoming states on slice t,
+the bulk merging them to a single object at t+1; coordinate-free, the
+input→result edges timelike). The carriers are merges of varying bulk-step
+geometry — parametrized here by two scales: the **worldtube** timelike edges
+(those incident to the holonomy cycles, where the register lives) and the
+**bulk** timelike edges (the rest). Every carrier realizes the merge (the
+period residual is machine-zero — the carried space is topological), so the
+selection is driven purely by
+
+    A_kappa(W)  =  S_Regge(W)  +  kappa * E(W),
+
+the complex dual Lorentzian (Sorkin) action plus the coupling to the carried
+state's field energy E (the Riemannian register norm — the matter). The
+emergent dual is the damping-regulated selection
+
+    W*(kappa)  =  argmin_W  [ Re S_Regge(W) + kappa * E(W) + lambda * |Im S_Regge(W)| ],
+
+with |Im S| the boost damping (from the spacelike-hinge rapidities). The
+headline, physical and well-posed:
+
+  * **The matter regulates the conformal mode.** At kappa = 0 both Re S and
+    the damping |Im S| fall monotonically with the conformal scale — the
+    action alone runs the emergent dual to the largest geometry (the
+    conformal runaway; the damping does not pin it either). The matter is the
+    only term with an interior minimum, so it provides the **restoring force**
+    that makes the emergent dual finite — stress-energy sources the scale of
+    spacetime, rather than deflecting an already-finite one.
+  * **It sources the geometry where the charge lives.** The carried register
+    sits on the holonomy worldtubes, so E depends far more strongly on the
+    worldtube scale than the bulk scale; the matter pins the worldtube
+    direction of the emergent dual first and tightest — charge curves the
+    fill, near the charge.
+  * **Lorentzian and realizable throughout.** S is complex (Im S the
+    spacelike-hinge boosts); every carrier's period residual is machine-zero
+    (realizability is topological, independent of the metric).
+
+Run:
+    python examples/cobordism/backreaction_emergent_dual.py
+    python examples/cobordism/backreaction_emergent_dual.py --plot
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_HERE, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = _load("spectral_gate_realizability")
+MC = _load("merge_cobordism")
+np = BASE.np
+tessera = MC.tessera
+cob = tessera.cobordism
+
+LAM = 1.0                       # the boost-damping regulator weight
+GRID = np.linspace(0.5, 2.5, 9)  # carrier scales (worldtube x bulk)
+
+
+class EmergentDual:
+    """The merge substrate with a two-scale carrier family: the worldtube
+    timelike edges (incident to a holonomy cycle — where the register sits)
+    and the remaining bulk timelike edges. Each (s_wt, s_bulk) is a carrier
+    of the merge; the action and the matter energy are read off it."""
+
+    def __init__(self):
+        self.m = MC.MergeCobordism()
+        self.m.st.materializeFacets()
+        self.holes = [list(t) for t in self.m.hole_circles]
+        self.emap = {}
+        for e in self.m.st.getEdgeList().toVector():
+            a, b = e.getSource().getId(), e.getTarget().getId()
+            self.emap[(min(a, b), max(a, b))] = e
+        tl = [k for k in self.emap
+              if self.m._is_result(k[0]) != self.m._is_result(k[1])]
+        holev = {v for c in self.m.hole_circles for v in c}
+        self.wt = [k for k in tl if (k[0] in holev or k[1] in holev)]
+        self.bulk = [k for k in tl if k not in set(self.wt)]
+        self.set_scales(1.0, 1.0)
+        # a genuinely carried 9-period target (a register harmonic's own
+        # periods) — the realizability gate, machine-zero at every carrier
+        P = np.asarray(self.m.es.cyclePeriods(self.holes),
+                       dtype=complex).reshape(self.m.dim, 9)
+        self.target = P[0]
+
+    def set_scales(self, s_wt, s_bulk):
+        for k in self.wt:
+            self.emap[k].setSquaredLength(-float(s_wt))
+        for k in self.bulk:
+            self.emap[k].setSquaredLength(-float(s_bulk))
+        self.m.st.materializeFacets()
+        self.m.read_spectral()
+
+    def action(self):
+        return self.m.regge_action()                       # complex (Sorkin)
+
+    def energy(self):
+        w1 = np.asarray(cob.HodgeLaplacian(self.m.st).weights(1), dtype=float)
+        P = np.asarray(self.m.es.cyclePeriods(self.holes),
+                       dtype=complex).reshape(self.m.dim, 9)
+        c, *_ = np.linalg.lstsq(P.T, self.target, rcond=None)
+        h = c @ self.m.H
+        return float(np.real(np.vdot(h, w1 * h)))
+
+    def residual(self):
+        return float(self.m.es.residualForPeriods(
+            self.holes, [complex(z) for z in self.target]))
+
+    def scan(self, grid=GRID):
+        """The carrier landscape over (s_wt, s_bulk)."""
+        out = {}
+        for sw in grid:
+            for sb in grid:
+                self.set_scales(sw, sb)
+                S = self.action()
+                out[(round(float(sw), 3), round(float(sb), 3))] = {
+                    "ReS": S.real, "ImS": S.imag,
+                    "E": self.energy(), "residual": self.residual()}
+        return out
+
+    @staticmethod
+    def select(scan, kappa, lam=LAM):
+        """The emergent dual: argmin of the damping-regulated, matter-coupled
+        free energy over the carriers."""
+        best, bg = None, np.inf
+        for k, v in scan.items():
+            g = v["ReS"] + kappa * v["E"] + lam * abs(v["ImS"])
+            if g < bg:
+                bg, best = g, k
+        return best
+
+
+def _interior(grid):
+    return (grid[0], grid[-1])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--plot", action="store_true")
+    ap.add_argument("--out", default="/tmp/cobordism")
+    args = ap.parse_args()
+
+    checks = []
+
+    def check(label, passed):
+        checks.append((label, bool(passed)))
+        return bool(passed)
+
+    print("Backreaction: matter sources the emergent dual on the merge "
+          "substrate\n  (the stress-energy regulates the action's conformal "
+          "runaway and pins the\n  damping-selected emergent geometry — "
+          "shifting it with the coupling kappa)\n")
+    prog = BASE._progress()
+    prog.phase("scanning the carrier family")
+    ed = EmergentDual()
+    scan = ed.scan()
+    prog.finish(f"{len(scan)} carriers scored")
+
+    lo, hi = _interior(GRID)
+    res_max = max(v["residual"] for v in scan.values())
+    im_min = min(abs(v["ImS"]) for v in scan.values())
+    print(f"  carriers: {len(scan)} merges over (s_wt, s_bulk) in "
+          f"[{lo},{hi}]²; max period residual = {res_max:.1e} "
+          f"(realizable); min |Im S| = {im_min:.2f} (>0: Lorentzian).")
+    check("every carrier realizes the merge (period residual machine-zero — "
+          "realizability is topological)", res_max < 1e-9)
+    check("the action is complex on every carrier (Lorentzian — the "
+          "spacelike-hinge boosts)", im_min > 1e-6)
+
+    # -- the conformal runaway at kappa = 0 --------------------------------- #
+    w0 = EmergentDual.select(scan, 0.0)
+    on_edge = (w0[0] in (lo, hi)) or (w0[1] in (lo, hi))
+    print(f"\n  kappa = 0 (action + damping only): emergent dual at "
+          f"(s_wt, s_bulk) = {w0} — {'on the grid edge: the CONFORMAL RUNAWAY' if on_edge else 'interior'}.")
+    check("at kappa=0 the action+damping run the emergent dual to the edge "
+          "(the conformal mode is not pinned)", on_edge)
+
+    # -- the matter is the regulator (interior minimum, worldtube-dominated)  #
+    Emin = min(scan.values(), key=lambda v: v["E"])
+    wEmin = [k for k, v in scan.items() if v["E"] == Emin["E"]][0]
+    E_edge = min(v["E"] for k, v in scan.items()
+                 if k[0] in (lo, hi) or k[1] in (lo, hi))
+    e_int = wEmin[0] not in (lo, hi) and wEmin[1] not in (lo, hi)
+    print(f"  matter energy E: interior minimum at {wEmin} "
+          f"(E={Emin['E']:.5f}); E rises toward the edges "
+          f"(min edge E={E_edge:.5f}) — the restoring force.")
+    # worldtube-dominance: E varies more along s_wt than s_bulk
+    mid = GRID[len(GRID) // 2]
+    e_along_wt = [scan[(round(float(s), 3), round(float(mid), 3))]["E"] for s in GRID]
+    e_along_bulk = [scan[(round(float(mid), 3), round(float(s), 3))]["E"] for s in GRID]
+    span_wt = max(e_along_wt) - min(e_along_wt)
+    span_bulk = max(e_along_bulk) - min(e_along_bulk)
+    print(f"  matter sensitivity: ΔE along worldtube scale = {span_wt:.5f} vs "
+          f"along bulk scale = {span_bulk:.5f} "
+          f"(ratio {span_wt/max(span_bulk,1e-12):.1f}× — the charge lives on "
+          f"the worldtubes).")
+    check("the matter energy has an interior minimum (the regulator that "
+          "pins the runaway)", e_int)
+    check("the matter sources the worldtube direction far more than the bulk "
+          "(charge curves the fill near the charge)", span_wt > 3 * span_bulk)
+
+    # -- the emergent dual: pinned and shifted by the matter ---------------- #
+    print("\n  emergent dual W*(kappa) = argmin[Re S + kappa·E + "
+          f"{LAM}|Im S|]:")
+    traj = []
+    for kappa in (0.0, 100.0, 300.0, 600.0, 1200.0, 2500.0, 5000.0):
+        w = EmergentDual.select(scan, kappa)
+        traj.append((kappa, w))
+        edge = (w[0] in (lo, hi)) or (w[1] in (lo, hi))
+        print(f"      kappa={kappa:>6.0f}: (s_wt, s_bulk) = {w}"
+              f"{'  [edge: runaway]' if edge else '  [interior: matter-pinned]'}")
+    pinned = [k for k, w in traj if not ((w[0] in (lo, hi)) or (w[1] in (lo, hi)))]
+    moved = traj[-1][1] != traj[0][1]
+    check("a finite coupling pins the emergent dual to a finite interior "
+          "geometry (the matter regulates the conformal mode)", len(pinned) > 0)
+    check("the emergent dual shifts with kappa (the matter sources it)", moved)
+    # the pinned worldtube scale tracks the matter's preferred scale
+    final = traj[-1][1]
+    check("the matter-pinned emergent dual sits at the matter's preferred "
+          "worldtube scale", abs(final[0] - wEmin[0]) <= (GRID[1] - GRID[0]) + 1e-9)
+
+    if args.plot:
+        from backreaction_emergent_dual_plot import render
+        path = render(scan, traj, GRID, args.out)
+        print(f"\n  landscape + trajectory plot: {path}")
+
+    if not args.no_write:
+        os.makedirs(args.out, exist_ok=True)
+        with open(os.path.join(args.out, "backreaction_emergent_dual.json"),
+                  "w") as h:
+            json.dump({"scan": {f"{k[0]},{k[1]}": v for k, v in scan.items()},
+                       "trajectory": [(kp, list(w)) for kp, w in traj],
+                       "E_min_at": list(wEmin), "kappa0_at": list(w0),
+                       "span_wt": span_wt, "span_bulk": span_bulk}, h, indent=2)
+
+    ok = all(p for _l, p in checks)
+    if not ok:
+        print("\n  FAILED checks:")
+        for label, passed in checks:
+            if not passed:
+                print(f"      - {label}")
+    print("\n  Verdict: " + (
+        "SUPPORTED — backreaction on the merge substrate: every carrier "
+        "realizes the merge, the action is Lorentzian (complex), and the "
+        "matter stress-energy regulates the action's conformal runaway — "
+        "providing the restoring force that pins the damping-selected "
+        "emergent dual at a finite scale and shifts it with the coupling, "
+        "sourced most strongly on the holonomy worldtubes where the charge "
+        "lives. The stress-energy sources the scale of the emergent "
+        "spacetime."
+        if ok else
+        "NOT SUPPORTED — a claim failed; inspect the FAILED checks above."))
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/backreaction_emergent_dual_plot.py
+++ b/examples/cobordism/backreaction_emergent_dual_plot.py
@@ -1,0 +1,86 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Render of the backreaction selection (companion to
+``backreaction_emergent_dual.py``): the matter-energy landscape over the
+carrier family, with the emergent dual W*(kappa) tracking from the conformal
+runaway corner toward the matter's interior minimum as the coupling grows."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt          # noqa: E402
+
+
+def render(scan, traj, grid, outdir):
+    g = np.asarray(grid)
+    E = np.array([[scan[(round(float(sw), 3), round(float(sb), 3))]["E"]
+                   for sw in g] for sb in g])      # rows = s_bulk, cols = s_wt
+    ReS = np.array([[scan[(round(float(sw), 3), round(float(sb), 3))]["ReS"]
+                     for sw in g] for sb in g])
+
+    fig, (axE, axS) = plt.subplots(1, 2, figsize=(13.5, 5.4))
+    ext = (g[0], g[-1], g[0], g[-1])
+
+    # -- matter energy + the emergent-dual trajectory ----------------------- #
+    im = axE.imshow(E, origin="lower", extent=ext, aspect="auto",
+                    cmap="viridis")
+    fig.colorbar(im, ax=axE, label="matter energy E")
+    iEmin = np.unravel_index(np.argmin(E), E.shape)
+    axE.plot(g[iEmin[1]], g[iEmin[0]], "*", ms=18, mfc="#FFD700",
+             mec="black", mew=1.2, label="matter minimum")
+    ks = [k for k, _ in traj]
+    xs = [w[0] for _, w in traj]
+    ys = [w[1] for _, w in traj]
+    axE.plot(xs, ys, "-o", color="#D55E00", lw=2, ms=6, mec="white",
+             label=r"emergent dual $W^*(\kappa)$")
+    for (kp, w) in (traj[0], traj[-1]):
+        axE.annotate(rf"$\kappa={kp:.0f}$", (w[0], w[1]),
+                     textcoords="offset points", xytext=(6, 6),
+                     fontsize=8.5, color="#D55E00")
+    axE.set_xlabel("worldtube timelike scale  $s_{wt}$")
+    axE.set_ylabel("bulk timelike scale  $s_{bulk}$")
+    axE.set_title("matter regulates & sources the emergent dual\n"
+                  r"($\kappa=0$ at the conformal-runaway corner → pinned to the "
+                  r"matter minimum)", fontsize=10.5)
+    axE.legend(loc="lower left", fontsize=8.5, framealpha=0.9)
+
+    # -- the action (the runaway it regulates) ------------------------------ #
+    im2 = axS.imshow(ReS, origin="lower", extent=ext, aspect="auto",
+                     cmap="magma")
+    fig.colorbar(im2, ax=axS, label=r"Re $S_{\mathrm{Regge}}$")
+    axS.plot(xs, ys, "-o", color="#56B4E9", lw=2, ms=6, mec="white")
+    axS.set_xlabel("worldtube timelike scale  $s_{wt}$")
+    axS.set_ylabel("bulk timelike scale  $s_{bulk}$")
+    axS.set_title("Re $S$ falls monotonically toward the corner —\nthe "
+                  "conformal mode the matter must regulate", fontsize=10.5)
+
+    fig.suptitle("Backreaction on the merge substrate — the stress-energy "
+                 "sources the emergent dual", fontsize=12.5, fontweight="bold")
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
+    os.makedirs(outdir, exist_ok=True)
+    path = os.path.join(outdir, "backreaction_emergent_dual.png")
+    fig.savefig(path, dpi=130, facecolor="white")
+    return path

--- a/tests/cobordism/test_backreaction_emergent_dual_python.py
+++ b/tests/cobordism/test_backreaction_emergent_dual_python.py
@@ -1,0 +1,138 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Backreaction on the merge substrate
+(``examples/cobordism/backreaction_emergent_dual.py``).
+
+The carried state's stress-energy shifts the action-selected,
+damping-regulated emergent dual. These tests pin the well-posed picture:
+
+  1. **Realizable, Lorentzian carriers.** Every merge carrier in the family
+     realizes the merge (period residual machine-zero — realizability is
+     topological), and the dual Regge action is complex (Lorentzian, the
+     spacelike-hinge boosts).
+  2. **The conformal runaway.** With action + damping only (kappa=0) the
+     emergent dual sits on the grid edge — Re S and |Im S| fall monotonically
+     with the conformal scale, so neither pins it.
+  3. **The matter is the regulator.** The matter energy E has an interior
+     minimum (the restoring force), and it sources the worldtube scale far
+     more than the bulk scale (charge curves the fill near the charge).
+  4. **It pins and shifts the emergent dual.** A finite coupling pins the
+     emergent dual to a finite interior geometry, its worldtube scale tracks
+     the matter's preferred scale, and it shifts with kappa.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLE = os.path.join(_HERE, "..", "..", "examples", "cobordism",
+                        "backreaction_emergent_dual.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("backreaction_emergent_dual",
+                                                  _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["backreaction_emergent_dual"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BE = _load_example()
+# one shared scan (deterministic; the construction has no randomness)
+_ED = BE.EmergentDual()
+_SCAN = _ED.scan()
+_GRID = BE.GRID
+_LO, _HI = _GRID[0], _GRID[-1]
+
+
+def _is_edge(w):
+    return w[0] in (_LO, _HI) or w[1] in (_LO, _HI)
+
+
+class RealizableLorentzianTest(unittest.TestCase):
+    """1: every carrier is a realizable, Lorentzian merge."""
+
+    def test_all_carriers_realizable(self):
+        self.assertLess(max(v["residual"] for v in _SCAN.values()), 1e-9)
+
+    def test_action_is_complex_everywhere(self):
+        self.assertGreater(min(abs(v["ImS"]) for v in _SCAN.values()), 1e-6)
+
+
+class ConformalRunawayTest(unittest.TestCase):
+    """2: action + damping alone don't pin the scale."""
+
+    def test_kappa0_on_the_edge(self):
+        self.assertTrue(_is_edge(BE.EmergentDual.select(_SCAN, 0.0)))
+
+    def test_ReS_falls_with_scale(self):
+        # Re S more negative at the large-scale corner than the small one
+        big = _SCAN[(round(float(_HI), 3), round(float(_HI), 3))]["ReS"]
+        small = _SCAN[(round(float(_LO), 3), round(float(_LO), 3))]["ReS"]
+        self.assertLess(big, small)
+
+
+class MatterRegulatorTest(unittest.TestCase):
+    """3: the matter has an interior minimum and is worldtube-dominated."""
+
+    def test_energy_interior_minimum(self):
+        wmin = min(_SCAN, key=lambda k: _SCAN[k]["E"])
+        self.assertNotIn(wmin[0], (_LO, _HI))
+        self.assertNotIn(wmin[1], (_LO, _HI))
+
+    def test_matter_sources_worldtube_more_than_bulk(self):
+        mid = _GRID[len(_GRID) // 2]
+        e_wt = [_SCAN[(round(float(s), 3), round(float(mid), 3))]["E"] for s in _GRID]
+        e_bulk = [_SCAN[(round(float(mid), 3), round(float(s), 3))]["E"] for s in _GRID]
+        span_wt = max(e_wt) - min(e_wt)
+        span_bulk = max(e_bulk) - min(e_bulk)
+        self.assertGreater(span_wt, 3 * span_bulk)
+
+
+class EmergentDualShiftTest(unittest.TestCase):
+    """4: the matter pins and shifts the emergent dual."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.traj = [(k, BE.EmergentDual.select(_SCAN, k))
+                    for k in (0.0, 300.0, 2500.0, 5000.0)]
+
+    def test_finite_coupling_pins_an_interior_geometry(self):
+        self.assertTrue(any(not _is_edge(w) for _k, w in self.traj))
+
+    def test_emergent_dual_shifts_with_kappa(self):
+        self.assertNotEqual(self.traj[0][1], self.traj[-1][1])
+
+    def test_pinned_worldtube_scale_tracks_the_matter_minimum(self):
+        wEmin = min(_SCAN, key=lambda k: _SCAN[k]["E"])
+        final = self.traj[-1][1]
+        self.assertLessEqual(abs(final[0] - wEmin[0]),
+                             (_GRID[1] - _GRID[0]) + 1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Closes #293 — backreaction, in the well-posed form the physics delivers (confirmed with the user across the framing): **the carried state's stress-energy shifts the action-selected, damping-regulated emergent dual**, on the **merge** substrate.

Not a from-scratch discrete Einstein solve — the merge bulk is intrinsically curved (no flat vacuum to deflect from; the deficit residual can't be driven to zero in the causal box) and the Lorentzian Regge action has a conformal runaway, so a raw EOM solve is ill-posed. Instead, following the merged stationary-phase / Sorkin-damping selection (`level1_stationary_phase`): the emergent dual is the carrier the damped action concentrates on, **W\*(κ) = argmin[Re S_Regge + κE + λ|Im S_Regge|]**, and the matter's energy E re-ranks the carriers.

## Measured (81-carrier scan over worldtube × bulk timelike scales)
- **Realizable + Lorentzian throughout**: every carrier's period residual is machine-zero (realizability is topological), the dual action is complex (min |Im S| 36.7 — the spacelike-hinge boosts).
- **The conformal runaway**: at κ=0 both Re S and the damping |Im S| fall monotonically with the conformal scale → the emergent dual runs to the grid edge; neither pins it.
- **The matter is the regulator**: E has an interior minimum (the restoring force) and sources the **worldtube scale 7.4× more than the bulk** — charge curves the fill near the charge.
- **It sources the scale**: a finite κ pins the emergent dual to a finite interior geometry whose worldtube scale tracks the matter minimum, shifting with κ. *The stress-energy sources the scale of the emergent spacetime.*

A landscape+trajectory plot accompanies (`backreaction_emergent_dual_plot.render`).

## Test plan
- [x] `pytest tests/cobordism/test_backreaction_emergent_dual_python.py` — 9 passed
- [x] Full `tests/cobordism` suite: **689 passed, 1 skipped, 0 failures**
- [x] `backreaction_emergent_dual.py --plot` — verdict SUPPORTED

Closes #293.
