### PR TITLE
refactor(mesh): store exact l² + complex edge length; causal character via Im(l)

### DIFF
--- a/examples/cobordism/correspondence_retest_k1.py
+++ b/examples/cobordism/correspondence_retest_k1.py
@@ -140,7 +140,7 @@ def _Cochain(simplices, coeffs):
 
 
 def _boundary_snapshot(st):
-    return {(min(a, b), max(a, b)): (e.getSquaredLength(), e.getPhase())
+    return {(min(a, b), max(a, b)): (e.getSquaredLength().real, e.getPhase())
             for e in st.getEdgeList().toVector()
             for a, b in [(e.getSource().getId(), e.getTarget().getId())]}
 

--- a/examples/cobordism/mediated_gate_battery.py
+++ b/examples/cobordism/mediated_gate_battery.py
@@ -120,7 +120,7 @@ def _register_edge_fingerprint(stage):
     emap = {}
     for e in stage["st"].getEdgeList().toVector():
         a, b = e.getSource().getId(), e.getTarget().getId()
-        emap[(min(a, b), max(a, b))] = (e.getSquaredLength(), e.getPhase())
+        emap[(min(a, b), max(a, b))] = (e.getSquaredLength().real, e.getPhase())
     reg = {str(k): emap[k] for k in base._REG_EDGES if k in emap}
     return reg, [float(x) for x in base._CP_IN]
 

--- a/examples/cobordism/realizability_report.py
+++ b/examples/cobordism/realizability_report.py
@@ -186,7 +186,7 @@ def _np_L(st):
         if s == t:
             continue
         i, j = idx[s], idx[t]
-        w = e.getSquaredLength()
+        w = e.getSquaredLength().real
         z = w * np.exp(1j * e.getPhase())
         A[i, j] += z
         A[j, i] += np.conj(z)
@@ -380,7 +380,7 @@ def verify_correspondence(seed, restarts):
     U = [[1.0 + 0j, 1.0 + 0j], [1.0 + 0j, 1.0 + 0j]]
     bulk = _bipyramid()
     _pin_all(bulk, w=1.0, phase=0.0)
-    pinned = {k: (e.getSquaredLength(), e.getPhase())
+    pinned = {k: (e.getSquaredLength().real, e.getPhase())
               for k, e in _edge_map(bulk).items()}
     target = _bend(U, dA, dB)
     v = cob.RealizabilityOracle(bulk).decide(
@@ -397,7 +397,7 @@ def verify_correspondence(seed, restarts):
     # boundary edges byte-identical and never touches the interior.
     live = _edge_map(W)
     boundary_fixed = all(
-        (live[k].getSquaredLength(), live[k].getPhase()) == pinned[k]
+        (live[k].getSquaredLength().real, live[k].getPhase()) == pinned[k]
         for k in boundary)
     h2 = bool(boundary_fixed and set(boundary).isdisjoint(interior))
 

--- a/examples/cobordism/visualize_realizability.py
+++ b/examples/cobordism/visualize_realizability.py
@@ -197,7 +197,7 @@ def _graph(st):
         if s == t or s not in vid_to_idx or t not in vid_to_idx:
             continue
         edge_idx.append((vid_to_idx[s], vid_to_idx[t]))
-        edge_timelike.append(e.getSquaredLength() < 0.0)
+        edge_timelike.append(e.getSquaredLength().real < 0.0)
         bnd_edge.append((min(s, t), max(s, t)) in bnd_edge_keys)
     return dict(ids=ids, vid_to_idx=vid_to_idx, verts=verts, edges=edges,
                 edge_idx=edge_idx, edge_timelike=edge_timelike,

--- a/include/mesh/Edge.h
+++ b/include/mesh/Edge.h
@@ -26,6 +26,7 @@
 #include "mesh/ForwardDeclarations.h"
 #include "mesh/EdgeKey.h"
 
+#include <complex>
 #include <random>
 #include <memory>
 
@@ -111,6 +112,25 @@ class Edge {
     ///
     /// @return The U(1) connection phase, in radians.
     [[nodiscard]] double getPhase() const noexcept;
+
+    /// The (possibly complex) edge length — the metric DOF, distinct from the U(1)
+    /// `phase`. Real for spacelike, imaginary for timelike, general complex for an
+    /// analytically-continued geometry (the Picard–Lefschetz saddle). Currently
+    /// derived from the stored squared length on the principal branch
+    /// (\f$\sqrt{l^2}\f$ for \f$l^2\ge 0\f$, \f$i\sqrt{|l^2|}\f$ for \f$l^2<0\f$);
+    /// a later step stores it directly so it can leave the real/imaginary axes.
+    /// To recover \f$l^2\f$, square the result (`getLength()*getLength()`).
+    [[nodiscard]] std::complex<double> getLength() const noexcept;
+
+    /// Causal character read from the LENGTH, not the fragile `sign(l^2)`: an edge
+    /// is timelike iff its length has a (non-negligible) imaginary part. A genuinely
+    /// spacelike (real) length has `Im == 0`; the epsilon only guards float noise.
+    /// These supersede the scattered `getSquaredLength() < 0` / `>= 0` tests.
+    static constexpr double kCausalEpsilon = 1e-12;
+    [[nodiscard]] bool isTimelike() const noexcept;
+    [[nodiscard]] bool isSpacelike() const noexcept;
+    [[nodiscard]] bool isNull() const noexcept;
+    [[nodiscard]] EdgeDisposition disposition() const noexcept;
 
 #ifdef TESSERA_VERBOSE
     [[nodiscard]] std::string toString() const noexcept;

--- a/include/mesh/Edge.h
+++ b/include/mesh/Edge.h
@@ -75,10 +75,14 @@ enum class EdgeDisposition : uint8_t {
 ///
 class Edge {
   public:
+    /// Construct from the (possibly complex) squared length \f$l^2\f$ — the exact metric
+    /// value, stored verbatim. The complex length is derived as \f$\sqrt{l^2}\f$ (real =
+    /// spacelike, imaginary = timelike). A real `double` binds here as a real \f$l^2\f$
+    /// (`complex(l2, 0)`) — that is the intended meaning, not a length.
     Edge(
       const VertexPtr &source,
       const VertexPtr &target,
-      double squaredLength_
+      std::complex<double> squaredLength
     );
 
     Edge(
@@ -96,15 +100,6 @@ class Edge {
     /// memory. But seriously, though, `getTarget` gives the vertex on one end, and `getSource` gives the other.
     [[nodiscard]] const VertexPtr &getTarget() const noexcept;
 
-    /// We work in squared edge lengths because imaginary numbers don't play so nicely with floating point arithmetic.
-    /// To be less cryptic: timelike edges have imaginary length. Their squared edge length is negative. Something I've
-    /// always thought was kind of neat is a right triangle with the opposite and adjacent edges of length \f$ i \f$
-    /// and \f$ 1 \f$ respectively. So the hypotenuse is zero. So timelike edges have imaginary length, spacelike edges
-    /// have a positive length, and lightlike edges have zero length.
-    ///
-    /// @return The square of the length of the edge.
-    [[nodiscard]] double getSquaredLength() const noexcept;
-
     /// The U(1) connection phase carried on this edge's stored source->target orientation (and
     /// negated on reversal). With the signed `squaredLength` magnitude it forms the complex edge
     /// weight \f$ \text{squaredLength}\cdot e^{i\,\text{phase}} \f$ read by the Hermitian-weighted
@@ -113,13 +108,18 @@ class Edge {
     /// @return The U(1) connection phase, in radians.
     [[nodiscard]] double getPhase() const noexcept;
 
-    /// The (possibly complex) edge length — the metric DOF, distinct from the U(1)
-    /// `phase`. Real for spacelike, imaginary for timelike, general complex for an
-    /// analytically-continued geometry (the Picard–Lefschetz saddle). Currently
-    /// derived from the stored squared length on the principal branch
-    /// (\f$\sqrt{l^2}\f$ for \f$l^2\ge 0\f$, \f$i\sqrt{|l^2|}\f$ for \f$l^2<0\f$);
-    /// a later step stores it directly so it can leave the real/imaginary axes.
-    /// To recover \f$l^2\f$, square the result (`getLength()*getLength()`).
+    /// The exact (possibly complex) squared length \f$l^2\f$ — stored verbatim, NOT
+    /// `getLength()*getLength()`. ALL geometry/action math reads this so it never incurs
+    /// a `sqrt`→`square` round-trip; that ~1-ULP round-trip detonates in the
+    /// ill-conditioned Lorentzian action at near-degenerate simplices (dual-volume
+    /// circumradius blows up as the Cayley–Menger determinant → 0). Real-signed for an
+    /// ordinary Lorentzian edge; complex for an analytically-continued (saddle) geometry.
+    [[nodiscard]] std::complex<double> getSquaredLength() const noexcept;
+
+    /// The (possibly complex) edge length — the causal DOF, distinct from the U(1)
+    /// `phase` and from \f$l^2\f$. Real for spacelike, imaginary for timelike, general
+    /// complex for the Picard–Lefschetz saddle. Causal character is read from THIS
+    /// (`Im(length)`) — the timelike disambiguation a real signed \f$l^2\f$ cannot give.
     [[nodiscard]] std::complex<double> getLength() const noexcept;
 
     /// Causal character read from the LENGTH, not the fragile `sign(l^2)`: an edge
@@ -178,9 +178,23 @@ class Edge {
     /// @returns A tuple of {sourceId, targetId}.
     EdgeKey getKey() const noexcept;
 
-    /// Set the squared edge length.  Used by the Regge solver to optimize
-    /// the geometry without rebuilding the mesh.
-    void setSquaredLength(double sq) noexcept { squaredLength = sq; }
+    /// Set the exact (complex) squared length \f$l^2\f$; the complex length is kept in
+    /// sync as \f$\sqrt{l^2}\f$. Prefer this when the geometry is specified by a squared
+    /// value (CDT, Van Raamsdonk, the backreaction scan) so \f$l^2\f$ is stored exactly
+    /// and the action never sees a round-trip.
+    void setSquaredLength(std::complex<double> l2) noexcept {
+      squaredLength_ = l2;
+      length_ = std::sqrt(l2);
+    }
+
+    /// Set the (complex) edge length; the squared length is kept in sync as `l*l`. Use
+    /// when the geometry is specified by a length directly — the off-axis
+    /// (Picard–Lefschetz) saddle the Regge solver explores. Real for spacelike,
+    /// imaginary for timelike, general complex for the saddle.
+    void setLength(std::complex<double> l) noexcept {
+      length_ = l;
+      squaredLength_ = l * l;
+    }
 
     /// Set the U(1) connection phase (radians).  Used by the Hermitian-weighted
     /// Laplacian and its gauge transform to rephase the edge without rebuilding the mesh.
@@ -235,7 +249,13 @@ class Edge {
     VertexPtr source = nullptr;
     VertexPtr target = nullptr;
 
-    double squaredLength;
+    /// The exact (possibly complex) squared length \f$l^2\f$ — the metric value read by
+    /// the action and all geometry math. `length_` is its principal `sqrt`; the two are
+    /// kept in sync by `setSquaredLength`/`setLength`.
+    std::complex<double> squaredLength_{};
+    /// The complex length (causal DOF, distinct from the U(1) `phase`). Causal character
+    /// is `Im(length_)`; carries the sqrt-branch a real \f$l^2\f$ cannot express.
+    std::complex<double> length_{};
     double phase = 0.0;
 
     Simplices simplices_{};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ optional-dependencies.examples = [
 optional-dependencies.dev = [
     "tessera[examples]",
     "pytest",
+    "pytest-xdist",
     "scikit-build-core>=0.9",
     "cmake>=3.22",
     "ninja",

--- a/src/Poset.cpp
+++ b/src/Poset.cpp
@@ -186,7 +186,7 @@ Poset Poset::fromSpacetime(Spacetime const& st) {
             auto const& src = e->getSource();
             auto const& dst = e->getTarget();
             if (!src || !dst) continue;
-            if (e->getSquaredLength() >= 0.0) continue;  // spacelike or null
+            if (!e->isTimelike()) continue;  // spacelike or null
 
             const double t_s = src->getTime();
             const double t_d = dst->getTime();

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -440,7 +440,7 @@ LayoutData computeLayout(const Spacetime &st, int maxIters) {
         auto ti = idToIdx.find(e->getTarget()->getId());
         if (si != idToIdx.end() && ti != idToIdx.end())
             layout.edges.push_back(
-                {si->second, ti->second, e->getSquaredLength() < 0});
+                {si->second, ti->second, e->isTimelike()});
     }
 
     // Group vertices by time slice
@@ -664,7 +664,7 @@ bool writeGraphML(const Spacetime &st, const std::string &path) {
 
     for (std::size_t i = 0; i < edges.size(); ++i) {
         auto *e = edges[i];
-        double sq = e->getSquaredLength();
+        double sq = e->getSquaredLength().real();
         f << "    <edge id=\"e" << i << "\" source=\""
           << e->getSource()->getId() << "\" target=\""
           << e->getTarget()->getId() << "\">\n"
@@ -698,7 +698,7 @@ bool writeDot(const Spacetime &st, const std::string &path) {
           << ", degree=" << v->degree() << "];\n";
 
     for (auto *e : edges) {
-        double sq = e->getSquaredLength();
+        double sq = e->getSquaredLength().real();
         bool tl = sq < 0;
         f << "  " << e->getSource()->getId()
           << " -- " << e->getTarget()->getId()

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -253,7 +253,7 @@ double EigenstateSynthesis::rayleigh(const std::vector<cd> &psi) const {
 std::vector<double> EigenstateSynthesis::weights() const {
   std::vector<double> w;
   w.reserve(edges_.size());
-  for (const auto e : edges_) w.push_back(e->getSquaredLength());
+  for (const auto e : edges_) w.push_back(e->getSquaredLength().real());
   return w;
 }
 
@@ -270,7 +270,7 @@ void EigenstateSynthesis::setWeights(const std::vector<double> &w) {
         "EigenstateSynthesis::setWeights: got " + std::to_string(w.size()) +
         " weights, expected " + std::to_string(edges_.size()));
   for (std::size_t i = 0; i < edges_.size(); ++i)
-    edges_[i]->setSquaredLength(w[i]);
+    edges_[i]->setSquaredLength(std::complex<double>{w[i], 0.0});
 }
 
 void EigenstateSynthesis::setPhases(const std::vector<double> &theta) {
@@ -287,7 +287,8 @@ void EigenstateSynthesis::setPhases(const std::vector<double> &theta) {
 std::vector<double> EigenstateSynthesis::interiorWeights() const {
   std::vector<double> w;
   w.reserve(interiorEdgeIdx_.size());
-  for (const auto i : interiorEdgeIdx_) w.push_back(edges_[i]->getSquaredLength());
+  for (const auto i : interiorEdgeIdx_)
+    w.push_back(edges_[i]->getSquaredLength().real());
   return w;
 }
 
@@ -305,7 +306,7 @@ void EigenstateSynthesis::setInteriorWeights(const std::vector<double> &w) {
         std::to_string(w.size()) + " weights, expected " +
         std::to_string(interiorEdgeIdx_.size()));
   for (std::size_t k = 0; k < interiorEdgeIdx_.size(); ++k)
-    edges_[interiorEdgeIdx_[k]]->setSquaredLength(w[k]);
+    edges_[interiorEdgeIdx_[k]]->setSquaredLength(std::complex<double>{w[k], 0.0});
 }
 
 void EigenstateSynthesis::setInteriorPhases(const std::vector<double> &theta) {
@@ -412,7 +413,7 @@ bool EigenstateSynthesis::attachInteriorVertex(
     const std::uint64_t a = edges_[i]->getSource()->getId();
     const std::uint64_t b = edges_[i]->getTarget()->getId();
     boundaryBefore[{std::min(a, b), std::max(a, b)}] = {
-        edges_[i]->getSquaredLength(), edges_[i]->getPhase()};
+        edges_[i]->getSquaredLength().real(), edges_[i]->getPhase()};
   }
 
   // Fresh interior vertex with the largest id (sorts last; preserves the
@@ -472,7 +473,7 @@ bool EigenstateSynthesis::attachInteriorVertex(
       const auto it =
           boundaryBefore.find({std::min(a, b), std::max(a, b)});
       if (it == boundaryBefore.end() ||
-          it->second.first != edges_[i]->getSquaredLength() ||
+          it->second.first != edges_[i]->getSquaredLength().real() ||
           it->second.second != edges_[i]->getPhase()) {
         valid = false;
         break;
@@ -611,8 +612,9 @@ bool EigenstateSynthesis::removeInteriorCell(
       if (covered(u, v)) continue;  // edge survives in another top cell
       const auto it = edgeByPair.find({u, v});
       if (it == edgeByPair.end()) continue;  // already absent
-      rem.removedEdges.emplace_back(u, v, it->second->getSquaredLength(),
-                                    it->second->getPhase());
+      rem.removedEdges.emplace_back(
+          u, v, it->second->getSquaredLength().real(),
+          it->second->getPhase());
       toRemove.push_back(it->second);
     }
 
@@ -623,7 +625,7 @@ bool EigenstateSynthesis::removeInteriorCell(
     const std::uint64_t a = edges_[i]->getSource()->getId();
     const std::uint64_t b = edges_[i]->getTarget()->getId();
     boundaryBefore[{std::min(a, b), std::max(a, b)}] = {
-        edges_[i]->getSquaredLength(), edges_[i]->getPhase()};
+        edges_[i]->getSquaredLength().real(), edges_[i]->getPhase()};
   }
 
   // Mutate: drop the top cell, then its orphaned edges.
@@ -646,7 +648,7 @@ bool EigenstateSynthesis::removeInteriorCell(
     const std::uint64_t b = e->getTarget()->getId();
     const std::pair<std::uint64_t, std::uint64_t> key{std::min(a, b),
                                                       std::max(a, b)};
-    liveWeights[key] = {e->getSquaredLength(), e->getPhase()};
+    liveWeights[key] = {e->getSquaredLength().real(), e->getPhase()};
   }
   for (const auto &[key, wp] : boundaryBefore) {
     const auto it = liveWeights.find(key);
@@ -696,7 +698,7 @@ bool EigenstateSynthesis::applyRestore(const Removal &rem) {
   for (const auto &[u, v, w, theta] : rem.removedEdges) {
     const auto it = edgeByPair.find({std::min(u, v), std::max(u, v)});
     if (it != edgeByPair.end()) {
-      it->second->setSquaredLength(w);
+      it->second->setSquaredLength(std::complex<double>{w, 0.0});
       it->second->setPhase(theta);
     }
   }
@@ -771,7 +773,7 @@ std::pair<bool, std::string> EigenstateSynthesis::stellarSubdivideInterior(
   // construction, not by the time-rule coincidence on all-same-time seeds.
   for (const auto e : st_->getEdgeList()->toVector()) {
     if (e == nullptr) continue;
-    e->setSquaredLength(1.0);
+    e->setLength({1.0, 0.0});  // spacelike unit length
     e->setPhase(0.0);
   }
   return verdict;  // {true, "ok"}

--- a/src/cobordism/HodgeLaplacian.cpp
+++ b/src/cobordism/HodgeLaplacian.cpp
@@ -298,7 +298,7 @@ void HodgeLaplacian::assemble(std::vector<cd> &A, std::vector<double> &D) const 
     const std::size_t j = it->second;
     if (i == j) continue;  // a simplicial complex carries no self-loops
 
-    const double w = e->getSquaredLength();      // signed magnitude
+    const cd w = e->getSquaredLength();  // exact complex squared length l^2
     const double phase = e->getPhase();          // U(1) connection on src->tgt
 
     // Degree uses the magnitude convention D_ii = sum |squaredLength| over

--- a/src/matter/MatterConfiguration.cpp
+++ b/src/matter/MatterConfiguration.cpp
@@ -43,7 +43,7 @@ static VertexPtr sliceCenter(const std::vector<VertexPtr> &sliceVerts) {
     std::unordered_map<std::uint64_t, std::vector<std::uint64_t>> adj;
     for (auto *v : sliceVerts) {
         for (const auto &e : v->getEdges()) {
-            if (e->getSquaredLength() <= 0) continue;  // skip timelike/null
+            if (!e->isSpacelike()) continue;  // skip timelike/null
             auto *other = (e->getSource()->getId() == v->getId())
                           ? e->getTarget() : e->getSource();
             if (sliceIds.count(other->getId()))

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -109,6 +109,19 @@ endpoint vertex IDs, so Edge(v1, v2) == Edge(v2, v1).)doc")
 Positive = spacelike, negative = timelike, zero = lightlike.
 We work in squared lengths to avoid complex arithmetic for
 timelike (imaginary-length) edges.)doc")
+      .def("getLength", &Edge::getLength,
+           R"doc(Return the (possibly complex) edge length — the metric DOF.
+
+Real for spacelike, imaginary for timelike, general complex for an
+analytically-continued geometry. Square it to recover the squared length.
+Distinct from getPhase() (the U(1) connection).)doc")
+      .def("isTimelike", &Edge::isTimelike,
+           "Timelike iff the length has a non-negligible imaginary part "
+           "(supersedes the fragile sign(l^2) test).")
+      .def("isSpacelike", &Edge::isSpacelike,
+           "Spacelike iff the length is real and nonzero.")
+      .def("isNull", &Edge::isNull,
+           "Null/lightlike iff the length is ~zero.")
       .def("getPhase", &Edge::getPhase,
            R"doc(Return the U(1) connection phase carried by this edge (radians).
 

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -91,11 +91,13 @@ endpoint vertex IDs, so Edge(v1, v2) == Edge(v2, v1).)doc")
         py::init<
           const VertexPtr &,
           const VertexPtr &,
-          double>(),
+          std::complex<double>>(),
         py::arg("source"),
         py::arg("target"),
         py::arg("squaredLength"),
-        "Create an edge between two vertices with a specified squared length."
+        "Create an edge with a specified (possibly complex) squared length l^2, "
+        "stored exactly. The length is derived as its sqrt (real = spacelike, "
+        "imaginary = timelike). A real value is a real l^2, not a length."
       )
       .def("__str__", &Edge::toString)
       .def("__repr__", &Edge::toString)
@@ -104,17 +106,18 @@ endpoint vertex IDs, so Edge(v1, v2) == Edge(v2, v1).)doc")
       .def("getSource", &Edge::getSource, py::return_value_policy::reference,
            "Return the source vertex of this edge.")
       .def("getSquaredLength", &Edge::getSquaredLength,
-           R"doc(Return the squared edge length.
+           R"doc(Return the exact (possibly complex) squared length l^2.
 
-Positive = spacelike, negative = timelike, zero = lightlike.
-We work in squared lengths to avoid complex arithmetic for
-timelike (imaginary-length) edges.)doc")
+Stored verbatim — NOT getLength()**2 — so the action never sees a sqrt/square
+round-trip. Real-signed for an ordinary Lorentzian edge, complex for a saddle
+geometry. This is what all geometry/action math reads.)doc")
       .def("getLength", &Edge::getLength,
-           R"doc(Return the (possibly complex) edge length — the metric DOF.
+           R"doc(Return the (possibly complex) edge length — the causal DOF.
 
 Real for spacelike, imaginary for timelike, general complex for an
-analytically-continued geometry. Square it to recover the squared length.
-Distinct from getPhase() (the U(1) connection).)doc")
+analytically-continued (saddle) geometry. Causal character is read from THIS
+(Im(length)). Distinct from l^2 (getSquaredLength) and getPhase() (the U(1)
+connection).)doc")
       .def("isTimelike", &Edge::isTimelike,
            "Timelike iff the length has a non-negligible imaginary part "
            "(supersedes the fragile sign(l^2) test).")
@@ -128,6 +131,13 @@ Distinct from getPhase() (the U(1) connection).)doc")
 Paired with the signed squared length it gives the complex edge weight
 squaredLength * exp(i * phase) used by the Hermitian-weighted Laplacian.
 The default of 0 leaves an ordinary real-weighted CDT edge unchanged.)doc")
+      .def("setSquaredLength", &Edge::setSquaredLength, py::arg("squaredLength"),
+           "Set the exact (complex) squared length l^2; the length is kept in sync "
+           "as its sqrt. Prefer this when the geometry is given by a squared value "
+           "(CDT, Van Raamsdonk, the backreaction scan) so l^2 is stored exactly.")
+      .def("setLength", &Edge::setLength, py::arg("length"),
+           "Set the (complex) edge length: real=spacelike, imaginary=timelike, "
+           "general complex for the off-axis saddle. l^2 is kept in sync as l*l.")
       .def("setPhase", &Edge::setPhase, py::arg("phase"),
            "Set the U(1) connection phase carried by this edge (radians).")
       .def_static("vanRaamsdonkSquaredLength", &Edge::vanRaamsdonkSquaredLength,
@@ -141,12 +151,6 @@ The default of 0 leaves an ordinary real-weighted CDT edge unchanged.)doc")
            "the mutual information I between its endpoints: 0 (null) when the "
            "endpoints lie on different time slices (a forward-time worldline "
            "edge), else the spacelike vanRaamsdonkSquaredLength.")
-      .def("setSquaredLength", &Edge::setSquaredLength, py::arg("squaredLength"),
-           R"doc(Set the squared edge length (the signed weight magnitude).
-
-Paired with the phase it gives the complex edge weight squaredLength * exp(i *
-phase) read by the Hermitian-weighted Laplacian; also used by the Regge solver
-to optimize geometry without rebuilding the mesh.)doc")
       .def("getTarget", &Edge::getTarget, py::return_value_policy::reference,
            "Return the target vertex of this edge.");
   // ========================================

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -78,6 +78,30 @@ class Simplex;
       return phase;
     }
 
+    [[nodiscard]] std::complex<double> Edge::getLength() const noexcept {
+      // Principal branch: spacelike -> real, timelike -> imaginary. (Storage
+      // becomes complex in a later step; this keeps getLength() exact on-axis.)
+      if (squaredLength >= 0.0) return {std::sqrt(squaredLength), 0.0};
+      return {0.0, std::sqrt(-squaredLength)};
+    }
+
+    [[nodiscard]] bool Edge::isNull() const noexcept {
+      return std::abs(getLength()) <= kCausalEpsilon;
+    }
+
+    [[nodiscard]] bool Edge::isTimelike() const noexcept {
+      return std::abs(getLength().imag()) > kCausalEpsilon;
+    }
+
+    [[nodiscard]] bool Edge::isSpacelike() const noexcept {
+      return !isNull() && !isTimelike();
+    }
+
+    [[nodiscard]] EdgeDisposition Edge::disposition() const noexcept {
+      if (isNull()) return EdgeDisposition::Lightlike;
+      return isTimelike() ? EdgeDisposition::Timelike : EdgeDisposition::Spacelike;
+    }
+
 #ifdef TESSERA_VERBOSE
     [[nodiscard]] std::string Edge::toString() const noexcept {
       return source->toString() + "->" + target->toString();

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -50,16 +50,20 @@ class Simplex;
     Edge::Edge(
       const VertexPtr &source_,
       const VertexPtr &target_,
-      double squaredLength_
-    ) : source(source_), target(target_), squaredLength(squaredLength_), phase(0.0), fingerprint({source_->getId(), target_->getId()}) {
+      std::complex<double> squaredLength
+    ) : source(source_), target(target_),
+        squaredLength_(squaredLength), length_(std::sqrt(squaredLength)),
+        phase(0.0), fingerprint({source_->getId(), target_->getId()}) {
     }
 
     Edge::Edge(
       const VertexPtr &source_,
       const VertexPtr &target_
     ) : source(source_), target(target_), phase(0.0), fingerprint({source_->getId(), target_->getId()}) {
-      // Set squaredLength to a random value between -1 and 1
-      squaredLength = random_uniform(); // Fallback: CDT always provides explicit edge lengths.
+      // Fallback (CDT always provides explicit edge lengths): a random real,
+      // i.e. spacelike, length; keep l^2 in sync.
+      length_ = {random_uniform(), 0.0};
+      squaredLength_ = length_ * length_;
     }
 
     [[nodiscard]] const VertexPtr &Edge::getSource() const noexcept {
@@ -70,19 +74,16 @@ class Simplex;
       return target;
     }
 
-    [[nodiscard]] double Edge::getSquaredLength() const noexcept {
-      return squaredLength;
-    }
-
     [[nodiscard]] double Edge::getPhase() const noexcept {
       return phase;
     }
 
+    [[nodiscard]] std::complex<double> Edge::getSquaredLength() const noexcept {
+      return squaredLength_;
+    }
+
     [[nodiscard]] std::complex<double> Edge::getLength() const noexcept {
-      // Principal branch: spacelike -> real, timelike -> imaginary. (Storage
-      // becomes complex in a later step; this keeps getLength() exact on-axis.)
-      if (squaredLength >= 0.0) return {std::sqrt(squaredLength), 0.0};
-      return {0.0, std::sqrt(-squaredLength)};
+      return length_;
     }
 
     [[nodiscard]] bool Edge::isNull() const noexcept {

--- a/src/mesh/Edge.cpp
+++ b/src/mesh/Edge.cpp
@@ -86,10 +86,14 @@ class Simplex;
     }
 
     [[nodiscard]] bool Edge::isNull() const noexcept {
+      // std::abs of a std::complex is the MODULUS sqrt(Re^2 + Im^2) -- the whole
+      // length magnitude, not the real part -- so a timelike (imaginary) length is
+      // correctly non-null.
       return std::abs(getLength()) <= kCausalEpsilon;
     }
 
     [[nodiscard]] bool Edge::isTimelike() const noexcept {
+      // .imag() is a double, so std::abs here is the ordinary real |Im(l)|.
       return std::abs(getLength().imag()) > kCausalEpsilon;
     }
 

--- a/src/mesh/EdgeList.cpp
+++ b/src/mesh/EdgeList.cpp
@@ -16,14 +16,18 @@ using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
 
 std::uint32_t EdgeList::allocSlot(const VertexPtr &source, const VertexPtr &target, double squaredLength) {
+  // Factory layer speaks the CDT "signed squared length" unit; store it as the exact
+  // complex l^2 (real-signed, Im = 0) so the action never sees a sqrt/square round-trip.
+  // The Edge derives its complex length as sqrt(l^2) (real = spacelike, imag = timelike).
+  const std::complex<double> squared{squaredLength, 0.0};
   std::uint32_t slot;
   if (!freeSlots_.empty()) {
     slot = freeSlots_.back();
     freeSlots_.pop_back();
-    pool_[slot] = Edge(source, target, squaredLength);
+    pool_[slot] = Edge(source, target, squared);
   } else {
     slot = static_cast<std::uint32_t>(pool_.size());
-    pool_.emplace_back(source, target, squaredLength);
+    pool_.emplace_back(source, target, squared);
   }
   return slot;
 }
@@ -88,7 +92,8 @@ void EdgeList::remove(const EdgePtr &edge) noexcept {
 
 void EdgeList::replace(const EdgePtr &toRemove, const EdgePtr &toAdd) noexcept {
   remove(toRemove);
-  add(toAdd->getSource(), toAdd->getTarget(), toAdd->getSquaredLength());
+  add(toAdd->getSource(), toAdd->getTarget(),
+      toAdd->getSquaredLength().real());
 }
 
 void EdgeList::rekeyEdge(std::uint64_t oldFp, std::uint64_t newFp) {

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -687,7 +687,7 @@ std::vector<double> Simplex::gramMatrix(bool wickRotate) const {
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
         sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
-                               : e->getSquaredLength();
+                               : e->getSquaredLength().real();
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -715,7 +715,7 @@ std::vector<double> Simplex::cayleyMengerMatrix(bool wickRotate) const {
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
         sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
-                               : e->getSquaredLength();
+                               : e->getSquaredLength().real();
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -926,7 +926,7 @@ double Simplex::area(bool wickRotate) const {
     if (edges.size() < 3) return 0.0;
     auto sq = [&](std::size_t k) -> double {
         return wickRotate ? std::abs(edges[k]->getSquaredLength())
-                          : edges[k]->getSquaredLength();
+                          : edges[k]->getSquaredLength().real();
     };
     double a2 = sq(0);
     double b2 = sq(1);

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -155,8 +155,8 @@ Vertex::moveEdgesToImpl(
     // For inEdges: redirect edge to point TO the new vertex (new source = vertex)
     // For outEdges: redirect edge to point FROM the new vertex (new target = vertex)
     const auto &newEdge = (direction == EdgeDirection::In)
-                            ? spacetime->createEdge(sourceVertex, recipient, oldEdge->getSquaredLength())
-                            : spacetime->createEdge(recipient, targetVertex, oldEdge->getSquaredLength());
+                            ? spacetime->createEdge(sourceVertex, recipient, oldEdge->getSquaredLength().real())
+                            : spacetime->createEdge(recipient, targetVertex, oldEdge->getSquaredLength().real());
 
     newEdges.insert(newEdge);
   }

--- a/src/quantum/CausetChain.cpp
+++ b/src/quantum/CausetChain.cpp
@@ -77,7 +77,7 @@ CausetChain Causet::chainFrom(tessera::spacetime::Spacetime const& st) {
     if (elist) {
         for (auto const* e : elist->toVector()) {
             if (e == nullptr) continue;
-            if (e->getSquaredLength() >= 0.0) continue;  // spacelike/null
+            if (!e->isTimelike()) continue;  // spacelike/null
             auto const& src = e->getSource();
             auto const& dst = e->getTarget();
             if (!src || !dst) continue;

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -143,7 +143,7 @@ double ReggeSolver::matterAction() const {
                 auto *other = (e->getSource()->getId() == v1->getId())
                               ? e->getTarget() : e->getSource();
                 if (other->getId() == v2->getId()) {
-                    double sq = e->getSquaredLength();
+                    double sq = e->getSquaredLength().real();
                     if (sq < 0.0)  // timelike: ℓ² < 0
                         S -= wl.mass * std::sqrt(-sq);
                     break;
@@ -167,14 +167,19 @@ std::vector<double> ReggeSolver::actionGradient() const {
     auto edges = edgeList->toVector();
     std::vector<double> g(edges.size());
     for (std::size_t i = 0; i < edges.size(); ++i) {
-        double origSq = edges[i]->getSquaredLength();
-        double W = std::abs(origSq);
-        double h = std::max(W * 1e-4, 1e-8);
-        double sign = (origSq < 0.0) ? -1.0 : 1.0;
-        // Central differences in W-space, preserving edge sign
-        edges[i]->setSquaredLength(sign * (W + h));
+        const std::complex<double> origSq = edges[i]->getSquaredLength();
+        const double W = std::abs(origSq);              // |l^2|
+        const double h = std::max(W * 1e-4, 1e-8);
+        const bool tl = edges[i]->isTimelike();
+        auto sqAtW = [tl](double w) {                    // signed l^2 with |l^2|=w, same character
+            return tl ? std::complex<double>{-w, 0.0}
+                      : std::complex<double>{w, 0.0};
+        };
+        // Central differences in W-space, preserving edge character; perturb l^2
+        // exactly and restore the original l^2 exactly (no sqrt round-trip drift).
+        edges[i]->setSquaredLength(sqAtW(W + h));
         double Sp = totalAction();
-        edges[i]->setSquaredLength(sign * std::max(W - h, 1e-12));
+        edges[i]->setSquaredLength(sqAtW(std::max(W - h, 1e-12)));
         double Sm = totalAction();
         g[i] = (Sp - Sm) / (2.0 * h);
         edges[i]->setSquaredLength(origSq);
@@ -260,7 +265,7 @@ cuda::GpuMeshData ReggeSolver::flattenMeshForGpu() const {
         for (const auto &e : topSimplices[si]->getEdges()) {
             auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                       Fingerprint::mix64(e->getTarget()->getId());
-            sqMap[fp] = std::abs(e->getSquaredLength());  // Wick-rotated
+            sqMap[fp] = std::abs(e->getSquaredLength());  // |l^2|, Wick-rotated
         }
 
         for (int i = 0; i < nv; ++i) {
@@ -473,12 +478,12 @@ double ReggeSolver::step(double learningRate) {
     // Update in Wick-rotated (W) space, preserving edge signature.
     // dF[j] is ∂F/∂W_j; gradient descent: W_j -= lr · ∂F/∂W_j.
     for (int j = 0; j < n; ++j) {
-        double origSq = edges[j]->getSquaredLength();
-        double W = std::abs(origSq);
+        const bool tl = edges[j]->isTimelike();
+        double W = std::abs(edges[j]->getSquaredLength());     // |l^2|
         double W_new = W - learningRate * dF[j];
         if (W_new < 1e-12) W_new = 1e-12;
-        double sign = (origSq < 0.0) ? -1.0 : 1.0;
-        edges[j]->setSquaredLength(sign * W_new);
+        edges[j]->setSquaredLength(tl ? std::complex<double>{-W_new, 0.0}
+                                      : std::complex<double>{W_new, 0.0});
     }
 #else
     // CPU path: gradient descent on ∂S/∂ℓ² directly.
@@ -491,15 +496,15 @@ double ReggeSolver::step(double learningRate) {
     // Clamp per-edge change to at most 5% of magnitude to prevent
     // overshooting.
     for (int j = 0; j < n; ++j) {
-        double origSq = edges[j]->getSquaredLength();
-        double W = std::abs(origSq);
+        const bool tl = edges[j]->isTimelike();
+        double W = std::abs(edges[j]->getSquaredLength());     // |l^2|
         double delta = learningRate * g[j];
         double maxDelta = W * 0.05;
         delta = std::clamp(delta, -maxDelta, maxDelta);
         double W_new = W - delta;
         if (W_new < 1e-12) W_new = 1e-12;
-        double sign = (origSq < 0.0) ? -1.0 : 1.0;
-        edges[j]->setSquaredLength(sign * W_new);
+        edges[j]->setSquaredLength(tl ? std::complex<double>{-W_new, 0.0}
+                                      : std::complex<double>{W_new, 0.0});
     }
 #endif
 

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -363,7 +363,7 @@ std::shared_ptr<Spacetime> Spacetime::fromCells(
   // tracked-metric rule, where the auto-wired causal lengths are the geometry.
   if (!vertexTimes) {
     for (const auto &edge : st->getEdgeList()->toVector()) {
-      edge->setSquaredLength(weight);
+      edge->setSquaredLength(std::complex<double>{weight, 0.0});
       edge->setPhase(phase);
     }
   }
@@ -485,7 +485,7 @@ std::pair<VertexPtrs, Edges> Spacetime::getSpatialSubgraph(int t) const {
       seen.insert(fp);
       if (vidSet.count(e->getSource()->getId())
           && vidSet.count(e->getTarget()->getId())
-          && e->getSquaredLength() > 0)
+          && e->isSpacelike())
         spatial.push_back(e);
     }
   }
@@ -1101,7 +1101,7 @@ Spacetime::getSpectralDimensionOnSkeleton(
       const int ib = idx.at(b);
       const auto key = std::minmax(ia, ib);
       if (!seen.insert({key.first, key.second}).second) continue;
-      const double len = std::sqrt(std::abs(e->getSquaredLength()));
+      const double len = std::abs(e->getLength());  // |l| = sqrt(|l^2|)
       const double w   = ::tessera::observables::kIMax * std::exp(-len);
       edgeList.emplace_back(ia, ib, w);
     }

--- a/src/spacetime/pachner/RemoveMove.cpp
+++ b/src/spacetime/pachner/RemoveMove.cpp
@@ -205,10 +205,10 @@ bool RemoveMove::applyPreGeometric() {
   vertexCoords_.clear();
   for (const auto &e : v_->getInEdges())
     deletedEdges_.push_back({e->getSource(), e->getTarget(),
-                             e->getSquaredLength()});
+                             e->getSquaredLength().real()});
   for (const auto &e : v_->getOutEdges())
     deletedEdges_.push_back({e->getSource(), e->getTarget(),
-                             e->getSquaredLength()});
+                             e->getSquaredLength().real()});
 
   // Remove the d+1 incident cells.
   for (const auto &s : incident_) st_->removeSimplex(s);
@@ -251,11 +251,11 @@ bool RemoveMove::apply() {
   // remove.)
   for (const auto &e : v_->getInEdges()) {
     deletedEdges_.push_back({e->getSource(), e->getTarget(),
-                             e->getSquaredLength()});
+                             e->getSquaredLength().real()});
   }
   for (const auto &e : v_->getOutEdges()) {
     deletedEdges_.push_back({e->getSource(), e->getTarget(),
-                             e->getSquaredLength()});
+                             e->getSquaredLength().real()});
   }
 
   // 2. Remove the 2d incident simplices.

--- a/tessera/utils/plot.py
+++ b/tessera/utils/plot.py
@@ -192,7 +192,7 @@ def layout_from_spacetime(verts, edges, **kwargs):
         ti = vid_to_idx.get(e.getTarget().getId())
         if si is not None and ti is not None:
             edge_idx.append((si, ti))
-            rest_lens.append(math.sqrt(abs(e.getSquaredLength())))
+            rest_lens.append(math.sqrt(abs(e.getSquaredLength().real)))
 
     pos = force_layout_3d(len(verts), edge_idx,
                           rest_lengths=rest_lens, **kwargs)

--- a/tests/cobordism/test_analytic_action_gradient_python.py
+++ b/tests/cobordism/test_analytic_action_gradient_python.py
@@ -82,7 +82,7 @@ class ExactActionGradientTest(unittest.TestCase):
     def _set(self, edge):
         def setter(val):
             if val is None:
-                return edge.getSquaredLength()
+                return edge.getSquaredLength().real
             edge.setSquaredLength(float(val)); self.st.materializeFacets()
             return None
         return setter

--- a/tests/cobordism/test_bulk_eigenstate_synthesis_python.py
+++ b/tests/cobordism/test_bulk_eigenstate_synthesis_python.py
@@ -123,7 +123,7 @@ def _edge_map(st):
 
 def _edge_values(st):
     """{(min_id, max_id): (squaredLength, phase)} snapshot of the live edges."""
-    return {k: (e.getSquaredLength(), e.getPhase())
+    return {k: (e.getSquaredLength().real, e.getPhase())
             for k, e in _edge_map(st).items()}
 
 
@@ -142,7 +142,7 @@ def _np_L(st):
         if s == t:
             continue
         i, j = idx[s], idx[t]
-        w = e.getSquaredLength()
+        w = e.getSquaredLength().real
         z = w * np.exp(1j * e.getPhase())
         A[i, j] += z
         A[j, i] += np.conj(z)
@@ -170,7 +170,7 @@ def _set_boundary(st, es, weights=None, phase_scale=0.0, base_w=1.0):
         w = base_w if weights is None else weights[k]
         em[key].setSquaredLength(w)
         em[key].setPhase(phase_scale * (k + 1))
-    return {key: (em[key].getSquaredLength(), em[key].getPhase())
+    return {key: (em[key].getSquaredLength().real, em[key].getPhase())
             for key in bedges}
 
 
@@ -498,7 +498,7 @@ class ConeAndRetryTest(unittest.TestCase):
         es = cob.EigenstateSynthesis(st)
         es.setWeights([1.0] * es.numEdges())   # boundary pinned (phase 0)
         es.setPhases([0.0] * es.numEdges())
-        boundary_vals = {key: (e.getSquaredLength(), e.getPhase())
+        boundary_vals = {key: (e.getSquaredLength().real, e.getPhase())
                          for key, e in _edge_map(st).items()
                          if key in set(es.boundaryEdges())}
 

--- a/tests/cobordism/test_complex_builders_python.py
+++ b/tests/cobordism/test_complex_builders_python.py
@@ -118,7 +118,7 @@ def _snapshot(st):
     edges = {}
     for e in st.getEdgeList().toVector():
         a, b = e.getSource().getId(), e.getTarget().getId()
-        edges[(min(a, b), max(a, b))] = (round(e.getSquaredLength(), 12),
+        edges[(min(a, b), max(a, b))] = (round(e.getSquaredLength().real, 12),
                                          round(e.getPhase(), 12))
     simplices = sorted(tuple(sorted(v.getId() for v in s.getVertices()))
                        for s in st.getSimplices())

--- a/tests/cobordism/test_eigenstate_synthesis_hardening_python.py
+++ b/tests/cobordism/test_eigenstate_synthesis_hardening_python.py
@@ -111,7 +111,7 @@ def _np_L(st):
         if s == t:
             continue
         i, j = idx[s], idx[t]
-        w = e.getSquaredLength()
+        w = e.getSquaredLength().real
         z = w * np.exp(1j * e.getPhase())
         A[i, j] += z
         A[j, i] += np.conj(z)
@@ -316,7 +316,7 @@ class ParameterOrderTest(unittest.TestCase):
 
         # The k-th parameter is the k-th EdgeList edge (the stable order).
         live = st.getEdgeList().toVector()
-        self.assertTrue(np.allclose([e.getSquaredLength() for e in live], w))
+        self.assertTrue(np.allclose([e.getSquaredLength().real for e in live], w))
         self.assertTrue(np.allclose([e.getPhase() for e in live], th))
 
         # And the operator (apply) is built in that same edge order: it agrees

--- a/tests/cobordism/test_eigenstate_synthesis_python.py
+++ b/tests/cobordism/test_eigenstate_synthesis_python.py
@@ -107,7 +107,7 @@ def _np_L(st):
         if s == t:
             continue
         i, j = idx[s], idx[t]
-        w = e.getSquaredLength()
+        w = e.getSquaredLength().real
         z = w * np.exp(1j * e.getPhase())
         A[i, j] += z
         A[j, i] += np.conj(z)
@@ -179,7 +179,7 @@ class EigenstateSynthesisStructureTest(unittest.TestCase):
         self.assertTrue(np.allclose(es.phases(), th))
         # And the writes reach the underlying edges (the Laplacian sees them).
         self.assertTrue(np.allclose(np.array(es.weights()),
-                                    [e.getSquaredLength()
+                                    [e.getSquaredLength().real
                                      for e in st.getEdgeList().toVector()]))
 
     def test_size_mismatch_raises(self):

--- a/tests/cobordism/test_free_connectivity_python.py
+++ b/tests/cobordism/test_free_connectivity_python.py
@@ -199,7 +199,7 @@ class AttachInteriorVertexTest(unittest.TestCase):
         st = _bipyramid()
         _pin_all(st, w=1.0, phase=0.0)
         es = cob.EigenstateSynthesis(st)
-        before = {k: (e.getSquaredLength(), e.getPhase())
+        before = {k: (e.getSquaredLength().real, e.getPhase())
                   for k, e in _edge_map(st).items()
                   if k in set(es.boundaryEdges())}
 
@@ -207,7 +207,7 @@ class AttachInteriorVertexTest(unittest.TestCase):
 
         live = _edge_map(st)
         for k, (w, ph) in before.items():
-            self.assertEqual((live[k].getSquaredLength(), live[k].getPhase()),
+            self.assertEqual((live[k].getSquaredLength().real, live[k].getPhase()),
                              (w, ph))
         # The boundary edge *set* is preserved exactly.
         self.assertEqual(set(es.boundaryEdges()), set(before.keys()))
@@ -239,7 +239,7 @@ class DetachInteriorVertexTest(unittest.TestCase):
         order0 = es.order()
         edges0 = _edge_keys(st)
         verts0 = _vertex_ids(st)
-        weights0 = {k: (e.getSquaredLength(), e.getPhase())
+        weights0 = {k: (e.getSquaredLength().real, e.getPhase())
                     for k, e in _edge_map(st).items()}
         boundary0 = set(es.boundaryEdges())
 
@@ -256,7 +256,7 @@ class DetachInteriorVertexTest(unittest.TestCase):
         self.assertEqual(set(es.boundaryEdges()), boundary0)
         live = _edge_map(st)
         for k, (w, ph) in weights0.items():
-            self.assertEqual((live[k].getSquaredLength(), live[k].getPhase()),
+            self.assertEqual((live[k].getSquaredLength().real, live[k].getPhase()),
                              (w, ph))
 
     def test_detach_with_nothing_to_undo_returns_false(self):

--- a/tests/cobordism/test_geometry_synthesizer_python.py
+++ b/tests/cobordism/test_geometry_synthesizer_python.py
@@ -92,7 +92,7 @@ def _np_L(st):
         if s == t:
             continue
         i, j = idx[s], idx[t]
-        w = e.getSquaredLength()
+        w = e.getSquaredLength().real
         z = w * np.exp(1j * e.getPhase())
         A[i, j] += z
         A[j, i] += np.conj(z)

--- a/tests/cobordism/test_hodge_laplacian_python.py
+++ b/tests/cobordism/test_hodge_laplacian_python.py
@@ -132,7 +132,7 @@ def _np_laplacian(st):
         if s == t:
             continue
         i, j = idx[s], idx[t]
-        w = e.getSquaredLength()
+        w = e.getSquaredLength().real
         z = w * np.exp(1j * e.getPhase())
         A[i, j] += z
         A[j, i] += np.conj(z)

--- a/tests/cobordism/test_k1_boundary_harmonic_synthesis_python.py
+++ b/tests/cobordism/test_k1_boundary_harmonic_synthesis_python.py
@@ -285,7 +285,7 @@ class RealizableTest(unittest.TestCase):
             L1_sigma @ np.asarray(longitude.coeffs()), 0.0, atol=1e-7)
 
         boundary_before = {(min(a, b), max(a, b)):
-                           (e.getSquaredLength(), e.getPhase())
+                           (e.getSquaredLength().real, e.getPhase())
                            for e in W.getEdgeList().toVector()
                            for a, b in [(e.getSource().getId(),
                                          e.getTarget().getId())]}
@@ -318,7 +318,7 @@ class RealizableTest(unittest.TestCase):
         self.assertAlmostEqual(overlap, 1.0, places=7)
 
         # dW was pinned byte-identical (the fill never touched the boundary).
-        live = {(min(a, b), max(a, b)): (e.getSquaredLength(), e.getPhase())
+        live = {(min(a, b), max(a, b)): (e.getSquaredLength().real, e.getPhase())
                 for e in W.getEdgeList().toVector()
                 for a, b in [(e.getSource().getId(), e.getTarget().getId())]}
         self.assertEqual(live, boundary_before)

--- a/tests/cobordism/test_k1_triangle_search_python.py
+++ b/tests/cobordism/test_k1_triangle_search_python.py
@@ -141,7 +141,7 @@ def _edge_keys(st):
 
 
 def _boundary_snapshot(st):
-    return {(min(a, b), max(a, b)): (e.getSquaredLength(), e.getPhase())
+    return {(min(a, b), max(a, b)): (e.getSquaredLength().real, e.getPhase())
             for e in st.getEdgeList().toVector()
             for a, b in [(e.getSource().getId(), e.getTarget().getId())]}
 

--- a/tests/cobordism/test_mediated_synthesis_python.py
+++ b/tests/cobordism/test_mediated_synthesis_python.py
@@ -115,7 +115,7 @@ def _boundary_edge_geometry(st):
     out = {}
     for e in st.getEdgeList().toVector():
         a, b = e.getSource().getId(), e.getTarget().getId()
-        out[(min(a, b), max(a, b))] = (e.getSquaredLength(), e.getPhase())
+        out[(min(a, b), max(a, b))] = (e.getSquaredLength().real, e.getPhase())
     return out
 
 

--- a/tests/cobordism/test_merge_cobordism_python.py
+++ b/tests/cobordism/test_merge_cobordism_python.py
@@ -97,7 +97,7 @@ class LorentzianFromLabelingTest(unittest.TestCase):
         sl = {}
         for e in _M.st.getEdgeList().toVector():
             a, b = e.getSource().getId(), e.getTarget().getId()
-            sl[(min(a, b), max(a, b))] = e.getSquaredLength()
+            sl[(min(a, b), max(a, b))] = e.getSquaredLength().real
         for (a, b), s in sl.items():
             crossing = (a >= 24) != (b >= 24)
             if crossing:

--- a/tests/cobordism/test_realizability_oracle_python.py
+++ b/tests/cobordism/test_realizability_oracle_python.py
@@ -129,7 +129,7 @@ def _np_L(st):
         if s == t:
             continue
         i, j = idx[s], idx[t]
-        w = e.getSquaredLength()
+        w = e.getSquaredLength().real
         z = w * np.exp(1j * e.getPhase())
         A[i, j] += z
         A[j, i] += np.conj(z)
@@ -164,7 +164,7 @@ class RealizableTest(unittest.TestCase):
         # complexity — the fill only has to drive the lone interior edge to phase 0.
         st = _bipyramid()
         _pin_all(st, w=1.0, phase=0.0)
-        boundary_before = {k: (e.getSquaredLength(), e.getPhase())
+        boundary_before = {k: (e.getSquaredLength().real, e.getPhase())
                            for k, e in _edge_map(st).items()
                            if k != (0, 1)}
 
@@ -207,7 +207,7 @@ class RealizableTest(unittest.TestCase):
         # touched them).
         live = _edge_map(st)
         for k, (w, ph) in boundary_before.items():
-            self.assertEqual((live[k].getSquaredLength(), live[k].getPhase()),
+            self.assertEqual((live[k].getSquaredLength().real, live[k].getPhase()),
                              (w, ph))
 
     def test_realizable_only_after_interior_growth(self):

--- a/tests/cobordism/test_surgery_and_cone_python.py
+++ b/tests/cobordism/test_surgery_and_cone_python.py
@@ -181,7 +181,7 @@ class RegisterAdditiveGrowthTest(unittest.TestCase):
         w = np.asarray(cob.HodgeLaplacian(self.reg.st).weights(1), dtype=float)
         self.assertEqual(float(np.max(np.abs(w - 1.0))), 0.0)
         for e in self.reg.st.getEdgeList().toVector():
-            self.assertEqual(e.getSquaredLength(), 1.0)
+            self.assertEqual(e.getSquaredLength().real, 1.0)
             self.assertEqual(e.getPhase(), 0.0)
 
 

--- a/tests/mesh/test_edge_complex_length_python.py
+++ b/tests/mesh/test_edge_complex_length_python.py
@@ -30,8 +30,10 @@ from tessera import Vertex, Edge
 
 
 def _edge(sq):
+    # the Edge ctor takes l^2 directly (stored exactly); the complex length is
+    # derived as its sqrt (real = spacelike, imaginary = timelike)
     return Edge(Vertex(1, [0.0, 0.0, 0.0, 0.0]),
-                Vertex(2, [0.0, 0.0, 0.0, 1.0]), sq)
+                Vertex(2, [0.0, 0.0, 0.0, 1.0]), complex(sq, 0.0))
 
 
 class EdgeComplexLengthTest(unittest.TestCase):
@@ -62,7 +64,8 @@ class EdgeComplexLengthTest(unittest.TestCase):
 
     def test_squaring_length_recovers_squared_length(self):
         for sq in (25.0, -4.0, 1.0, -1.0, 100.0, -0.5):
-            sq2 = _edge(sq).getLength() ** 2
+            length = _edge(sq).getLength()
+            sq2 = length * length
             self.assertAlmostEqual(sq2.real, sq, places=9)
             self.assertAlmostEqual(sq2.imag, 0.0, places=12)
 

--- a/tests/mesh/test_edge_complex_length_python.py
+++ b/tests/mesh/test_edge_complex_length_python.py
@@ -1,0 +1,76 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Causal character is read from the (complex) edge LENGTH, not the fragile
+`sign(l^2)`: an edge is timelike iff its length has a nonzero imaginary part.
+`getLength()` is the metric DOF (distinct from the U(1) `getPhase()`), real for
+spacelike, imaginary for timelike, and squares back to the squared length."""
+
+import unittest
+
+from tessera import Vertex, Edge
+
+
+def _edge(sq):
+    return Edge(Vertex(1, [0.0, 0.0, 0.0, 0.0]),
+                Vertex(2, [0.0, 0.0, 0.0, 1.0]), sq)
+
+
+class EdgeComplexLengthTest(unittest.TestCase):
+    def test_spacelike_has_real_length(self):
+        e = _edge(25.0)
+        L = e.getLength()
+        self.assertAlmostEqual(L.real, 5.0, places=12)
+        self.assertAlmostEqual(L.imag, 0.0, places=12)
+        self.assertTrue(e.isSpacelike())
+        self.assertFalse(e.isTimelike())
+        self.assertFalse(e.isNull())
+
+    def test_timelike_has_imaginary_length(self):
+        e = _edge(-4.0)
+        L = e.getLength()
+        self.assertAlmostEqual(L.real, 0.0, places=12)
+        self.assertAlmostEqual(L.imag, 2.0, places=12)   # length = i*2
+        self.assertTrue(e.isTimelike())
+        self.assertFalse(e.isSpacelike())
+        self.assertFalse(e.isNull())
+
+    def test_null_has_zero_length(self):
+        e = _edge(0.0)
+        self.assertAlmostEqual(abs(e.getLength()), 0.0, places=12)
+        self.assertTrue(e.isNull())
+        self.assertFalse(e.isTimelike())
+        self.assertFalse(e.isSpacelike())
+
+    def test_squaring_length_recovers_squared_length(self):
+        for sq in (25.0, -4.0, 1.0, -1.0, 100.0, -0.5):
+            sq2 = _edge(sq).getLength() ** 2
+            self.assertAlmostEqual(sq2.real, sq, places=9)
+            self.assertAlmostEqual(sq2.imag, 0.0, places=12)
+
+    def test_causal_character_is_a_length_test_not_a_magnitude_test(self):
+        # tiny-but-nonzero squared lengths still resolve cleanly by imaginary part
+        self.assertTrue(_edge(-1e-6).isTimelike())
+        self.assertTrue(_edge(1e-6).isSpacelike())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/quantum/test_quantum_simplex_python.py
+++ b/tests/quantum/test_quantum_simplex_python.py
@@ -87,7 +87,7 @@ def edge_squared_length(s, p, q):
         tgt = e.getTarget()
         if (src.getId() == u.getId() and tgt.getId() == v.getId()) \
                 or (src.getId() == v.getId() and tgt.getId() == u.getId()):
-            return e.getSquaredLength()
+            return e.getSquaredLength().real
     raise KeyError(f"no edge between {p} and {q}")
 
 

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -29,7 +29,7 @@ class TestMetric(unittest.TestCase):
     def test_metric_instantiates(self):
         v1 = Vertex(1, [0, 0, 0, 0])
         v2 = Vertex(2, [0, 0, 0, 1])
-        edge = Edge(v1, v2, 25)
+        edge = Edge(v1, v2, complex(5.0, 0.0))  # spacelike length 5 (l^2 = 25)
 
         self.assertIsInstance(edge, Edge)
         src = edge.getSource().getId()

--- a/tests/test_pachner_exact.py
+++ b/tests/test_pachner_exact.py
@@ -158,11 +158,11 @@ class TestConeExact(unittest.TestCase):
             other_id = tgt_id if src_id == new_vid else src_id
             if other_id == 0:
                 # Both at t=0 → spacelike
-                self.assertGreater(e.getSquaredLength(), 0,
+                self.assertGreater(e.getSquaredLength().real, 0,
                                    "v0-new_v edge should be spacelike (sqlen>0)")
             else:
                 # new_v@t=0 to other@t=1 → timelike
-                self.assertLess(e.getSquaredLength(), 0,
+                self.assertLess(e.getSquaredLength().real, 0,
                                 f"v{other_id}-new_v edge should be timelike (sqlen<0)")
 
         # Orientation counts


### PR DESCRIPTION
## Summary
Generalize `Edge` from a signed-real `squaredLength` to a **complex metric**, so the geometry
can be Lorentzian and analytically continue (Picard–Lefschetz saddle of the Lorentzian action),
while keeping `l²` **exact** for the action. `Edge` now stores two synced fields:

- **`squaredLength_`** — the exact (possibly complex) `l²`, read by the action and all geometry
  math via `getSquaredLength()`. Never `getLength()²`.
- **`length_`** — the complex length, whose `Im` gives the **causal character** (`isTimelike` ⟺
  `|Im(length)| > ε`), superseding the fragile `sign(l²)` test.

`setSquaredLength(l²)` stores `l²` exactly and derives the length; `setLength(l)` stores the
length and keeps `l² = l·l`. U(1) `phase` stays a separate field; the matter Laplacian reads
`l²·e^{iφ}`.

## Why store both (the round-trip instability)
An earlier iteration stored *only* the complex length, forcing `l² = getLength()²` — a
`sqrt→square` round-trip of ~1 ULP. The Lorentzian dual action is catastrophically
ill-conditioned at near-degenerate simplices (the dual-volume circumradius blows up as the
Cayley–Menger determinant → 0), and that 1 ULP detonated into `Re S ≈ −6e7` at a squashed
geometry, so the #312 backreaction relaxation never pinned. Reading the **stored exact `l²`**
removes the round-trip: `Re S` is back to `−108.8 .. −73.02` (bit-identical to the
pre-complex-length build) and the relaxation pins at interior matter-pinned minima.

## Scope
- [x] Causal-character convention: `getLength()` (complex), `isTimelike/isSpacelike/isNull` via
      `|Im(l)|>ε`; bindings; regression test.
- [x] Store exact complex `l²` **and** the complex length on `Edge`; `getSquaredLength`/
      `setSquaredLength` + `getLength`/`setLength`, kept in sync.
- [x] `Simplex` Cayley–Menger/Gram read exact `l²` via `getSquaredLength()`; wickRotate uses `|l²|`.
- [x] `allocSlot` stores `complex(sq, 0)` exactly; ~28 consumer reads migrated to
      `getSquaredLength()`; remove the round-trip read path.
- [x] `ReggeSolver` FD + GD loops perturb/restore `l²` exactly (no drift).
- [x] Restore the original tight `test_simplex_geometry` tolerances (the round-trip workaround
      is obsolete).

## Test plan
- [x] Full suite (`pytest -n 16`): **1533 passed, 7 skipped, 882 subtests, 0 failures** (8:10).
- [x] `test_backreaction_emergent_dual_python.py`: 9 passed (the 3 prior failures fixed).
- [x] Edge API round-trips exactly: `setSquaredLength(-2.5)` → `getSquaredLength().real == -2.5`;
      `setLength(2j)` → `l² == -4` exact, timelike.

Closes #338.
