### PR TITLE
refactor(observables): route volume-profile computation and averaging through VolumeProfile

### DIFF
--- a/examples/effective_action.py
+++ b/examples/effective_action.py
@@ -279,22 +279,10 @@ def main():
     lengths = [len(p) for p in profiles]
     T = max(lengths)
 
-    # Center each profile on its peak (circular roll) and subtract stalk.
-    centered = []
-    for p in profiles:
-        arr = np.zeros(T)
-        arr[:len(p)] = p
-        stalk = float(arr.min())
-        arr -= stalk
-        peak_idx = int(np.argmax(arr))
-        shift = T // 2 - peak_idx
-        arr = np.roll(arr, shift)       # peak now at T//2
-        centered.append(arr)
-
-    avg_centered = np.mean(centered, axis=0)
-    peak_val = avg_centered.max()
-    if peak_val > 0:
-        avg_centered /= peak_val        # normalise to peak = 1
+    # Center on peak, subtract the stalk, and normalise the peak to 1 in a
+    # single shared C++ pass (see VolumeProfile.centeredAverage).
+    avg_centered = np.asarray(tessera.VolumeProfile.centeredAverage(
+        profiles, subtractStalk=True, normalizePeak=True))
 
     # x-axis: centered time so peak is at 0
     tau_centered = np.arange(T) - T // 2

--- a/examples/probe_spectral.py
+++ b/examples/probe_spectral.py
@@ -49,19 +49,18 @@ def slice_widths(st):
     return {t: len(st.getVerticesAtTime(t)) for t in times}
 
 
-def volume_profile(st, d=4):
-    """N4(t) profile: count of (d+1)-simplices whose minimum-time vertex is at t."""
-    profile = {}
-    dPlus1 = d + 1
-    for s in st.getSimplices():
-        verts = s.getVertices()
-        if len(verts) != dPlus1:
-            continue
-        ts = sorted(int(v.getTime()) for v in verts)
-        if len(set(ts)) != 2:
-            continue
-        profile[ts[0]] = profile.get(ts[0], 0) + 1
-    return profile
+def volume_profile(st):
+    """N4(t): per-slab top-simplex counts via the C++ VolumeProfile.
+
+    ``VolumeProfile`` counts every top simplex by its minimum-time slice
+    (``getTi()``); for a well-formed CDT this is identical to the old
+    2-distinct-times filter, since every causal top simplex spans exactly
+    two adjacent slices.  We drop empty interior slices so the reported
+    stats still describe populated slabs.
+    """
+    vp = tessera.VolumeProfile()
+    vp.compute(st)
+    return [c for c in vp.getProfile() if c > 0]
 
 
 def report(label, st, max_sigma=200.0, n_walks=20, seed=0):
@@ -88,9 +87,9 @@ def report(label, st, max_sigma=200.0, n_walks=20, seed=0):
         ds_small = ds_large = float("nan")
 
     if profile:
-        n4_min = min(profile.values())
-        n4_max = max(profile.values())
-        n4_mean = sum(profile.values()) / len(profile)
+        n4_min = min(profile)
+        n4_max = max(profile)
+        n4_mean = sum(profile) / len(profile)
         n_slabs = len(profile)
     else:
         n4_min = n4_max = n4_mean = n_slabs = 0

