### PR TITLE
refactor(layout): replace pure-Python force-directed layouts with C++ ForceLayout

### DIFF
--- a/examples/curvature_slice_gif.py
+++ b/examples/curvature_slice_gif.py
@@ -28,7 +28,7 @@ from PIL import Image
 import tessera
 from tessera.utils.memory_monitor import MemoryMonitor
 from tessera.utils.plot import (build_spacetime, time_slices, spatial_subgraph,
-                              bfs_distances, save_gif)
+                              bfs_distances, save_gif, radial_layout_2d)
 from tessera.utils.progress import SingleTaskProgress
 
 
@@ -65,6 +65,12 @@ def _radial_layout_2d(verts, edges, center_vid, bfs_dist, *,
                       iters=200, prev_angles=None, seed=42):
     """Place vertices in 2D: radius = BFS distance, angles from force layout.
 
+    The radius-constrained angular solve runs in C++
+    (``tessera.ForceLayout.layout2D`` via :func:`radial_layout_2d`); this
+    wrapper keeps the per-frame angular-continuity bookkeeping in Python:
+    seeding initial angles from the previous frame and recording the solved
+    angles for the next one.
+
     Returns (pos_2d, vid_to_idx, edge_idx, angles_by_dist) where
     angles_by_dist maps BFS distance to list of (angle, vid) for seeding
     the next frame.
@@ -77,14 +83,17 @@ def _radial_layout_2d(verts, edges, center_vid, bfs_dist, *,
     # Group vertices by BFS distance
     max_d = max(bfs_dist.values()) if bfs_dist else 1
 
-    # Initialize: place on circles by BFS distance with angular spread
-    pos = np.zeros((n, 2))
+    # Initialize: place on circles by BFS distance with angular spread.
+    # Radius is pinned to the BFS distance; the center stays at the origin.
+    init_pos = np.zeros((n, 2))
+    target_radii = np.zeros(n)
     for v in verts:
         idx = vid_to_idx[v.getId()]
         d = bfs_dist.get(v.getId(), max_d + 1)
         if v.getId() == center_vid:
             continue
         r = float(d)
+        target_radii[idx] = r
         # Try to use previous frame's angular structure for stability
         if prev_angles and d in prev_angles and prev_angles[d]:
             # Pick the angle closest to a uniform distribution
@@ -96,7 +105,7 @@ def _radial_layout_2d(verts, edges, center_vid, bfs_dist, *,
             angle = base_angle + 2 * math.pi * used / max(n_at_d, 1)
         else:
             angle = rng.uniform(0, 2 * math.pi)
-        pos[idx] = [r * math.cos(angle), r * math.sin(angle)]
+        init_pos[idx] = [r * math.cos(angle), r * math.sin(angle)]
 
     # Build edge index
     edge_idx = []
@@ -106,61 +115,9 @@ def _radial_layout_2d(verts, edges, center_vid, bfs_dist, *,
         if si is not None and ti is not None:
             edge_idx.append((si, ti))
 
-    # Force-directed refinement (angular only — preserve radii)
-    step = 0.3
-    eps = 1e-6
-    for _ in range(iters):
-        forces = np.zeros_like(pos)
-
-        # Spring forces along edges
-        for si, ti in edge_idx:
-            d = pos[ti] - pos[si]
-            dist = max(np.linalg.norm(d), eps)
-            f = 0.02 * (dist - 1.0) * d / dist
-            forces[si] += f
-            forces[ti] -= f
-
-        # Repulsion between vertices at the same BFS distance
-        cap = min(n, 200)
-        for a in range(cap):
-            for b in range(a + 1, cap):
-                d = pos[a] - pos[b]
-                d2 = np.dot(d, d) + eps
-                f = 0.3 / d2 * d / math.sqrt(d2)
-                forces[a] += f
-                forces[b] -= f
-
-        # Pin center
-        forces[center_idx] = 0.0
-
-        # Project forces to preserve radii (tangential only)
-        for i in range(n):
-            if i == center_idx:
-                continue
-            r = np.linalg.norm(pos[i])
-            if r < eps:
-                continue
-            radial = pos[i] / r
-            # Remove radial component of force
-            f_radial = np.dot(forces[i], radial)
-            forces[i] -= f_radial * radial
-
-        norms = np.linalg.norm(forces, axis=1, keepdims=True)
-        norms = np.maximum(norms, eps)
-        forces = np.where(norms > step, forces / norms * step, forces)
-        pos += forces
-
-        # Re-snap to correct radii
-        for i in range(n):
-            if i == center_idx:
-                continue
-            vid = verts[i].getId()
-            target_r = float(bfs_dist.get(vid, max_d + 1))
-            r = np.linalg.norm(pos[i])
-            if r > eps:
-                pos[i] = pos[i] / r * target_r
-
-        step *= 0.995
+    # Radius-constrained, tangential-only angular solve (C++).
+    pos = radial_layout_2d(n, edge_idx, target_radii, center_idx=center_idx,
+                           init_pos=init_pos, iters=iters, seed=seed)
 
     # Record angles for next frame
     angles_by_dist = {}

--- a/examples/wilson_loops.py
+++ b/examples/wilson_loops.py
@@ -12,7 +12,6 @@ Usage:
 """
 import argparse
 import math
