### PR TITLE
refactor(quantum): use the bound MutualInformation helpers in the quantum examples

### DIFF
--- a/examples/quantum/plot_mi_vs_separation.py
+++ b/examples/quantum/plot_mi_vs_separation.py
@@ -24,7 +24,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 
-from tessera.quantum import SchwingerQuench, TDVPConfig
+from tessera.quantum import MutualInformation, SchwingerQuench, TDVPConfig
 from examples.quantum.temporally_connected_entangled_spacetime import (
     _bond_matrices,
 )
@@ -57,14 +57,21 @@ def _config(N, mg, T, dt, max_bond):
 
 
 def _spatial_dvr(bond_mi, eps_floor=1e-300):
-    """For each snapshot t, return (|n-m|, d=-log MI) arrays."""
+    """For each snapshot t, return (|n-m|, d=-log MI) arrays.
+
+    The van Raamsdonk map ℓ = −log(I) is applied by the canonical
+    ``MutualInformation.edgeLength`` (vectorised over the whole bond-MI
+    matrix); MI below ``eps_floor`` maps to +inf ("no edge") and is
+    dropped downstream rather than plotted at an arbitrary floor.
+    """
     K, B, _ = bond_mi.shape
     per_t = []
     for t in range(K):
         ii, jj = np.triu_indices(B, k=1)
         seps   = (jj - ii).astype(np.int64)
         mi     = bond_mi[t][ii, jj]
-        d      = -np.log(np.clip(mi, eps_floor, None))
+        dmat   = np.asarray(MutualInformation.edgeLength(bond_mi[t], eps_floor))
+        d      = dmat[ii, jj]
         per_t.append((seps, d, mi))
     return per_t
 
@@ -77,11 +84,12 @@ def _bin_mean(xs, ys, n_bins):
     std  = np.full(n_bins, np.nan, dtype=float)
     n    = np.zeros(n_bins, dtype=int)
     for k, c in enumerate(centers):
-        mask = (xs == c)
-        if mask.any():
-            mean[k] = ys[mask].mean()
-            std[k]  = ys[mask].std()
-            n[k]    = int(mask.sum())
+        yv = ys[(xs == c)]
+        yv = yv[np.isfinite(yv)]   # drop +inf edges (MI below the floor)
+        if yv.size:
+            mean[k] = yv.mean()
+            std[k]  = yv.std()
+            n[k]    = int(yv.size)
     return centers, mean, std, n
 
 
@@ -166,9 +174,10 @@ def main():
     mean_mat = np.full((K, B - 1), np.nan, dtype=float)
     for t, (seps, d, _) in enumerate(per_t):
         for k in range(B - 1):
-            mask = (seps == k + 1)
-            if mask.any():
-                mean_mat[t, k] = d[mask].mean()
+            dv = d[(seps == k + 1)]
+            dv = dv[np.isfinite(dv)]   # drop +inf edges (MI below the floor)
+            if dv.size:
+                mean_mat[t, k] = dv.mean()
     im = axBL.imshow(mean_mat, aspect="auto", origin="lower", cmap="magma",
                       extent=[0.5, B - 0.5, -0.5, K - 0.5])
     axBL.set_xlabel(r"bond separation $|n-m|$")
@@ -193,7 +202,7 @@ def main():
                 vals.extend(avg[mask].tolist())
             if vals:
                 vals = np.array(vals)
-                d_mean = -np.log(np.clip(vals.mean(), 1e-300, None))
+                d_mean = MutualInformation.edgeLength(float(vals.mean()), 1e-300)
                 means_per_stride.append(d_mean)
             else:
                 means_per_stride.append(np.nan)

--- a/examples/quantum/run_majorization.py
+++ b/examples/quantum/run_majorization.py
@@ -56,26 +56,19 @@ import sys
 from typing import Iterable
 
 try:
-    from tessera.quantum import QuantumConfig, SchwingerModel
+    from tessera.quantum import MutualInformation, QuantumConfig, SchwingerModel
 except ImportError as e:
     print(f"tessera.quantum unavailable: {e}", file=sys.stderr)
     print("\nRebuild with: TESSERA_QUANTUM=1 pip install -e .", file=sys.stderr)
     sys.exit(1)
 
 
