### PR TITLE
feat(simulations): analytic Hessian of the dual Regge action (exact ∂²S/∂ℓ²∂ℓ²)

### DIFF
--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -412,6 +412,18 @@ class Simplex {
     [[nodiscard]] std::map<std::pair<std::uint64_t, std::uint64_t>, double>
     dualVolumeGradient() const;
 
+    /// Exact analytic Hessian of this hinge's ``dualVolume``:
+    /// \f$ \partial^2 |\!\star\!\sigma| / \partial \ell^2_e \partial \ell^2_f \f$.
+    /// One derivative beyond ``dualVolumeGradient``: the DEC facet→top recursion
+    /// carried to second order through the circumradii (``d2CircumR2``, with
+    /// \f$ \partial_f\beta = G^{-1}(\partial_f h - \partial_f G\,\beta) \f$) and the
+    /// signed-sqrt heights (\f$ g''(x) = -\mathrm{sign}(x)/4|x|^{3/2} \f$). Keyed
+    /// by the (sorted) edge pair; symmetric.
+    [[nodiscard]] std::map<std::pair<std::pair<std::uint64_t, std::uint64_t>,
+                                     std::pair<std::uint64_t, std::uint64_t>>,
+                           double>
+    dualVolumeHessian() const;
+
     /// Diagonal Hodge-star ratio ⋆ = |★σ| / |σ| (dual content over primal
     /// content) for this simplex — the bridge between the primal Laplacian
     /// weights and the dual Regge action.

--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -331,6 +331,20 @@ class Simplex {
                            std::complex<double>>
     lorentzianDeficitAngleGradient() const;
 
+    /// Exact analytic Hessian of this hinge's deficit angle:
+    /// \f$ \partial^2 \varepsilon / \partial \ell^2_e \partial \ell^2_f \f$.
+    /// One derivative beyond ``lorentzianDeficitAngleGradient``: the same
+    /// per-top-cell Cayley-Menger machinery carried to second order, with the
+    /// cofactor second derivative
+    /// \f$ \partial^2 C_{pq} = \partial(\det B\,T) \f$ (T the gradient's
+    /// bracket), \f$ d\theta/dr = -1/\sin\theta \f$ and
+    /// \f$ d^2\theta/dr^2 = -r/\sin^3\theta \f$. Keyed by the (sorted) edge pair;
+    /// symmetric. Complex (the boost part is carried, not truncated).
+    [[nodiscard]] std::map<std::pair<std::pair<std::uint64_t, std::uint64_t>,
+                                     std::pair<std::uint64_t, std::uint64_t>>,
+                           std::complex<double>>
+    lorentzianDeficitAngleHessian() const;
+
     /// Area of this simplex interpreted as a triangular hinge (3 vertices).
     /// Uses Heron's formula on the three edge squared lengths; ``wickRotate``
     /// selects signed (default) vs. |l^2| (see ``gramMatrix``).

--- a/include/simulations/ReggeSolver.h
+++ b/include/simulations/ReggeSolver.h
@@ -114,6 +114,16 @@ class ReggeSolver {
     /// machine precision but at one pass, not 2·|E| action evaluations.
     [[nodiscard]] std::vector<std::complex<double>> actionGradientExact() const;
 
+    /// Exact analytic Hessian ∂²S/∂ℓ²_e∂ℓ²_f of the dual Lorentzian Regge action,
+    /// as a dense |E|×|E| complex matrix in the ``getEdgeList`` order. The next
+    /// product-rule layer beyond ``actionGradientExact``:
+    /// Σ_h [∂²|★h|·ε_h + ∂|★h|_e·∂ε_h_f + ∂|★h|_f·∂ε_h_e + |★h|·∂²ε_h], assembled
+    /// from the per-hinge ``dualVolumeHessian`` / ``lorentzianDeficitAngleHessian``
+    /// (and their gradients) — no finite differences. Removes the FD-Hessian floor
+    /// in the stationary-action relaxation (exact Newton / Gauss-Newton).
+    [[nodiscard]] std::vector<std::vector<std::complex<double>>>
+    actionHessianExact() const;
+
     // ==================== Solver ====================
 
     /// One gradient-descent step minimizing \f$F = \|\nabla S\|^2\f$.

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -408,7 +408,12 @@ Python-driven materialization corrupted dualVolume(). Reference fixes it
            "Exact analytic d(deficit)/d(l^2_e) for each surrounding edge, as a "
            "dict {(v0,v1): complex}. Cofactor-derivative of the Cayley-Menger "
            "dihedral with the boost-safe sin(theta) branch; matches finite "
-           "differences to machine precision.");
+           "differences to machine precision.")
+      .def("lorentzianDeficitAngleHessian",
+           &Simplex::lorentzianDeficitAngleHessian,
+           "Exact analytic d^2(deficit)/d(l^2_e)d(l^2_f), as a dict "
+           "{((v0,v1),(v2,v3)): complex}. One derivative beyond the gradient "
+           "(cofactor second derivative + d^2theta/dr^2); symmetric.");
 
   py::class_<SimplexHash, std::shared_ptr<SimplexHash> >(m, "SimplexHash")
       .def(py::init<>());

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -390,6 +390,11 @@ Python-driven materialization corrupted dualVolume(). Reference fixes it
            "dict {(v0,v1): float}. Differentiates the DEC circumradius recursion "
            "(R^2 = h^T G^-1 h); matches finite differences to machine precision. "
            "(n-2)-hinge case only.")
