### PR TITLE
refactor(examples): route cobordism helpers through bound C++

### DIFF
--- a/examples/cobordism/algebraic_correspondence.py
+++ b/examples/cobordism/algebraic_correspondence.py
@@ -108,24 +108,6 @@ def _testbed():
     return st
 
 
-def _edge(st, a, b):
-    for e in st.getEdgeList().toVector():
-        if {e.getSource().getId(), e.getTarget().getId()} == {a, b}:
-            return e
-    raise KeyError((a, b))
-
-
-def _cycle_flux(st, cycle):
-    total = 0.0
-    n = len(cycle)
-    for k in range(n):
-        a, b = cycle[k], cycle[(k + 1) % n]
-        e = _edge(st, a, b)
-        sign = 1.0 if (e.getSource().getId(), e.getTarget().getId()) == (a, b) else -1.0
-        total += sign * e.getPhase()
-    return total
-
-
 def _rand_state(rng, dim=2):
     v = rng.normal(size=dim) + 1j * rng.normal(size=dim)
     return [complex(x) for x in v / np.linalg.norm(v)]
@@ -169,14 +151,19 @@ def check_c3(rng):
         e.setPhase(float(rng.uniform(-math.pi, math.pi)))
     ids = sorted(v.getId() for v in st.getVertexList().toVector())
     cycles = ([0, 1, 2], [0, 2, 3])
+    wl = tessera.WilsonLoop(st)
+    by_id = {v.getId(): v for v in st.getVertexList().toVector()}
     e0 = np.array(sorted(cob.HodgeLaplacian(st).eigenvalues()))
-    f0 = np.array([_cycle_flux(st, c) for c in cycles])
+    # Cycle flux = WilsonLoop U(1)-connection holonomy (oriented Edge.phase sum
+    # around the vertex cycle, reduced mod 2pi).  Reduction cancels in the
+    # dphi residual below, so the gauge-invariance check is unchanged.
+    f0 = np.array([wl.evaluateU1Connection([by_id[i] for i in c]).value for c in cycles])
     alpha = {vid: float(rng.uniform(-math.pi, math.pi)) for vid in ids}
     for e in st.getEdgeList().toVector():
         s, t = e.getSource().getId(), e.getTarget().getId()
         e.setPhase(e.getPhase() + alpha[s] - alpha[t])
     e1 = np.array(sorted(cob.HodgeLaplacian(st).eigenvalues()))
-    f1 = np.array([_cycle_flux(st, c) for c in cycles])
+    f1 = np.array([wl.evaluateU1Connection([by_id[i] for i in c]).value for c in cycles])
     dphi = np.angle(np.exp(1j * (f1 - f0)))  # flux residual mod 2pi
     res = max(float(np.max(np.abs(e1 - e0))), float(np.max(np.abs(dphi))))
     return res < 1e-10, res, "spec(L) and both cycle fluxes invariant under vertex rephasing"

--- a/examples/cobordism/loosened_gate_retest.py
+++ b/examples/cobordism/loosened_gate_retest.py
@@ -191,7 +191,12 @@ def creates_superposition(U, tol=1e-9):
 def operator_schmidt_rank(U, tol=1e-9):
     """1 iff U factors as a one-qubit tensor product (local); >1 iff entangling."""
     reshaped = np.asarray(U).reshape(2, 2, 2, 2).transpose(0, 2, 1, 3).reshape(4, 4)
-    s = np.linalg.svd(reshaped, compute_uv=False)
+    # Operator-Schmidt singular values via the C++ SVD primitive.  The
+    # realignment above is the operator bipartition (distinct from
+    # ChoiJamiolkowski's vec(U) Choi bipartition), so only the singular-value
+    # computation is shared; the threshold count stays here.
+    s = np.asarray(tessera.quantum.ChoiJamiolkowski.singularValues(
+        [complex(x) for x in reshaped.ravel()], 4, 4))
     return int(np.sum(s > tol * max(s[0], 1.0)))
 
 

--- a/examples/cobordism/topological_correspondence.py
+++ b/examples/cobordism/topological_correspondence.py
@@ -235,25 +235,6 @@ def _make(cls, st, seed, boundary_fixed=False):
     return cls(st, seed, PRE, boundary_fixed)
 
 