-def _entropy(spectrum: list[float]) -> float:
-    """Shannon (von Neumann) entropy of a Schmidt spectrum, base e."""
-    s = 0.0
-    for p in spectrum:
-        if p > 1e-15:
-            s -= p * math.log(p)
-    return s
-
-
 def _print_intervals_table(intervals, spectra, top_k: int | None) -> None:
     rows = []
     for iv, spec in zip(intervals, spectra):
-        rows.append((iv.i, iv.j, _entropy(spec), len(spec), spec))
+        # von Neumann / Shannon entropy of the Schmidt spectrum (nats).
+        S = MutualInformation.vonNeumannEntropy(list(spec))
+        rows.append((iv.i, iv.j, S, len(spec), spec))
     # Sort by entropy descending so the most-entangled intervals are
     # surfaced first.
     rows.sort(key=lambda r: -r[2])

--- a/include/quantum/MutualInformation.hpp
+++ b/include/quantum/MutualInformation.hpp
@@ -20,6 +20,7 @@
 
 #include <Eigen/Dense>
 #include <itensor/all.h>
+#include <vector>
 
 // === tessera subsystem ns fwd-decls ===
 namespace tessera::graph {}
@@ -69,6 +70,15 @@ public:
     [[nodiscard]] static double
     vonNeumannEntropy(Eigen::MatrixXcd const& rho, double tol = 1e-12);
 
+    // Von Neumann / Shannon entropy directly from an already-diagonal
+    // spectrum (e.g. a Schmidt spectrum or density-matrix eigenvalues),
+    // in nats: -Σ pᵢ log pᵢ over pᵢ > tol. Same convention as the matrix
+    // overloads (the spectrum is assumed trace-normalised); avoids
+    // re-diagonalising a diagonal input.
+    [[nodiscard]] static double
+    vonNeumannEntropy(std::vector<double> const& eigenvalues,
+                      double tol = 1e-12);
+
     // Site-site mutual information I({i} : {j}) on the MPS, in nats.
     // = S(ρ_i) + S(ρ_j) - S(ρ_{ij}).
     [[nodiscard]] static double
@@ -85,6 +95,13 @@ public:
     // mutual information to a metric weight.
     [[nodiscard]] static double
     edgeLength(double I, double epsilon = 1e-10) noexcept;
+
+    // Elementwise edge length on a matrix of mutual-information values:
+    // ℓ_{ij} = -log(I_{ij}), with +inf where I_{ij} < epsilon. Same map
+    // as the scalar overload, vectorised so callers (e.g. a B×B bond-MI
+    // matrix) need not loop in Python.
+    [[nodiscard]] static Eigen::MatrixXd
+    edgeLength(Eigen::MatrixXd const& I, double epsilon = 1e-10);
 
     // ── Dual / bond-cut observables (van Raamsdonk graph) ──────────────
     //

