### PR TITLE
docs(cpp-api): document the cobordism headers missing from cpp_api.md

### DIFF
--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -150,6 +150,22 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} CombinatorialDimension.h
 ```
+```{doxygenfile} Cochain.h
+```
+```{doxygenfile} Spectrum.h
+```
+```{doxygenfile} LevenbergMarquardt.h
+```
+```{doxygenfile} GeometrySynthesizer.h
+```
+```{doxygenfile} RealizabilityOracle.h
+```
+```{doxygenfile} BoundaryStateSpace.h
+```
+```{doxygenfile} PreparedBoundaryState.h
+```
+```{doxygenfile} Register.h
+```
 
 ## Quantum
 


### PR DESCRIPTION
## Summary

Fixes the `test_cpp_api_docs_coverage::test_every_header_is_documented` failure that is red on `main`. The recent cobordism merges added 8 public headers under `include/cobordism/` without matching `{doxygenfile}` entries on the C++ API page; this adds them to the **Cobordism** section of `docs/source/cpp_api.md`:

`BoundaryStateSpace.h`, `Cochain.h`, `GeometrySynthesizer.h`, `LevenbergMarquardt.h`, `PreparedBoundaryState.h`, `RealizabilityOracle.h`, `Register.h`, `Spectrum.h`

Docs page only — no code/header changes.

## Test plan
- [x] `pytest tests/test_cpp_api_docs_coverage.py` — 3 passed (every header documented, no stale entries, populated)

Closes #320.