-def _tops(st):
-    sizes = [len(s.getVertices()) for s in st.getSimplices()]
-    if not sizes:
-        return []
-    top = max(sizes)
-    return [tuple(sorted(v.getId() for v in s.getVertices()))
-            for s in st.getSimplices() if len(s.getVertices()) == top]
-
-
-def _is_closed_pseudomanifold(tops):
-    """Every codim-1 face is shared by exactly two top cells."""
-    counts = {}
-    for t in tops:
-        for drop in range(len(t)):
-            facet = t[:drop] + t[drop + 1:]
-            counts[facet] = counts.get(facet, 0) + 1
-    return bool(counts) and all(c == 2 for c in counts.values())
-
-
 def _pachner_z_series(max_depth, seed):
     """Apply interior pre-geometric Pachner moves to S²×S¹ and record Z(W) at
     every depth for both cocycles (the |V| cap keeps the flat space enumerable).
@@ -278,7 +259,11 @@ def _pachner_z_series(max_depth, seed):
             if m.propose() and m.apply():
                 depth += 1
                 counts[cls.__name__] += 1
-                closed &= _is_closed_pseudomanifold(_tops(st))
+                # Closed = no boundary facet (codim-1 face in exactly one top
+                # cell).  Pachner moves preserve the PL-manifold structure, so
+                # branching (a facet in >=3 cells) can't arise here, making the
+                # boundary-empty check from Cobordism.boundaryFaces sufficient.
+                closed &= len(cob.Cobordism.boundaryFaces(st)) == 0
                 zt_d = DijkgraafWitten(st, Cocycle.Trivial).partitionFunction()
                 zs_d = DijkgraafWitten(st, Cocycle.Sign).partitionFunction()
                 drift = max(drift, abs(zt_d - zt0), abs(zs_d - zs0))


### PR DESCRIPTION
## Summary

Replaces three hand-rolled helpers in the cobordism examples with their already-bound C++ equivalents (all confirmed still-bound on current `main`):

| Example | Before | After |
|---|---|---|
| `algebraic_correspondence.py` | `_cycle_flux` (oriented `Edge.phase` sum) | `WilsonLoop.evaluateU1Connection(cycle).value` |
| `loosened_gate_retest.py` | `operator_schmidt_rank` via `np.linalg.svd` | singular values via `ChoiJamiolkowski.singularValues` (realignment + threshold stay in Python) |
| `topological_correspondence.py` | `_is_closed_pseudomanifold(_tops(st))` | `len(Cobordism.boundaryFaces(st)) == 0` |

No C++ changes — all three call existing bindings.

### Notes on faithfulness
- **Cycle flux**: `evaluateU1Connection` reduces the holonomy mod 2π, but that cancels inside `check_c3`'s `dphi = angle(exp(i·(f1−f0)))` residual, so the gauge-invariance check is identical.
- **Closedness**: `boundaryFaces` covers the boundary half (codim-1 face in exactly one cell). The dropped branching half (a facet in ≥3 cells) can't arise under the Pachner moves used here, which preserve the PL-manifold structure — verified equal across 25 moves.

### Deliberately *not* migrated (the 4th ticket item)
The GF(2) nullspace/span helpers in `dw_spectral_bridge.py` are left in numpy: they are subroutines of the **independent** numpy Dijkgraaf–Witten oracle (`numpy_dw_boundary`), which exists to cross-check the C++ state sum. Routing them through `cobordism.gf2_*` would erode that independence. (`topological_correspondence.py`'s own `_cycle_flux` is kept for the same reason — it's the `check_t4` hand-flux oracle cross-checked against WilsonLoop.)

## Test plan
- [x] Equivalence verified against the original helpers:
  - cycle flux == `evaluateU1Connection` (mod 2π); `check_c3` passes (res 1.8e-15)
  - `operator_schmidt_rank` matches `np.linalg.svd` on I (1), CNOT (2), SWAP (4), random (4)
  - `boundaryFaces`-empty == `_is_closed_pseudomanifold` across 26 states / 25 Pachner moves
- [x] `py_compile` clean; the 3 examples are not covered by the test suite (research scripts), so no suite changes needed.

Closes #311.