### PR TITLE
feat(cobordism): build a proton from quarks via merge cobordisms — emergent charge/radius/mass

### DIFF
--- a/examples/cobordism/merge_cobordism.py
+++ b/examples/cobordism/merge_cobordism.py
@@ -105,6 +105,24 @@ def _staircase(faces, bot_off, top_off):
     return sorted(set(tets))
 
 
+# --------------------------------------------------------------------------- #
+# THE ONLY VALID WAY to build / evolve / compose a cobordism (a HARD rule):
+#   fix a state (or output state) as the BOUNDARY, relax the bulk INTO a
+#   cobordism, and let the input states evolve ONLY while their harmonic /
+#   residual is preserved (the Γ·r_U term in StationaryActionRelaxer). The
+#   result must EMERGE in the bulk and be read off after-the-fact -- never
+#   hand-placed.
+# Surgical / topology-changing moves are NECESSARY and ALLOWED -- they are
+# GATED: the Pachner propose() rejects >2-coface results
+# (pachner_detail::topCofaceCount) and the synthesizer's dualComplexValid is the
+# FULL manifold check (codim-1 cofaces <= 2, ridge links unpinched, vertex links
+# 2-spheres/disks). COMPOSE by feeding one cobordism's RESULT STATE as the next
+# one's incoming BOUNDARY -- NEVER hand-identify two cobordisms' interior
+# simplices ("the weld"): three sheets then meet along one face -> a codim-1
+# facet with >2 cofaces -> NOT a manifold, and it BYPASSES the gate above. That
+# was never allowed. __init__ asserts dualComplexValid so a torn complex can
+# never be relaxed.
+# --------------------------------------------------------------------------- #
 class MergeCobordism:
     """The merge bulk of two inputs into one result. Vertex blocks:
     input A = [0,12), input B = [12,24) -- both on slice t (spatial); result
@@ -132,6 +150,17 @@ class MergeCobordism:
         self._set_causal()
         self.es = cob.EigenstateSynthesis(self.st, 1)
         self.read_spectral()
+        # MANIFOLD GATE -- never relax/compose a torn complex. dualComplexValid
+        # (ChainComplex::dualComplexIsValid) is the full check: every codim-1
+        # facet shared by <=2 top cells, ridge links unpinched, vertex links
+        # 2-spheres/disks. A single merge is manifold by construction; assert it
+        # HARD so any construction that isn't -- e.g. a hand-weld of two
+        # cobordisms' interiors -- is caught here instead of silently relaxed.
+        if not self.dual_valid:
+            raise RuntimeError(
+                f"MergeCobordism is not a valid manifold: {self.dual_reason}. "
+                "Build cobordisms via gated surgical moves or the "
+                "fix-boundary/relax-bulk path; never hand-weld interiors.")
 
     # ---- coordinate-free causal labeling: input->result edges timelike ---- #
     def _is_result(self, vid):

--- a/examples/cobordism/proton_from_quarks.py
+++ b/examples/cobordism/proton_from_quarks.py
@@ -18,17 +18,21 @@ Representation (settled; see issue #352)
   applied: reg.sign * periods / sign0,sign1 -- see reference_register_sign_convention).
 - Fractions are NOT imposed; total electric charge / flavor is DEFERRED pending data.
 
-Approach (reading 1): color is topological (the three holes of ONE neutral
-register carrying the singlet); the cobordism's job is the DYNAMICS. So we relax a
-merge bulk carrying the color singlet to a stationary action (delta S = 0) and read
-the emergent mass (curvature) and radius (geometry extent) out of the relaxed
-geometry -- never imposing them.
+Approach: build the proton from first principles. A free colored quark does NOT
+carry (confinement); a pair-created q-qbar pair is color-neutral (Sigma = 0) and
+DOES carry. So we pin the carriable (neutral-pair) INPUT states as the boundary of
+a merge cobordism, relax the bulk to a stationary action (delta S = 0) while
+PRESERVING each input's residual, and read the EMERGENT result (its color charge,
+radius = geometry extent, mass = curvature) out of the relaxed geometry
+after-the-fact. Nothing is imposed on the result -- the singlet is never inserted.
 
 STAGE 1: color-configuration realizability map (confinement + gauge invariance).
-STAGE 3: relax the singlet-carrying bulk to convergence; read mass/radius.
-  Objective Phi = ||grad S||^2 + Gamma*r_U (StationaryActionRelaxer): EXTREMIZE the
-  full complex Lorentzian action (delta S = 0), keep Im S, never minimize S; r_U is
-  the realizability (carried-register) penalty.
+STAGE 3: first-principles merge build (build_merge_from_inputs).
+  Objective Phi = ||grad S||^2 + Gamma*(r_U_A + r_U_B): the full complex Lorentzian
+  dual Regge action is the MEDIATOR (||grad S||^2 -> 0 is delta S = 0, keep Im S,
+  never minimize S); the per-state r_U terms hold each input carried (the rule
+  "inputs evolve only while their residual is preserved"). See merge_cobordism's
+  "ONLY VALID WAY" note; the merge substrate asserts manifold-validity.
 """
 
 from __future__ import annotations
@@ -106,49 +110,95 @@ def gauge_invariance(reg, periods):
 
 
 # --------------------------------------------------------------------------- #
