### PR TITLE
feat(cobordism): FP32 cuBLAS GPU port of the r_U gradient loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,8 @@ if (TESSERA_CUDA)
         ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
     find_package(CUDAToolkit REQUIRED)
-    target_link_libraries(tessera_cuda PRIVATE CUDA::cudart)
+    # cuBLAS (SGEMM) backs the FP32 r_U-gradient GPU path (eigenstate_cuda.cu).
+    target_link_libraries(tessera_cuda PRIVATE CUDA::cudart CUDA::cublas)
 endif()
 
 # ---- <tessera_core static library> ----------------------------------------
@@ -291,7 +292,7 @@ target_compile_definitions(tessera_core PUBLIC
 if (TESSERA_CUDA)
     message(STATUS "CUDA acceleration turned ON.")
     target_compile_definitions(tessera_core PUBLIC TESSERA_CUDA=1)
-    target_link_libraries(tessera_core PUBLIC tessera_cuda CUDA::cudart)
+    target_link_libraries(tessera_core PUBLIC tessera_cuda CUDA::cudart CUDA::cublas)
 else()
     message(STATUS "CUDA acceleration turned OFF.")
 endif()

--- a/examples/cobordism/level2_ru_gradient_fp32_gpu.py
+++ b/examples/cobordism/level2_ru_gradient_fp32_gpu.py
@@ -1,0 +1,141 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""FP32 cuBLAS GPU port of the r_U gradient: precision + speedup vs FP64 CPU (#348).
+
+``EigenstateSynthesis.residualForPeriodsGradientGpu`` runs the per-edge analytic
+r_U-gradient loop as an FP32 cuBLAS (SGEMM) path on the GPU; the FP64 CPU
+``residualForPeriodsGradient`` is the default and the correctness oracle. This
+run verifies, on the geodesically-subdivided merge substrate at ``--level N``
+PERTURBED so r_U > 0 (at the base geometry r_U ~ 0, so dr_U ~ 0 — a degenerate
+test):
+
+  1. FP32-GPU vs FP64-CPU gradient  -> relative L2 error (expect ~1e-5), cosine.
+  2. Both vs a central finite difference of residualForPeriods on a few cells.
+  3. Wall-clock speedup of the GPU path vs the ~82 s level-2 CPU baseline.
+
+The level-2 substrate is ``probe_deep.build_merge(2)`` (n1=2724); ``--level 0``
+is the small fast smoke over the same merge family.
+
+    OMP_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16 \
+        python examples/cobordism/level2_ru_gradient_fp32_gpu.py [--level 2]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "deep_merge_baseline"))
+sys.path.insert(0, _HERE)
+import probe_deep as PD  # noqa: E402  (importable: no run-loop side effects)
+
+tessera = PD.tessera
+cob = tessera.cobordism
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--level", type=int, default=2, help="geodesic subdivision level")
+    ap.add_argument("--cells", type=int, default=3, help="how many cells to FD-check")
+    args = ap.parse_args()
+
+    t0 = time.time()
+    st, nreg, holes3, _hole_vs, _cells = PD.build_merge(args.level)
+    st.materializeFacets()
+    es = cob.EigenstateSynthesis(st, 1)
+    circles = [sorted(v + off for v in h) for off in (0, nreg, 2 * nreg) for h in holes3]
+    holes = [list(c) for c in circles]
+    P = np.asarray(es.cyclePeriods(holes), dtype=complex)
+    m = len(holes)
+    dim = len(P) // m
+    target = [complex(z) for z in P.reshape(dim, m)[0]]
+    cells1 = [tuple(int(v) for v in c) for c in es.cellSimplices()]
+    n1 = len(cells1)
+    print(f"level {args.level}: n1={n1} edges, {st.getVertexList().size()}v, "
+          f"register dim={dim}, build {time.time() - t0:.1f}s", flush=True)
+
+    emap = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        emap[(min(a, b), max(a, b))] = e
+    # perturb non-uniformly so the register is no longer exactly realized (r_U > 0)
+    for i in range(0, n1, 7):
+        ek = (min(cells1[i]), max(cells1[i]))
+        emap[ek].setSquaredLength(emap[ek].getSquaredLength().real * 1.3)
+    st.materializeFacets()
+    print(f"r_U = {es.residualForPeriods(holes, target):.6e}  (perturbed; must be > 0)",
+          flush=True)
+
+    t1 = time.time()
+    g_cpu = np.asarray(es.residualForPeriodsGradient(holes, target), float)
+    t_cpu = time.time() - t1
+    print(f"FP64 CPU residualForPeriodsGradient    {t_cpu:8.2f}s", flush=True)
+
+    t2 = time.time()
+    g_gpu = np.asarray(es.residualForPeriodsGradientGpu(holes, target), float)
+    t_gpu = time.time() - t2
+    print(f"FP32 GPU residualForPeriodsGradientGpu {t_gpu:8.2f}s", flush=True)
+
+    # ---- precision: FP32-GPU vs FP64-CPU ----
+    denom = np.linalg.norm(g_cpu)
+    rel = np.linalg.norm(g_gpu - g_cpu) / denom if denom > 0 else float("nan")
+    amax = np.max(np.abs(g_gpu - g_cpu))
+    cos = float(g_cpu @ g_gpu / (np.linalg.norm(g_cpu) * np.linalg.norm(g_gpu)))
+    print(f"\nFP32-GPU vs FP64-CPU: rel L2 = {rel:.3e}  max|d| = {amax:.3e}  "
+          f"cos = {cos:.8f}  (||g_cpu|| = {denom:.3e})", flush=True)
+    print(f"speedup (CPU/GPU)    = {t_cpu / t_gpu:.1f}x  ({t_cpu:.1f}s -> {t_gpu:.2f}s)",
+          flush=True)
+
+    # ---- both vs central finite difference of residualForPeriods ----
+    h = 1e-6
+    worst_cpu = worst_gpu = 0.0
+    probe = sorted(set(int(i) for i in np.linspace(0, n1 - 1, args.cells)))
+    print(f"\nfinite-difference cross-check (h={h:g}):", flush=True)
+    for idx in probe:
+        ek = (min(cells1[idx]), max(cells1[idx]))
+        e = emap[ek]
+        l0 = e.getSquaredLength().real
+        e.setSquaredLength(l0 + h); st.materializeFacets()
+        rp = es.residualForPeriods(holes, target)
+        e.setSquaredLength(l0 - h); st.materializeFacets()
+        rm = es.residualForPeriods(holes, target)
+        e.setSquaredLength(l0); st.materializeFacets()
+        fd = (rp - rm) / (2 * h)
+        dc, dg = abs(g_cpu[idx] - fd), abs(g_gpu[idx] - fd)
+        worst_cpu, worst_gpu = max(worst_cpu, dc), max(worst_gpu, dg)
+        print(f"  cell {idx:5d}: CPU {g_cpu[idx]:+.4e}  GPU {g_gpu[idx]:+.4e}  "
+              f"FD {fd:+.4e}  |CPU-FD|={dc:.2e}  |GPU-FD|={dg:.2e}", flush=True)
+    print(f"\nworst |CPU-FD| = {worst_cpu:.2e}   worst |GPU-FD| = {worst_gpu:.2e}  "
+          f"(n1={n1})", flush=True)
+
+    ok = (rel < 1e-4) and (cos > 0.9999)
+    print(f"\nVERDICT: FP32-GPU {'MATCHES' if ok else 'DOES NOT MATCH'} FP64-CPU "
+          f"to the approved ~1e-5 tolerance (rel<1e-4, cos>0.9999).", flush=True)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -352,6 +352,22 @@ class EigenstateSynthesis {
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
+    /// FP32 cuBLAS (SGEMM) GPU port of `residualForPeriodsGradient` (#348): the
+    /// identical analytic gradient, but the dominant per-edge GEMMs
+    /// (\f$ U_{nn}^\top f_a \f$, the core product, \f$ dU_n = U_{nn}(\dots) \f$,
+    /// \f$ dM\,p \f$ and \f$ M\,d\psi \f$) run in single precision on the GPU,
+    /// while the dense eigensolve and the cheap small-dimension per-edge algebra
+    /// (and the final \f$ O(n_1) \f$ dot-product reductions) stay on the CPU in
+    /// FP64. FP32 in those GEMMs is the only approximation (pre-approved: ~1e-5
+    /// relative vs FP64 at level-2, identical descent direction); the FP64
+    /// `residualForPeriodsGradient` above is the default and the correctness
+    /// oracle. Requires a `TESSERA_CUDA` build; otherwise throws.
+    /// @throws std::runtime_error if `targetPeriods.size() != holes.size()`, or
+    ///   if tessera was built without CUDA.
+    [[nodiscard]] std::vector<double> residualForPeriodsGradientGpu(
+        const std::vector<std::vector<std::uint64_t>> &holes,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
     /// The **carried representative** \f$ \psi \f$ that `residualForPeriods`
     /// scores — exposed as a cochain in its own right (the read-out
     /// `residualForPeriods` builds internally but does not return). Builds the

--- a/include/cuda/eigenstate_cuda.h
+++ b/include/cuda/eigenstate_cuda.h
@@ -1,0 +1,62 @@
+// MIT License -- Copyright (c) 2025 Andrew Kelleher
+#pragma once
+
+namespace tessera {
+namespace cuda {
+
+/// FP32 cuBLAS (SGEMM) accelerator for the per-edge analytic r_U-gradient loop
+/// of `EigenstateSynthesis::residualForPeriodsGradient` (#348) — the level-2
+/// relaxation bottleneck (~82 s/call at n1=2724 edges on 16-core CPU FP64).
+///
+/// The loop-invariant matrices (the non-null / null eigenvector blocks of the
+/// metric Laplacian M = L1, M itself, and the unit carried representative p) are
+/// uploaded once as single precision; each edge then streams only its low-rank
+/// dM/dl² factors `fa`, `fb`, and the heavy GEMMs run on the GPU in FP32. The
+/// dense eigensolve and the cheap small-dimension per-edge algebra stay on the
+/// CPU in FP64; FP32 in these GEMMs is the ONLY approximation (pre-approved:
+/// ~1e-5 relative vs FP64 at level-2, identical descent direction). The FP64
+/// CPU path remains the default and the correctness oracle.
+///
+/// All matrices are COLUMN-MAJOR (matching Eigen's default storage and cuBLAS),
+/// so the caller passes `Eigen::MatrixXf::data()` directly. Complex N-vectors
+/// are packed as an N×2 column-major block `[Re | Im]`.
+class RuGradientGpu {
+ public:
+  /// Upload the loop-invariant matrices (column-major, FP32):
+  ///   `Unn`  (N×nnd) — non-null eigenvectors of M;
+  ///   `UnnS` (N×nnd) — `Unn` with column r scaled by invlam[r] = −1/λ_nn[r]
+  ///                    (so dUn = UnnS·core hoists the diagonal, by associativity);
+  ///   `Un`   (N×nd)  — null/harmonic eigenvectors of M;
+  ///   `M`    (N×N)   — the real metric Laplacian L1;
+  ///   `p2`   (N×2)   — `[Re p | Im p]`, the unit carried representative.
+  /// `rmax` is the largest per-edge rank (columns of `fa`/`fb`) — sizes scratch.
+  RuGradientGpu(int N, int nnd, int nd, int rmax,
+                const float* Unn, const float* UnnS, const float* Un,
+                const float* M, const float* p2);
+  ~RuGradientGpu();
+  RuGradientGpu(const RuGradientGpu&) = delete;
+  RuGradientGpu& operator=(const RuGradientGpu&) = delete;
+
+  /// Per-edge stage 1 (the dominant GEMMs). Given `fa`, `fb` (both N×r,
+  /// column-major FP32), compute on the GPU and download:
+  ///   `dUn`  (N×nd)  = UnnS · ((Unnᵀ·fa)·(fbᵀ·Un));
+  ///   `dMp2` (N×2)   = fa · (fbᵀ · p2)            — the complex dM·p, packed [Re|Im].
+  void edgeStage1(const float* fa, const float* fb, int r,
+                  float* dUn, float* dMp2);
+
+  /// Per-edge stage 2: `Mdpsi2` (N×2) = M · `dpsi2` (N×2), the dense GEMV against
+  /// the post-leak perturbed cochain (packed [Re|Im]).
+  void edgeStage2(const float* dpsi2, float* Mdpsi2);
+
+ private:
+  int N_, nnd_, nd_, rmax_;
+  void* handle_;  // cublasHandle_t, opaque so the header stays cuBLAS-free
+  // Loop-invariant device constants.
+  float *dUnn_, *dUnnS_, *dUn_, *dM_, *dP2_;
+  // Per-edge device scratch (sized by N, nnd, nd, rmax in the ctor).
+  float *dFa_, *dFb_, *dL_, *dR_, *dCore_, *dDUn_, *dT2_, *dDMp2_;
+  float *dDpsi2_, *dMdpsi2_;
+};
+
+}  // namespace cuda
+}  // namespace tessera

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -537,6 +537,16 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "the per-edge low-rank dM/dl^2 through eigenvector perturbation theory "
            "and the pseudo-inverse derivative (the C++ port of the relaxation's "
            "Python drU). Raises on a hole/target length mismatch.")
+      .def("residualForPeriodsGradientGpu",
+           &EigenstateSynthesis::residualForPeriodsGradientGpu,
+           py::arg("holes"), py::arg("target_periods"),
+           "FP32 cuBLAS (SGEMM) GPU port of residualForPeriodsGradient (#348): "
+           "the identical analytic gradient, with the dominant per-edge GEMMs run "
+           "in single precision on the GPU and the eigensolve + cheap small-dim "
+           "algebra + final reductions kept on the CPU in FP64. FP32 is the only "
+           "approximation (~1e-5 vs FP64); residualForPeriodsGradient stays the "
+           "default and the correctness oracle. Requires a TESSERA_CUDA build "
+           "(raises otherwise), and raises on a hole/target length mismatch.")
       // ----- Surgery: the topology-changing interior remove move (#196) -----
       .def("interiorTopCells", &EigenstateSynthesis::interiorTopCells,
            "The interior top cells (all-interior vertices, on no dW face) as "

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -47,6 +47,10 @@
 #include "spacetime/Spacetime.h"
 #include "spacetime/pachner/AddMove.h"
 
+#ifdef TESSERA_CUDA
+#include "cuda/eigenstate_cuda.h"
+#endif
+
 namespace tessera::cobordism {
 
 using cd = std::complex<double>;
@@ -1147,6 +1151,257 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
                (2.0 * rU / nrm) * (p.dot(dpsi)).real();
   }
   return grad;
+}
+
+std::vector<double> EigenstateSynthesis::residualForPeriodsGradientGpu(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+#ifndef TESSERA_CUDA
+  (void)holes;
+  (void)targetPeriods;
+  throw std::runtime_error(
+      "EigenstateSynthesis::residualForPeriodsGradientGpu: tessera was built "
+      "without CUDA (TESSERA_CUDA=OFF); use the CPU residualForPeriodsGradient.");
+#else
+  using Eigen::Index;
+  using Eigen::MatrixXd;
+  using Eigen::MatrixXf;
+  using Eigen::VectorXcd;
+  using Eigen::VectorXd;
+  // The setup below MIRRORS residualForPeriodsGradient verbatim through r_U so
+  // the FP64 CPU method stays the untouched correctness oracle; only the
+  // dominant per-edge GEMMs are offloaded to FP32 cuBLAS (the sole
+  // approximation). Any divergence here would be a bug, not a design choice.
+  const std::size_t n1 = order_;
+  std::vector<double> grad(n1, 0.0);
+  const std::size_t m = holes.size();
+  if (n1 == 0 || m == 0) return grad;
+  if (targetPeriods.size() != m)
+    throw std::runtime_error(
+        "EigenstateSynthesis::residualForPeriodsGradientGpu: " +
+        std::to_string(targetPeriods.size()) + " target periods for " +
+        std::to_string(m) + " holes");
+  static constexpr double kNullTol = 1e-7;
+  const Index N = static_cast<Index>(n1);
+
+  // ---- chain complex, weights, and the metric Laplacian M = L1 ----
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const std::vector<std::vector<std::uint64_t>> &cells1 = cellSimplices();
+  const auto tris = cc.kSimplexVertices(2);
+  const std::size_t n2 = tris.size();
+  const std::vector<long> &d1flat = cc.boundaryMatrix(1);  // n0 x n1
+  const std::vector<long> &d2flat = cc.boundaryMatrix(2);  // n1 x n2
+  const std::size_t n0 = d1flat.size() / n1;
+  const HodgeLaplacian hl(st_);
+  const std::vector<double> W1v = hl.weights(1);  // n1
+  const std::vector<double> W2v = hl.weights(2);  // n2
+  const std::vector<cd> Lflat = hl.laplacian(1, /*metric=*/true, /*lorentzian=*/false);
+
+  MatrixXd M(N, N);
+  for (std::size_t i = 0; i < n1; ++i)
+    for (std::size_t j = 0; j < n1; ++j)
+      M(static_cast<Index>(i), static_cast<Index>(j)) = Lflat[i * n1 + j].real();
+  VectorXd W1(N), D1d(N), D1pd(N);  // W1, 1/sqrt(W1), sqrt(W1)
+  for (std::size_t i = 0; i < n1; ++i) {
+    W1[static_cast<Index>(i)] = W1v[i];
+    D1pd[static_cast<Index>(i)] = std::sqrt(W1v[i]);
+    D1d[static_cast<Index>(i)] = 1.0 / std::sqrt(W1v[i]);
+  }
+  MatrixXd d1m(static_cast<Index>(n0), N);
+  for (std::size_t v = 0; v < n0; ++v)
+    for (std::size_t c = 0; c < n1; ++c)
+      d1m(static_cast<Index>(v), static_cast<Index>(c)) =
+          static_cast<double>(d1flat[v * n1 + c]);
+  MatrixXd d2m(N, static_cast<Index>(n2));
+  for (std::size_t c = 0; c < n1; ++c)
+    for (std::size_t t = 0; t < n2; ++t)
+      d2m(static_cast<Index>(c), static_cast<Index>(t)) =
+          static_cast<double>(d2flat[c * n2 + t]);
+  const MatrixXd K1 = d1m.transpose() * d1m;  // n1 x n1
+  VectorXd W2inv(static_cast<Index>(n2));
+  for (std::size_t t = 0; t < n2; ++t) W2inv[static_cast<Index>(t)] = 1.0 / W2v[t];
+  const MatrixXd K2 = d2m * W2inv.asDiagonal() * d2m.transpose();  // n1 x n1
+
+  // ---- index maps: cell -> index, edge -> l^2, edge -> incident triangles ----
+  auto key = [](std::uint64_t a, std::uint64_t b) {
+    return std::pair<std::uint64_t, std::uint64_t>(std::min(a, b), std::max(a, b));
+  };
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> cidx1;
+  for (std::size_t i = 0; i < n1; ++i) cidx1[key(cells1[i][0], cells1[i][1])] = i;
+  std::map<std::pair<std::uint64_t, std::uint64_t>, double> l2map;
+  for (auto *e : edges_)
+    l2map[key(e->getSource()->getId(), e->getTarget()->getId())] =
+        e->getSquaredLength().real();
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::vector<std::size_t>> trisOf;
+  for (std::size_t ti = 0; ti < n2; ++ti)
+    for (int i = 0; i < 3; ++i)
+      for (int j = i + 1; j < 3; ++j)
+        trisOf[key(tris[ti][i], tris[ti][j])].push_back(ti);
+  auto L2 = [&](std::uint64_t a, std::uint64_t b) -> double {
+    if (a == b) return 0.0;
+    auto it = l2map.find(key(a, b));
+    return it == l2map.end() ? 0.0 : it->second;
+  };
+
+  // ---- Q (hole-boundary covector) + each hole's leak column ----
+  MatrixXd Q = MatrixXd::Zero(static_cast<Index>(m), N);
+  std::vector<std::size_t> leakCol(m);
+  for (std::size_t q = 0; q < m; ++q) {
+    const auto &h = holes[q];
+    for (int j = 0; j < 3; ++j) {
+      std::vector<std::uint64_t> facet;
+      for (int i = 0; i < 3; ++i)
+        if (i != j) facet.push_back(h[i]);
+      Q(static_cast<Index>(q), static_cast<Index>(cidx1.at(key(facet[0], facet[1])))) +=
+          (j % 2 == 0 ? 1.0 : -1.0);
+    }
+    leakCol[q] = cidx1.at(key(h[0], h[1]));
+  }
+
+  // ---- eigendecomposition of M; harmonic (null) / non-null split ----
+  Eigen::SelfAdjointEigenSolver<MatrixXd> eig(M);
+  const VectorXd lam = eig.eigenvalues();
+  const MatrixXd U = eig.eigenvectors();
+  std::vector<Index> nullIdx, nnIdx;
+  for (Index i = 0; i < N; ++i) (std::abs(lam[i]) < kNullTol ? nullIdx : nnIdx).push_back(i);
+  const Index nd = static_cast<Index>(nullIdx.size());
+  const Index nnd = static_cast<Index>(nnIdx.size());
+  if (nd == 0) return grad;  // no harmonics -> nothing carried
+  MatrixXd Un(N, nd), Unn(N, nnd);
+  for (Index r = 0; r < nd; ++r) Un.col(r) = U.col(nullIdx[r]);
+  for (Index r = 0; r < nnd; ++r) Unn.col(r) = U.col(nnIdx[r]);
+  VectorXd invlam(nnd);  // 1 / (0 - lambda_nn) for the eigenvector perturbation
+  for (Index r = 0; r < nnd; ++r) invlam[r] = -1.0 / lam[nnIdx[r]];
+
+  // ---- carried representative psi (via Un / Q / pseudo-inverse), p, rho, r_U ----
+  VectorXcd target(static_cast<Index>(m));
+  for (std::size_t q = 0; q < m; ++q) target[static_cast<Index>(q)] = targetPeriods[q];
+  const MatrixXd A = Q * Un;                            // m x nd
+  const MatrixXd AtAi = (A.transpose() * A).inverse();  // nd x nd
+  const VectorXcd c = (AtAi * A.transpose()).cast<cd>() * target;  // nd
+  VectorXcd psi = Un.cast<cd>() * c;                    // n1
+  const VectorXcd carried = Q.cast<cd>() * psi;         // m
+  for (std::size_t q = 0; q < m; ++q)
+    psi[static_cast<Index>(leakCol[q])] +=
+        target[static_cast<Index>(q)] - carried[static_cast<Index>(q)];
+  const double nrm = psi.norm();
+  if (nrm <= 0.0) return grad;
+  const VectorXcd p = psi / nrm;
+  const VectorXcd Mp = M.cast<cd>() * p;
+  const double lamR = (p.dot(Mp)).real();
+  const VectorXcd rho = Mp - lamR * p;
+  const double rU = rho.squaredNorm();
+  if (nnd == 0) return grad;  // eigenvector perturbation needs a non-null block
+
+  // ---- upload the loop-invariant blocks (FP32, column-major) to the GPU ----
+  // UnnS = Unn * diag(invlam): by associativity this hoists the per-edge
+  // diagonal so dUn = UnnS * core == Unn * (invlam.asDiagonal() * core).
+  const MatrixXf UnnF = Unn.cast<float>();
+  const MatrixXf UnnSF = (Unn * invlam.asDiagonal()).cast<float>();
+  const MatrixXf UnF = Un.cast<float>();
+  const MatrixXf MF = M.cast<float>();
+  MatrixXf P2F(N, 2);
+  P2F.col(0) = p.real().cast<float>();
+  P2F.col(1) = p.imag().cast<float>();
+  // rmax: the widest per-edge low-rank dM = fa*fb^T (the 2 fixed [e,w] columns
+  // plus one per incident triangle) — sizes the GPU scratch once.
+  std::size_t rmax = 2;
+  for (const auto &kv : trisOf) rmax = std::max(rmax, 2 + kv.second.size());
+
+  cuda::RuGradientGpu gpu(static_cast<int>(N), static_cast<int>(nnd),
+                          static_cast<int>(nd), static_cast<int>(rmax),
+                          UnnF.data(), UnnSF.data(), UnF.data(), MF.data(),
+                          P2F.data());
+
+  // ---- per-edge analytic gradient d r_U / d l^2 (FP32 GEMMs on GPU) ----
+  std::vector<float> dUnBuf(static_cast<std::size_t>(N) * nd);
+  std::vector<float> dMp2Buf(static_cast<std::size_t>(N) * 2);
+  std::vector<float> dpsi2Buf(static_cast<std::size_t>(N) * 2);
+  std::vector<float> Mdpsi2Buf(static_cast<std::size_t>(N) * 2);
+  for (std::size_t je = 0; je < n1; ++je) {
+    const Index j = static_cast<Index>(je);
+    const auto ek = key(cells1[je][0], cells1[je][1]);
+    const double l2 = l2map.at(ek);
+    const double dW1je = (l2 >= 0.0 ? 1.0 : -1.0) / (2.0 * std::sqrt(std::abs(l2)));
+    const double s1 = -0.5 * dW1je / std::pow(W1[j], 1.5);
+    const double s2 = 0.5 * dW1je / std::sqrt(W1[j]);
+    const VectorXd w = s1 * K1.row(j).transpose().cwiseProduct(D1d) +
+                       s2 * K2.row(j).transpose().cwiseProduct(D1pd);
+    // dM = fa * fb^T (symmetric, low rank): columns [e, w] then one per triangle.
+    std::vector<VectorXd> colsA, colsB;
+    VectorXd ev = VectorXd::Zero(N);
+    ev[j] = 1.0;
+    colsA.push_back(ev);
+    colsB.push_back(w);
+    colsA.push_back(w);
+    colsB.push_back(ev);
+    for (std::size_t ti : trisOf[ek]) {
+      const auto &t = tris[ti];
+      Eigen::Matrix2d G;
+      for (int i = 0; i < 2; ++i)
+        for (int jj = 0; jj < 2; ++jj)
+          G(i, jj) = 0.5 * (L2(t[0], t[i + 1]) + L2(t[0], t[jj + 1]) - L2(t[i + 1], t[jj + 1]));
+      const double detG = G.determinant();
+      const double W2ti = W2v[ti];
+      if (std::abs(std::sqrt(std::abs(detG)) / 2.0 - W2ti) > 1e-9 || std::abs(detG) < 1e-12)
+        continue;
+      auto ind = [&](int pp, int qq) -> double {
+        return (pp != qq && key(t[pp], t[qq]) == ek) ? 1.0 : 0.0;
+      };
+      Eigen::Matrix2d dG;
+      for (int i = 0; i < 2; ++i)
+        for (int jj = 0; jj < 2; ++jj)
+          dG(i, jj) = 0.5 * (ind(0, i + 1) + ind(0, jj + 1) - ind(i + 1, jj + 1));
+      const double dW2ti = (W2ti / 2.0) * (G.inverse() * dG).trace();
+      const VectorXd cj = D1pd.cwiseProduct(d2m.col(static_cast<Index>(ti)));
+      colsA.push_back(cj);
+      colsB.push_back((-dW2ti / (W2ti * W2ti)) * cj);
+    }
+    const int r = static_cast<int>(colsA.size());
+    MatrixXf fa(N, r), fb(N, r);
+    for (int k = 0; k < r; ++k) {
+      fa.col(k) = colsA[static_cast<std::size_t>(k)].cast<float>();
+      fb.col(k) = colsB[static_cast<std::size_t>(k)].cast<float>();
+    }
+
+    // GPU stage 1 (FP32 GEMMs): dUn (N x nd) and dMp = dM*p (N, complex).
+    gpu.edgeStage1(fa.data(), fb.data(), r, dUnBuf.data(), dMp2Buf.data());
+    const MatrixXd dUn =
+        Eigen::Map<const MatrixXf>(dUnBuf.data(), N, nd).cast<double>();
+    VectorXcd dMp(N);
+    for (Index i = 0; i < N; ++i)
+      dMp[i] = cd(dMp2Buf[static_cast<std::size_t>(i)],
+                  dMp2Buf[static_cast<std::size_t>(N + i)]);
+
+    // Cheap small-dimension algebra stays FP64 on the host (as the oracle does):
+    // pseudo-inverse perturbation, dc, dpsi, and the minimal-leak adjustment.
+    const MatrixXd dA = Q * dUn;                                          // m x nd
+    const MatrixXd dAplus =
+        -AtAi * (dA.transpose() * A + A.transpose() * dA) * AtAi * A.transpose() +
+        AtAi * dA.transpose();                                            // nd x m
+    const VectorXcd dc = dAplus.cast<cd>() * target;                      // nd
+    VectorXcd dpsi = dUn.cast<cd>() * c + Un.cast<cd>() * dc;             // n1
+    const VectorXcd dcarried = Q.cast<cd>() * dpsi;                       // m
+    for (std::size_t q = 0; q < m; ++q)
+      dpsi[static_cast<Index>(leakCol[q])] += -dcarried[static_cast<Index>(q)];
+
+    // GPU stage 2 (FP32 GEMV): Mdpsi = M*dpsi for the post-leak perturbation.
+    for (Index i = 0; i < N; ++i) {
+      dpsi2Buf[static_cast<std::size_t>(i)] = static_cast<float>(dpsi[i].real());
+      dpsi2Buf[static_cast<std::size_t>(N + i)] = static_cast<float>(dpsi[i].imag());
+    }
+    gpu.edgeStage2(dpsi2Buf.data(), Mdpsi2Buf.data());
+    VectorXcd Mdpsi(N);
+    for (Index i = 0; i < N; ++i)
+      Mdpsi[i] = cd(Mdpsi2Buf[static_cast<std::size_t>(i)],
+                    Mdpsi2Buf[static_cast<std::size_t>(N + i)]);
+
+    grad[je] = 2.0 * (rho.dot(dMp)).real() +
+               (2.0 / nrm) * (rho.dot(Mdpsi - lamR * dpsi)).real() -
+               (2.0 * rU / nrm) * (p.dot(dpsi)).real();
+  }
+  return grad;
+#endif
 }
 
 }  // namespace tessera::cobordism

