### PR TITLE
refactor(examples): build the Wilson-loop dual complex from getDualAdjacency

### DIFF
--- a/examples/wilson_loops.py
+++ b/examples/wilson_loops.py
@@ -38,43 +38,47 @@ def _skey(s):
 def _build_dual_complex(st):
     """Build the full dual complex: nodes = top-simplices, edges = shared facets.
 
-    Returns (key_to_idx, all_keys, dual_edges, key_to_simplex).
+    Topology comes straight from ``Spacetime.getDualAdjacency()`` (computed in
+    C++ — far faster than walking simplices/facets/cofaces from Python, and it
+    sidesteps the ``getCofaces`` detached-copy hazard).  Node ``i`` is the
+    ``i``-th entry of ``getTopSimplices()``, matching the COO indexing.
+
+    The per-edge timelike flag is the only thing not in the COO: two adjacent
+    top simplices share exactly their common ``(d-1)``-facet, i.e. the
+    intersection of their vertex-id sets, so we classify it as timelike when
+    those shared vertices span more than one time slice.
+
+    Returns (key_to_idx, top_simplices, dual_edges, edge_types).
     """
-    # Find top-simplex size from data
-    top_size = 0
-    for s in st.getSimplices():
-        sz = len(s.getVertices())
-        if sz > top_size:
-            top_size = sz
+    top_simplices = st.getTopSimplices()
+    key_to_idx = {}
+    vid_sets = []
+    vid_time = {}
+    for i, s in enumerate(top_simplices):
+        verts = s.getVertices()
+        ids = frozenset(v.getId() for v in verts)
+        key_to_idx[ids] = i
+        vid_sets.append(ids)
+        for v in verts:
+            vid_time[v.getId()] = round(v.getTime())
 
-    all_simplices = {}
-    for s in st.getSimplices():
-        if len(s.getVertices()) == top_size:
-            all_simplices[_skey(s)] = s
+    rows, cols, _n = st.getDualAdjacency()
+    edge_list = []
+    edge_types = []
+    seen = set()
+    for a, b in zip(rows, cols):
+        if a == b:
+            continue
+        edge = (a, b) if a < b else (b, a)
+        if edge in seen:
+            continue
+        seen.add(edge)
+        shared = vid_sets[edge[0]] & vid_sets[edge[1]]
+        is_tl = len({vid_time[v] for v in shared}) > 1
+        edge_list.append(edge)
+        edge_types.append(is_tl)
 
-    key_list = sorted(all_simplices.keys(), key=lambda k: sorted(k))
-    key_to_idx = {k: i for i, k in enumerate(key_list)}
-
-    dual_edges = {}  # (a, b) -> is_timelike
-    for k in key_list:
-        s = all_simplices[k]
-        for facet in s.getFacets():
-            for coface in facet.getCofaces():
-                ck = _skey(coface)
-                if ck in key_to_idx and ck != k:
-                    a, b = key_to_idx[k], key_to_idx[ck]
-                    edge = (min(a, b), max(a, b))
-                    if edge not in dual_edges:
-                        # Classify by shared facet: timelike if vertices
-                        # span multiple time slices
-                        fv = facet.getVertices()
-                        t0 = round(fv[0].getTime())
-                        is_tl = any(round(v.getTime()) != t0 for v in fv)
-                        dual_edges[edge] = is_tl
-
-    edge_list = list(dual_edges.keys())
-    edge_types = [dual_edges[e] for e in edge_list]
-    return key_to_idx, key_list, edge_list, edge_types, all_simplices
+    return key_to_idx, top_simplices, edge_list, edge_types
 
 
 def _loop_indices(loop, key_to_idx):
@@ -287,9 +291,9 @@ def main():
 
     # Build full dual-complex layout (shared across all loop types)
     prog.phase("layouting", extra="dual complex")