+      .def("dualVolumeHessian", &Simplex::dualVolumeHessian,
+           "Exact analytic d^2(dualVolume)/d(l^2_e)d(l^2_f), as a dict "
+           "{((v0,v1),(v2,v3)): float}. One derivative beyond the gradient "
+           "(d2CircumR2 + signed-sqrt second derivative); symmetric. "
+           "(n-2)-hinge case only.")
       .def("hodgeStar", &Simplex::hodgeStar,
            "Diagonal Hodge-star ratio |*sigma|/|sigma| (dual over primal "
            "content).")

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -922,6 +922,144 @@ Simplex::lorentzianDeficitAngleGradient() const {
     return grad;
 }
 
+std::map<std::pair<std::pair<std::uint64_t, std::uint64_t>,
+                   std::pair<std::uint64_t, std::uint64_t>>,
+         std::complex<double>>
+Simplex::lorentzianDeficitAngleHessian() const {
+    using cd = std::complex<double>;
+    using EK = std::pair<std::uint64_t, std::uint64_t>;
+    std::map<std::pair<EK, EK>, cd> hess;
+    if (!spacetime || vertices.empty()) return hess;
+    const int topSize =
+        spacetime->getMetric()->getSignature()->getDimensions() + 1;
+
+    // d^2(eps)/dl^2_e dl^2_f = -sum_tau d^2(theta_tau). Same top-cell set and
+    // cofactor machinery as lorentzianDeficitAngleGradient, carried one more
+    // derivative: d^2 theta = (d2theta/dr^2) dr_e dr_f + (dtheta/dr) d2r.
+    for (const auto &tau : vertices[0]->getSimplices()) {
+        if (static_cast<int>(tau->size()) != topSize) continue;
+        bool containsAll = true;
+        for (std::size_t i = 1; i < vertices.size(); ++i)
+            if (!tau->hasVertex(vertices[i])) { containsAll = false; break; }
+        if (!containsAll) continue;
+
+        const auto &tv = tau->getVertices();
+        const int m = static_cast<int>(tv.size());
+        std::vector<int> opp;
+        for (int k = 0; k < m; ++k) {
+            bool inHinge = false;
+            for (const auto &hv : vertices)
+                if (hv->getId() == tv[k]->getId()) { inHinge = true; break; }
+            if (!inHinge) opp.push_back(k);
+        }
+        if (opp.size() != 2) continue;
+        const int bi = opp[0] + 1, bj = opp[1] + 1;
+
+        const int n = m + 1;
+        const std::vector<double> B = tau->cayleyMengerMatrix(/*wickRotate=*/false);
+        const double detB = determinant(B, n);
+        if (std::abs(detB) < 1e-300) continue;
+        const std::vector<double> C = cofactorMatrix(B, n);
+        std::vector<double> Binv(static_cast<std::size_t>(n) * n);
+        for (int i = 0; i < n; ++i)
+            for (int j = 0; j < n; ++j)
+                Binv[i * n + j] = C[j * n + i] / detB;
+
+        const double Cij = C[bi * n + bj];
+        const double Cii = C[bi * n + bi];
+        const double Cjj = C[bj * n + bj];
+        const double sC = (Cii >= 0.0) ? 1.0 : -1.0;
+        const double sP = (Cii * Cjj >= 0.0) ? 1.0 : -1.0;
+        const double D = std::sqrt(std::abs(Cii * Cjj));
+        if (D < 1e-300) continue;
+        const double denom = sC * D;
+        const double r = -Cij / denom;
+        const cd theta = std::acos(cd(r, 0.0));
+        const cd sinT = std::sin(theta);
+        if (std::abs(sinT) < 1e-300) continue;
+        const cd dthetaDr = cd(-1.0, 0.0) / sinT;
+        const cd d2thetaDr2 = cd(-r, 0.0) / (sinT * sinT * sinT);
+
+        auto bb = [&](int x, int y) -> double { return Binv[x * n + y]; };
+        // dC_pq/dl^2_(a,b): a,b local vertex indices (CM border = +1).
+        auto dCof = [&](int p, int q, int a, int b) -> double {
+            const int A = a + 1, Bn = b + 1;
+            return detB * (2.0 * bb(A, Bn) * bb(p, q)
+                           - bb(p, A) * bb(Bn, q) - bb(p, Bn) * bb(A, q));
+        };
+        // dBinv_xy/dl^2_(c,d) = -(Binv_xC Binv_Dy + Binv_xD Binv_Cy).
+        auto dBi = [&](int x, int y, int c, int d) -> double {
+            const int Cn = c + 1, Dn = d + 1;
+            return -(bb(x, Cn) * bb(Dn, y) + bb(x, Dn) * bb(Cn, y));
+        };
+        // d^2 C_pq/dl^2_(a,b) dl^2_(c,d) = ddetB*T + detB*dT.
+        auto d2Cof = [&](int p, int q, int a, int b, int c, int d) -> double {
+            const int A = a + 1, Bn = b + 1, Cn = c + 1, Dn = d + 1;
+            const double T = 2.0 * bb(A, Bn) * bb(p, q)
+                             - bb(p, A) * bb(Bn, q) - bb(p, Bn) * bb(A, q);
+            const double ddetB = detB * 2.0 * bb(Cn, Dn);
+            const double dT =
+                2.0 * (dBi(A, Bn, c, d) * bb(p, q) + bb(A, Bn) * dBi(p, q, c, d))
+                - (dBi(p, A, c, d) * bb(Bn, q) + bb(p, A) * dBi(Bn, q, c, d))
+                - (dBi(p, Bn, c, d) * bb(A, q) + bb(p, Bn) * dBi(A, q, c, d));
+            return ddetB * T + detB * dT;
+        };
+
+        struct Loc { int a, b; std::uint64_t va, vb; double dr; };
+        std::vector<Loc> es;
+        for (int a = 0; a < m; ++a)
+            for (int b = a + 1; b < m; ++b) {
+                const double dCij = dCof(bi, bj, a, b);
+                const double dCii = dCof(bi, bi, a, b);
+                const double dCjj = dCof(bj, bj, a, b);
+                const double dD = sP * (dCii * Cjj + Cii * dCjj) / (2.0 * D);
+                const double ddenom = sC * dD;
+                const double dr =
+                    -(dCij * denom - Cij * ddenom) / (denom * denom);
+                es.push_back({a, b, tv[a]->getId(), tv[b]->getId(), dr});
+            }
+
+        for (const auto &e : es) {
+            const double dCij_e = dCof(bi, bj, e.a, e.b);
+            const double dCii_e = dCof(bi, bi, e.a, e.b);
+            const double dCjj_e = dCof(bj, bj, e.a, e.b);
+            const double dP_e = dCii_e * Cjj + Cii * dCjj_e;
+            const double ddenom_e = sC * sP * dP_e / (2.0 * D);
+            for (const auto &f : es) {
+                const double dCij_f = dCof(bi, bj, f.a, f.b);
+                const double dCii_f = dCof(bi, bi, f.a, f.b);
+                const double dCjj_f = dCof(bj, bj, f.a, f.b);
+                const double dP_f = dCii_f * Cjj + Cii * dCjj_f;
+                const double ddenom_f = sC * sP * dP_f / (2.0 * D);
+
+                const double d2Cij = d2Cof(bi, bj, e.a, e.b, f.a, f.b);
+                const double d2Cii = d2Cof(bi, bi, e.a, e.b, f.a, f.b);
+                const double d2Cjj = d2Cof(bj, bj, e.a, e.b, f.a, f.b);
+                const double d2P = d2Cii * Cjj + dCii_e * dCjj_f
+                                   + dCii_f * dCjj_e + Cii * d2Cjj;
+                const double d2D = sP * d2P / (2.0 * D)
+                                   - dP_e * dP_f / (4.0 * D * D * D);
+                const double d2denom = sC * d2D;
+
+                // r = N/Den, N = -Cij, Den = denom.
+                const double N = -Cij, Ne = -dCij_e, Nf = -dCij_f, Nef = -d2Cij;
+                const double Den = denom, De = ddenom_e, Df = ddenom_f,
+                             Def = d2denom;
+                const double d2r =
+                    ((Nef * Den + Ne * Df - Nf * De - N * Def) * Den
+                     - 2.0 * (Ne * Den - N * De) * Df) / (Den * Den * Den);
+
+                const cd d2theta = d2thetaDr2 * cd(e.dr, 0.0) * cd(f.dr, 0.0)
+                                   + dthetaDr * cd(d2r, 0.0);
+                const EK ke{std::min(e.va, e.vb), std::max(e.va, e.vb)};
+                const EK kf{std::min(f.va, f.vb), std::max(f.va, f.vb)};
+                hess[{ke, kf}] -= d2theta;      // eps = 2pi - sum theta
+            }
+        }
+    }
+    return hess;
+}
+
 double Simplex::area(bool wickRotate) const {
     if (edges.size() < 3) return 0.0;
     auto sq = [&](std::size_t k) -> double {

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -1242,6 +1242,71 @@ double dCircumR2(const ::tessera::mesh::Simplex* s,
     return r;
 }
 
+// Exact d^2(R^2)/d(l^2_e)d(l^2_f). Since dR^2 = 2(dh)^T beta - beta^T dG beta and
+// G is linear in l^2 (dG, dh constant indicators), the second derivative is
+// 2(dh_e)^T (d_f beta) - 2 beta^T dG_e (d_f beta), with
+// d_f beta = G^-1 (dh_f - dG_f beta). Symmetric in (e,f).
+double d2CircumR2(const ::tessera::mesh::Simplex* s,
+                  std::uint64_t ea, std::uint64_t eb,
+                  std::uint64_t fa, std::uint64_t fb) {
+    const int d = static_cast<int>(s->size()) - 1;
+    if (d <= 0) return 0.0;
+    const auto& sv = s->getVertices();
+    const std::vector<double> G = s->gramMatrix(/*wickRotate=*/false);
+    const double detG = ::tessera::mesh::Simplex::determinant(G, d);
+    if (std::abs(detG) < 1e-300) return 0.0;
+    const std::vector<double> cofG =
+        ::tessera::mesh::Simplex::cofactorMatrix(G, d);
+    std::vector<double> Ginv(static_cast<std::size_t>(d) * d);
+    for (int i = 0; i < d; ++i)
+        for (int j = 0; j < d; ++j)
+            Ginv[i * d + j] = cofG[j * d + i] / detG;   // (G^-1)_ij = C_ji/det
+    std::vector<double> h(d), beta(d, 0.0);
+    for (int i = 0; i < d; ++i) h[i] = 0.5 * G[i * d + i];
+    for (int i = 0; i < d; ++i) {
+        double a = 0.0;
+        for (int j = 0; j < d; ++j) a += Ginv[i * d + j] * h[j];
+        beta[i] = a;
+    }
+    auto indMat = [&](std::uint64_t e0, std::uint64_t e1,
+                      std::vector<double>& dG, std::vector<double>& dh) {
+        const std::uint64_t lo = std::min(e0, e1), hi = std::max(e0, e1);
+        auto ind = [&](int p, int q) -> double {
+            if (p == q) return 0.0;
+            const std::uint64_t a = sv[p]->getId(), b = sv[q]->getId();
+            return (std::min(a, b) == lo && std::max(a, b) == hi) ? 1.0 : 0.0;
+        };
+        dG.assign(static_cast<std::size_t>(d) * d, 0.0);
+        dh.assign(d, 0.0);
+        for (int i = 0; i < d; ++i)
+            for (int j = 0; j < d; ++j)
+                dG[i * d + j] =
+                    0.5 * (ind(0, i + 1) + ind(0, j + 1) - ind(i + 1, j + 1));
+        for (int i = 0; i < d; ++i) dh[i] = 0.5 * dG[i * d + i];
+    };
+    std::vector<double> dG_e, dh_e, dG_f, dh_f;
+    indMat(ea, eb, dG_e, dh_e);
+    indMat(fa, fb, dG_f, dh_f);
+    // d_f beta = G^-1 (dh_f - dG_f beta)
+    std::vector<double> tmp(d, 0.0), dbeta_f(d, 0.0);
+    for (int i = 0; i < d; ++i) {
+        double a = dh_f[i];
+        for (int j = 0; j < d; ++j) a -= dG_f[i * d + j] * beta[j];
+        tmp[i] = a;
+    }
+    for (int i = 0; i < d; ++i) {
+        double a = 0.0;
+        for (int j = 0; j < d; ++j) a += Ginv[i * d + j] * tmp[j];
+        dbeta_f[i] = a;
+    }
+    double r = 0.0;
+    for (int i = 0; i < d; ++i) r += 2.0 * dh_e[i] * dbeta_f[i];
+    for (int i = 0; i < d; ++i)
+        for (int j = 0; j < d; ++j)
+            r -= 2.0 * beta[i] * dG_e[i * d + j] * dbeta_f[j];
+    return r;
+}
+
 }  // namespace
 
 std::vector<double> Simplex::circumcenterBarycentric() const {
@@ -1325,6 +1390,90 @@ Simplex::dualVolumeGradient() const {
         grad[e] = dV * inv;
     }
     return grad;
+}
+
+std::map<std::pair<std::pair<std::uint64_t, std::uint64_t>,
+                   std::pair<std::uint64_t, std::uint64_t>>,
+         double>
+Simplex::dualVolumeHessian() const {
+    using EK = std::pair<std::uint64_t, std::uint64_t>;
+    std::map<std::pair<EK, EK>, double> hess;
+    if (vertices.empty()) return hess;
+    const Simplex* top = this;
+    while (!top->getCofaces().empty()) top = top->getCofaces()[0];
+    const int n = static_cast<int>(top->size()) - 1;
+    const int k = static_cast<int>(size()) - 1;
+    if (k != n - 2) return hess;
+
+    const double Rh2 = circumradiusSquared();
+    struct Facet {
+        const Simplex* cf; double sgn; double R1;
+        std::vector<std::pair<const Simplex*, std::pair<double, double>>> tops;
+    };
+    std::vector<Facet> fs;
+    std::set<EK> edges;
+    for (const auto& cf : getCofaces()) {
+        Facet f; f.cf = cf; f.sgn = oppositeVertexSign(cf, this);
+        f.R1 = cf->circumradiusSquared();
+        for (const auto& tp : cf->getCofaces()) {
+            const double sgn2 = oppositeVertexSign(tp, cf);
+            f.tops.push_back({tp, {sgn2, tp->circumradiusSquared()}});
+            const auto& tv = tp->getVertices();
+            for (std::size_t i = 0; i < tv.size(); ++i)
+                for (std::size_t j = i + 1; j < tv.size(); ++j) {
+                    const std::uint64_t a = tv[i]->getId(), b = tv[j]->getId();
+                    edges.insert({std::min(a, b), std::max(a, b)});
+                }
+        }
+        fs.push_back(std::move(f));
+    }
+    const double inv = 1.0 / (static_cast<double>(n - k) * (n - k - 1));
+    auto gp = [](double x) -> double {
+        return 1.0 / (2.0 * std::sqrt(std::abs(x) + 1e-300));
+    };
+    auto gpp = [](double x) -> double {
+        const double ax = std::abs(x) + 1e-300;
+        return -((x < 0.0) ? -1.0 : 1.0) / (4.0 * ax * std::sqrt(ax));
+    };
+    const std::vector<EK> ev(edges.begin(), edges.end());
+    for (const auto& e : ev) {
+        const double dRh_e = dCircumR2(this, e.first, e.second);
+        for (const auto& f : ev) {
+            const double dRh_f = dCircumR2(this, f.first, f.second);
+            const double d2Rh =
+                d2CircumR2(this, e.first, e.second, f.first, f.second);
+            double dV2 = 0.0;
+            for (const auto& fac : fs) {
+                const double dR1_e = dCircumR2(fac.cf, e.first, e.second);
+                const double dR1_f = dCircumR2(fac.cf, f.first, f.second);
+                const double d2R1 =
+                    d2CircumR2(fac.cf, e.first, e.second, f.first, f.second);
+                const double x1 = fac.R1 - Rh2;
+                const double ss1 = signedSqrt(x1);
+                const double dx1_e = dR1_e - dRh_e, dx1_f = dR1_f - dRh_f;
+                const double dss1_e = gp(x1) * dx1_e, dss1_f = gp(x1) * dx1_f;
+                const double d2ss1 = gpp(x1) * dx1_e * dx1_f + gp(x1) * (d2R1 - d2Rh);
+                double S = 0.0, dS_e = 0.0, dS_f = 0.0, d2S = 0.0;
+                for (const auto& t : fac.tops) {
+                    const double sgn2 = t.second.first, R2 = t.second.second;
+                    const double dR2_e = dCircumR2(t.first, e.first, e.second);
+                    const double dR2_f = dCircumR2(t.first, f.first, f.second);
+                    const double d2R2 =
+                        d2CircumR2(t.first, e.first, e.second, f.first, f.second);
+                    const double x2 = R2 - fac.R1;
+                    const double dx2_e = dR2_e - dR1_e, dx2_f = dR2_f - dR1_f;
+                    S += sgn2 * signedSqrt(x2);
+                    dS_e += sgn2 * gp(x2) * dx2_e;
+                    dS_f += sgn2 * gp(x2) * dx2_f;
+                    d2S += sgn2 * (gpp(x2) * dx2_e * dx2_f + gp(x2) * (d2R2 - d2R1));
+                }
+                dV2 += fac.sgn
+                       * (d2ss1 * S + dss1_e * dS_f + dss1_f * dS_e + ss1 * d2S);
+            }
+            hess[{e, f}] = dV2 * inv;
+        }
+    }
+    return hess;
 }
 
 double Simplex::hodgeStar() const {

--- a/src/simulations/Bindings.cpp
+++ b/src/simulations/Bindings.cpp
@@ -292,6 +292,12 @@ Einstein equations).  F ≥ 0, and F = 0 at the solution.)doc")
            "Assembled from the per-hinge dualVolume/deficit analytic gradients "
            "(no finite differences); matches FD of dualReggeAction to machine "
            "precision in one pass.")