-# STAGE 3 -- relax the singlet-carrying merge bulk; read mass/radius emergent.
+# STAGE 3 -- FIRST-PRINCIPLES merge build: pin the carriable INPUT states as the
+# fixed boundary, relax the bulk to delta S = 0 while preserving each input's
+# residual, and read the EMERGENT result block after-the-fact. Nothing is imposed
+# on the result -- the singlet is never inserted. (The removed relax_singlet
+# imposed [1,w,w^2] on every block by fiat; that was not a build.)
 # --------------------------------------------------------------------------- #
-def color_singlet_periods(perm=None):
-    """The carried color singlet [1, w, w^2] (plain-sum-0) in the oriented period
-    frame (SIGN_BLOCK applied), the per-block known harmonic. *perm* permutes the
-    three colors -- an S3 gauge transformation (observables must be invariant)."""
-    singlet = np.array([1, OMEGA, OMEGA**2], dtype=complex)
-    if perm is not None:
-        singlet = singlet[list(perm)]
-    return np.array(SIGN_BLOCK, dtype=complex) * singlet
+def neutral_pairs():
+    """Pair-created q-qbar pairs -- the carriable inputs the proton is built from.
+    A pair is color-neutral (plain sum Sigma = 0) and therefore CARRIES, unlike a
+    free colored quark (Sigma != 0, confined). Three plain period vectors on the
+    color holes (R-Gbar, R-Bbar, G-Bbar); SIGN_BLOCK is applied downstream."""
+    return {"R-Gbar": np.array([1, -1, 0], dtype=complex),
+            "R-Bbar": np.array([1, 0, -1], dtype=complex),
+            "G-Bbar": np.array([0, 1, -1], dtype=complex)}
 
 
-def relax_singlet(gamma=1e3, maxiter=1000, perm=None):
-    """Reading (1): relax the merge bulk carrying the color singlet (the diagonal
-    known harmonic on the three blocks), extremizing the full complex action
-    (delta S = 0) subject to the carried register. Reads mass (curvature / action)
-    and radius (relaxed spatial geometry extent) out of the converged geometry --
-    never imposed. *perm* permutes the singlet's colors (an S3 gauge check)."""
+def build_merge_from_inputs(psi_a, psi_b, gamma=1e5, maxiter=200):
+    """Build a merge cobordism from FIRST PRINCIPLES. Pin the two INPUT states
+    psi_a, psi_b as the boundary data (their periods, held by a SEPARATE per-state
+    residual r_U_A, r_U_B), relax the merge bulk to a stationary action
+    (delta S = 0) while preserving those residuals, and read the EMERGENT result
+    block after-the-fact. NOTHING is imposed on the result -- the singlet is never
+    inserted. Inputs must be carriable (neutral, Sigma = 0); free colored quarks
+    do not carry (confinement) and the relaxation strains (r_U floors, geometry
+    blows up).
+
+    Objective  Phi = ||grad S||^2 + gamma*(r_U_A + r_U_B): the full complex
+    Lorentzian dual Regge action is the MEDIATOR (||grad S||^2 -> 0 is delta S = 0,
+    Im S kept, never minimize S); the per-state r_U terms ARE the rule "inputs
+    evolve only while their residual is preserved". The gravity gradient uses the
+    exact analytic Hessian (Gauss-Newton): grad(||grad S||^2) = 2 Re(H conj(grad S)).
+
+    psi_a, psi_b : length-3 complex PLAIN period vectors on the color holes
+                   (SIGN_BLOCK is applied here). The merge substrate asserts
+                   manifold-validity in its constructor (the gate the weld skipped)."""
     import stationary_action_relaxation as sar
+    from scipy.optimize import minimize
     rx = sar.StationaryActionRelaxer(gamma=gamma)
-    target = np.tile(color_singlet_periods(perm), 3)   # singlet on A, B, R (diagonal)
-    rx.target = target
-    rx.target_c = [complex(z) for z in target]
+    rx.VAR = sorted(rx.emap.keys())                   # all edges evolve...
+    rx.x0 = np.array([rx.emap[k].getSquaredLength().real for k in rx.VAR])
+    sgn = np.array(SIGN_BLOCK, dtype=complex)
+    pA = [complex(z) for z in sgn * np.asarray(psi_a, dtype=complex)]
+    pB = [complex(z) for z in sgn * np.asarray(psi_b, dtype=complex)]
+    Ah = [list(h) for h in rx.holes[0:3]]             # color holes on input A
+    Bh = [list(h) for h in rx.holes[3:6]]             # color holes on input B
+    ix = [rx.EIDX[k] for k in rx.VAR]                 # VAR edges in gradient order
+    G = float(gamma)
 
-    _P0, _g0, sr0, rU0, S0 = rx.objective(rx.x0)
+    def phi(x):
+        g, _S = rx._dS_VAR(x)
+        statres = float(np.vdot(g, g).real)           # ||grad S||^2 (full complex)
+        # PURE GRAVITY: dualReggeAction / actionGradientExact / actionHessianExact
+        # never read the matter config (no matter_ reference). The empty default
+        # MatterConfiguration() is ONLY ReggeSolver's required ctor arg -- NO matter
+        # is imposed or added. Matter is observed solely as curvature (the deficit
+        # in S); the lone matter term in Phi is the r_U penalty (no Dirichlet source).
+        H = np.array(sar.tessera.ReggeSolver(rx.st, sar.tessera.MatterConfiguration())
+                     .actionHessianExact(), dtype=complex)[np.ix_(ix, ix)]
+        grad_stat = 2.0 * np.real(H @ np.conj(g))     # exact Gauss-Newton step
+        rUA = float(rx.es.residualForPeriods(Ah, pA))
+        rUB = float(rx.es.residualForPeriods(Bh, pB))
+        gA = np.asarray(rx.es.residualForPeriodsGradient(Ah, pA), float)
+        gB = np.asarray(rx.es.residualForPeriodsGradient(Bh, pB), float)
+        drU = np.array([gA[rx.cidx1[k]] + gB[rx.cidx1[k]] for k in rx.VAR])
+        return statres + G * (rUA + rUB), grad_stat + G * drU
+
     curv_ref = rx.curvature()