-    key_to_idx, key_list, dual_edges, edge_types, _ = _build_dual_complex(st)
+    key_to_idx, top_simplices, dual_edges, edge_types = _build_dual_complex(st)
     dual_pos = force_layout_3d(
-        len(key_list), dual_edges,
+        len(top_simplices), dual_edges,
         spring_k=0.05, repulsion_k=0.3, repulsion_cap=300, iters=300)
 
     # Render GIF: for each loop type, show rotating views

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -375,6 +375,12 @@ class Spacetime {
     /// (all simplices of all dimensions registered in the complex).
     [[nodiscard]] const std::vector<SimplexPtr>& getSimplices() const noexcept;
 
+    /// @return Const reference to the top-dimensional simplices only, in the
+    /// same order used by @ref getDualAdjacency (i.e. element \a i is dual
+    /// node \a i).  Lets callers attach per-node data to the dual COO without
+    /// re-deriving the top-simplex indexing from Python.
+    [[nodiscard]] const std::vector<SimplexPtr>& getTopSimplices() const noexcept;
+
     /// Deterministically seed the spacetime's internal RNG. The RNG drives
     /// the @ref getRandomVertex / @ref getRandomSimplex / @ref getRandomTopSimplex
     /// family used by Pachner moves' first-step sigma selection. Call this

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -433,7 +433,19 @@ Returns:
                out.append(py::cast(s, py::return_value_policy::reference_internal, self));
              return out;
            },
-           "Return all top-dimensional simplices in the complex.")
+           "Return all simplices (every dimension) registered in the complex.")
+      .def("getTopSimplices",
+           [](py::object self) {
+             py::list out;
+             for (const auto &s : py::cast<Spacetime &>(self).getTopSimplices())
+               out.append(py::cast(s, py::return_value_policy::reference_internal, self));
+             return out;
+           },
+           R"doc(Return the top-dimensional simplices in dual-node order.
+
+Element i is dual node i in getDualAdjacency(), so per-node data (vertex
+sets, times, ...) can be attached to the dual COO without re-deriving the
+top-simplex indexing from Python.)doc")
       .def("getExternalSimplices",
            [](py::object self) {
              py::list out;

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -932,6 +932,10 @@ const std::vector<SimplexPtr>& Spacetime::getSimplices() const noexcept {
   return simplicesVec;
 }
 
+const std::vector<SimplexPtr>& Spacetime::getTopSimplices() const noexcept {
+  return topSimplicesVec;
+}
+
 VertexPtr Spacetime::getRandomVertex() { return getRandomVertex(rng); }
 
 VertexPtr Spacetime::getRandomVertex(std::mt19937 &generator) {


### PR DESCRIPTION
## Summary

`examples/wilson_loops.py::_build_dual_complex` walked `getSimplices` / `getFacets` / `getCofaces` from Python to derive the dual adjacency (nodes = top simplices, edges = shared facets). `Spacetime::getDualAdjacency()` already returns that dual COO from C++ — much faster, and it sidesteps a known correctness hazard: `getCofaces` returns detached copies (`return_value_policy::copy`), which corrupts coface relationships when the skeleton is materialized from Python.

## Changes

- **`examples/wilson_loops.py`** — `_build_dual_complex` now takes its topology from `getDualAdjacency()`. The COO doesn't carry the per-edge timelike/spacelike tag (the one thing the issue flagged as PARTIAL), but two adjacent top simplices share **exactly** their common `(d-1)`-facet — the intersection of their vertex-id sets — so the flag is recovered from vertex times using only the safe `getVertices` accessor. No `getFacets`/`getCofaces` calls remain.
- **`Spacetime::getTopSimplices()`** (new, `include/spacetime/Spacetime.h` + `src/spacetime/Spacetime.cpp`, bound in `src/spacetime/Bindings.cpp`) — returns the top simplices in `getDualAdjacency` node order. `getDualAdjacency` indexes nodes by position in `topSimplicesVec`, which previously had no Python accessor; this is the bridge that lets callers attach per-node data (vertex sets, times) to the dual COO. Also corrects the `getSimplices` docstring, which wrongly claimed it returned only top simplices (it returns all dimensions).

## Test plan
- [x] `pip install -e ".[dev]"` rebuilds cleanly
- [x] Parity: rebuilt dual complex is identical to the old `getFacets`/`getCofaces` version — same node count, same edge set (as vertex-key pairs), **zero** timelike-flag mismatches
- [x] `wilson_loops.py --n-simplices 50` runs end-to-end and renders the loops over the dual complex
- [x] `tests/test_spacetime.py` + `tests/test_wilson_loop.py` pass (28 passed, 1 skipped)

Closes #307.