### PR TITLE
test(examples): land stranded spectral_dimension assertion fix from #315

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -120,7 +120,7 @@ class TestSpectralDimension(unittest.TestCase):
         os.unlink(path)
 
     def test_builds_dual_adjacency(self):
-        """Should report diffusion walks were collected."""
+        """Should report the dual-graph return probabilities were collected."""
         rc, out, err, path = run_example(
             "spectral_dimension.py",
             ["--n-simplices", "80", "--n-therm", "2",
@@ -128,7 +128,8 @@ class TestSpectralDimension(unittest.TestCase):
              "--max-sigma", "10", "--sweeps-between", "1",
              "--workers", "1"])
         self.assertEqual(rc, 0, f"stderr:\n{err}")
-        self.assertIn("diffusion walks", out)
+        self.assertIn("Collected", out)
+        self.assertIn("configurations", out)
         if os.path.exists(path):
             os.unlink(path)
 


### PR DESCRIPTION
## Summary

Follow-up hotfix for #315 (which closed #304). #315 was merged at its **3rd** commit while the full local test suite was still running, stranding the **4th** commit — the test-assertion update. As a result `main` is currently red.

`spectral_dimension.py` now prints **"Collected N configurations"** (it averages per-configuration return-probability curves instead of collecting per-walk diffusion arrays), but `tests/test_examples.py::test_builds_dual_adjacency` still asserts the old **"diffusion walks"** string. This lands the stranded one-line assertion fix.

## Test plan
- [x] `pytest tests/test_examples.py::TestSpectralDimension` — 2 passed (verified against `main`'s merged example code)

## Note
The `test_cpp_api_docs_coverage::test_every_header_is_documented` failure also visible in a full local run is **pre-existing on `main`** (8 cobordism headers — incl. `Register.h` — missing `{doxygenfile}` entries in `docs/source/cpp_api.md`) and is unrelated to this change.