-from collections import defaultdict, deque
 
 import numpy as np
 import matplotlib
@@ -23,68 +22,8 @@ from PIL import Image
 
 import tessera
 from tessera.utils.memory_monitor import MemoryMonitor
+from tessera.utils.plot import force_layout_3d
 from tessera.utils.progress import SingleTaskProgress
-
-
-# =========================================================================
-# Layout helpers (adapted from curvature_slice_gif.py)
-# =========================================================================
-
-def _slice_subgraph(st, t):
-    verts = [v for v in st.getVertexList().toVector()
-             if round(v.getTime()) == t]
-    vid_set = {v.getId() for v in verts}
-    edges = []
-    seen = set()
-    for v in verts:
-        for e in v.getEdges():
-            fp = id(e)
-            if fp in seen:
-                continue
-            seen.add(fp)
-            s, t_ = e.getSource().getId(), e.getTarget().getId()
-            if s in vid_set and t_ in vid_set and e.getSquaredLength() > 0:
-                edges.append(e)
-    return verts, edges
-
-
-def _force_layout_3d(verts, edges, *, iters=200, rng=None):
-    if rng is None:
-        rng = np.random.default_rng(42)
-    n = len(verts)
-    vid_to_idx = {v.getId(): i for i, v in enumerate(verts)}
-    pos = rng.standard_normal((n, 3)) * 0.5
-
-    edge_idx = []
-    for e in edges:
-        si = vid_to_idx.get(e.getSource().getId())
-        ti = vid_to_idx.get(e.getTarget().getId())
-        if si is not None and ti is not None:
-            edge_idx.append((si, ti))
-
-    step = 0.5
-    for _ in range(iters):
-        forces = np.zeros_like(pos)
-        for si, ti in edge_idx:
-            d = pos[ti] - pos[si]
-            dist = max(np.linalg.norm(d), 1e-6)
-            f = 0.01 * (dist - 1.0) * d / dist
-            forces[si] += f
-            forces[ti] -= f
-        cap = min(n, 200)
-        for a in range(cap):
-            for b in range(a + 1, cap):
-                d = pos[a] - pos[b]
-                d2 = np.dot(d, d) + 1e-6
-                f = 0.5 / d2 * d / math.sqrt(d2)
-                forces[a] += f
-                forces[b] -= f
-        norms = np.linalg.norm(forces, axis=1, keepdims=True)
-        norms = np.maximum(norms, 1e-6)
-        forces = np.where(norms > step, forces / norms * step, forces)
-        pos += forces
-        step *= 0.995
-    return pos, vid_to_idx, edge_idx
 
 
 # =========================================================================
@@ -136,37 +75,6 @@ def _build_dual_complex(st):
     edge_list = list(dual_edges.keys())
     edge_types = [dual_edges[e] for e in edge_list]
     return key_to_idx, key_list, edge_list, edge_types, all_simplices
-
-
-def _dual_complex_layout(key_list, dual_edges, n, *, iters=300, rng=None):
-    """Force-directed layout of the full dual complex."""
-    if rng is None:
-        rng = np.random.default_rng(42)
-
-    pos = rng.standard_normal((n, 3)) * 1.0
-    step = 0.5
-    for _ in range(iters):
-        forces = np.zeros_like(pos)
-        for a, b in dual_edges:
-            d = pos[b] - pos[a]
-            dist = max(np.linalg.norm(d), 1e-6)
-            f = 0.05 * (dist - 1.0) * d / dist
-            forces[a] += f
-            forces[b] -= f
-        cap = min(n, 300)
-        for a in range(cap):
-            for b in range(a + 1, cap):
-                d = pos[a] - pos[b]
-                d2 = np.dot(d, d) + 1e-6
-                f = 0.3 / d2 * d / math.sqrt(d2)
-                forces[a] += f
-                forces[b] -= f
-        norms = np.linalg.norm(forces, axis=1, keepdims=True)
-        norms = np.maximum(norms, 1e-6)
-        forces = np.where(norms > step, forces / norms * step, forces)
-        pos += forces
-        step *= 0.995
-    return pos
 
 
 def _loop_indices(loop, key_to_idx):