-    res = rx.relax(maxiter=maxiter)
-    _Pf, _gf, srf, rUf, Sf = rx.objective(res.x)
+    res = minimize(phi, rx.x0, jac=True, method="L-BFGS-B",
+                   options={"maxiter": maxiter, "ftol": 1e-14, "gtol": 1e-12})
+    rx.set_var(res.x)
+    g, S = rx._dS_VAR(res.x)
     curv_relax = rx.curvature()
 
-    spatial = res.x[res.x > 0]                          # spacelike edges (l^2 > 0)
-    timelike = res.x[res.x < 0]                         # timelike edges (l^2 < 0)
-    radius_rms = float(np.sqrt(np.mean(spatial))) if spatial.size else 0.0
-    total_def_ref = float(sum(curv_ref[d][0] for d in curv_ref))
-    total_def_relax = float(sum(curv_relax[d][0] for d in curv_relax))
+    # EMERGENT result block (holes 6,7,8 = the R block), read AFTER relaxation --
+    # not pinned, not imposed: whatever the two inputs merged into.
+    P = np.array(rx.es.cyclePeriods([list(h) for h in rx.holes]),
+                 dtype=complex).reshape(rx.dim, 9)
+    result = P[0, 6:9]
+    spatial = res.x[res.x > 0]
     return {"n_var": len(rx.VAR), "dim": rx.dim, "iters": int(res.nit),
-            "success": bool(res.success), "sr0": sr0, "srf": srf,
-            "rU0": rU0, "rUf": rUf, "S0": S0, "Sf": Sf,
-            "radius_rms": radius_rms, "l2_min": float(res.x.min()),
-            "l2_max": float(res.x.max()), "n_spatial": int(spatial.size),
-            "n_timelike": int(timelike.size), "total_def_ref": total_def_ref,
-            "total_def_relax": total_def_relax,
-            "curv_ref": curv_ref, "curv_relax": curv_relax}
+            "success": bool(res.success), "statres": float(np.vdot(g, g).real),
+            "S": complex(S), "result": result, "sigma_R": complex(result.sum()),
+            "rU_A": float(rx.es.residualForPeriods(Ah, pA)),
+            "rU_B": float(rx.es.residualForPeriods(Bh, pB)),
+            "radius_rms": float(np.sqrt(np.mean(spatial))) if spatial.size else 0.0,
+            "l2_min": float(res.x.min()), "l2_max": float(res.x.max()),
+            "n_spatial": int(spatial.size), "n_timelike": int((res.x < 0).sum()),
+            "total_def_relax": float(sum(curv_relax[d][0] for d in curv_relax)),
+            "total_def_ref": float(sum(curv_ref[d][0] for d in curv_ref))}
 
 
 def _print_stage1(sgr, reg):
@@ -169,34 +219,33 @@ def _print_stage1(sgr, reg):
               f"({'INVARIANT' if spread < 1e-6 else 'GAUGE ARTIFACT'})")
 
 
