### PR TITLE
feat(cobordism): port the analytic r_U gradient to C++ (+ level-2 feasibility)

### DIFF
--- a/examples/cobordism/deep_merge_baseline/probe_deep.py
+++ b/examples/cobordism/deep_merge_baseline/probe_deep.py
@@ -4,7 +4,7 @@ import importlib.util, os, sys, time
 from collections import defaultdict, deque
 import numpy as np
 
-HERE = os.path.expanduser("~/deep-merge/examples/cobordism")
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # examples/cobordism
 sys.path.insert(0, HERE)
 spec = importlib.util.spec_from_file_location(
     "merge_cobordism", os.path.join(HERE, "merge_cobordism.py"))
@@ -82,7 +82,7 @@ def curvature_profile(st, dist):
     return bins
 
 
-for level in (0, 1, 2):
+for level in ((0, 1, 2) if __name__ == "__main__" else ()):  # importable: no side effects
     t0 = time.time()
     st, nreg, holes, hole_vs, cells = build_merge(level)
     nE = len(st.getEdgeList().toVector())

--- a/examples/cobordism/level2_ru_gradient_feasibility.py
+++ b/examples/cobordism/level2_ru_gradient_feasibility.py
@@ -1,0 +1,112 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Level-2 feasibility for the C++ r_U gradient (#343).
+
+The level-0 relaxation test pins correctness; this checks the C++
+``EigenstateSynthesis.residualForPeriodsGradient`` stays correct — and the
+relaxer scales — on the geodesically-subdivided level-2 merge substrate (the
+~2724-edge deep merge of #313). It is a slow, manual feasibility run (a full
+gradient call is ~100 s on CPU), NOT a suite test: verified n1=2724 gives
+``|C++ - FD| ~ 1e-8``.
+
+Full level-2 *convergence* is out of scope here — at this scale a gradient call
+is dominated by the dense eigensolve (~17 s) AND the O(n1^3) per-edge
+perturbation loop (~85 s). Speeding it up is the GPU eigensolve ticket (#342)
+plus a faster per-edge sweep; this run only establishes correctness + feasibility.
+
+    python examples/cobordism/level2_ru_gradient_feasibility.py [--level 2]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "deep_merge_baseline"))
+sys.path.insert(0, _HERE)
+import probe_deep as PD  # noqa: E402  (importable: no run-loop side effects)
+
+tessera = PD.tessera
+cob = tessera.cobordism
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--level", type=int, default=2, help="geodesic subdivision level")
+    ap.add_argument("--cells", type=int, default=3, help="how many cells to FD-check")
+    args = ap.parse_args()
+
+    t0 = time.time()
+    st, nreg, holes3, _hole_vs, _cells = PD.build_merge(args.level)
+    st.materializeFacets()
+    es = cob.EigenstateSynthesis(st, 1)
+    circles = [sorted(v + off for v in h) for off in (0, nreg, 2 * nreg) for h in holes3]
+    holes = [list(c) for c in circles]
+    P = np.asarray(es.cyclePeriods(holes), dtype=complex)
+    m = len(holes)
+    dim = len(P) // m
+    target = [complex(z) for z in P.reshape(dim, m)[0]]
+    cells1 = [tuple(int(v) for v in c) for c in es.cellSimplices()]
+    n1 = len(cells1)
+    print(f"level {args.level}: n1={n1} edges, {st.getVertexList().size()}v, "
+          f"register dim={dim}, build {time.time() - t0:.1f}s", flush=True)
+
+    emap = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        emap[(min(a, b), max(a, b))] = e
+    # perturb non-uniformly so the register is no longer exactly realized (r_U > 0)
+    for i in range(0, n1, 7):
+        ek = (min(cells1[i]), max(cells1[i]))
+        emap[ek].setSquaredLength(emap[ek].getSquaredLength().real * 1.3)
+    st.materializeFacets()
+
+    t1 = time.time()
+    g = np.asarray(es.residualForPeriodsGradient(holes, target), float)
+    print(f"r_U={es.residualForPeriods(holes, target):.4e}; "
+          f"C++ gradient call {time.time() - t1:.1f}s", flush=True)
+
+    h = 1e-6
+    worst = 0.0
+    probe = sorted(set(int(i) for i in np.linspace(0, n1 - 1, args.cells)))
+    for idx in probe:
+        ek = (min(cells1[idx]), max(cells1[idx]))
+        e = emap[ek]
+        l0 = e.getSquaredLength().real
+        e.setSquaredLength(l0 + h); st.materializeFacets()
+        rp = es.residualForPeriods(holes, target)
+        e.setSquaredLength(l0 - h); st.materializeFacets()
+        rm = es.residualForPeriods(holes, target)
+        e.setSquaredLength(l0); st.materializeFacets()
+        fd = (rp - rm) / (2 * h)
+        d = abs(g[idx] - fd)
+        worst = max(worst, d)
+        print(f"  cell {idx:5d}: C++ {g[idx]:+.4e}  FD {fd:+.4e}  |d|={d:.2e}", flush=True)
+    print(f"level-{args.level} worst |C++ - FD| = {worst:.2e}  (n1={n1})", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/stationary_action_relaxation.py
+++ b/examples/cobordism/stationary_action_relaxation.py
@@ -96,8 +96,11 @@ class StationaryActionRelaxer:
     the emergent-dual geometry. The input (slice-t) spatial edges are held fixed.
     """
 
-    def __init__(self, gamma=1e3, merge=None):
+    def __init__(self, gamma=1e3, merge=None, use_cpp_gradient=True):
         self.gamma = float(gamma)
+        # the analytic r_U gradient: the C++ residualForPeriodsGradient (fast) or
+        # the Python low-rank perturbation below (the correctness oracle).
+        self.use_cpp_gradient = bool(use_cpp_gradient)
         self.m = merge if merge is not None else MC.MergeCobordism()
         self.m.st.materializeFacets()
         self.st = self.m.st
@@ -253,27 +256,37 @@ class StationaryActionRelaxer:
         statres = float(np.vdot(g, g).real)
 
         # MATTER: d r_U over VAR via the single-spectrum low-rank dM.
-        invlam = 1.0 / (0.0 - lam[notnull])
-        Unn = U[:, notnull]
-        K2 = self.d2 @ np.diag(1.0 / W2) @ self.d2.T
-        D1d, D1pd = 1.0 / sW1, sW1
-        drU = np.empty(len(self.VAR))
-        for vi, ek in enumerate(self.VAR):
-            fa, fb = self._dM_factors(ek, W1, W2, K2, D1d, D1pd)
-            dMp = fa @ (fb.T @ p)
-            core = (Unn.T @ fa) @ (fb.T @ Un)
-            dUn = Unn @ (core * invlam[:, None])
-            dA = self.Q @ dUn
-            dAplus = -AtAi @ (dA.T @ A + A.T @ dA) @ AtAi @ A.T + AtAi @ dA.T
-            dc = dAplus @ self.target
-            dh = dUn @ c + Un @ dc
-            dcarried = self.Q @ dh
-            dpsi = dh.astype(complex).copy()
-            for q in range(self.M_HOLES):
-                dpsi[self.leakCol[q]] += -dcarried[q]
-            drU[vi] = (2.0 * np.real(np.vdot(rho, dMp))
-                       + (2.0 / nrm) * np.real(np.vdot(rho, M @ dpsi - lamR * dpsi))
-                       - (2.0 * rU / nrm) * np.real(np.vdot(p, dpsi)))
+        if self.use_cpp_gradient:
+            # C++ analytic gradient (residualForPeriodsGradient), returned per
+            # cellSimplices cell; map to the VAR-edge order. Verified == the
+            # Python oracle below == FD.
+            g_all = np.asarray(
+                self.es.residualForPeriodsGradient(self.holes, self.target_c), float)
+            drU = np.array([g_all[self.cidx1[k]] for k in self.VAR])
+        else:
+            # Python oracle: the low-rank dM/dl² + spectral pseudo-inverse
+            # perturbation per VAR edge (the reference the C++ port reproduces).
+            invlam = 1.0 / (0.0 - lam[notnull])
+            Unn = U[:, notnull]
+            K2 = self.d2 @ np.diag(1.0 / W2) @ self.d2.T
+            D1d, D1pd = 1.0 / sW1, sW1
+            drU = np.empty(len(self.VAR))
+            for vi, ek in enumerate(self.VAR):
+                fa, fb = self._dM_factors(ek, W1, W2, K2, D1d, D1pd)
+                dMp = fa @ (fb.T @ p)
+                core = (Unn.T @ fa) @ (fb.T @ Un)
+                dUn = Unn @ (core * invlam[:, None])
+                dA = self.Q @ dUn
+                dAplus = -AtAi @ (dA.T @ A + A.T @ dA) @ AtAi @ A.T + AtAi @ dA.T
+                dc = dAplus @ self.target
+                dh = dUn @ c + Un @ dc
+                dcarried = self.Q @ dh
+                dpsi = dh.astype(complex).copy()
+                for q in range(self.M_HOLES):
+                    dpsi[self.leakCol[q]] += -dcarried[q]
+                drU[vi] = (2.0 * np.real(np.vdot(rho, dMp))
+                           + (2.0 / nrm) * np.real(np.vdot(rho, M @ dpsi - lamR * dpsi))
+                           - (2.0 * rU / nrm) * np.real(np.vdot(p, dpsi)))
 
         # d statres = 2 Re(H conj(g)) = 2[Re(H·Re g) + Im(H·Im g)]; each
         # Hessian-vector is ONE FD step of the exact complex actionGradientExact.

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -339,6 +339,19 @@ class EigenstateSynthesis {
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
+    /// The analytic gradient \f$ \partial r_U / \partial l^2_e \f$ of
+    /// `residualForPeriods` w.r.t. each edge's squared length, returned in
+    /// `cellSimplices()` (\f$ k = 1 \f$ cell) order. Eigendecomposes the metric
+    /// Laplacian \f$ M = L_1 \f$, builds the same carried representative \f$ \psi \f$,
+    /// then propagates the per-edge low-rank \f$ dM/dl^2 \f$ through first-order
+    /// eigenvector perturbation theory and the pseudo-inverse derivative — the C++
+    /// port of the Python relaxation's `drU` (verified against it and a finite
+    /// difference). \f$ O(n_1^3) \f$ (one dense eigensolve plus a per-edge sweep).
+    /// @throws std::runtime_error if `targetPeriods.size() != holes.size()`.
+    [[nodiscard]] std::vector<double> residualForPeriodsGradient(
+        const std::vector<std::vector<std::uint64_t>> &holes,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
     /// The **carried representative** \f$ \psi \f$ that `residualForPeriods`
     /// scores — exposed as a cochain in its own right (the read-out
     /// `residualForPeriods` builds internally but does not return). Builds the

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -528,6 +528,15 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "sign +1), and returns residual(psi): -> 0 iff the targets lie "
            "in the carried register, floored otherwise. Raises on a "
            "hole/target length mismatch or a malformed hole.")
+      .def("residualForPeriodsGradient",
+           &EigenstateSynthesis::residualForPeriodsGradient,
+           py::arg("holes"), py::arg("target_periods"),
+           "The analytic gradient d r_U / d l^2 of residualForPeriods w.r.t. each "
+           "edge's squared length, in cellSimplices() (k=1 cell) order. "
+           "Eigendecomposes M = L1, builds the same carried psi, then propagates "
+           "the per-edge low-rank dM/dl^2 through eigenvector perturbation theory "
+           "and the pseudo-inverse derivative (the C++ port of the relaxation's "
+           "Python drU). Raises on a hole/target length mismatch.")
       // ----- Surgery: the topology-changing interior remove move (#196) -----
       .def("interiorTopCells", &EigenstateSynthesis::interiorTopCells,
            "The interior top cells (all-interior vertices, on no dW face) as "

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -955,4 +955,198 @@ double EigenstateSynthesis::residualForPeriods(
   return residual(psi);
 }
 
+std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+  using Eigen::Index;
+  using Eigen::MatrixXd;
+  using Eigen::VectorXcd;
+  using Eigen::VectorXd;
+  const std::size_t n1 = order_;
+  std::vector<double> grad(n1, 0.0);
+  const std::size_t m = holes.size();
+  if (n1 == 0 || m == 0) return grad;
+  if (targetPeriods.size() != m)
+    throw std::runtime_error(
+        "EigenstateSynthesis::residualForPeriodsGradient: " +
+        std::to_string(targetPeriods.size()) + " target periods for " +
+        std::to_string(m) + " holes");
+  static constexpr double kNullTol = 1e-7;
+  const Index N = static_cast<Index>(n1);
+
+  // ---- chain complex, weights, and the metric Laplacian M = L1 ----
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const std::vector<std::vector<std::uint64_t>> &cells1 = cellSimplices();
+  const auto tris = cc.kSimplexVertices(2);
+  const std::size_t n2 = tris.size();
+  const std::vector<long> &d1flat = cc.boundaryMatrix(1);  // n0 x n1
+  const std::vector<long> &d2flat = cc.boundaryMatrix(2);  // n1 x n2
+  const std::size_t n0 = d1flat.size() / n1;
+  const HodgeLaplacian hl(st_);
+  const std::vector<double> W1v = hl.weights(1);  // n1
+  const std::vector<double> W2v = hl.weights(2);  // n2
+  const std::vector<cd> Lflat = hl.laplacian(1, /*metric=*/true, /*lorentzian=*/false);
+
+  MatrixXd M(N, N);
+  for (std::size_t i = 0; i < n1; ++i)
+    for (std::size_t j = 0; j < n1; ++j)
+      M(static_cast<Index>(i), static_cast<Index>(j)) = Lflat[i * n1 + j].real();
+  VectorXd W1(N), D1d(N), D1pd(N);  // W1, 1/sqrt(W1), sqrt(W1)
+  for (std::size_t i = 0; i < n1; ++i) {
+    W1[static_cast<Index>(i)] = W1v[i];
+    D1pd[static_cast<Index>(i)] = std::sqrt(W1v[i]);
+    D1d[static_cast<Index>(i)] = 1.0 / std::sqrt(W1v[i]);
+  }
+  MatrixXd d1m(static_cast<Index>(n0), N);
+  for (std::size_t v = 0; v < n0; ++v)
+    for (std::size_t c = 0; c < n1; ++c)
+      d1m(static_cast<Index>(v), static_cast<Index>(c)) =
+          static_cast<double>(d1flat[v * n1 + c]);
+  MatrixXd d2m(N, static_cast<Index>(n2));
+  for (std::size_t c = 0; c < n1; ++c)
+    for (std::size_t t = 0; t < n2; ++t)
+      d2m(static_cast<Index>(c), static_cast<Index>(t)) =
+          static_cast<double>(d2flat[c * n2 + t]);
+  const MatrixXd K1 = d1m.transpose() * d1m;  // n1 x n1
+  VectorXd W2inv(static_cast<Index>(n2));
+  for (std::size_t t = 0; t < n2; ++t) W2inv[static_cast<Index>(t)] = 1.0 / W2v[t];
+  const MatrixXd K2 = d2m * W2inv.asDiagonal() * d2m.transpose();  // n1 x n1
+
+  // ---- index maps: cell -> index, edge -> l^2, edge -> incident triangles ----
+  auto key = [](std::uint64_t a, std::uint64_t b) {
+    return std::pair<std::uint64_t, std::uint64_t>(std::min(a, b), std::max(a, b));
+  };
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> cidx1;
+  for (std::size_t i = 0; i < n1; ++i) cidx1[key(cells1[i][0], cells1[i][1])] = i;
+  std::map<std::pair<std::uint64_t, std::uint64_t>, double> l2map;
+  for (auto *e : edges_)
+    l2map[key(e->getSource()->getId(), e->getTarget()->getId())] =
+        e->getSquaredLength().real();
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::vector<std::size_t>> trisOf;
+  for (std::size_t ti = 0; ti < n2; ++ti)
+    for (int i = 0; i < 3; ++i)
+      for (int j = i + 1; j < 3; ++j)
+        trisOf[key(tris[ti][i], tris[ti][j])].push_back(ti);
+  auto L2 = [&](std::uint64_t a, std::uint64_t b) -> double {
+    if (a == b) return 0.0;
+    auto it = l2map.find(key(a, b));
+    return it == l2map.end() ? 0.0 : it->second;
+  };
+
+  // ---- Q (hole-boundary covector) + each hole's leak column ----
+  MatrixXd Q = MatrixXd::Zero(static_cast<Index>(m), N);
+  std::vector<std::size_t> leakCol(m);
+  for (std::size_t q = 0; q < m; ++q) {
+    const auto &h = holes[q];
+    for (int j = 0; j < 3; ++j) {
+      std::vector<std::uint64_t> facet;
+      for (int i = 0; i < 3; ++i)
+        if (i != j) facet.push_back(h[i]);
+      Q(static_cast<Index>(q), static_cast<Index>(cidx1.at(key(facet[0], facet[1])))) +=
+          (j % 2 == 0 ? 1.0 : -1.0);
+    }
+    leakCol[q] = cidx1.at(key(h[0], h[1]));
+  }
+
+  // ---- eigendecomposition of M; harmonic (null) / non-null split ----
+  Eigen::SelfAdjointEigenSolver<MatrixXd> eig(M);
+  const VectorXd lam = eig.eigenvalues();
+  const MatrixXd U = eig.eigenvectors();
+  std::vector<Index> nullIdx, nnIdx;
+  for (Index i = 0; i < N; ++i) (std::abs(lam[i]) < kNullTol ? nullIdx : nnIdx).push_back(i);
+  const Index nd = static_cast<Index>(nullIdx.size());
+  const Index nnd = static_cast<Index>(nnIdx.size());
+  if (nd == 0) return grad;  // no harmonics -> nothing carried
+  MatrixXd Un(N, nd), Unn(N, nnd);
+  for (Index r = 0; r < nd; ++r) Un.col(r) = U.col(nullIdx[r]);
+  for (Index r = 0; r < nnd; ++r) Unn.col(r) = U.col(nnIdx[r]);
+  VectorXd invlam(nnd);  // 1 / (0 - lambda_nn) for the eigenvector perturbation
+  for (Index r = 0; r < nnd; ++r) invlam[r] = -1.0 / lam[nnIdx[r]];
+
+  // ---- carried representative psi (via Un / Q / pseudo-inverse), p, rho, r_U ----
+  VectorXcd target(static_cast<Index>(m));
+  for (std::size_t q = 0; q < m; ++q) target[static_cast<Index>(q)] = targetPeriods[q];
+  const MatrixXd A = Q * Un;                            // m x nd
+  const MatrixXd AtAi = (A.transpose() * A).inverse();  // nd x nd
+  const VectorXcd c = (AtAi * A.transpose()).cast<cd>() * target;  // nd
+  VectorXcd psi = Un.cast<cd>() * c;                    // n1
+  const VectorXcd carried = Q.cast<cd>() * psi;         // m
+  for (std::size_t q = 0; q < m; ++q)
+    psi[static_cast<Index>(leakCol[q])] +=
+        target[static_cast<Index>(q)] - carried[static_cast<Index>(q)];
+  const double nrm = psi.norm();
+  if (nrm <= 0.0) return grad;
+  const VectorXcd p = psi / nrm;
+  const VectorXcd Mp = M.cast<cd>() * p;
+  const double lamR = (p.dot(Mp)).real();
+  const VectorXcd rho = Mp - lamR * p;
+  const double rU = rho.squaredNorm();
+
+  // ---- per-edge analytic gradient d r_U / d l^2 (low-rank dM + perturbation) ----
+  for (std::size_t je = 0; je < n1; ++je) {
+    const Index j = static_cast<Index>(je);
+    const auto ek = key(cells1[je][0], cells1[je][1]);
+    const double l2 = l2map.at(ek);
+    const double dW1je = (l2 >= 0.0 ? 1.0 : -1.0) / (2.0 * std::sqrt(std::abs(l2)));
+    const double s1 = -0.5 * dW1je / std::pow(W1[j], 1.5);
+    const double s2 = 0.5 * dW1je / std::sqrt(W1[j]);
+    const VectorXd w = s1 * K1.row(j).transpose().cwiseProduct(D1d) +
+                       s2 * K2.row(j).transpose().cwiseProduct(D1pd);
+    // dM = fa * fb^T (symmetric, low rank): columns [e, w] then one per triangle.
+    std::vector<VectorXd> colsA, colsB;
+    VectorXd ev = VectorXd::Zero(N);
+    ev[j] = 1.0;
+    colsA.push_back(ev);
+    colsB.push_back(w);
+    colsA.push_back(w);
+    colsB.push_back(ev);
+    for (std::size_t ti : trisOf[ek]) {
+      const auto &t = tris[ti];
+      Eigen::Matrix2d G;
+      for (int i = 0; i < 2; ++i)
+        for (int jj = 0; jj < 2; ++jj)
+          G(i, jj) = 0.5 * (L2(t[0], t[i + 1]) + L2(t[0], t[jj + 1]) - L2(t[i + 1], t[jj + 1]));
+      const double detG = G.determinant();
+      const double W2ti = W2v[ti];
+      if (std::abs(std::sqrt(std::abs(detG)) / 2.0 - W2ti) > 1e-9 || std::abs(detG) < 1e-12)
+        continue;
+      auto ind = [&](int pp, int qq) -> double {
+        return (pp != qq && key(t[pp], t[qq]) == ek) ? 1.0 : 0.0;
+      };
+      Eigen::Matrix2d dG;
+      for (int i = 0; i < 2; ++i)
+        for (int jj = 0; jj < 2; ++jj)
+          dG(i, jj) = 0.5 * (ind(0, i + 1) + ind(0, jj + 1) - ind(i + 1, jj + 1));
+      const double dW2ti = (W2ti / 2.0) * (G.inverse() * dG).trace();
+      const VectorXd cj = D1pd.cwiseProduct(d2m.col(static_cast<Index>(ti)));
+      colsA.push_back(cj);
+      colsB.push_back((-dW2ti / (W2ti * W2ti)) * cj);
+    }
+    const Index r = static_cast<Index>(colsA.size());
+    MatrixXd fa(N, r), fb(N, r);
+    for (Index k = 0; k < r; ++k) {
+      fa.col(k) = colsA[static_cast<std::size_t>(k)];
+      fb.col(k) = colsB[static_cast<std::size_t>(k)];
+    }
+    // dM p, the eigenvector perturbation dUn, the pseudo-inverse perturbation, dpsi.
+    const VectorXcd dMp = fa.cast<cd>() * (fb.transpose().cast<cd>() * p);
+    const MatrixXd core = (Unn.transpose() * fa) * (fb.transpose() * Un);  // nnd x nd
+    const MatrixXd dUn = Unn * (invlam.asDiagonal() * core);               // n1 x nd
+    const MatrixXd dA = Q * dUn;                                           // m x nd
+    const MatrixXd dAplus =
+        -AtAi * (dA.transpose() * A + A.transpose() * dA) * AtAi * A.transpose() +
+        AtAi * dA.transpose();                                             // nd x m
+    const VectorXcd dc = dAplus.cast<cd>() * target;                       // nd
+    VectorXcd dpsi = dUn.cast<cd>() * c + Un.cast<cd>() * dc;              // n1
+    const VectorXcd dcarried = Q.cast<cd>() * dpsi;                        // m
+    for (std::size_t q = 0; q < m; ++q)
+      dpsi[static_cast<Index>(leakCol[q])] += -dcarried[static_cast<Index>(q)];
+    const VectorXcd Mdpsi = M.cast<cd>() * dpsi;
+    grad[je] = 2.0 * (rho.dot(dMp)).real() +
+               (2.0 / nrm) * (rho.dot(Mdpsi - lamR * dpsi)).real() -
+               (2.0 * rU / nrm) * (p.dot(dpsi)).real();
+  }
+  return grad;
+}
+
 }  // namespace tessera::cobordism

--- a/tests/cobordism/test_stationary_action_relaxation_python.py
+++ b/tests/cobordism/test_stationary_action_relaxation_python.py
@@ -63,6 +63,7 @@ _RX = SAR.StationaryActionRelaxer(gamma=1e3)    # one shared level-0 relaxer
 class StationaryActionRelaxationTest(unittest.TestCase):
     def setUp(self):
         _RX.set_var(_RX.x0)            # reset the geometry before each test
+        _RX.use_cpp_gradient = True    # the default path (C++ r_U gradient)
 
     def test_objective_no_dirichlet_full_complex_action(self):
         """Φ = ‖∇S‖² + Γ·r_U, the matter term is r_U ALONE (no Dirichlet), and
@@ -101,6 +102,25 @@ class StationaryActionRelaxationTest(unittest.TestCase):
         self.assertLess(srf, sr0)                        # ‖∇S‖² descended
         self.assertLess(rUf, 1e-3)                       # realizability maintained
         self.assertGreater(abs(Sf.imag), 1e-6)           # still Lorentzian
+
+    def test_cpp_gradient_matches_python_oracle_and_fd(self):
+        """The C++ residualForPeriodsGradient (the wired-in r_U gradient) matches
+        the Python perturbation-theory oracle to ~machine precision, and the full
+        Φ gradient still matches a finite difference — checked at a perturbed
+        geometry where r_U > 0 (at the base r_U ≈ 0, so dr_U is trivially ~0)."""
+        x = _RX.x0.copy()
+        x[::2] *= 1.3                                     # non-uniform -> r_U > 0
+        _RX.use_cpp_gradient = True
+        _, g_cpp, _, rU_cpp, _ = _RX.objective(x)
+        _RX.use_cpp_gradient = False
+        _, g_py, _, rU_py, _ = _RX.objective(x)
+        _RX.use_cpp_gradient = True
+        self.assertGreater(rU_cpp, 1e-4)                 # a non-trivial test point
+        self.assertAlmostEqual(rU_cpp, rU_py, places=10)
+        # the C++ dr_U equals the Python oracle (the gradients differ only in the
+        # gamma*dr_U term; statres is identical), to ~machine precision.
+        self.assertLess(float(np.max(np.abs(g_cpp - g_py))) / _RX.gamma, 1e-9)
+        self.assertLess(_RX.check_gradient(x=x, n=2), 1e-3)   # full grad == FD at x
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Port the analytic `r_U` gradient (the per-edge realizability-residual derivative) from the
Python `StationaryActionRelaxer` (#341) to C++ — `EigenstateSynthesis::residualForPeriodsGradient`
— so the per-edge gradient loop is no longer Python-bound. The relaxer routes through it by
default (`use_cpp_gradient`), keeping the Python low-rank perturbation as the correctness oracle.

The C++ method eigendecomposes `M = L₁`, rebuilds the carried representative ψ, then propagates
the per-edge low-rank `dM/dl²` through first-order eigenvector perturbation theory and the
pseudo-inverse derivative — returned in `cellSimplices()` (k=1 cell) order.

## Test plan
- [x] C++ `residualForPeriodsGradient` matches FD (level-0, perturbed): **worst |C++ − FD| = 1.06e-9**.
- [x] C++ == the Python `drU` oracle to ~machine precision: **|drU_cpp − drU_py| = 4.16e-15** (same r_U).
- [x] `StationaryActionRelaxer.use_cpp_gradient` (default True) routes through it; the full Φ gradient still matches FD (3.78e-7). New regression test green.
- [x] Bounded level-2 feasibility (`build_merge(2)`, **n1=2724 edges**): C++ gradient matches FD to **~1.2e-8**; a gradient call runs in ~103s — correct at scale, the relaxer runs.
- [x] Full suite green (`pytest -n 16`): **1538 passed, 6 skipped, 0 failures**.

## Note on level-2 scaling
A level-2 gradient call (~103s) is dominated by **both** the dense eigensolve (~17s) **and**
the `O(n1³)` per-edge perturbation loop (~85s, now in C++). So full level-2 *convergence*
needs more than #342's eigensolve speedup alone — the per-edge sweep is the larger term. This
PR establishes correctness + feasibility at scale; convergence is deliberately deferred.

Closes #343.