--- a/src/cuda/eigenstate_cuda.cu
+++ b/src/cuda/eigenstate_cuda.cu
@@ -1,0 +1,144 @@
+// MIT License -- Copyright (c) 2025 Andrew Kelleher
+//
+// FP32 cuBLAS (SGEMM) accelerator for the per-edge r_U-gradient loop of
+// EigenstateSynthesis::residualForPeriodsGradient (#348).
+//
+// The loop-invariant matrices are uploaded once; each edge streams its low-rank
+// dM/dl² factors fa, fb. The heavy GEMMs run in single precision on the GPU;
+// the CPU FP64 path stays the correctness oracle. Column-major throughout
+// (Eigen default + cuBLAS).
+
+#include "cuda/eigenstate_cuda.h"
+
+#include <cstdio>
+#include <stdexcept>
+
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
+#define CUDA_CHECK(call)                                                     \
+  do {                                                                       \
+    cudaError_t err = (call);                                                \
+    if (err != cudaSuccess) {                                                \
+      char msg[256];                                                         \
+      snprintf(msg, sizeof(msg), "CUDA error at %s:%d: %s", __FILE__,        \
+               __LINE__, cudaGetErrorString(err));                          \
+      throw std::runtime_error(msg);                                         \
+    }                                                                        \
+  } while (0)
+
+#define CUBLAS_CHECK(call)                                                   \
+  do {                                                                       \
+    cublasStatus_t st = (call);                                              \
+    if (st != CUBLAS_STATUS_SUCCESS) {                                       \
+      char msg[256];                                                         \
+      snprintf(msg, sizeof(msg), "cuBLAS error at %s:%d: status %d",         \
+               __FILE__, __LINE__, static_cast<int>(st));                    \
+      throw std::runtime_error(msg);                                         \
+    }                                                                        \
+  } while (0)
+
+namespace tessera {
+namespace cuda {
+
+namespace {
+// Allocate n floats on the device and (optionally) upload n host floats.
+float* devAlloc(int n, const float* host = nullptr) {
+  float* d = nullptr;
+  CUDA_CHECK(cudaMalloc(&d, static_cast<size_t>(n) * sizeof(float)));
+  if (host != nullptr)
+    CUDA_CHECK(cudaMemcpy(d, host, static_cast<size_t>(n) * sizeof(float),
+                          cudaMemcpyHostToDevice));
+  return d;
+}
+}  // namespace
+
+RuGradientGpu::RuGradientGpu(int N, int nnd, int nd, int rmax,
+                             const float* Unn, const float* UnnS,
+                             const float* Un, const float* M, const float* p2)
+    : N_(N), nnd_(nnd), nd_(nd), rmax_(rmax) {
+  cublasHandle_t h = nullptr;
+  CUBLAS_CHECK(cublasCreate(&h));
+  handle_ = h;
+
+  // Loop-invariant constants.
+  dUnn_ = devAlloc(N * nnd, Unn);
+  dUnnS_ = devAlloc(N * nnd, UnnS);
+  dUn_ = devAlloc(N * nd, Un);
+  dM_ = devAlloc(N * N, M);
+  dP2_ = devAlloc(N * 2, p2);
+
+  // Per-edge scratch (sized by the largest rank rmax).
+  dFa_ = devAlloc(N * rmax);
+  dFb_ = devAlloc(N * rmax);
+  dL_ = devAlloc(nnd * rmax);
+  dR_ = devAlloc(rmax * nd);
+  dCore_ = devAlloc(nnd * nd);
+  dDUn_ = devAlloc(N * nd);
+  dT2_ = devAlloc(rmax * 2);
+  dDMp2_ = devAlloc(N * 2);
+  dDpsi2_ = devAlloc(N * 2);
+  dMdpsi2_ = devAlloc(N * 2);
+}
+
+RuGradientGpu::~RuGradientGpu() {
+  cudaFree(dUnn_); cudaFree(dUnnS_); cudaFree(dUn_); cudaFree(dM_);
+  cudaFree(dP2_);
+  cudaFree(dFa_); cudaFree(dFb_); cudaFree(dL_); cudaFree(dR_);
+  cudaFree(dCore_); cudaFree(dDUn_); cudaFree(dT2_); cudaFree(dDMp2_);
+  cudaFree(dDpsi2_); cudaFree(dMdpsi2_);
+  if (handle_ != nullptr)
+    cublasDestroy(reinterpret_cast<cublasHandle_t>(handle_));
+}
+
+void RuGradientGpu::edgeStage1(const float* fa, const float* fb, int r,
+                               float* dUn, float* dMp2) {
+  cublasHandle_t h = reinterpret_cast<cublasHandle_t>(handle_);
+  const float one = 1.0f, zero = 0.0f;
+  const int N = N_, nnd = nnd_, nd = nd_;
+
+  CUDA_CHECK(cudaMemcpy(dFa_, fa, static_cast<size_t>(N) * r * sizeof(float),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(dFb_, fb, static_cast<size_t>(N) * r * sizeof(float),
+                        cudaMemcpyHostToDevice));
+
+  // L = Unnᵀ·fa            (nnd×r)
+  CUBLAS_CHECK(cublasSgemm(h, CUBLAS_OP_T, CUBLAS_OP_N, nnd, r, N, &one, dUnn_,
+                           N, dFa_, N, &zero, dL_, nnd));
+  // R = fbᵀ·Un             (r×nd)
+  CUBLAS_CHECK(cublasSgemm(h, CUBLAS_OP_T, CUBLAS_OP_N, r, nd, N, &one, dFb_, N,
+                           dUn_, N, &zero, dR_, r));
+  // core = L·R             (nnd×nd)
+  CUBLAS_CHECK(cublasSgemm(h, CUBLAS_OP_N, CUBLAS_OP_N, nnd, nd, r, &one, dL_,
+                           nnd, dR_, r, &zero, dCore_, nnd));
+  // dUn = UnnS·core        (N×nd)   [UnnS folds the invlam diagonal]
+  CUBLAS_CHECK(cublasSgemm(h, CUBLAS_OP_N, CUBLAS_OP_N, N, nd, nnd, &one,
+                           dUnnS_, N, dCore_, nnd, &zero, dDUn_, N));
+  // T2 = fbᵀ·P2            (r×2)
+  CUBLAS_CHECK(cublasSgemm(h, CUBLAS_OP_T, CUBLAS_OP_N, r, 2, N, &one, dFb_, N,
+                           dP2_, N, &zero, dT2_, r));
+  // dMp2 = fa·T2           (N×2)
+  CUBLAS_CHECK(cublasSgemm(h, CUBLAS_OP_N, CUBLAS_OP_N, N, 2, r, &one, dFa_, N,
+                           dT2_, r, &zero, dDMp2_, N));
+
+  CUDA_CHECK(cudaMemcpy(dUn, dDUn_, static_cast<size_t>(N) * nd * sizeof(float),
+                        cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(dMp2, dDMp2_, static_cast<size_t>(N) * 2 * sizeof(float),
+                        cudaMemcpyDeviceToHost));
+}
+
+void RuGradientGpu::edgeStage2(const float* dpsi2, float* Mdpsi2) {
+  cublasHandle_t h = reinterpret_cast<cublasHandle_t>(handle_);
+  const float one = 1.0f, zero = 0.0f;
+  const int N = N_;
+  CUDA_CHECK(cudaMemcpy(dDpsi2_, dpsi2, static_cast<size_t>(N) * 2 * sizeof(float),
+                        cudaMemcpyHostToDevice));
+  // Mdpsi2 = M·dpsi2       (N×2)
+  CUBLAS_CHECK(cublasSgemm(h, CUBLAS_OP_N, CUBLAS_OP_N, N, 2, N, &one, dM_, N,
+                           dDpsi2_, N, &zero, dMdpsi2_, N));
+  CUDA_CHECK(cudaMemcpy(Mdpsi2, dMdpsi2_, static_cast<size_t>(N) * 2 * sizeof(float),
+                        cudaMemcpyDeviceToHost));
+}
+
+}  // namespace cuda
+}  // namespace tessera

--- a/tests/cobordism/test_ru_gradient_gpu_python.py
+++ b/tests/cobordism/test_ru_gradient_gpu_python.py
@@ -1,0 +1,225 @@
+# MIT License
+# Copyright (c) 2025 Andrew Kelleher
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The FP32 cuBLAS GPU r_U gradient returns the SAME gradient as the FP64 CPU
+oracle (#348).
+
+`EigenstateSynthesis.residualForPeriodsGradientGpu` (FP32 cuBLAS) must agree with
+`EigenstateSynthesis.residualForPeriodsGradient` (FP64 CPU, the correctness
+oracle) to single precision — element-wise, in L2, and in direction — across
+substrate levels, perturbation scales/patterns, and register targets. "Same"
+means: matches to FP32 tolerance (the gradients are not bit-identical by design,
+since one is FP32 and the other FP64), with an identical descent direction.
+
+GPU-gated: skipped without a CUDA build + a GPU. The slow level-2 scale check is
+opt-in via RU_GPU_LEVEL2=1 (a single CPU-oracle call there is ~90s)."""
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EX = os.path.join(_HERE, "..", "..", "examples", "cobordism")
+sys.path.insert(0, os.path.join(_EX, "deep_merge_baseline"))
+sys.path.insert(0, _EX)
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_EX, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MC = _load("merge_cobordism")
+tessera = MC.tessera
+cob = tessera.cobordism
+import probe_deep as PD  # noqa: E402  (build_merge for the subdivided substrates)
+
+
+def _gpu_available():
+    """The GPU path is live iff the method exists and a trivial call succeeds
+    (a CPU-only TESSERA_CUDA=OFF build has no GPU path)."""
+    if not hasattr(cob.EigenstateSynthesis, "residualForPeriodsGradientGpu"):
+        return False
+    try:
+        m = MC.MergeCobordism()
+        m.st.materializeFacets()
+        holes = [list(t) for t in m.hole_circles]
+        tgt = [complex(z) for z in
+               np.asarray(m.es.cyclePeriods(holes), complex).reshape(m.dim, 9)[0]]
+        m.es.residualForPeriodsGradientGpu(holes, tgt)
+        return True
+    except Exception:
+        return False
+
+
+_GPU = _gpu_available()
+
+
+def _level0():
+    """Level-0 merge (MergeCobordism, n1=174): st, es, holes, period matrix."""
+    m = MC.MergeCobordism()
+    m.st.materializeFacets()
+    holes = [list(t) for t in m.hole_circles]
+    P = np.asarray(m.es.cyclePeriods(holes), complex).reshape(m.dim, len(holes))
+    return m.st, m.es, holes, P
+
+
+def _level(n):
+    """Subdivided merge (build_merge(n)): st, es, holes, period matrix."""
+    st, nreg, holes3, _hv, _c = PD.build_merge(n)
+    st.materializeFacets()
+    es = cob.EigenstateSynthesis(st, 1)
+    holes = [sorted(v + off for v in h) for off in (0, nreg, 2 * nreg) for h in holes3]
+    P = np.asarray(es.cyclePeriods(holes), complex)
+    m = len(holes)
+    return st, es, holes, P.reshape(len(P) // m, m)
+
+
+def _emap(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _perturb(st, es, factor):
+    """Scale each cell's edge squared length by factor(i) (1.0 = unchanged)."""
+    cells = [tuple(int(v) for v in c) for c in es.cellSimplices()]
+    em = _emap(st)
+    for i, c in enumerate(cells):
+        f = factor(i)
+        if f != 1.0:
+            ek = (min(c), max(c))
+            em[ek].setSquaredLength(em[ek].getSquaredLength().real * f)
+    st.materializeFacets()
+
+
+def _both(es, holes, target):
+    """The FP64 CPU oracle gradient and the FP32 GPU gradient at the current geometry."""
+    tc = [complex(z) for z in target]
+    g_cpu = np.asarray(es.residualForPeriodsGradient(holes, tc), float)
+    g_gpu = np.asarray(es.residualForPeriodsGradientGpu(holes, tc), float)
+    return g_gpu, g_cpu
+
+
+@unittest.skipUnless(_GPU, "CUDA build / GPU not available")
+class RuGradientGpuEqualsCpuTest(unittest.TestCase):
+    """FP32-GPU == FP64-CPU oracle to single precision, everywhere we can check."""
+
+    def _assert_same(self, g_gpu, g_cpu, ctx):
+        self.assertEqual(len(g_gpu), len(g_cpu), f"{ctx}: length mismatch")
+        self.assertTrue(np.all(np.isfinite(g_gpu)), f"{ctx}: GPU produced non-finite values")
+        max_d = float(np.max(np.abs(g_gpu - g_cpu)))
+        # element-wise FP32 agreement: |gpu - cpu| <= atol + rtol*|cpu|
+        self.assertTrue(
+            np.allclose(g_gpu, g_cpu, rtol=1e-3, atol=1e-5),
+            f"{ctx}: not allclose (max|Δ|={max_d:.2e}, max|cpu|={np.max(np.abs(g_cpu)):.2e})")
+        den = float(np.linalg.norm(g_cpu))
+        if den > 1e-9:  # non-trivial gradient: also check L2-relative + direction
+            rel = float(np.linalg.norm(g_gpu - g_cpu) / den)
+            self.assertLess(rel, 1e-3, f"{ctx}: L2 relative error {rel:.2e}")
+            cos = float(np.dot(g_gpu, g_cpu) /
+                        (np.linalg.norm(g_gpu) * np.linalg.norm(g_cpu)))
+            self.assertGreater(cos, 0.9999, f"{ctx}: descent-direction cosine {cos:.6f}")
+
+    def test_realizable_base(self):
+        """At the realizable base (r_U≈0) both gradients are ~0 and agree."""
+        st, es, holes, P = _level0()
+        g_gpu, g_cpu = _both(es, holes, P[0])
+        self._assert_same(g_gpu, g_cpu, "level0 base")
+
+    def test_uniform_perturbation_scales(self):
+        """A range of perturbation strengths (so r_U sweeps from small to large)."""
+        for s in (1.1, 1.3, 1.6, 2.0, 3.0):
+            with self.subTest(scale=s):
+                st, es, holes, P = _level0()
+                _perturb(st, es, lambda i, s=s: s if i % 2 == 0 else 1.0)
+                g_gpu, g_cpu = _both(es, holes, P[0])
+                self._assert_same(g_gpu, g_cpu, f"level0 scale={s}")
+
+    def test_perturbation_patterns(self):
+        """Different spatial patterns of the perturbation across the edges."""
+        patterns = {
+            "all*1.3": lambda i: 1.3,
+            "every2*1.4": lambda i: 1.4 if i % 2 == 0 else 1.0,
+            "every3*1.5": lambda i: 1.5 if i % 3 == 0 else 1.0,
+            "ramp": lambda i: 1.0 + 0.4 * ((i % 5) / 4.0),
+            "alternating": lambda i: (1.6 if i % 2 == 0 else 0.7),
+        }
+        for name, fn in patterns.items():
+            with self.subTest(pattern=name):
+                st, es, holes, P = _level0()
+                _perturb(st, es, fn)
+                g_gpu, g_cpu = _both(es, holes, P[0])
+                self._assert_same(g_gpu, g_cpu, f"level0 pattern={name}")
+
+    def test_register_targets(self):
+        """Different register targets (period rows / combinations / scalings)."""
+        st, es, holes, P = _level0()
+        _perturb(st, es, lambda i: 1.4 if i % 2 == 0 else 1.0)
+        targets = {
+            "P0": P[0],
+            "P1": P[1] if P.shape[0] > 1 else P[0],
+            "2*P0": 2.0 * P[0],
+            "P0+P1": P[0] + (P[1] if P.shape[0] > 1 else P[0]),
+        }
+        for name, tgt in targets.items():
+            with self.subTest(target=name):
+                g_gpu, g_cpu = _both(es, holes, tgt)
+                self._assert_same(g_gpu, g_cpu, f"level0 target={name}")
+
+    def test_level1_substrate(self):
+        """A larger (once-subdivided) substrate, a couple of perturbations."""
+        for s in (1.3, 1.8):
+            with self.subTest(scale=s):
+                st, es, holes, P = _level(1)
+                _perturb(st, es, lambda i, s=s: s if i % 3 == 0 else 1.0)
+                g_gpu, g_cpu = _both(es, holes, P[0])
+                self._assert_same(g_gpu, g_cpu, f"level1 scale={s}")
+
+    @unittest.skipUnless(os.environ.get("RU_GPU_LEVEL2"),
+                         "slow level-2 scale check; set RU_GPU_LEVEL2=1 to run")
+    def test_level2_scale(self):
+        """The level-2 deep merge (n1=2724) — the worst-conditioned, most
+        stringent FP32 case. Slow (a CPU-oracle call is ~90s)."""
+        st, es, holes, P = _level(2)
+        _perturb(st, es, lambda i: 1.3 if i % 7 == 0 else 1.0)
+        g_gpu, g_cpu = _both(es, holes, P[0])
+        self._assert_same(g_gpu, g_cpu, "level2 scale")
+
+    def test_gpu_determinism(self):
+        """The GPU path is deterministic — same geometry, bit-identical output."""
+        st, es, holes, P = _level0()
+        _perturb(st, es, lambda i: 1.5 if i % 2 == 0 else 1.0)
+        tc = [complex(z) for z in P[0]]
+        g1 = np.asarray(es.residualForPeriodsGradientGpu(holes, tc), float)
+        g2 = np.asarray(es.residualForPeriodsGradientGpu(holes, tc), float)
+        self.assertTrue(np.array_equal(g1, g2), "GPU gradient is not deterministic")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Ports the per-edge analytic r_U-gradient loop in `EigenstateSynthesis::residualForPeriodsGradient` (the level-2 relaxation bottleneck, ~82 s/call at n1=2724 edges, 16-core CPU FP64) to a single-precision (FP32) cuBLAS (SGEMM) GPU path, behind the existing `TESSERA_CUDA` build option.

- New `EigenstateSynthesis::residualForPeriodsGradientGpu(holes, target)` — same result as the FP64 CPU method, with the dominant per-edge GEMMs (`Unnᵀ·fa`, the `core` product, `dUn = UnnS·core`, `dM·p`, `M·dpsi`) run as FP32 SGEMM on the GPU. The loop-invariant blocks upload once; `fa`/`fb` stream per edge. The dense eigendecomposition, the cheap small-dimension per-edge algebra, and the final O(N) dot-product reductions stay on the CPU in FP64, so FP32 in those GEMMs is the only approximation.
- The FP64 CPU `residualForPeriodsGradient` is untouched (byte-for-byte) — it stays the default and the correctness oracle.
- New `tessera::cuda::RuGradientGpu` (`eigenstate_cuda.h/.cu`) holds the cuBLAS handle + device buffers; `CUDA::cublas` linked next to `CUDA::cudart`. No custom kernels, so the path is GPU-arch-agnostic.
- `UnnS = Unn·diag(invlam)` hoists the per-edge diagonal so `dUn = UnnS·core` (by associativity, value-preserving) — the only implementation reshaping; the math is otherwise identical to the oracle.

## Results (verified)
Perturbed level-2 merge substrate `build_merge(2)` (n1=2724, r_U=5.45e-3), RTX 4090, 16-core CPU:

- [x] Build the worktree with `TESSERA_CUDA=ON` (CUDA + cuBLAS link). — builds clean; `_tessera.so` links `libcublas.so.12`.
- [x] FP32-GPU matches FP64-CPU oracle: **rel L2 = 6.65e-06**, max|d| = 1.18e-07, **cos = 1.0** (well within the approved ~1e-5).
- [x] Both match a central finite difference of `residualForPeriods`: worst |CPU−FD| = 2.0e-9, **worst |GPU−FD| = 1.81e-9**.
- [x] Benchmark vs the ~82 s CPU baseline: **4.4× speedup (89.5 s → 20.2 s)**.
- [x] `examples/cobordism/level2_ru_gradient_fp32_gpu.py` drives the above (level-0 smoke: rel L2 = 2.8e-7, cos 1.0).

Closes #348.