@@ -380,7 +288,9 @@ def main():
     # Build full dual-complex layout (shared across all loop types)
     prog.phase("layouting", extra="dual complex")
     key_to_idx, key_list, dual_edges, edge_types, _ = _build_dual_complex(st)
-    dual_pos = _dual_complex_layout(key_list, dual_edges, len(key_list))
+    dual_pos = force_layout_3d(
+        len(key_list), dual_edges,
+        spring_k=0.05, repulsion_k=0.3, repulsion_cap=300, iters=300)
 
     # Render GIF: for each loop type, show rotating views
     prog.phase("rendering", extra=args.save)

--- a/include/ForceLayout.h
+++ b/include/ForceLayout.h
@@ -6,36 +6,97 @@
 
 namespace tessera {
 
-/// Spring-electrical force-directed layout in 3D.
+/// Fruchterman-Reingold spring-electrical graph layout.
 ///
-/// Places \a n nodes in 3D space using Fruchterman-Reingold-style
-/// spring attraction along edges and Coulomb repulsion between all
-/// node pairs.  Returns a flat row-major vector of size \a n * 3
-/// containing the (x, y, z) positions.
-///
-/// @param n           Number of nodes
-/// @param edges       Index pairs (i, j) defining graph edges
-/// @param centerIdx   If >= 0, pin this node at the origin
-/// @param initPos     Initial positions (flat, n*3).  Random if empty.
-/// @param restLengths Per-edge rest lengths (unit if empty)
-/// @param springK     Spring constant for edge attraction
-/// @param repulsionK  Coulomb constant for node repulsion
-/// @param iters       Number of iterations
-/// @param cooling     Multiplicative step-size decay per iteration
-/// @param repulsionCap Max nodes for all-pairs repulsion (limits O(n^2))
-/// @param seed        Random seed for reproducible layouts
-/// @return Flat row-major vector of size n*3 with (x, y, z) positions
-[[nodiscard]] std::vector<double> forceLayout3D(
-    int n,
-    const std::vector<std::pair<int, int>> &edges,
-    int centerIdx = -1,
-    const std::vector<double> &initPos = {},
-    const std::vector<double> &restLengths = {},
-    double springK = 0.01,
-    double repulsionK = 0.5,
-    int iters = 300,
-    double cooling = 0.995,
-    int repulsionCap = 200,
-    int seed = 42);
+/// Static-method utility class: spring attraction along edges plus Coulomb
+/// repulsion between node pairs, with multiplicative step cooling and an
+/// O(n^2)-repulsion cap for large graphs.
+class ForceLayout {
+public:
+    /// Spring-electrical force-directed layout in 3D.
+    ///
+    /// Places \a n nodes in 3D space using spring attraction along edges
+    /// and Coulomb repulsion between node pairs.  Returns a flat row-major
+    /// vector of size \a n * 3 containing the (x, y, z) positions.
+    ///
+    /// @param n           Number of nodes
+    /// @param edges       Index pairs (i, j) defining graph edges
+    /// @param centerIdx   If >= 0, pin this node at the origin
+    /// @param initPos     Initial positions (flat, n*3).  Random if empty.
+    /// @param restLengths Per-edge rest lengths (unit if empty)
+    /// @param springK     Spring constant for edge attraction
+    /// @param repulsionK  Coulomb constant for node repulsion
+    /// @param iters       Number of iterations
+    /// @param cooling     Multiplicative step-size decay per iteration
+    /// @param repulsionCap Max nodes for all-pairs repulsion (limits O(n^2))
+    /// @param seed        Random seed for reproducible layouts
+    /// @return Flat row-major vector of size n*3 with (x, y, z) positions
+    [[nodiscard]] static std::vector<double> layout3D(
+        int n,
+        const std::vector<std::pair<int, int>> &edges,
+        int centerIdx = -1,
+        const std::vector<double> &initPos = {},
+        const std::vector<double> &restLengths = {},
+        double springK = 0.01,
+        double repulsionK = 0.5,
+        int iters = 300,
+        double cooling = 0.995,
+        int repulsionCap = 200,
+        int seed = 42);
+
+    /// Spring-electrical force-directed layout in 2D.
+    ///
+    /// Backs both the per-time-slice spacetime render layout and the radial
+    /// curvature-slice layout via two optional constraints:
+    ///
+    ///   * \a targetRadii (length n) — radius-constrained mode.  Each node's
+    ///     distance from the origin is pinned to \a targetRadii[i] and only
+    ///     the angular coordinate is solved: forces are projected tangentially
+    ///     and radii re-snapped every iteration, so nodes slide along circles.
+    ///   * \a groups (length n) — group-scoped repulsion.  Coulomb repulsion
+    ///     runs only between nodes sharing a group id (e.g. one time slice);
+    ///     when empty, repulsion is global (capped).
+    ///
+    /// The two are independent and may be combined.  The \a centerIdx node is
+    /// pinned at the origin.  Returns a flat row-major vector of size
+    /// \a n * 2 with the (x, y) positions.
+    ///
+    /// @param n           Number of nodes
+    /// @param edges       Index pairs (i, j) defining graph edges
+    /// @param targetRadii Per-node pinned radius (length n enables radial mode)
+    /// @param groups      Per-node group id (length n scopes repulsion)
+    /// @param centerIdx   If >= 0, pin this node at the origin
+    /// @param initPos     Initial positions (flat, n*2).  Random if empty.
+    /// @param restLengths Per-edge rest lengths (unit if empty)
+    /// @param springK     Spring constant for edge attraction
+    /// @param repulsionK  Coulomb constant for node repulsion
+    /// @param iters       Number of iterations
+    /// @param cooling     Multiplicative step-size decay per iteration
+    /// @param repulsionCap Max nodes per repulsion group (limits O(n^2))
+    /// @param initialStep Initial per-iteration max displacement
+    /// @param seed        Random seed for reproducible layouts
+    /// @return Flat row-major vector of size n*2 with (x, y) positions
+    [[nodiscard]] static std::vector<double> layout2D(
+        int n,
+        const std::vector<std::pair<int, int>> &edges,
+        const std::vector<double> &targetRadii = {},
+        const std::vector<int> &groups = {},
+        int centerIdx = -1,
+        const std::vector<double> &initPos = {},
+        const std::vector<double> &restLengths = {},
+        double springK = 0.02,
+        double repulsionK = 0.3,
+        int iters = 200,
+        double cooling = 0.995,
+        int repulsionCap = 200,
+        double initialStep = 0.5,
+        int seed = 42);
+
+private:
+    /// Accumulate the pairwise Coulomb repulsion between 2D nodes a and b.
+    static void repel2D(std::vector<double> &pos,
+                        std::vector<double> &forces,
+                        int a, int b, double repulsionK, double eps);
+};
 
 } // namespace tessera