--- a/src/quantum/Bindings.cpp
+++ b/src/quantum/Bindings.cpp
@@ -770,6 +770,16 @@ operations (vonNeumannEntropy, edgeLength) on numpy data without
 needing an MPS in hand.
 )doc")
         .def_static("vonNeumannEntropy",
+            static_cast<double(*)(std::vector<double> const&, double)>(
+                &MutualInformation::vonNeumannEntropy),
+            py::arg("eigenvalues"), py::arg("tol") = 1e-12,
+            R"doc(Von Neumann / Shannon entropy of an already-diagonal spectrum
+(e.g. a Schmidt spectrum), in nats: -sum p_i log p_i over p_i > tol.
+
+Pass the eigenvalue / probability list directly — no need to wrap it in a
+diagonal density matrix (which the matrix overload would re-diagonalise).
+)doc")
+        .def_static("vonNeumannEntropy",
             [](py::array_t<std::complex<double>,
                             py::array::c_style | py::array::forcecast> rho,
                 double tol) -> double {
@@ -796,9 +806,17 @@ pipeline we only need 2×2 (single-site marginals) and 4×4 (two-site
 joint reduced density matrices).
 )doc")
         .def_static("edgeLength",
-            &MutualInformation::edgeLength,
+            static_cast<double(*)(double, double) noexcept>(
+                &MutualInformation::edgeLength),
             py::arg("I"), py::arg("epsilon") = 1e-10,
-            R"doc(ℓ = -log(I) with infinity floor at -log(epsilon).)doc");
+            R"doc(ℓ = -log(I) with infinity floor at -log(epsilon).)doc")
+        .def_static("edgeLength",
+            static_cast<Eigen::MatrixXd(*)(Eigen::MatrixXd const&, double)>(
+                &MutualInformation::edgeLength),
+            py::arg("I"), py::arg("epsilon") = 1e-10,
+            R"doc(Elementwise edge length on a matrix of mutual-information values:
+ell_{ij} = -log(I_{ij}), with +inf where I_{ij} < epsilon. Vectorised form of
+the scalar overload, so a B x B bond-MI matrix maps in one call.)doc");
 
     // ─── ChoiJamiolkowski: dense map–state duality ("bending") ─────────
     py::class_<ChoiJamiolkowski>(m, "ChoiJamiolkowski",

--- a/src/quantum/MutualInformation.cpp
+++ b/src/quantum/MutualInformation.cpp
@@ -201,6 +201,17 @@ MutualInformation::vonNeumannEntropy(Eigen::MatrixXcd const& rho, double tol) {
 }
 
 double
+MutualInformation::vonNeumannEntropy(std::vector<double> const& eigenvalues,
+                                     double tol) {
+    // Already-diagonal input: entropy is -Σ pᵢ log pᵢ directly, matching
+    // entropyFromEigenvalues (no re-diagonalisation).
+    double S = 0.0;
+    for (double p : eigenvalues)
+        if (p > tol) S -= p * std::log(p);
+    return S;
+}
+
+double
 MutualInformation::siteSite(itensor::MPS const& psi, int i, int j) {
     if (i == j) return 0.0;
     if (i > j) std::swap(i, j);
@@ -246,6 +257,14 @@ double
 MutualInformation::edgeLength(double I, double epsilon) noexcept {
     if (I < epsilon) return std::numeric_limits<double>::infinity();
     return -std::log(I);
+}
+
+Eigen::MatrixXd
+MutualInformation::edgeLength(Eigen::MatrixXd const& I, double epsilon) {
+    return I.unaryExpr([epsilon](double v) {
+        return v < epsilon ? std::numeric_limits<double>::infinity()
+                           : -std::log(v);
+    });
 }
 
 // ─── Dual / bond-cut observables ─────────────────────────────────────

--- a/tests/quantum/test_mutual_information_python.py
+++ b/tests/quantum/test_mutual_information_python.py
@@ -73,5 +73,56 @@ class TestEdgeLength(unittest.TestCase):
         self.assertFalse(math.isinf(MutualInformation.edgeLength(eps * 2, eps)))
 
 
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without TESSERA_QUANTUM=1")
+class TestVonNeumannEntropySpectrum(unittest.TestCase):
+    """Spectrum overload: entropy straight from an eigenvalue list."""
+
+    def test_matches_manual_formula(self) -> None:
+        spec = [0.7, 0.2, 0.08, 0.02]
+        expected = -sum(p * math.log(p) for p in spec)
+        self.assertAlmostEqual(
+            MutualInformation.vonNeumannEntropy(spec), expected, places=12)
+
+    def test_matches_diagonal_density_matrix(self) -> None:
+        """Spectrum overload must agree with the matrix overload on diag(ρ)."""
+        spec = [0.5, 0.3, 0.15, 0.05]
+        from_spec = MutualInformation.vonNeumannEntropy(spec)
+        from_matrix = MutualInformation.vonNeumannEntropy(
+            np.diag(spec).astype(complex))
+        self.assertAlmostEqual(from_spec, from_matrix, places=12)
+
+    def test_uniform_spectrum(self) -> None:
+        self.assertAlmostEqual(
+            MutualInformation.vonNeumannEntropy([0.5, 0.5]), math.log(2),
+            places=12)
+
+    def test_zero_entries_handled(self) -> None:
+        self.assertAlmostEqual(
+            MutualInformation.vonNeumannEntropy([1.0, 0.0, 0.0]), 0.0, places=12)
+
+
+@unittest.skipUnless(HAVE_QUANTUM, "tessera built without TESSERA_QUANTUM=1")
+class TestEdgeLengthMatrix(unittest.TestCase):
+    """Vectorised ℓ = -log(I) over a matrix of MI values."""
+
+    def test_matches_scalar_elementwise(self) -> None:
+        rng = np.random.default_rng(0)
+        m = np.abs(rng.standard_normal((5, 5))) * 0.3 + 1e-3
+        out = np.asarray(MutualInformation.edgeLength(m))
+        ref = -np.log(m)
+        self.assertTrue(np.allclose(out, ref, atol=1e-12))
+
+    def test_below_cutoff_entries_are_infinite(self) -> None:
+        m = np.array([[0.5, 1e-15], [1e-15, 0.5]])
+        out = np.asarray(MutualInformation.edgeLength(m, 1e-10))
+        self.assertTrue(math.isinf(out[0, 1]) and out[0, 1] > 0)
+        self.assertFalse(math.isinf(out[0, 0]))
+
+    def test_shape_preserved(self) -> None:
+        m = np.full((3, 4), 0.5)
+        out = np.asarray(MutualInformation.edgeLength(m))
+        self.assertEqual(out.shape, (3, 4))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two quantum examples hand-rolled formulas already canonicalised on `MutualInformation`: the van Raamsdonk edge length `ℓ = −log(I)` and the von Neumann entropy `−Σ pᵢ log pᵢ`. The bound overloads didn't fit the examples' inputs (`edgeLength` was scalar-only; `vonNeumannEntropy` took a density *matrix*, not a spectrum), so this adds the two missing overloads and routes the examples through them.

## Changes

**C++ `MutualInformation`** (`include/quantum/MutualInformation.hpp`, `src/quantum/MutualInformation.cpp`, bound in `src/quantum/Bindings.cpp`):
- `vonNeumannEntropy(const std::vector<double>& eigenvalues, tol=1e-12)` — entropy straight from an already-diagonal spectrum (`−Σ pᵢ log pᵢ`, same trace-normalised convention as the matrix overloads), so callers don't wrap a Schmidt spectrum in a diagonal density matrix only to re-diagonalise it.
- `edgeLength(const Eigen::MatrixXd& I, epsilon=1e-10)` — elementwise `ℓ = −log(I)` with the same `+inf` floor as the scalar overload, vectorised over a B×B bond-MI matrix.

The Python spectrum overload is registered **before** the existing complex-matrix `vonNeumannEntropy` so a 1-D list dispatches to it while a 2-D complex array still hits the matrix path; the scalar/matrix `edgeLength` split on dimensionality.

**Examples:**
- `plot_mi_vs_separation.py` — spatial (`_spatial_dvr`) and temporal edge lengths now come from `edgeLength`. Sub-floor MI maps to `+inf` ("no edge") and is dropped in the per-bin means (`_bin_mean` and the heatmap now filter non-finite) instead of being plotted at an arbitrary `−log(1e-300)` spike.
- `run_majorization.py` — the interval table's entropy column uses `vonNeumannEntropy(spectrum)`; the hand-rolled `_entropy` is gone.

## Test plan
- [x] `pip install -e ".[dev]"` rebuilds cleanly
- [x] New overloads reproduce the hand-rolled values exactly (spectrum entropy vs `−Σ p log p`; matrix `edgeLength` parity max|diff| = 0.0 vs `−log(clip)`); correct overload dispatch (list→spectrum, 2-D complex→matrix; float→scalar, 2-D→matrix)
- [x] `plot_mi_vs_separation.py` and `run_majorization.py` run end-to-end
- [x] `tests/quantum/test_mutual_information_python.py` — 15 passed (8 existing + 7 new); `test_bond_mutual_information_python.py` passes — existing matrix/scalar dispatch unaffected

Closes #310.