-def _print_stage3(out):
-    print(f"\nSTAGE 3 -- relax singlet-carrying merge bulk (Phi=||grad S||^2 + "
-          f"Gamma*r_U, extremize S)")
-    print(f"  variable bulk edges = {out['n_var']}, register dim = {out['dim']}, "
+def _print_stage3(out, label_a, label_b):
+    print(f"\nSTAGE 3 -- FIRST-PRINCIPLES merge: inputs '{label_a}' (x) '{label_b}' "
+          f"pinned as boundary; bulk relaxed to delta S = 0; result EMERGENT")
+    print(f"  variable edges = {out['n_var']}, register dim = {out['dim']}, "
           f"iters = {out['iters']}, success = {out['success']}")
-    print(f"  ||grad S||^2: {out['sr0']:.4f} -> {out['srf']:.4f}   (delta S -> 0)")
-    print(f"  r_U: {out['rU0']:.3e} -> {out['rUf']:.3e}   (register stays carried)")
-    print(f"  S (action): {out['S0']:.3f} -> {out['Sf']:.3f}")
-    print(f"  geometry: {out['n_spatial']} spacelike + {out['n_timelike']} timelike "
-          f"edges, l^2 in [{out['l2_min']:.3f}, {out['l2_max']:.3f}]")
-    print(f"  RADIUS proxy  (rms spacelike length): {out['radius_rms']:.4f}")
-    print(f"  MASS proxy    (total Re-deficit): {out['total_def_ref']:.3f} (ref) "
-          f"-> {out['total_def_relax']:.3f} (relaxed)")
-    print("  curvature Re-deficit by shell from color holes:")
-    print("    ref  :", " ".join(f"{out['curv_ref'][d][0]:+.3f}"
-                                  for d in sorted(out['curv_ref'])))
-    print("    relax:", " ".join(f"{out['curv_relax'][d][0]:+.3f}"
-                                  for d in sorted(out['curv_relax'])))
+    print(f"  mediator ||grad S||^2 = {out['statres']:.4f}  (delta S -> 0; "
+          f"S = {out['S'].real:.3f}{out['S'].imag:+.3f}i, Im kept)")
+    print(f"  inputs carried? r_U_A = {out['rU_A']:.2e}, r_U_B = {out['rU_B']:.2e} "
+          f"(residual preserved => carriable)")
+    print("  EMERGENT result periods (read after-the-fact, NOT imposed):")
+    print("      [" + ", ".join(f"{z.real:+.3f}{z.imag:+.3f}i" for z in out['result'])
+          + "]")
+    print(f"      color leak |Sigma_R| = {abs(out['sigma_R']):.3e} "
+          f"({'singlet (neutral)' if abs(out['sigma_R']) < 1e-3 else 'NOT a singlet'})")
+    print(f"  geometry: {out['n_spatial']} spacelike + {out['n_timelike']} timelike, "
+          f"l^2 in [{out['l2_min']:.3f}, {out['l2_max']:.3f}]")
+    print(f"  RADIUS proxy (rms spacelike length): {out['radius_rms']:.4f}")
+    print(f"  MASS proxy   (total Re-deficit): {out['total_def_relax']:.3f} "
+          f"(ref {out['total_def_ref']:.3f})")
 
 
 def _main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--relax", action="store_true",
-                    help="stage 3: relax the singlet-carrying bulk to convergence")
-    ap.add_argument("--gamma", type=float, default=1e3)
-    ap.add_argument("--maxiter", type=int, default=1000)
-    ap.add_argument("--perm", type=str, default=None,
-                    help="S3 gauge check: permute the singlet colors, e.g. 1,2,0")
+                    help="stage 3: first-principles merge build from neutral-pair inputs")
+    ap.add_argument("--gamma", type=float, default=1e5)
+    ap.add_argument("--maxiter", type=int, default=200)
     args = ap.parse_args()
 
     sgr = _register_path()
@@ -204,11 +253,11 @@ def _main():
     _print_stage1(sgr, reg)
 
     if args.relax:
-        perm = tuple(int(i) for i in args.perm.split(",")) if args.perm else None
-        out = relax_singlet(gamma=args.gamma, maxiter=args.maxiter, perm=perm)
-        _print_stage3(out)
+        (la, pa), (lb, pb), *_ = neutral_pairs().items()
+        out = build_merge_from_inputs(pa, pb, gamma=args.gamma, maxiter=args.maxiter)
+        _print_stage3(out, la, lb)
     else:
-        print("\n(stage 3 relaxation: rerun with --relax)")
+        print("\n(stage 3 first-principles merge: rerun with --relax)")
 
 
 if __name__ == "__main__":

--- a/examples/cobordism/proton_from_quarks.py
+++ b/examples/cobordism/proton_from_quarks.py
@@ -1,4 +1,4 @@
-"""Build a proton from quarks via merge cobordisms -- emergent charge/radius/mass.
+"""Build a proton from quarks via cobordisms -- emergent charge/radius/mass.
 
 Reference is PDG/experiment (lattice-QCD-flavored, not QE). Read out emergent-first:
 dimensionless ratios first, then calibrate one scale (tessera is coordinate-free).
@@ -7,36 +7,39 @@ Representation (settled; see issue #352)
 ----------------------------------------
 - The three holonomy holes {[a],[b],[a+b]} are the three COLORS (R,G,B). The S3
   permuting them is the Weyl group of color SU(3) -- a discrete color GAUGE
-  redundancy, so "which hole is which color" is unphysical. Observables must be
-  S3-invariant (a hard gauge-invariance test).
-- The carried register is the Sigma=0 subspace of the three hole-periods
-  (color-neutral). Hypothesis: a lone quark (one hole, Sigma != 0) FLOORS
-  (confinement); color-singlet (Sigma=0) configurations realize (r_U -> 0).
-- Fractions are NOT imposed on the classes (Z2 gives halves, not thirds; thirds
-  live in the Z3 < S3 cyclic structure, the cube-roots of unity). Total electric
-  charge is read out, target +1.
-- What flavor is / where it lives is DEFERRED -- we gather data first.
+  redundancy, so "which hole is which color" is unphysical; observables must be
+  S3-invariant.
+- The carried register is the color-neutral subspace. A bare colored quark FLOORS
+  (confinement) on EVERY substrate -- single register, merge, AND transport
+  (measured). Only color-neutral states are carried anywhere; there are no free
+  quarks to merge.
+- The carried color singlet is the plain-sum-0 state, e.g. the Z3 cube-root state
+  [1, w, w^2], scored in the oriented period frame (the induced-orientation signs
+  applied: reg.sign * periods / sign0,sign1 -- see reference_register_sign_convention).
+- Fractions are NOT imposed; total electric charge / flavor is DEFERRED pending data.
 
-STAGE 1 (this module): the color-configuration realizability map
-----------------------------------------------------------------
-Score a battery of color configurations (period vectors on the three holes) with
-the register's genuine stage-1 spectral residual (the same `spectral_residual`
-primitive `synthesize_state` uses), and let the data show the confinement/singlet
-structure -- which configurations the register carries vs floors -- with NO flavor
-assumption. Includes the S3 (gauge) invariance check.
+Approach (reading 1): color is topological (the three holes of ONE neutral
+register carrying the singlet); the cobordism's job is the DYNAMICS. So we relax a
+merge bulk carrying the color singlet to a stationary action (delta S = 0) and read
+the emergent mass (curvature) and radius (geometry extent) out of the relaxed
+geometry -- never imposing them.
 