--- a/src/ForceLayout.cpp
+++ b/src/ForceLayout.cpp
@@ -4,10 +4,15 @@
 #include <algorithm>
 #include <cmath>
 #include <random>
+#include <unordered_map>
 
 namespace tessera {
 
-std::vector<double> forceLayout3D(
+namespace {
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+} // namespace
+
+std::vector<double> ForceLayout::layout3D(
     int n,
     const std::vector<std::pair<int, int>> &edges,
     int centerIdx,
@@ -102,6 +107,184 @@ std::vector<double> forceLayout3D(
     }
 
     return pos;
+}
+
+std::vector<double> ForceLayout::layout2D(
+    int n,
+    const std::vector<std::pair<int, int>> &edges,
+    const std::vector<double> &targetRadii,
+    const std::vector<int> &groups,
+    int centerIdx,
+    const std::vector<double> &initPos,
+    const std::vector<double> &restLengths,
+    double springK,
+    double repulsionK,
+    int iters,
+    double cooling,
+    int repulsionCap,
+    double initialStep,
+    int seed) {
+
+    constexpr double eps = 1e-6;
+    const bool radial  = (static_cast<int>(targetRadii.size()) == n);
+    const bool grouped = (static_cast<int>(groups.size()) == n);
+
+    // Initialize 2D positions
+    std::vector<double> pos(n * 2, 0.0);
+    if (!initPos.empty() && static_cast<int>(initPos.size()) == n * 2) {
+        pos = initPos;
+    } else {
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<double> angle(0.0, kTwoPi);
+        std::normal_distribution<double> normal(0.0, 0.5);
+        for (int i = 0; i < n; ++i) {
+            if (radial) {
+                double r = (i == centerIdx) ? 0.0 : targetRadii[i];
+                double a = angle(rng);
+                pos[i * 2]     = r * std::cos(a);
+                pos[i * 2 + 1] = r * std::sin(a);
+            } else {
+                pos[i * 2]     = normal(rng);
+                pos[i * 2 + 1] = normal(rng);
+            }
+        }
+    }
+
+    // Pinned radii for the radius-constrained mode.
+    std::vector<double> radii;
+    if (radial) {
+        radii = targetRadii;
+        if (centerIdx >= 0 && centerIdx < n)
+            radii[centerIdx] = 0.0;
+    }
+
+    // Bucket nodes by group so repulsion can run intra-group only.
+    std::vector<std::vector<int>> buckets;
+    if (grouped) {
+        std::unordered_map<int, int> groupToBucket;
+        for (int i = 0; i < n; ++i) {
+            auto it = groupToBucket.find(groups[i]);
+            if (it == groupToBucket.end()) {
+                groupToBucket.emplace(groups[i],
+                                      static_cast<int>(buckets.size()));
+                buckets.emplace_back();
+                buckets.back().push_back(i);
+            } else {
+                buckets[it->second].push_back(i);
+            }
+        }
+    }
+
+    double step = initialStep;
+    std::vector<double> forces(n * 2, 0.0);
+
+    for (int iter = 0; iter < iters; ++iter) {
+        std::fill(forces.begin(), forces.end(), 0.0);
+
+        // Spring forces along edges
+        for (std::size_t ei = 0; ei < edges.size(); ++ei) {
+            int a = edges[ei].first;
+            int b = edges[ei].second;
+            double dx = pos[b * 2]     - pos[a * 2];
+            double dy = pos[b * 2 + 1] - pos[a * 2 + 1];
+            double dist = std::sqrt(dx * dx + dy * dy);
+            dist = std::max(dist, eps);
+            double rl = (!restLengths.empty()) ? restLengths[ei] : 1.0;
+            double f = springK * (dist - rl) / dist;
+            forces[a * 2]     += f * dx;
+            forces[a * 2 + 1] += f * dy;
+            forces[b * 2]     -= f * dx;
+            forces[b * 2 + 1] -= f * dy;
+        }
+
+        // Coulomb repulsion: within each group if grouped, else global.
+        if (grouped) {
+            for (const auto &bucket : buckets) {
+                int m = std::min(static_cast<int>(bucket.size()), repulsionCap);
+                for (int ia = 0; ia < m; ++ia) {
+                    for (int ib = ia + 1; ib < m; ++ib) {
+                        repel2D(pos, forces, bucket[ia], bucket[ib],
+                                repulsionK, eps);
+                    }
+                }
+            }
+        } else {
+            int cap = std::min(n, repulsionCap);
+            for (int a = 0; a < cap; ++a)
+                for (int b = a + 1; b < cap; ++b)
+                    repel2D(pos, forces, a, b, repulsionK, eps);
+        }
+
+        // Pin center node
+        if (centerIdx >= 0 && centerIdx < n) {
+            forces[centerIdx * 2]     = 0.0;
+            forces[centerIdx * 2 + 1] = 0.0;
+        }
+
+        // Radius constraint: project out radial force so nodes move only
+        // tangentially (keeps each node on its target circle).
+        if (radial) {
+            for (int i = 0; i < n; ++i) {
+                if (i == centerIdx)
+                    continue;
+                double r = std::sqrt(pos[i * 2] * pos[i * 2] +
+                                     pos[i * 2 + 1] * pos[i * 2 + 1]);
+                if (r < eps)
+                    continue;
+                double rx = pos[i * 2] / r;
+                double ry = pos[i * 2 + 1] / r;
+                double fr = forces[i * 2] * rx + forces[i * 2 + 1] * ry;
+                forces[i * 2]     -= fr * rx;
+                forces[i * 2 + 1] -= fr * ry;
+            }
+        }
+
+        // Clamp and apply forces
+        for (int i = 0; i < n; ++i) {
+            double fx = forces[i * 2];
+            double fy = forces[i * 2 + 1];
+            double mag = std::sqrt(fx * fx + fy * fy);
+            if (mag > step) {
+                double s = step / mag;
+                fx *= s; fy *= s;
+            }
+            pos[i * 2]     += fx;
+            pos[i * 2 + 1] += fy;
+        }
+
+        // Re-snap to the pinned radius after moving (radius-constrained mode).
+        if (radial) {
+            for (int i = 0; i < n; ++i) {
+                if (i == centerIdx)
+                    continue;
+                double r = std::sqrt(pos[i * 2] * pos[i * 2] +
+                                     pos[i * 2 + 1] * pos[i * 2 + 1]);
+                if (r > eps) {
+                    double s = radii[i] / r;
+                    pos[i * 2]     *= s;
+                    pos[i * 2 + 1] *= s;
+                }
+            }
+        }
+
+        step *= cooling;
+    }
+
+    return pos;
+}
+
+void ForceLayout::repel2D(std::vector<double> &pos,
+                          std::vector<double> &forces,
+                          int a, int b, double repulsionK, double eps) {
+    double dx = pos[a * 2]     - pos[b * 2];
+    double dy = pos[a * 2 + 1] - pos[b * 2 + 1];
+    double d2 = dx * dx + dy * dy + eps;
+    double dist = std::sqrt(d2);
+    double f = repulsionK / d2 / dist;
+    forces[a * 2]     += f * dx;
+    forces[a * 2 + 1] += f * dy;
+    forces[b * 2]     -= f * dx;
+    forces[b * 2 + 1] -= f * dy;
 }
 
 } // namespace tessera

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,6 +1,7 @@
 // MIT License -- Copyright (c) 2025 Andrew Kelleher
 #include "Renderer.h"
 
+#include "ForceLayout.h"
 #include "spacetime/Spacetime.h"
 #include "mesh/Vertex.h"
 #include "mesh/Edge.h"
@@ -480,60 +481,32 @@ LayoutData computeLayout(const Spacetime &st, int maxIters) {
     else if (N > 5000) iters = std::min(iters, 50);
     else if (N > 1000) iters = std::min(iters, 200);
 
-    constexpr double springK = 0.01;
-    constexpr double repulsionK = 0.5;
-    constexpr double restLength = 1.0;
-    constexpr double eps = 1e-6;
-    constexpr double cooling = 0.995;
-    constexpr std::size_t repulsionCap = 200;
-    double step = 0.5;
+    // Solve the spatial (x, z) coordinates with the shared 2D layout engine:
+    // each vertex's time slice is a repulsion group, so nodes spread only
+    // against others in the same slice; the y/time coordinate stays fixed.
+    std::vector<std::pair<int, int>> layoutEdges;
+    layoutEdges.reserve(layout.edges.size());
+    for (const auto &e : layout.edges)
+        layoutEdges.emplace_back(static_cast<int>(e.src),
+                                 static_cast<int>(e.tgt));
 
-    std::vector<Vec3> forces(N);
+    std::vector<int> groups(N);
+    std::vector<double> initPos(N * 2);
+    for (std::size_t i = 0; i < N; ++i) {
+        groups[i] = static_cast<int>(std::round(times[i]));
+        initPos[i * 2]     = layout.pos[i].x;
+        initPos[i * 2 + 1] = layout.pos[i].z;
+    }
 
-    for (int iter = 0; iter < iters; ++iter) {
-        for (auto &f : forces) f = {0, 0, 0};
+    auto solved = ForceLayout::layout2D(
+        static_cast<int>(N), layoutEdges, /*targetRadii=*/{}, groups,
+        /*centerIdx=*/-1, initPos, /*restLengths=*/{},
+        /*springK=*/0.01, /*repulsionK=*/0.5, iters, /*cooling=*/0.995,
+        /*repulsionCap=*/200, /*initialStep=*/0.5);
 
-        // Spring forces (edges): attract toward rest length
-        for (const auto &e : layout.edges) {
-            Vec3 d = layout.pos[e.tgt] - layout.pos[e.src];
-            double dx = d.x, dz = d.z;
-            double dist = std::sqrt(dx * dx + dz * dz + eps);
-            double f = springK * (dist - restLength);
-            Vec3 force = {f * dx / dist, 0, f * dz / dist};
-            forces[e.src] += force;
-            forces[e.tgt] += force * (-1.0);
-        }
-
-        // Repulsion within same time slice
-        for (auto &[t, indices] : slices) {
-            auto n = std::min(indices.size(), repulsionCap);
-            for (std::size_t a = 0; a < n; ++a) {
-                for (std::size_t b = a + 1; b < n; ++b) {
-                    auto i = indices[a], j = indices[b];
-                    double dx = layout.pos[i].x - layout.pos[j].x;
-                    double dz = layout.pos[i].z - layout.pos[j].z;
-                    double dist2 = dx * dx + dz * dz + eps;
-                    double dist = std::sqrt(dist2);
-                    double f = repulsionK / dist2;
-                    Vec3 force = {f * dx / dist, 0, f * dz / dist};
-                    forces[i] += force;
-                    forces[j] += force * (-1.0);
-                }
-            }
-        }
-
-        // Apply forces (x, z only; y/time stays fixed)
-        for (std::size_t i = 0; i < N; ++i) {
-            double fx = forces[i].x, fz = forces[i].z;
-            double mag = std::sqrt(fx * fx + fz * fz + eps);
-            if (mag > step) {
-                fx = fx / mag * step;
-                fz = fz / mag * step;
-            }
-            layout.pos[i].x += fx;
-            layout.pos[i].z += fz;
-        }
-        step *= cooling;
+    for (std::size_t i = 0; i < N; ++i) {
+        layout.pos[i].x = solved[i * 2];
+        layout.pos[i].z = solved[i * 2 + 1];
     }
 
     return layout;

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -180,7 +180,9 @@ Returns a list of vertices, one per time slice, ordered by time.)doc")
   // ========================================
   // ForceLayout
   // ========================================
-  m.def("forceLayout3D", &forceLayout3D,
+  py::class_<ForceLayout>(m, "ForceLayout",
+        "Fruchterman-Reingold spring-electrical graph layout.")
+      .def_static("layout3D", &ForceLayout::layout3D,
         py::arg("n"),
         py::arg("edges"),
         py::arg("centerIdx") = -1,
@@ -208,6 +210,47 @@ Args:
     iters: Number of iterations (default 300).
     cooling: Step-size decay per iteration (default 0.995).
     repulsionCap: Max nodes for O(n^2) repulsion (default 200).
+    seed: Random seed (default 42).)doc")
+      .def_static("layout2D", &ForceLayout::layout2D,
+        py::arg("n"),
+        py::arg("edges"),
+        py::arg("targetRadii") = std::vector<double>{},
+        py::arg("groups") = std::vector<int>{},
+        py::arg("centerIdx") = -1,
+        py::arg("initPos") = std::vector<double>{},
+        py::arg("restLengths") = std::vector<double>{},
+        py::arg("springK") = 0.02,
+        py::arg("repulsionK") = 0.3,
+        py::arg("iters") = 200,
+        py::arg("cooling") = 0.995,
+        py::arg("repulsionCap") = 200,
+        py::arg("initialStep") = 0.5,
+        py::arg("seed") = 42,
+        R"doc(Spring-electrical force-directed layout in 2D.
+
+Returns a flat list of n*2 floats (row-major x,y positions).
+Reshape to (n, 2) with numpy: ``np.array(result).reshape(n, 2)``.
+
+Two optional constraints (independent, may be combined):
+  * targetRadii (length n) pins each node's radius — only the angle is
+    solved (tangential forces, radii re-snapped each step).
+  * groups (length n) scopes repulsion to nodes sharing a group id;
+    when empty, repulsion is global (capped).
+
+Args:
+    n: Number of nodes.
+    edges: List of (i, j) index pairs.
+    targetRadii: Per-node pinned radius (length n enables radial mode).
+    groups: Per-node group id (length n scopes repulsion).
+    centerIdx: Pin this node at the origin (-1 to disable).
+    initPos: Flat initial positions (length n*2). Random if empty.
+    restLengths: Per-edge rest lengths. Unit if empty.
+    springK: Spring constant (default 0.02).
+    repulsionK: Coulomb constant (default 0.3).
+    iters: Number of iterations (default 200).
+    cooling: Step-size decay per iteration (default 0.995).
+    repulsionCap: Max nodes per repulsion group (default 200).
+    initialStep: Initial max displacement per iteration (default 0.5).
     seed: Random seed (default 42).)doc");
 
 #ifdef TESSERA_VERSION

--- a/tessera/__init__.py
+++ b/tessera/__init__.py
@@ -15,7 +15,7 @@ the canonical ``from tessera.spacetime import Spacetime``.
 """
 
 # Root-namespace classes / free functions (Poset, OrderAgreement,
-# MatterConfiguration, HingeType, renderSpacetime, forceLayout3D, ...).
+# MatterConfiguration, HingeType, renderSpacetime, ForceLayout, ...).
 from tessera._tessera import *                              # noqa: F401,F403
 from tessera._tessera import __doc__                        # noqa: F401
 

--- a/tessera/utils/plot.py
+++ b/tessera/utils/plot.py
@@ -130,11 +130,11 @@ def force_layout_3d(n, edges, *, center_idx=None, init_pos=None,
                     seed=42):
     """Spring-electrical force-directed layout in 3D.
 
-    Delegates to ``tessera.forceLayout3D`` (C++) for performance.
+    Delegates to ``tessera.ForceLayout.layout3D`` (C++) for performance.
 
     Returns an ``(n, 3)`` numpy array of positions.
     """
-    flat = tessera.forceLayout3D(
+    flat = tessera.ForceLayout.layout3D(
         n=n,
         edges=edges,
         centerIdx=center_idx if center_idx is not None else -1,
@@ -148,6 +148,35 @@ def force_layout_3d(n, edges, *, center_idx=None, init_pos=None,
         seed=seed,
     )
     return np.array(flat).reshape(n, 3)
+
+
+def radial_layout_2d(n, edges, target_radii, *, center_idx=None,
+                     init_pos=None, spring_k=0.02, repulsion_k=0.3,
+                     rest_lengths=None, iters=200, cooling=0.995,
+                     repulsion_cap=200, initial_step=0.3, seed=42):
+    """Radius-constrained 2D radial force-directed layout.
+
+    Delegates to ``tessera.ForceLayout.layout2D`` (C++).  Each node's radius
+    is pinned to ``target_radii``; only the angular coordinate is solved.
+
+    Returns an ``(n, 2)`` numpy array of positions.
+    """
+    flat = tessera.ForceLayout.layout2D(
+        n=n,
+        edges=edges,
+        targetRadii=list(target_radii),
+        centerIdx=center_idx if center_idx is not None else -1,
+        initPos=list(init_pos.ravel()) if init_pos is not None else [],
+        restLengths=list(rest_lengths) if rest_lengths is not None else [],
+        springK=spring_k,
+        repulsionK=repulsion_k,
+        iters=iters,
+        cooling=cooling,
+        repulsionCap=repulsion_cap,
+        initialStep=initial_step,
+        seed=seed,
+    )
+    return np.array(flat).reshape(n, 2)
 
 
 def layout_from_spacetime(verts, edges, **kwargs):


### PR DESCRIPTION
## Summary

Four hand-rolled copies of the same Fruchterman–Reingold force-directed layout existed: the canonical C++ `forceLayout3D`, a private `computeLayout` inside `renderSpacetime`, and two NumPy duplicates in the examples. This consolidates them onto a single `ForceLayout` class (per the no-free-functions house rule) with two static methods:

- `ForceLayout::layout3D` — the existing 3D spring-electrical layout (migrated from the free function `forceLayout3D`).
- `ForceLayout::layout2D` — a 2D engine with two optional, composable constraints:
  - **radius pinning** (`targetRadii`): each node's radius is fixed and only the angle is solved (tangential forces + per-step re-snap) — backs the curvature-slice radial layout.
  - **group-scoped repulsion** (`groups`): Coulomb repulsion runs only within a group — backs the spacetime renderer's per-time-slice layout.

### Callers rewired
- `src/Renderer.cpp::computeLayout` — delegates its spatial (x, z) solve to `layout2D` (one repulsion group per time slice, y/time fixed). Removes the fourth copy the ticket missed.
- `examples/wilson_loops.py` — deletes the dead `_force_layout_3d`, the live `_dual_complex_layout`, and the unused `_slice_subgraph`; calls the `force_layout_3d` wrapper.
- `examples/curvature_slice_gif.py` — `_radial_layout_2d` keeps only the per-frame angular-continuity bookkeeping in Python and hands the solve to `layout2D`.
- `tessera/utils/plot.py` — `force_layout_3d` retargeted to `ForceLayout.layout3D`; new `radial_layout_2d` wrapper added.

## Test plan
- [x] `pip install -e ".[dev]"` rebuilds the C++ extension cleanly
- [x] `python examples/wilson_loops.py --n-simplices 50` produces a GIF
- [x] `python examples/curvature_slice_gif.py --n-simplices 50` converges and produces a GIF (radial solve via `layout2D`)
- [x] `Spacetime.save(...)` (`renderSpacetime`) produces PNG + GIF via the refactored `computeLayout`
- [x] new bindings smoke-tested (`layout3D`, `layout2D` radial + grouped); radii verified pinned
- [x] no tests reference the changed APIs

Closes #305.