--- a/examples/volume_profile_phases.py
+++ b/examples/volume_profile_phases.py
@@ -87,35 +87,16 @@ def _phase_worker(phase_id, label, k0, delta, n_simplices, n_therm, n_meas,
     return label, profiles, cdt.getAcceptanceRates(), cdt.getK4()
 
 
-def average_profile(profiles, center=True):
-    """Average volume profiles, optionally centering on the peak first.
+def average_profile(profiles):
+    """Peak-centered average of volume profiles via the C++ VolumeProfile.
 
     On a torus the de Sitter blob can sit at any time slice and its
     position diffuses along the Markov chain.  Naive bin-by-bin averaging
-    smears the blob into uniform noise.  When *center=True* (default),
-    each profile is circularly rolled so its peak aligns at T//2 before
-    averaging — the same technique used in effective_action.py and
+    smears the blob into uniform noise, so each profile is circularly
+    rolled to align its peak at T//2 before averaging — the technique
     described in the CDT literature (Ambjorn et al., 2005).
     """
-    max_len = max(len(p) for p in profiles)
-    if center:
-        centered = []
-        for p in profiles:
-            arr = np.zeros(max_len)
-            arr[:len(p)] = p
-            peak_idx = int(np.argmax(arr))
-            shift = max_len // 2 - peak_idx
-            arr = np.roll(arr, shift)
-            centered.append(arr)
-        return np.mean(centered, axis=0)
-    else:
-        avg = np.zeros(max_len)
-        counts = np.zeros(max_len)
-        for p in profiles:
-            avg[:len(p)] += p
-            counts[:len(p)] += 1
-        counts[counts == 0] = 1
-        return avg / counts
+    return np.asarray(tessera.VolumeProfile.centeredAverage(profiles))
 
 
 def plot_universe_surface(profile, title, ax, color_map=cm.coolwarm):

--- a/include/observables/VolumeProfile.h
+++ b/include/observables/VolumeProfile.h
@@ -90,6 +90,31 @@ class VolumeProfile : public Observable {
     /// @return The average volume profile over all recorded measurements.
     [[nodiscard]] std::vector<double> getAverageProfile() const;
 
+    /// Peak-centered average of the recorded measurements.
+    ///
+    /// Equivalent to ::centeredAverage applied to the accumulated
+    /// measurements (see ::measure).  See that overload for the algorithm.
+    [[nodiscard]] std::vector<double> getCenteredAverageProfile(
+        bool subtractStalk = false, bool normalizePeak = false) const;
+
+    /// Peak-centered average of a set of volume profiles.
+    ///
+    /// On a torus the de Sitter blob can sit at any time slice and its
+    /// position diffuses along the Markov chain, so naive bin-by-bin
+    /// averaging smears it into uniform noise.  Each profile is therefore
+    /// zero-padded to the longest length and circularly rolled so its peak
+    /// aligns at @c T/2 before the bin-wise mean is taken (Ambjorn,
+    /// Jurkiewicz, Loll, *Reconstructing the Universe*, 2005).
+    ///
+    /// @param profiles     The per-configuration volume profiles to average
+    /// @param subtractStalk Subtract each (padded) profile's minimum before
+    ///                       centering, removing the constant stalk volume
+    /// @param normalizePeak Rescale the result so its peak equals 1
+    /// @return The peak-centered average profile (empty if @p profiles is)
+    [[nodiscard]] static std::vector<double> centeredAverage(
+        const std::vector<std::vector<double>> &profiles,
+        bool subtractStalk = false, bool normalizePeak = false);
+
     /// Record the current volume profile for later averaging.
     /// Call this after each decorrelated Monte Carlo measurement to build statistics.
     ///

--- a/src/observables/Bindings.cpp
+++ b/src/observables/Bindings.cpp
@@ -252,6 +252,26 @@ multiple configurations for averaging.)doc")
            "Return the most recent volume profile as a list.")
       .def("getAverageProfile", &VolumeProfile::getAverageProfile,
            "Return the time-averaged volume profile (over all measure() calls).")
+      .def("getCenteredAverageProfile",
+           &VolumeProfile::getCenteredAverageProfile,
+           py::arg("subtractStalk") = false,
+           py::arg("normalizePeak") = false,
+           "Peak-centered average of all measure() calls (see centeredAverage).")
+      .def_static("centeredAverage", &VolumeProfile::centeredAverage,
+           py::arg("profiles"),
+           py::arg("subtractStalk") = false,
+           py::arg("normalizePeak") = false,
+           R"doc(Peak-centered average of a set of volume profiles.
+
+Each profile is zero-padded to the longest length and circularly rolled so
+its peak sits at T//2 before the bin-wise mean is taken, preventing the de
+Sitter blob from smearing when its position fluctuates along the chain
+(Ambjorn, Jurkiewicz, Loll, 2005).
+
+Args:
+    profiles: Per-configuration volume profiles (lists of counts).
+    subtractStalk: Subtract each padded profile's minimum before centering.
+    normalizePeak: Rescale the result so its peak equals 1.)doc")
       .def("measure", &VolumeProfile::measure, py::arg("spacetime"),
            "Compute and accumulate a volume profile measurement for averaging.")
       .def("reset", &VolumeProfile::reset,

--- a/src/observables/VolumeProfile.cpp
+++ b/src/observables/VolumeProfile.cpp
@@ -85,6 +85,58 @@ std::vector<double> VolumeProfile::getAverageProfile() const {
   return avg;
 }
 
+std::vector<double> VolumeProfile::getCenteredAverageProfile(
+    bool subtractStalk, bool normalizePeak) const {
+  std::vector<std::vector<double>> profiles;
+  profiles.reserve(measurements.size());
+  for (const auto &m : measurements)
+    profiles.emplace_back(m.begin(), m.end());
+  return centeredAverage(profiles, subtractStalk, normalizePeak);
+}
+
+std::vector<double> VolumeProfile::centeredAverage(
+    const std::vector<std::vector<double>> &profiles,
+    bool subtractStalk, bool normalizePeak) {
+  if (profiles.empty()) return {};
+
+  std::size_t maxLen = 0;
+  for (const auto &p : profiles) maxLen = std::max(maxLen, p.size());
+  if (maxLen == 0) return {};
+
+  std::vector<double> avg(maxLen, 0.0);
+  std::vector<double> arr(maxLen, 0.0);
+  const std::size_t mid = maxLen / 2;
+
+  for (const auto &p : profiles) {
+    // Zero-pad to the common length.
+    std::fill(arr.begin(), arr.end(), 0.0);
+    for (std::size_t i = 0; i < p.size(); ++i) arr[i] = p[i];
+
+    // Remove the constant stalk volume (min of the padded profile).
+    if (subtractStalk) {
+      double stalk = *std::min_element(arr.begin(), arr.end());
+      for (auto &v : arr) v -= stalk;
+    }
+
+    // Circularly roll so the peak (first max) sits at maxLen/2.  Matches
+    // numpy.roll: result[(i + shift) mod n] = arr[i].
+    std::size_t peakIdx = static_cast<std::size_t>(
+        std::max_element(arr.begin(), arr.end()) - arr.begin());
+    std::size_t shift = (mid + maxLen - peakIdx % maxLen) % maxLen;
+    for (std::size_t i = 0; i < maxLen; ++i)
+      avg[(i + shift) % maxLen] += arr[i];
+  }
+
+  for (auto &v : avg) v /= static_cast<double>(profiles.size());
+
+  if (normalizePeak) {
+    double peak = *std::max_element(avg.begin(), avg.end());
+    if (peak > 0.0)
+      for (auto &v : avg) v /= peak;
+  }
+  return avg;
+}
+
 void VolumeProfile::reset() {
   currentProfile.clear();
   measurements.clear();


### PR DESCRIPTION
## Summary

The peak-centered volume-profile average — pad profiles to a common length, circularly roll each so its peak sits at `T/2`, then take the bin-wise mean — was copy-pasted across `volume_profile_phases.py` and `effective_action.py` (the latter additionally subtracting the stalk and normalizing the peak). That load-bearing centering step lived only in Python, not in the bound `VolumeProfile` observable. Separately, `probe_spectral.py` re-implemented the per-slice `N(t)` count that `VolumeProfile::compute` already provides.

## Changes

**C++ `VolumeProfile`** (`include/observables/VolumeProfile.h`, `src/observables/VolumeProfile.cpp`, bound in `src/observables/Bindings.cpp`):
- `static centeredAverage(profiles, subtractStalk=false, normalizePeak=false)` — peak-centered average over an explicit set of profiles. Static because both examples accumulate profiles across worker threads and keep the raw list for *other* figures (volume-difference distributions), so an accumulator-only API wouldn't fit.
- `getCenteredAverageProfile(subtractStalk=false, normalizePeak=false)` — instance accessor over `measure()`'d configurations, mirroring the existing `getAverageProfile`.

**Examples:**
- `volume_profile_phases.py` — `average_profile` is now a one-line wrapper over `VolumeProfile.centeredAverage`; the duplicated centering loop is gone.
- `effective_action.py` — the inline Fig-13 center/stalk/normalize loop is replaced by `VolumeProfile.centeredAverage(profiles, subtractStalk=True, normalizePeak=True)`.
- `probe_spectral.py` — `volume_profile` now calls `VolumeProfile().compute(st)` / `getProfile()` (filtered to populated slabs). The old 2-distinct-times filter is equivalent for well-formed CDT, where every causal top simplex spans two adjacent slices.

## Out of scope
- `CDT::getVolumeProfile` and `InteractionSimulation::getVolumeProfile` are byte-identical C++ copies of the `N(t)` count, but they're bound, widely used, and GIL-release-guarded; deduping them is a separate change.

## Test plan
- [x] `pip install -e ".[dev]"` rebuilds cleanly
- [x] `centeredAverage` reproduces the prior NumPy results bit-for-bit (max|diff| = 0.0) in both plain and stalk+normalize modes, incl. float-ndarray input
- [x] `VolumeProfile().compute(st)` matches the old probe convention exactly (same per-slab value multiset)
- [x] `getCenteredAverageProfile` == static `centeredAverage` over the same measurements
- [x] `probe_spectral.py`, `volume_profile_phases.py`, `effective_action.py` all run end-to-end and save figures
- [x] `tests/test_volume_profile.py` (7) + `test_examples.py` VolumeProfilePhases/EffectiveAction (5) pass

Closes #306.