-Later stages: the q (x) q -> (diquark/meson) -> proton merge-cobordism sequence,
-the StationaryActionRelaxer (Phi = ||grad S||^2 + Gamma*r_U; extremize S, keep
-Im S), and the emergent charge/radius/mass readout.
+STAGE 1: color-configuration realizability map (confinement + gauge invariance).
+STAGE 3: relax the singlet-carrying bulk to convergence; read mass/radius.
+  Objective Phi = ||grad S||^2 + Gamma*r_U (StationaryActionRelaxer): EXTREMIZE the
+  full complex Lorentzian action (delta S = 0), keep Im S, never minimize S; r_U is
+  the realizability (carried-register) penalty.
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 
 import numpy as np
 
 OMEGA = np.exp(2j * np.pi / 3.0)   # primitive cube root of unity (the Z3 color phase)
+SIGN_BLOCK = (1, 1, -1)            # induced-orientation signs per register block
 
 
 def _register_path():
@@ -49,39 +52,32 @@ def _register_path():
     return sgr
 
 
+# --------------------------------------------------------------------------- #
+# STAGE 1 -- the color-configuration realizability map (confinement structure)
+# --------------------------------------------------------------------------- #
 def color_configs():
-    """A battery of color configurations -- period vectors on the three color
-    holes -- spanning lone quarks, two-body, and three-body combinations. No
-    flavor assumed; we are mapping which the register carries.
-
-    Returns a list of (label, np.array of 3 complex periods).
-    """
+    """A battery of color configurations (period vectors on the three color holes)
+    spanning lone quarks, two-body, and three-body combinations -- no flavor
+    assumed. Returns a list of (label, np.array of 3 complex periods)."""
     return [
-        # lone quark on one color hole (Sigma != 0): the confinement probe
         ("quark R", np.array([1, 0, 0], dtype=complex)),
         ("quark G", np.array([0, 1, 0], dtype=complex)),
         ("quark B", np.array([0, 0, 1], dtype=complex)),
-        # two same-sign (diquark, Sigma != 0)
         ("diquark RG (same)", np.array([1, 1, 0], dtype=complex)),
-        # two opposite (meson-like q qbar, Sigma = 0)
         ("meson R-Gbar", np.array([1, -1, 0], dtype=complex)),
         ("meson G-Bbar", np.array([0, 1, -1], dtype=complex)),
-        # three equal (the symmetric / trivial-rep direction, Sigma != 0)
         ("symmetric RGB", np.array([1, 1, 1], dtype=complex)),
-        # three-body Sigma = 0, real
         ("baryon real [1,1,-2]", np.array([1, 1, -2], dtype=complex)),
         ("baryon real [2,-1,-1]", np.array([2, -1, -1], dtype=complex)),
-        # three-body Z3 singlet (the natural color singlet: cube-root phases)
         ("baryon Z3 [1,w,w^2]", np.array([1, OMEGA, OMEGA**2], dtype=complex)),
-        # the generic carried input from the gate battery (Sigma = 0 reference)
         ("ref _CP_IN", np.array([1.0, 0.3, -1.3], dtype=complex)),
     ]
 
 
-def score(sgr, reg, periods):
+def score(reg, periods):
     """Genuine stage-1 spectral residual of the color configuration on the
-    surgery-grown register (same primitive as synthesize_state), plus the leak
-    |Sigma| (the un-carried period sum). r -> 0 iff carried (color singlet)."""
+    surgery-grown register, in the oriented period frame (reg.sign applied -- the
+    established convention), plus the leak |plain sum|. r -> 0 iff carried."""
     residual = float(reg.spectral_residual(reg.sign * periods))
     leak = float(abs(complex(periods.sum())))
     return residual, leak
@@ -94,43 +90,125 @@ def realizability_map(sgr=None, reg=None):
         reg = sgr.Register()
     rows = []
     for label, periods in color_configs():
-        residual, leak = score(sgr, reg, periods)
+        residual, leak = score(reg, periods)
         rows.append({"config": label, "leak": leak, "residual": residual,
                      "realizable": bool(residual < sgr.REALIZE)})
     return rows
 
 
-def gauge_invariance(sgr, reg, periods):
+def gauge_invariance(reg, periods):
     """S3 (color gauge) invariance test: every permutation of the three hole
-    periods must give the same residual. Returns (residuals over the 6
-    permutations, spread). A nonzero spread is a gauge artifact."""
+    periods must give the same residual. Returns (residuals, spread)."""
     from itertools import permutations
     res = [float(reg.spectral_residual(reg.sign * periods[list(p)]))
            for p in permutations(range(3))]
     return res, float(np.max(res) - np.min(res))
 
 
