### PR TITLE
chore(deps): dependency-license hygiene for proprietary relicense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,16 @@ target_include_directories(tessera_core PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(tessera_core PUBLIC ZLIB::ZLIB Eigen3::Eigen)
 
+# Eigen is MPL-2.0, but a handful of its modules pull in LGPL/GPL code
+# (unsupported/Eigen/FFT via FFTW, MPRealSupport via MPFR, and the
+# SparseCholesky / OrderingMethods AMD routines). tessera only uses MPL-2.0
+# modules (Core, Dense, SparseCore, KroneckerProduct); EIGEN_MPL2_ONLY makes
+# any future `#include` of a non-MPL2 module a hard compile error rather than
+# a silent copyleft contamination of the proprietary _tessera binary. PUBLIC
+# so it reaches every consumer that compiles Eigen headers (tessera_quantum,
+# the binding TUs, and the test executables all link tessera_core).
+target_compile_definitions(tessera_core PUBLIC EIGEN_MPL2_ONLY)
+
 # Optional OpenMP for the spectral-graph heat-kernel parallel loop and
 # similar embarrassingly-parallel hot paths. Bit-identical to the
 # serial code at OMP_NUM_THREADS=1 (the default in our 10-CPU-budget

--- a/README.md
+++ b/README.md
@@ -211,3 +211,5 @@ open _build/html/index.html
 
 Copyright (c) 2026 Twin Vector Labs LLC. All rights reserved. See [LICENSE.md](LICENSE.md).
 
+Third-party components linked or redistributed by tessera are inventoried in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,86 @@
+# Third-Party Notices
+
+tessera is proprietary software (Copyright (c) 2026 Twin Vector Labs LLC, all
+rights reserved). It builds against, links, or redistributes the third-party
+components listed below. Each is governed by its own license; nothing here
+grants any rights in tessera itself.
+
+This inventory covers components that are **compiled into or dynamically linked
+by the distributed `_tessera` extension**. Development-, test-, and docs-only
+dependencies (pytest, scikit-build-core, cmake, ninja, sphinx, furo,
+myst-parser, breathe, sphinxcontrib-bibtex, matplotlib, networkx, scipy, tqdm,
+pybind11-stubgen) are not distributed with the product and are therefore out of
+scope; all are under permissive licenses (BSD / MIT / Apache-2.0 / PSF), the
+sole exception being tqdm (MPL-2.0, weak/file-level, not imported by the core
+package).
+
+## Linked / compiled into `_tessera`
+
+| Component | Version | License | Notes |
+|---|---|---|---|
+| **ITensor** (v3) | submodule pin | Apache-2.0 | ITensor developers / Simons Foundation. Permissive. |
+| **ITensor / TDVP add-on** | submodule pin | **UNSTATED — see below** | Header-only (`tdvp.h`, `basisextension.h`), `#include`d by `src/quantum/TDVPRunner.cpp` and `ChoiState.cpp`. ⚠️ |
+| **Eigen** | 3.4 | MPL-2.0 | We use only MPL-2.0 modules (Core, Dense, SparseCore, KroneckerProduct). `EIGEN_MPL2_ONLY` is defined to make any non-MPL2 module a compile error. MPL-2.0 is file-level copyleft and does not restrict our proprietary use. |
+| **BLAS / LAPACK** | system | BSD-3-Clause | Resolves to the platform backend (Debian netlib reference BLAS/LAPACK = BSD-3; may be OpenBLAS = BSD-3, Accelerate = Apple system framework, or MKL = proprietary-redistributable depending on the host). None are copyleft. |
+| **zlib** (`libz`) | system | Zlib | Permissive. |
+| **OpenMP runtime** (`libgomp`) | system | GPL-3.0 **+ GCC Runtime Library Exception** | The Runtime Library Exception explicitly permits linking into proprietary software. (If built with Clang, `libomp` is Apache-2.0-WITH-LLVM-exception.) Dynamically linked system library. |
+| **NVIDIA CUDA runtime** (`libcudart`, `libcublas`) | CUDA 12 | NVIDIA CUDA EULA | Proprietary, **not** copyleft. Redistribution is governed by the CUDA EULA — see the redistribution note below. Built only when `TESSERA_CUDA=ON`. |
+
+## Test-only (not distributed)
+
+| Component | License | Notes |
+|---|---|---|
+| **Catch2** (`third_party/itensor/unittest/catch.hpp`) | Boost Software License 1.0 | Compiled only into ITensor's unit tests, never into `_tessera`. |
+| **pybind11** | BSD-3-Clause | Build-time header-only; the binding glue it generates is BSD-3, compatible with proprietary distribution. |
+
+## Runtime Python dependency
+
+| Component | License | Notes |
+|---|---|---|
+| **NumPy** | BSD-3-Clause | The only mandatory runtime Python dependency. |
+
+---
+
+## ⚠️ Unresolved: ITensor / TDVP license
+
+The TDVP add-on (`third_party/itensor_tdvp`, upstream
+<https://github.com/ITensor/TDVP>) ships **no LICENSE file and no per-file
+license headers**, and the GitHub licensing API reports none. tessera compiles
+these headers into the distributed binary (`itensor::tdvp(...)` is called from
+the Schwinger-quench pipeline), so this is a material obligation, not dead
+weight.
+
+Absent an explicit grant, the default is "all rights reserved" by the authors.
+The companion ITensor core repository is Apache-2.0, and TDVP is published by
+the same authors as a public ITensor add-on, so the *intent* is almost
+certainly permissive — but intent is not a license.
+
+**Action required:** obtain a written license grant from the ITensor authors
+(or confirmation that TDVP is covered by ITensor's Apache-2.0), and vendor a
+LICENSE copy here once obtained. If that cannot be secured, replace or remove
+the TDVP dependency before distributing tessera.
+
+## GPL-3.0 code present but NOT linked
+
+ITensor vendors GPL-3.0-or-later HDF5-serialization code
+(`third_party/itensor/itensor/util/h5/`, Copyright (C) 2011-2014 O. Parcollet).
+It is **never compiled or linked** into tessera:
+
+- the h5 `.cc` files are excluded from the ITensor source list in
+  `cmake/BuildITensor.cmake` (HDF5 serialization is disabled),
+- the headers are gated behind `#ifdef ITENSOR_USE_HDF5`, which tessera never
+  defines, and
+- `cmake/BuildITensor.cmake` contains a hard guard that fails configuration if
+  `ITENSOR_USE_HDF5` is ever set.
+
+It is listed here only for transparency. Do not enable `ITENSOR_USE_HDF5` while
+tessera remains proprietary.
+
+## NVIDIA CUDA redistribution
+
+The CUDA runtime libraries (`libcudart`, `libcublas`) are governed by the
+NVIDIA CUDA Toolkit EULA. They are not copyleft, but redistribution carries
+conditions: ship them as the NVIDIA-provided redistributable libraries
+(per the EULA's redistributable-software attachment) rather than statically
+embedding CUDA components, and include NVIDIA's required attribution. Builds
+with `TESSERA_CUDA=OFF` link none of this and are unaffected.

--- a/cmake/BuildITensor.cmake
+++ b/cmake/BuildITensor.cmake
@@ -27,6 +27,20 @@ function(tessera_build_itensor)
             "git submodule update --init --recursive")
     endif()
 
+    # LICENSE GUARD — do not remove. ITensor's optional HDF5 serialization
+    # (itensor/util/h5/, by O. Parcollet) is GPL-3.0-or-later. tessera is
+    # proprietary, so statically linking that code into _tessera would force
+    # the whole binary under the GPL. The h5 .cc files are deliberately
+    # excluded from the source list below and the headers are gated behind
+    # ITENSOR_USE_HDF5, so it is currently dead code. This guard makes the
+    # only switch that could revive it a hard configure-time error.
+    if(ITENSOR_USE_HDF5)
+        message(FATAL_ERROR
+            "ITENSOR_USE_HDF5 is set, but ITensor's HDF5 code (itensor/util/h5) "
+            "is GPL-3.0-or-later and must NOT be linked into the proprietary "
+            "_tessera binary. See THIRD_PARTY_NOTICES.md. Leave HDF5 disabled.")
+    endif()
+
     # Cache variable so users can override with -DITENSOR_PLATFORM=openblas
     # at configure time. The default tracks the OS's native backend:
     # Accelerate on macOS, reference LAPACK elsewhere (libblas + liblapack


### PR DESCRIPTION
## Summary
Follow-up to the MIT→proprietary relicense (#356/#357). Closes the four dependency-license gaps from the audit so no copyleft code can contaminate the distributed `_tessera` binary, and documents third-party obligations.

1. **`EIGEN_MPL2_ONLY`** defined on `tessera_core` (PUBLIC). We use only MPL-2.0 Eigen modules today; this turns any future include of an LGPL/GPL module into a compile error.
2. **GPL-3.0 h5 guard** in `cmake/BuildITensor.cmake` — `FATAL_ERROR` if `ITENSOR_USE_HDF5` is set. ITensor's HDF5 code (O. Parcollet) is GPL-3.0-or-later; it's currently dead code (excluded from the source list + `#ifdef`-gated), and this guard ensures it can never be revived silently into a proprietary binary.
3. **TDVP license** — investigated: `ITensor/TDVP` ships **no license** upstream (GitHub API 404, no LICENSE/headers). tessera *does* compile it (`itensor::tdvp(...)`), so it's documented in THIRD_PARTY_NOTICES.md as an **unresolved obligation requiring upstream resolution** — see below.
4. **`THIRD_PARTY_NOTICES.md`** — inventory of every distributed third-party component (ITensor Apache-2.0, Eigen MPL-2.0, netlib BLAS/LAPACK BSD, zlib, libgomp GPL+Runtime-Exception, Catch2 BSL-1.0, NVIDIA CUDA EULA + redistribution note), linked from the README.

## ⚠️ Needs a decision (item 3)
The TDVP add-on has no upstream license — technically "all rights reserved". It's by the ITensor authors as a public add-on (intent is clearly permissive) but that's not a grant. **Resolution requires obtaining a written license from upstream, confirming Apache-2.0 coverage, or removing the dependency** — outside what code can fix. Documented for now.

## Test plan (verified locally)
- [x] `pip install -e .` configures + compiles cleanly with `EIGEN_MPL2_ONLY`; define confirmed in build flags (our Eigen usage stays within MPL-2.0)
- [x] `import tessera` succeeds; `Sphere()` constructs and the `tessera.quantum` facade (ITensor + TDVP + Eigen linked) loads
- [x] Configuring with `-DITENSOR_USE_HDF5=ON` aborts with the guard's `FATAL_ERROR` at `BuildITensor.cmake:38` (exit 1)
- [ ] Full `pytest` suite — not run: changes are build-config + docs only (no source logic touched), and a clean compile + import + functional smoke were verified. The full suite remains the local gate per repo policy.

Closes #358.