+      .def("actionHessianExact", &ReggeSolver::actionHessianExact,
+           "Exact analytic Hessian ∂²S/∂ℓ²_e∂ℓ²_f of the dual Regge action: a "
+           "dense |E|x|E| complex matrix (getEdgeList order). Four-term product "
+           "rule over the per-hinge dualVolume/deficit Hessians + gradients (no "
+           "finite differences); matches a central difference of "
+           "actionGradientExact to machine precision.")
       .def("step", &ReggeSolver::step,
            py::arg("learningRate") = 0.001,
            "One gradient-descent step on F = ||∇S||². Returns F before the update.")

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -213,6 +213,51 @@ std::vector<std::complex<double>> ReggeSolver::actionGradientExact() const {
     return g;
 }
 
+std::vector<std::vector<std::complex<double>>>
+ReggeSolver::actionHessianExact() const {
+    using cd = std::complex<double>;
+    const auto edges = spacetime_->getEdgeList()->toVector();
+    std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> eidx;
+    for (std::size_t i = 0; i < edges.size(); ++i) {
+        const std::uint64_t a = edges[i]->getSource()->getId();
+        const std::uint64_t b = edges[i]->getTarget()->getId();
+        eidx[{std::min(a, b), std::max(a, b)}] = i;
+    }
+    const std::size_t E = edges.size();
+    std::vector<std::vector<cd>> H(E, std::vector<cd>(E, cd(0.0, 0.0)));
+    // d^2 S/dl^2_e dl^2_f = sum_h [ d2V_ef*eps + dV_e*dEps_f + dV_f*dEps_e
+    //                              + V*d2Eps_ef ].
+    for (const auto &h : collectHinges()) {
+        const cd eps = h->lorentzianDeficitAngle();
+        const double V = h->dualVolume();
+        const auto dEps = h->lorentzianDeficitAngleGradient();
+        const auto dV = h->dualVolumeGradient();
+        const auto d2Eps = h->lorentzianDeficitAngleHessian();
+        const auto d2V = h->dualVolumeHessian();
+        for (const auto &[e, dVe] : dV) {
+            const auto ie = eidx.find(e);
+            if (ie == eidx.end()) continue;
+            const auto dEe_it = dEps.find(e);
+            const cd dEe = (dEe_it != dEps.end()) ? dEe_it->second : cd(0.0, 0.0);
+            for (const auto &[f, dVf] : dV) {
+                const auto if_ = eidx.find(f);
+                if (if_ == eidx.end()) continue;
+                const auto dEf_it = dEps.find(f);
+                const cd dEf =
+                    (dEf_it != dEps.end()) ? dEf_it->second : cd(0.0, 0.0);
+                cd term = dVe * dEf + dVf * dEe;       // cross terms
+                const auto k = std::make_pair(e, f);
+                const auto d2Vit = d2V.find(k);
+                if (d2Vit != d2V.end()) term += d2Vit->second * eps;
+                const auto d2Eit = d2Eps.find(k);
+                if (d2Eit != d2Eps.end()) term += V * d2Eit->second;
+                H[ie->second][if_->second] += term;
+            }
+        }
+    }
+    return H;
+}
+
 double ReggeSolver::actionGradientNorm() const {
     auto g = actionGradient();
     double F = 0.0;


### PR DESCRIPTION
## Summary

Exact analytic second derivative of the dual Lorentzian Regge action, replacing the finite-difference Hessian-vector products the stationary-action relaxation used (the FD Hessian ~4e-7 was the confirmed `δS=0` convergence floor). General `ReggeSolver` capability — helps every Regge relaxation, not just the proton (#352).

`∂S/∂ℓ²_e = Σ_h [ ∂|*h|·ε_h + |*h|·∂ε_h ]`; the Hessian is the next product-rule layer: `Σ_h [ ∂²|*h|·ε_h + ∂|*h|_e·∂ε_h_f + ∂|*h|_f·∂ε_h_e + |*h|·∂²ε_h ]`.

## Done — every piece FD-gated
- [x] **Deficit-angle Hessian** `Simplex::lorentzianDeficitAngleHessian` — Cayley–Menger cofactor 2nd derivative + `d²θ/dr²` chain. **max dev 6.98e-11** vs `lorentzianDeficitAngleGradient`.
- [x] **Dual-volume Hessian** `Simplex::dualVolumeHessian` — recursive circumcentric (`d2CircumR2` with `∂_fβ = G⁻¹(∂_fh − ∂_fG·β)` + signed-sqrt 2nd deriv). **max dev 8.08e-11** vs `dualVolumeGradient`.
- [x] **`ReggeSolver::actionHessianExact`** — four-term assembly, dense `|E|×|E|` complex. **max dev 5.07e-10** vs central difference of `actionGradientExact` (174×174, merge cobordism).
- [x] **No regressions:** Regge/Simplex/Hodge/spectral suites = 118 tests + 232 subtests pass; only failure is a pre-existing CUDA-OOM in `solver.step` (GPU path), unrelated.

## Follow-up (separate)
Wire the relaxer/solver onto `actionHessianExact` (exact Newton) — done where it's consumed (the proton relaxation, #352), not here.

Closes #354.