-def _main():
-    sgr = _register_path()
-    reg = sgr.Register()
+# --------------------------------------------------------------------------- #
+# STAGE 3 -- relax the singlet-carrying merge bulk; read mass/radius emergent.
+# --------------------------------------------------------------------------- #
+def color_singlet_periods(perm=None):
+    """The carried color singlet [1, w, w^2] (plain-sum-0) in the oriented period
+    frame (SIGN_BLOCK applied), the per-block known harmonic. *perm* permutes the
+    three colors -- an S3 gauge transformation (observables must be invariant)."""
+    singlet = np.array([1, OMEGA, OMEGA**2], dtype=complex)
+    if perm is not None:
+        singlet = singlet[list(perm)]
+    return np.array(SIGN_BLOCK, dtype=complex) * singlet
+
+
+def relax_singlet(gamma=1e3, maxiter=1000, perm=None):
+    """Reading (1): relax the merge bulk carrying the color singlet (the diagonal
+    known harmonic on the three blocks), extremizing the full complex action
+    (delta S = 0) subject to the carried register. Reads mass (curvature / action)
+    and radius (relaxed spatial geometry extent) out of the converged geometry --
+    never imposed. *perm* permutes the singlet's colors (an S3 gauge check)."""
+    import stationary_action_relaxation as sar
+    rx = sar.StationaryActionRelaxer(gamma=gamma)
+    target = np.tile(color_singlet_periods(perm), 3)   # singlet on A, B, R (diagonal)
+    rx.target = target
+    rx.target_c = [complex(z) for z in target]
+
+    _P0, _g0, sr0, rU0, S0 = rx.objective(rx.x0)
+    curv_ref = rx.curvature()
+    res = rx.relax(maxiter=maxiter)
+    _Pf, _gf, srf, rUf, Sf = rx.objective(res.x)
+    curv_relax = rx.curvature()
+
+    spatial = res.x[res.x > 0]                          # spacelike edges (l^2 > 0)
+    timelike = res.x[res.x < 0]                         # timelike edges (l^2 < 0)
+    radius_rms = float(np.sqrt(np.mean(spatial))) if spatial.size else 0.0
+    total_def_ref = float(sum(curv_ref[d][0] for d in curv_ref))
+    total_def_relax = float(sum(curv_relax[d][0] for d in curv_relax))
+    return {"n_var": len(rx.VAR), "dim": rx.dim, "iters": int(res.nit),
+            "success": bool(res.success), "sr0": sr0, "srf": srf,
+            "rU0": rU0, "rUf": rUf, "S0": S0, "Sf": Sf,
+            "radius_rms": radius_rms, "l2_min": float(res.x.min()),
+            "l2_max": float(res.x.max()), "n_spatial": int(spatial.size),
+            "n_timelike": int(timelike.size), "total_def_ref": total_def_ref,
+            "total_def_relax": total_def_relax,
+            "curv_ref": curv_ref, "curv_relax": curv_relax}
+
+
+def _print_stage1(sgr, reg):
     print(f"carried register: dim ker L1 = {reg.dim}, orientation sign = "
           f"{tuple(int(s) for s in reg.sign)}, REALIZE < {sgr.REALIZE:g}\n")
-
     print("STAGE 1 -- color-configuration realizability map")
     print(f"{'config':>24} {'leak |Sigma|':>13} {'residual r_U':>15} {'realizable':>11}")
     for r in realizability_map(sgr, reg):
         print(f"{r['config']:>24} {r['leak']:13.6f} {r['residual']:15.3e} "
               f"{str(r['realizable']):>11}")
-
-    print("\nGauge (S3 color-relabel) invariance -- residual must be permutation-"
-          "invariant:")
+    print("\nGauge (S3 color-relabel) invariance:")
     for label, periods in [("baryon Z3 [1,w,w^2]",
                             np.array([1, OMEGA, OMEGA**2], dtype=complex)),
                            ("ref _CP_IN",
                             np.array([1.0, 0.3, -1.3], dtype=complex))]:
-        res, spread = gauge_invariance(sgr, reg, periods)
+        _res, spread = gauge_invariance(reg, periods)
         print(f"  {label:>22}: spread over 6 perms = {spread:.3e} "
               f"({'INVARIANT' if spread < 1e-6 else 'GAUGE ARTIFACT'})")
+
+
+def _print_stage3(out):
+    print(f"\nSTAGE 3 -- relax singlet-carrying merge bulk (Phi=||grad S||^2 + "
+          f"Gamma*r_U, extremize S)")
+    print(f"  variable bulk edges = {out['n_var']}, register dim = {out['dim']}, "
+          f"iters = {out['iters']}, success = {out['success']}")
+    print(f"  ||grad S||^2: {out['sr0']:.4f} -> {out['srf']:.4f}   (delta S -> 0)")
+    print(f"  r_U: {out['rU0']:.3e} -> {out['rUf']:.3e}   (register stays carried)")
+    print(f"  S (action): {out['S0']:.3f} -> {out['Sf']:.3f}")
+    print(f"  geometry: {out['n_spatial']} spacelike + {out['n_timelike']} timelike "
+          f"edges, l^2 in [{out['l2_min']:.3f}, {out['l2_max']:.3f}]")
+    print(f"  RADIUS proxy  (rms spacelike length): {out['radius_rms']:.4f}")
+    print(f"  MASS proxy    (total Re-deficit): {out['total_def_ref']:.3f} (ref) "
+          f"-> {out['total_def_relax']:.3f} (relaxed)")
+    print("  curvature Re-deficit by shell from color holes:")
+    print("    ref  :", " ".join(f"{out['curv_ref'][d][0]:+.3f}"
+                                  for d in sorted(out['curv_ref'])))
+    print("    relax:", " ".join(f"{out['curv_relax'][d][0]:+.3f}"
+                                  for d in sorted(out['curv_relax'])))
+
+
+def _main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--relax", action="store_true",
+                    help="stage 3: relax the singlet-carrying bulk to convergence")
+    ap.add_argument("--gamma", type=float, default=1e3)
+    ap.add_argument("--maxiter", type=int, default=1000)
+    ap.add_argument("--perm", type=str, default=None,
+                    help="S3 gauge check: permute the singlet colors, e.g. 1,2,0")
+    args = ap.parse_args()
+
+    sgr = _register_path()
+    reg = sgr.Register()
+    _print_stage1(sgr, reg)
+
+    if args.relax:
+        perm = tuple(int(i) for i in args.perm.split(",")) if args.perm else None
+        out = relax_singlet(gamma=args.gamma, maxiter=args.maxiter, perm=perm)
+        _print_stage3(out)
+    else:
+        print("\n(stage 3 relaxation: rerun with --relax)")
 
 
 if __name__ == "__main__":

--- a/examples/cobordism/proton_from_quarks.py
+++ b/examples/cobordism/proton_from_quarks.py
@@ -1,0 +1,137 @@
+"""Build a proton from quarks via merge cobordisms -- emergent charge/radius/mass.
+
+Reference is PDG/experiment (lattice-QCD-flavored, not QE). Read out emergent-first:
+dimensionless ratios first, then calibrate one scale (tessera is coordinate-free).
+
+Representation (settled; see issue #352)
+----------------------------------------
+- The three holonomy holes {[a],[b],[a+b]} are the three COLORS (R,G,B). The S3
+  permuting them is the Weyl group of color SU(3) -- a discrete color GAUGE
+  redundancy, so "which hole is which color" is unphysical. Observables must be
+  S3-invariant (a hard gauge-invariance test).
+- The carried register is the Sigma=0 subspace of the three hole-periods
+  (color-neutral). Hypothesis: a lone quark (one hole, Sigma != 0) FLOORS
+  (confinement); color-singlet (Sigma=0) configurations realize (r_U -> 0).
+- Fractions are NOT imposed on the classes (Z2 gives halves, not thirds; thirds
+  live in the Z3 < S3 cyclic structure, the cube-roots of unity). Total electric
+  charge is read out, target +1.
+- What flavor is / where it lives is DEFERRED -- we gather data first.
+
+STAGE 1 (this module): the color-configuration realizability map
+----------------------------------------------------------------
+Score a battery of color configurations (period vectors on the three holes) with
+the register's genuine stage-1 spectral residual (the same `spectral_residual`
+primitive `synthesize_state` uses), and let the data show the confinement/singlet
+structure -- which configurations the register carries vs floors -- with NO flavor
+assumption. Includes the S3 (gauge) invariance check.
+
+Later stages: the q (x) q -> (diquark/meson) -> proton merge-cobordism sequence,
+the StationaryActionRelaxer (Phi = ||grad S||^2 + Gamma*r_U; extremize S, keep
+Im S), and the emergent charge/radius/mass readout.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+OMEGA = np.exp(2j * np.pi / 3.0)   # primitive cube root of unity (the Z3 color phase)
+
+
+def _register_path():
+    """Import the working gate-realizability path (needs the tessera C++ build);
+    honor the 16-CPU cap before the BLAS is pulled in."""
+    for _v in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+               "BLIS_NUM_THREADS"):
+        os.environ.setdefault(_v, "16")
+    import spectral_gate_realizability as sgr
+    return sgr
+
+
+def color_configs():
+    """A battery of color configurations -- period vectors on the three color
+    holes -- spanning lone quarks, two-body, and three-body combinations. No
+    flavor assumed; we are mapping which the register carries.
+
+    Returns a list of (label, np.array of 3 complex periods).
+    """
+    return [
+        # lone quark on one color hole (Sigma != 0): the confinement probe
+        ("quark R", np.array([1, 0, 0], dtype=complex)),
+        ("quark G", np.array([0, 1, 0], dtype=complex)),
+        ("quark B", np.array([0, 0, 1], dtype=complex)),
+        # two same-sign (diquark, Sigma != 0)
+        ("diquark RG (same)", np.array([1, 1, 0], dtype=complex)),
+        # two opposite (meson-like q qbar, Sigma = 0)
+        ("meson R-Gbar", np.array([1, -1, 0], dtype=complex)),
+        ("meson G-Bbar", np.array([0, 1, -1], dtype=complex)),
+        # three equal (the symmetric / trivial-rep direction, Sigma != 0)
+        ("symmetric RGB", np.array([1, 1, 1], dtype=complex)),
+        # three-body Sigma = 0, real
+        ("baryon real [1,1,-2]", np.array([1, 1, -2], dtype=complex)),
+        ("baryon real [2,-1,-1]", np.array([2, -1, -1], dtype=complex)),
+        # three-body Z3 singlet (the natural color singlet: cube-root phases)
+        ("baryon Z3 [1,w,w^2]", np.array([1, OMEGA, OMEGA**2], dtype=complex)),
+        # the generic carried input from the gate battery (Sigma = 0 reference)
+        ("ref _CP_IN", np.array([1.0, 0.3, -1.3], dtype=complex)),
+    ]
+
+
+def score(sgr, reg, periods):
+    """Genuine stage-1 spectral residual of the color configuration on the
+    surgery-grown register (same primitive as synthesize_state), plus the leak
+    |Sigma| (the un-carried period sum). r -> 0 iff carried (color singlet)."""
+    residual = float(reg.spectral_residual(reg.sign * periods))
+    leak = float(abs(complex(periods.sum())))
+    return residual, leak
+
+
+def realizability_map(sgr=None, reg=None):
+    if sgr is None:
+        sgr = _register_path()
+    if reg is None:
+        reg = sgr.Register()
+    rows = []
+    for label, periods in color_configs():
+        residual, leak = score(sgr, reg, periods)
+        rows.append({"config": label, "leak": leak, "residual": residual,
+                     "realizable": bool(residual < sgr.REALIZE)})
+    return rows
+
+
+def gauge_invariance(sgr, reg, periods):
+    """S3 (color gauge) invariance test: every permutation of the three hole
+    periods must give the same residual. Returns (residuals over the 6
+    permutations, spread). A nonzero spread is a gauge artifact."""
+    from itertools import permutations
+    res = [float(reg.spectral_residual(reg.sign * periods[list(p)]))
+           for p in permutations(range(3))]
+    return res, float(np.max(res) - np.min(res))
+
+
+def _main():
+    sgr = _register_path()
+    reg = sgr.Register()
+    print(f"carried register: dim ker L1 = {reg.dim}, orientation sign = "
+          f"{tuple(int(s) for s in reg.sign)}, REALIZE < {sgr.REALIZE:g}\n")
+
+    print("STAGE 1 -- color-configuration realizability map")
+    print(f"{'config':>24} {'leak |Sigma|':>13} {'residual r_U':>15} {'realizable':>11}")
+    for r in realizability_map(sgr, reg):
+        print(f"{r['config']:>24} {r['leak']:13.6f} {r['residual']:15.3e} "
+              f"{str(r['realizable']):>11}")
+
+    print("\nGauge (S3 color-relabel) invariance -- residual must be permutation-"
+          "invariant:")
+    for label, periods in [("baryon Z3 [1,w,w^2]",
+                            np.array([1, OMEGA, OMEGA**2], dtype=complex)),
+                           ("ref _CP_IN",
+                            np.array([1.0, 0.3, -1.3], dtype=complex))]:
+        res, spread = gauge_invariance(sgr, reg, periods)
+        print(f"  {label:>22}: spread over 6 perms = {spread:.3e} "
+              f"({'INVARIANT' if spread < 1e-6 else 'GAUGE ARTIFACT'})")
+
+
+if __name__ == "__main__":
+    _main()

--- a/examples/cobordism/stationary_action_relaxation.py
+++ b/examples/cobordism/stationary_action_relaxation.py
@@ -94,6 +94,13 @@ class StationaryActionRelaxer:
     The variable edges ``VAR`` are every edge with at least one endpoint in the
     result block (the input→result worldtubes and the result-internal edges) —
     the emergent-dual geometry. The input (slice-t) spatial edges are held fixed.
+
+    This IS the only valid evolution: the boundary states are fixed (their spatial
+    edges held) and the bulk relaxes INTO the cobordism; where an input is allowed
+    to move (its result-touching edges), the Γ·r_U term holds its harmonic /
+    residual fixed, so it evolves ONLY while still carrying its state. The result
+    EMERGES in the bulk and is read after-the-fact, never inserted. Never compose
+    cobordisms by welding interiors — see ``merge_cobordism``'s "ONLY VALID WAY".
     """
 
     def __init__(self, gamma=1e3, merge=None, use_cpp_gradient=True):


### PR DESCRIPTION
## Summary

Build a proton from quarks as a sequence of merge cobordisms, reading out charge/radius/mass **emergent-first** against PDG/experiment (ratios first, then calibrate one scale). Representation (issue #352): three holes = color (gauge; S₃ = color Weyl group), Σ=0 = color singlet = confinement; fractions not imposed; flavor deferred pending data.

## Stage 1 result (color-configuration realizability map)
- **Confinement reproduced:** every Σ≠0 (colored) config floors at `r_U ~ 6–8` (lone quark, same-sign diquark, symmetric RGB); every Σ=0 (color-neutral) config realizes at machine zero `~1e-29` (mesons, all 3-body baryons incl. the Z₃ singlet `[1,ω,ω²]`).
- **Gauge-invariant:** the S₃ color-relabel residual is permutation-invariant to `~1e-29`.
- **Finding:** realizability = color-neutrality exactly; it does *not* distinguish meson/baryon or fix the proton. Baryon number + flavor + charge must come from the merge sequence + flavor data.

## Test plan
- [x] Stage 1: color-configuration realizability map (confinement + gauge invariance)
- [ ] Merge sequence `q ⊗ q → (diquark/meson) → proton` ending in one final state
- [ ] Relax (`StationaryActionRelaxer`, Φ = ‖∇S‖² + Γ·r_U; extremize S, keep Im S)
- [ ] Emergent readout: charge (target +1), radius (relaxed bulk extent / MI), mass (Regge curvature, ratio then calibrate)
- [ ] S₃ gauge-invariance of all observables

Closes #352.