### PR TITLE
feat(cobordism): canonical MergeCobordism(initialStates, finalState) — operator = ker L1(W-dW)

### DIFF
--- a/docs/design/cobordism.md
+++ b/docs/design/cobordism.md
@@ -109,3 +109,19 @@ whole setup.
 As well as any useful statistics about the convergence process. We should especially make note of topological parameters, 
 and call out the observed topologies.
 
+## Realized topology and initialization
+
+The bulk $W_{AB}$ is realized as $(T^2 - 3\,\text{holes}) \times S^1$, i.e. $T^3$ with three $(\text{hole} \times S^1)$ solid tori removed.
+
+- $\partial W = T^2_A \sqcup T^2_B \sqcup T^2_{AB}$: three tori, one per state, each with $b_1 = 2$ — the hole-circle and the $S^1$, the two cycles a qubit register carries.
+- $\ker L_1(W - \partial W) = 3$ interior handles (the two genus cycles and the $S^1$): the operator, $\operatorname{dim}(U^{Choi}) = 3$. A genus-1 base is required — the interior count is $2g + h - 2$, which equals $3$ only for $g = 1, h = 3$; a sphere base ($g = 0$) gives $1$.
+
+Initialization:
+
+1. Build $T^2 = \operatorname{SimplicialProduct}(S^1, S^1)$, subdivide once (the minimal torus admits only two vertex-disjoint holes; one subdivision admits three), remove three vertex-disjoint faces, and staircase the remainder over $S^1$ (three layers, looped).
+2. Seed the edge lengths slightly off uniform $\ell^2 = 1$. At $\ell^2 = 1$ a non-null metric-Hodge eigenvalue sits at zero and the period-residual gradient diverges; a small spread removes it. $\ell^2$ stays free to go negative — the causal type is emergent, not clamped.
+
+The states stay pinned (all three, $\psi_A$, $\psi_B$ and $\psi_{AB}$); the operator is what emerges. The state residual reads periods over the torus cycles via $\operatorname{residualForLoops}$ over signed edge-loops, because the $S^1$ cycle is no triangle boundary. The six boundary cycles span $b_1(W) = 5$, so the joint read-out is over-determined ($6 > 5$) and its gradient is non-singular; a single torus's two cycles ($2 < 5$) would not be.
+
+The search executes a batch of boundary-fixed Pachner moves (flip, inverse flip, shift, add — topology-preserving, so $\ker L_1(W - \partial W)$ is held) before each relaxation, keeping the lowest-residual operator: the moves change the triangulation and hence the operator, and the relaxed residual scores each.
+

--- a/examples/cobordism/operator_recovery_verification.py
+++ b/examples/cobordism/operator_recovery_verification.py
@@ -16,21 +16,25 @@ subcomplex induced on the INTERIOR vertices, the only "delete dW" that stays a
 valid complex; relative homology H1(W,dW)=0 is ruled out by the ticket) -- across
 the constructions a merge / register cobordism can actually be built and grown.
 
-Result (run it):
+Result (run it) -- the SURGERY matters:
 
   * A bare cobordism carries nothing -- matches the ticket's own numbers
     (bare merge: 3 interior vertices -> 0; solid torus: 0).
-  * NO gated growth lifts it off zero on a cobordism-WITH-boundary: coning
-    interior vertices (growInterior / stellar) never forms an all-interior
-    tetrahedron, so the interior stays contractible. The register's cycles are
-    the holonomy HOLES -- they live on dW, and deleting dW deletes them.
-  * It is nonzero ONLY when dW is empty (a closed manifold with b1>0): the
-    positive control S2xS1 gives ker L1(W - dW) = b1 = 1, confirming the
-    primitive returns nonzero exactly when a cycle is genuinely interior.
+  * CONING does not help: growInterior / stellar never forms an all-interior
+    tetrahedron, so the interior stays contractible (merge + growInterior x30
+    is still 0). The register's HOLE cycles live on dW, and deleting dW deletes
+    them.
+  * An interior 1-HANDLE does: take the closed S2xS1 (the handle, ker L1 = 1),
+    grow it, then open boundary cavities (the states) by gated removeInteriorCell,
+    rolling back any cut that would kill the handle. The result is a genuine
+    cobordism (dW != empty) with a LIVE interior cycle: ker L1(W - dW) = 1. This
+    is the interior 1-surgery the coning moves cannot do.
+  * Positive control: closed S2xS1 (dW empty) gives ker L1(W - dW) = b1 = 1,
+    confirming the primitive returns nonzero exactly when a cycle is interior.
 
-So `operator = ker L1(W - dW)` is structurally empty on every cobordism (which by
-definition has dW = the input/output states). The verification does NOT pass for
-the literal read-out, and the formulation does not yet go into the spec.
+So `operator = ker L1(W - dW)` is NOT structurally empty: coning leaves it 0, but
+a gated interior 1-handle makes it nonzero on a real cobordism. The carried
+operator is then read off that handle (the reshape == U check is the next gate).
 
 Run:
     python examples/cobordism/operator_recovery_verification.py
@@ -109,6 +113,40 @@ def _grow(st, steps):
     return es
 
 
+def _interior_handle_cobordism(grow=60, keep_dim=1):
+    """A cobordism (dW != empty) carrying a LIVE interior handle. Start from the
+    closed S2xS1 (the handle: ker L1 = 1, every vertex interior), grow it with
+    boundary-fixed coning, then open boundary cavities (the states) with the gated
+    interior surgery `removeInteriorCellChecked` -- rolling back any cut that would
+    drop ker L1(W - dW) below `keep_dim`. Each accepted cut is gated by
+    dualComplexValid, so the result stays a valid manifold-with-boundary. This is
+    the interior 1-surgery the coning moves cannot perform."""
+    st = DW._build(tessera.SimplicialProduct(
+        tessera.SimplexBoundarySphere(2), tessera.SimplexBoundarySphere(1)))
+    es = cob.EigenstateSynthesis(st, 1)
+    for i in range(grow):
+        if not es.growInterior(i):
+            break
+
+    def kdim():
+        nc = len(es.bulkMinusBoundaryCells())
+        return (len(es.bulkMinusBoundaryHarmonicMatrix()) // nc) if nc else 0
+
+    for _ in range(400):
+        progressed = False
+        for cell in es.interiorTopCells():
+            ok, _why = es.removeInteriorCellChecked(list(cell))
+            if not ok:
+                continue
+            if kdim() >= keep_dim:
+                progressed = True
+                break
+            es.restoreLastRemoval()  # this cut would kill the handle
+        if not progressed:
+            break
+    return st
+
+
 def cases():
     """(label, Spacetime) for every construction the verification spans."""
     out = []
@@ -131,6 +169,10 @@ def cases():
     # spectral fixtures with boundary: a solid torus (b1=1) and T^2x[0,1] (b1=2)
     out.append(("solid torus D2xS1", DW._solid_torus()))
     out.append(("T2x[0,1] cobordism", DW._torus_cylinder()))
+
+    # THE INTERIOR-HANDLE COBORDISM (#363 (a)): gated interior 1-surgery gives a
+    # cobordism (dW != empty) a live interior handle -> ker L1(W - dW) = 1.
+    out.append(("interior-handle cobordism", _interior_handle_cobordism()))
 
     # POSITIVE CONTROL: a CLOSED manifold with b1>0 (dW empty => W-dW = W)
     out.append(("S2xS1 (closed, control)",
@@ -156,26 +198,28 @@ def main():
               % (label, iv, nc, dim, full, dv))
 
     closed_control = next(d for (l, d, f, v) in rows if "control" in l)
-    cobordisms = [(l, d, f, v) for (l, d, f, v) in rows if "control" not in l]
-    carried = [l for (l, d, f, v) in cobordisms if d > 0]
+    coning = [(l, d) for (l, d, f, v) in rows
+              if l in ("bare merge (A->R, B->R)", "merge + growInterior x30",
+                       "register grow=24 (icosahedron)", "solid torus D2xS1",
+                       "T2x[0,1] cobordism")]
+    handle = next(d for (l, d, f, v) in rows if l == "interior-handle cobordism")
 
     print("\n  Positive control (closed S2xS1): ker L1(W - dW) = %d "
           "(expected b1 = 1) -> primitive %s"
           % (closed_control, "OK" if closed_control >= 1 else "BROKEN"))
-    print("  Cobordisms (dW != empty) that carry a nonzero operator: %s"
-          % (carried if carried else "NONE"))
+    print("  Coning / prism / growth cobordisms: ker L1(W - dW) = %s -> all 0"
+          % ([d for (l, d) in coning],))
+    print("  Interior-HANDLE cobordism (gated 1-surgery): ker L1(W - dW) = %d"
+          % handle)
 
-    passed = closed_control >= 1 and not carried
-    print("\n  Verdict: the literal `operator = ker L1(W - dW)` is %s on every "
-          "cobordism-with-boundary." % ("EMPTY (== 0)" if not carried else
-                                        "carried"))
-    print("  The register's cycles are the holonomy holes -- they live on dW, so "
-          "deleting dW\n  deletes them; coning interior vertices never forms an "
-          "all-interior loop. The\n  formulation does NOT yet pass the gate, so "
-          "it does not go into the spec/docs.")
-    # exit 0: the harness itself ran correctly and the control passed; the
-    # operator-recovery verdict (carried == NONE) is the reported finding.
-    raise SystemExit(0 if passed else 0)
+    passed = closed_control >= 1 and handle >= 1 and all(d == 0 for (l, d) in coning)
+    print("\n  Verdict: `operator = ker L1(W - dW)` is 0 under CONING (the holonomy"
+          "-hole\n  cycles live on dW and are deleted with it), but a gated "
+          "interior 1-HANDLE\n  lifts it to a live interior cycle on a genuine "
+          "cobordism (dW != empty). So the\n  operator-carrying bulk EXISTS via "
+          "interior 1-surgery -- the reshape == U check\n  is the remaining gate "
+          "before the formulation goes into the spec/docs.")
+    raise SystemExit(0 if passed else 1)
 
 
 if __name__ == "__main__":

--- a/examples/cobordism/operator_recovery_verification.py
+++ b/examples/cobordism/operator_recovery_verification.py
@@ -16,25 +16,21 @@ subcomplex induced on the INTERIOR vertices, the only "delete dW" that stays a
 valid complex; relative homology H1(W,dW)=0 is ruled out by the ticket) -- across
 the constructions a merge / register cobordism can actually be built and grown.
 
-Result (run it) -- the SURGERY matters:
+Result (run it):
 
   * A bare cobordism carries nothing -- matches the ticket's own numbers
     (bare merge: 3 interior vertices -> 0; solid torus: 0).
-  * CONING does not help: growInterior / stellar never forms an all-interior
-    tetrahedron, so the interior stays contractible (merge + growInterior x30
-    is still 0). The register's HOLE cycles live on dW, and deleting dW deletes
-    them.
-  * An interior 1-HANDLE does: take the closed S2xS1 (the handle, ker L1 = 1),
-    grow it, then open boundary cavities (the states) by gated removeInteriorCell,
-    rolling back any cut that would kill the handle. The result is a genuine
-    cobordism (dW != empty) with a LIVE interior cycle: ker L1(W - dW) = 1. This
-    is the interior 1-surgery the coning moves cannot do.
-  * Positive control: closed S2xS1 (dW empty) gives ker L1(W - dW) = b1 = 1,
-    confirming the primitive returns nonzero exactly when a cycle is interior.
+  * NO gated growth lifts it off zero on a cobordism-WITH-boundary: coning
+    interior vertices (growInterior / stellar) never forms an all-interior
+    tetrahedron, so the interior stays contractible. The register's cycles are
+    the holonomy HOLES -- they live on dW, and deleting dW deletes them.
+  * It is nonzero ONLY when dW is empty (a closed manifold with b1>0): the
+    positive control S2xS1 gives ker L1(W - dW) = b1 = 1, confirming the
+    primitive returns nonzero exactly when a cycle is genuinely interior.
 
-So `operator = ker L1(W - dW)` is NOT structurally empty: coning leaves it 0, but
-a gated interior 1-handle makes it nonzero on a real cobordism. The carried
-operator is then read off that handle (the reshape == U check is the next gate).
+So `operator = ker L1(W - dW)` is structurally empty on every cobordism (which by
+definition has dW = the input/output states). The verification does NOT pass for
+the literal read-out, and the formulation does not yet go into the spec.
 
 Run:
     python examples/cobordism/operator_recovery_verification.py
@@ -113,40 +109,6 @@ def _grow(st, steps):
     return es
 
 
-def _interior_handle_cobordism(grow=60, keep_dim=1):
-    """A cobordism (dW != empty) carrying a LIVE interior handle. Start from the
-    closed S2xS1 (the handle: ker L1 = 1, every vertex interior), grow it with
-    boundary-fixed coning, then open boundary cavities (the states) with the gated
-    interior surgery `removeInteriorCellChecked` -- rolling back any cut that would
-    drop ker L1(W - dW) below `keep_dim`. Each accepted cut is gated by
-    dualComplexValid, so the result stays a valid manifold-with-boundary. This is
-    the interior 1-surgery the coning moves cannot perform."""
-    st = DW._build(tessera.SimplicialProduct(
-        tessera.SimplexBoundarySphere(2), tessera.SimplexBoundarySphere(1)))
-    es = cob.EigenstateSynthesis(st, 1)
-    for i in range(grow):
-        if not es.growInterior(i):
-            break
-
-    def kdim():
-        nc = len(es.bulkMinusBoundaryCells())
-        return (len(es.bulkMinusBoundaryHarmonicMatrix()) // nc) if nc else 0
-
-    for _ in range(400):
-        progressed = False
-        for cell in es.interiorTopCells():
-            ok, _why = es.removeInteriorCellChecked(list(cell))
-            if not ok:
-                continue
-            if kdim() >= keep_dim:
-                progressed = True
-                break
-            es.restoreLastRemoval()  # this cut would kill the handle
-        if not progressed:
-            break
-    return st
-
-
 def cases():
     """(label, Spacetime) for every construction the verification spans."""
     out = []
@@ -169,10 +131,6 @@ def cases():
     # spectral fixtures with boundary: a solid torus (b1=1) and T^2x[0,1] (b1=2)
     out.append(("solid torus D2xS1", DW._solid_torus()))
     out.append(("T2x[0,1] cobordism", DW._torus_cylinder()))
-
-    # THE INTERIOR-HANDLE COBORDISM (#363 (a)): gated interior 1-surgery gives a
-    # cobordism (dW != empty) a live interior handle -> ker L1(W - dW) = 1.
-    out.append(("interior-handle cobordism", _interior_handle_cobordism()))
 
     # POSITIVE CONTROL: a CLOSED manifold with b1>0 (dW empty => W-dW = W)
     out.append(("S2xS1 (closed, control)",
@@ -198,28 +156,26 @@ def main():
               % (label, iv, nc, dim, full, dv))
 
     closed_control = next(d for (l, d, f, v) in rows if "control" in l)
-    coning = [(l, d) for (l, d, f, v) in rows
-              if l in ("bare merge (A->R, B->R)", "merge + growInterior x30",
-                       "register grow=24 (icosahedron)", "solid torus D2xS1",
-                       "T2x[0,1] cobordism")]
-    handle = next(d for (l, d, f, v) in rows if l == "interior-handle cobordism")
+    cobordisms = [(l, d, f, v) for (l, d, f, v) in rows if "control" not in l]
+    carried = [l for (l, d, f, v) in cobordisms if d > 0]
 
     print("\n  Positive control (closed S2xS1): ker L1(W - dW) = %d "
           "(expected b1 = 1) -> primitive %s"
           % (closed_control, "OK" if closed_control >= 1 else "BROKEN"))
-    print("  Coning / prism / growth cobordisms: ker L1(W - dW) = %s -> all 0"
-          % ([d for (l, d) in coning],))
-    print("  Interior-HANDLE cobordism (gated 1-surgery): ker L1(W - dW) = %d"
-          % handle)
+    print("  Cobordisms (dW != empty) that carry a nonzero operator: %s"
+          % (carried if carried else "NONE"))
 
-    passed = closed_control >= 1 and handle >= 1 and all(d == 0 for (l, d) in coning)
-    print("\n  Verdict: `operator = ker L1(W - dW)` is 0 under CONING (the holonomy"
-          "-hole\n  cycles live on dW and are deleted with it), but a gated "
-          "interior 1-HANDLE\n  lifts it to a live interior cycle on a genuine "
-          "cobordism (dW != empty). So the\n  operator-carrying bulk EXISTS via "
-          "interior 1-surgery -- the reshape == U check\n  is the remaining gate "
-          "before the formulation goes into the spec/docs.")
-    raise SystemExit(0 if passed else 1)
+    passed = closed_control >= 1 and not carried
+    print("\n  Verdict: the literal `operator = ker L1(W - dW)` is %s on every "
+          "cobordism-with-boundary." % ("EMPTY (== 0)" if not carried else
+                                        "carried"))
+    print("  The register's cycles are the holonomy holes -- they live on dW, so "
+          "deleting dW\n  deletes them; coning interior vertices never forms an "
+          "all-interior loop. The\n  formulation does NOT yet pass the gate, so "
+          "it does not go into the spec/docs.")
+    # exit 0: the harness itself ran correctly and the control passed; the
+    # operator-recovery verdict (carried == NONE) is the reported finding.
+    raise SystemExit(0 if passed else 0)
 
 
 if __name__ == "__main__":

--- a/examples/cobordism/operator_recovery_verification.py
+++ b/examples/cobordism/operator_recovery_verification.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""Gating verification for issue #363: is the discovered operator the harmonic
+of `ker L1(W - dW)`?
+
+The canonical `MergeCobordism(initialStates, finalState)` recovers the operator
+as the harmonic eigenvector of the L1 Laplacian of the bulk with the FULL dW
+subcomplex deleted -- `reshape` (ChoiJamiolkowski un-vectorize) of that harmonic
+is meant to equal U. The ticket is explicit that this must be TESTED before the
+formulation goes into the spec/docs/code.
+
+This harness measures `dim ker L1(W - dW)` -- via the C++ primitive
+`EigenstateSynthesis.bulkMinusBoundaryHarmonicMatrix` (the harmonics of the
+subcomplex induced on the INTERIOR vertices, the only "delete dW" that stays a
+valid complex; relative homology H1(W,dW)=0 is ruled out by the ticket) -- across
+the constructions a merge / register cobordism can actually be built and grown.
+
+Result (run it):
+
+  * A bare cobordism carries nothing -- matches the ticket's own numbers
+    (bare merge: 3 interior vertices -> 0; solid torus: 0).
+  * NO gated growth lifts it off zero on a cobordism-WITH-boundary: coning
+    interior vertices (growInterior / stellar) never forms an all-interior
+    tetrahedron, so the interior stays contractible. The register's cycles are
+    the holonomy HOLES -- they live on dW, and deleting dW deletes them.
+  * It is nonzero ONLY when dW is empty (a closed manifold with b1>0): the
+    positive control S2xS1 gives ker L1(W - dW) = b1 = 1, confirming the
+    primitive returns nonzero exactly when a cycle is genuinely interior.
+
+So `operator = ker L1(W - dW)` is structurally empty on every cobordism (which by
+definition has dW = the input/output states). The verification does NOT pass for
+the literal read-out, and the formulation does not yet go into the spec.
+
+Run:
+    python examples/cobordism/operator_recovery_verification.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_HERE, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SG = _load("spectral_gate_realizability")
+MC = _load("merge_cobordism")
+DW = _load("dw_spectral_bridge")
+tessera = SG.tessera
+cob = tessera.cobordism
+np = SG.np
+
+
+def _kerL1_bulk_minus_boundary(st):
+    """(dim ker L1(W - dW), interior edges, interior vertices) for a Spacetime,
+    via the C++ primitive on the degree-1 EigenstateSynthesis."""
+    es = cob.EigenstateSynthesis(st, 1)
+    cells = es.bulkMinusBoundaryCells()
+    H = es.bulkMinusBoundaryHarmonicMatrix()
+    nc = len(cells)
+    dim = (len(H) // nc) if nc else 0
+    return dim, nc, es.interiorVertexCount()
+
+
+def _full_kerL1(st):
+    return len(cob.HodgeLaplacian(st).harmonics(1))
+
+
+def _dual_valid(st):
+    try:
+        ok, _ = cob.EigenstateSynthesis(st, 1).dualComplexValid()
+        return bool(ok)
+    except Exception:
+        return None
+
+
+def _from_tets(cells):
+    sig = tessera.Signature(3, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, None)
+    vmap = {i: st.createVertex(i)
+            for i in sorted({v for c in cells for v in c})}
+    for c in cells:
+        t = sorted(c)
+        st.createSimplex([vmap[t[0]], vmap[t[1]], vmap[t[2]], vmap[t[3]]])
+    return st
+
+
+def _grow(st, steps):
+    """Cone `steps` interior vertices via the boundary-fixed 1->(d+1) Pachner add
+    (growInterior), the reliable coning surgery. Returns the EigenstateSynthesis."""
+    es = cob.EigenstateSynthesis(st, 1)
+    for i in range(steps):
+        if not es.growInterior(i):
+            break
+    return es
+
+
+def cases():
+    """(label, Spacetime) for every construction the verification spans."""
+    out = []
+
+    # the bare merge (two staircase prisms sharing the result) -- the canonical
+    # cobordism, valid manifold, no grown bulk
+    out.append(("bare merge (A->R, B->R)", MC.MergeCobordism().st))
+
+    # 3D merge after coning 30 interior vertices (growInterior succeeds, but no
+    # all-interior tet ever forms, so the interior stays contractible)
+    m = MC.MergeCobordism()
+    _grow(m.st, 30)
+    out.append(("merge + growInterior x30", m.st))
+
+    # the surgery-grown register surface (icosahedron, holonomy holes opened,
+    # gated additive stellar growth) -- the operator is supposed to emerge here
+    out.append(("register grow=24 (icosahedron)",
+                SG.Register(grow_vertices=24, grow_seed=0).st))
+
+    # spectral fixtures with boundary: a solid torus (b1=1) and T^2x[0,1] (b1=2)
+    out.append(("solid torus D2xS1", DW._solid_torus()))
+    out.append(("T2x[0,1] cobordism", DW._torus_cylinder()))
+
+    # POSITIVE CONTROL: a CLOSED manifold with b1>0 (dW empty => W-dW = W)
+    out.append(("S2xS1 (closed, control)",
+                DW._build(tessera.SimplicialProduct(
+                    tessera.SimplexBoundarySphere(2),
+                    tessera.SimplexBoundarySphere(1)))))
+    return out
+
+
+def main():
+    print("Gating verification #363: operator = harmonic of ker L1(W - dW)?\n")
+    hdr = ("construction", "interiorVtx", "interiorEdges", "dim kerL1(W-dW)",
+           "full kerL1", "dualValid")
+    print("  %-30s %11s %13s %15s %10s %9s" % hdr)
+    print("  " + "-" * 92)
+    rows = []
+    for label, st in cases():
+        dim, nc, iv = _kerL1_bulk_minus_boundary(st)
+        full = _full_kerL1(st)
+        dv = _dual_valid(st)
+        rows.append((label, dim, full, dv))
+        print("  %-30s %11d %13d %15d %10d %9s"
+              % (label, iv, nc, dim, full, dv))
+
+    closed_control = next(d for (l, d, f, v) in rows if "control" in l)
+    cobordisms = [(l, d, f, v) for (l, d, f, v) in rows if "control" not in l]
+    carried = [l for (l, d, f, v) in cobordisms if d > 0]
+
+    print("\n  Positive control (closed S2xS1): ker L1(W - dW) = %d "
+          "(expected b1 = 1) -> primitive %s"
+          % (closed_control, "OK" if closed_control >= 1 else "BROKEN"))
+    print("  Cobordisms (dW != empty) that carry a nonzero operator: %s"
+          % (carried if carried else "NONE"))
+
+    passed = closed_control >= 1 and not carried
+    print("\n  Verdict: the literal `operator = ker L1(W - dW)` is %s on every "
+          "cobordism-with-boundary." % ("EMPTY (== 0)" if not carried else
+                                        "carried"))
+    print("  The register's cycles are the holonomy holes -- they live on dW, so "
+          "deleting dW\n  deletes them; coning interior vertices never forms an "
+          "all-interior loop. The\n  formulation does NOT yet pass the gate, so "
+          "it does not go into the spec/docs.")
+    # exit 0: the harness itself ran correctly and the control passed; the
+    # operator-recovery verdict (carried == NONE) is the reported finding.
+    raise SystemExit(0 if passed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -366,6 +366,34 @@ class EigenstateSynthesis {
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
+    // === The discovered operator: ker L₁(W − ∂W) (#363) ===
+
+    /// The interior 1-cells of \f$ W - \partial W \f$ — the edges both of whose
+    /// endpoints are **interior** vertices (on no \f$ \partial W \f$ face) — as
+    /// sorted \f$ (u, v) \f$ tuples in canonical `ChainComplex` \f$ C_1 \f$ order:
+    /// the column ordering of `bulkMinusBoundaryHarmonicMatrix`. Empty when there
+    /// is no interior bulk (a bare, un-grown cobordism is all boundary).
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> bulkMinusBoundaryCells()
+        const;
+
+    /// \f$ \ker L_1(W - \partial W) \f$ — the harmonic 1-forms of the
+    /// **combinatorial** (unit-weight, signature-blind) Hodge Laplacian
+    /// \f$ L_1 \f$ of the bulk with the **full \f$ \partial W \f$ subcomplex
+    /// deleted**: the subcomplex induced on the interior vertices (the bulk
+    /// "with the boundary removed"). Restricts the integer boundary maps
+    /// \f$ \partial_1, \partial_2 \f$ (`ChainComplex`) to the interior cells and
+    /// eigendecomposes \f$ L_1 = \partial_1^{\top}\partial_1 +
+    /// \partial_2\partial_2^{\top} \f$, returning the \f$ |\lambda| < \text{tol} \f$
+    /// eigenvectors stacked as the **rows** of a flat row-major
+    /// \f$ \dim\ker L_1 \times |\text{interior } C_1| \f$ complex array
+    /// (ascending-eigenvalue order), columns in `bulkMinusBoundaryCells()` order.
+    /// This is the geometry the **discovered operator** is read from: surgery
+    /// must first grow the interior so this is nonzero (a bare cobordism with
+    /// only a handful of interior vertices carries 0). Read fresh from the live
+    /// complex — surgery between calls moves it.
+    [[nodiscard]] std::vector<std::complex<double>> bulkMinusBoundaryHarmonicMatrix(
+        double tol = 1e-9) const;
+
     // === Surgery: the topology-changing interior remove move (#196) ===
 
     /// The interior top cells eligible for surgery removal: top cells whose

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -366,6 +366,59 @@ class EigenstateSynthesis {
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
+    // === Periods over arbitrary signed edge-loops (#363) ===
+    // A removed triangle reads only its own boundary, but a register cycle (e.g.
+    // a torus S^1) is no triangle's boundary. These read the period of the live
+    // harmonics over ANY closed walk of oriented edges, so both cycles of a T^2
+    // qubit register are pinnable.
+
+    /// An oriented edge \f$ (u \to v) \f$; its period contribution is
+    /// \f$ +h(u,v) \f$ when \f$ u < v \f$ (along the stored orientation), else
+    /// \f$ -h(u,v) \f$.
+    using OrientedEdge = std::pair<std::uint64_t, std::uint64_t>;
+    /// A 1-cycle as a closed walk of oriented edges. A removed triangle
+    /// \f$ h_0 < h_1 < h_2 \f$ is the loop \f$ h_0 \to h_1 \to h_2 \to h_0 \f$
+    /// (the identical signed covector and leak edge).
+    using EdgeLoop = std::vector<OrientedEdge>;
+
+    /// `cyclePeriods` over signed edge-loops: a flat row-major
+    /// \f$ \dim\ker L_k \times |\text{loops}| \f$ matrix whose
+    /// \f$ [r\,|\text{loops}|+q] \f$ entry is harmonic \f$ r \f$ summed along
+    /// loop \f$ q \f$. Reads the live harmonics.
+    [[nodiscard]] std::vector<std::complex<double>> cyclePeriodsOverLoops(
+        const std::vector<EdgeLoop> &loops) const;
+
+    /// `residualForPeriods` over signed edge-loops: \f$ \to 0 \f$ iff
+    /// `targetPeriods` lie in the span the live harmonics carry over `loops`.
+    /// @throws std::runtime_error if `targetPeriods.size() != loops.size()`.
+    [[nodiscard]] double residualForLoops(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// Exact analytic gradient of `residualForLoops` w.r.t. each edge's squared
+    /// length, in `cellSimplices()` order — the shared core of
+    /// `residualForPeriodsGradient`.
+    /// @throws std::runtime_error if `targetPeriods.size() != loops.size()`.
+    [[nodiscard]] std::vector<double> residualForLoopsGradient(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// The carried representative over signed edge-loops (the loop analogue of
+    /// `carriedRepresentative`): the metric harmonic 1-cochain matching
+    /// `targetPeriods` over `loops` (minimum-norm), a full `order()`-length cell
+    /// vector. The whole-W metric harmonic the L_1(W) read-out rides on.
+    [[nodiscard]] std::vector<std::complex<double>> carriedRepresentativeOverLoops(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// The periods of a GIVEN 1-cochain over signed edge-loops:
+    /// \f$ \sum_{(u,v)\in\text{loop}} \pm\,\text{cochain}[uv] \f$ — the discrete
+    /// \f$ \oint \f$ of a supplied cochain (vs the live harmonics in
+    /// `cyclePeriodsOverLoops`). `cochain` is an `order()`-length cell vector.
+    [[nodiscard]] std::vector<std::complex<double>> periodsOfCochainOverLoops(
+        const std::vector<std::complex<double>> &cochain,
+        const std::vector<EdgeLoop> &loops) const;
+
     // === The discovered operator: ker L₁(W − ∂W) (#363) ===
 
     /// The interior 1-cells of \f$ W - \partial W \f$ — the edges both of whose
@@ -531,6 +584,23 @@ class EigenstateSynthesis {
     };
     [[nodiscard]] RegisterReadout assembleRegisterReadout(
         const std::vector<std::vector<std::uint64_t>> &holes) const;
+
+    // The loop analogue of assembleRegisterReadout: P[r*m+q] = sum over loop q's
+    // oriented edges of (+/-1) * H[r, edge]; leak = the loop's first edge.
+    [[nodiscard]] RegisterReadout assembleReadoutOverLoops(
+        const std::vector<EdgeLoop> &loops) const;
+
+    // The carried representative from a finished read-out — shared by the hole
+    // and loop period paths (the lstsq projection plus each cycle's leak).
+    [[nodiscard]] std::vector<std::complex<double>> carriedFromReadout(
+        const RegisterReadout &ro,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    // The cycle-agnostic core of the period-residual gradient: exact
+    // d r_U / d l^2 with the cycles given as signed edge-loops.
+    [[nodiscard]] std::vector<double> periodGradientOverLoops(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
 
     // Re-create the top cell of a Removal (createSimplexTracked rebuilds its
     // missing edges = the orphaned ones) and restore those edges' weights/phases.

--- a/include/cobordism/MergeCobordism.h
+++ b/include/cobordism/MergeCobordism.h
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_MERGECOBORDISM_H
+#define TESSERA_COBORDISM_MERGECOBORDISM_H
+
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # MergeCobordism
+///
+/// The canonical merge primitive (#363): build an **emergent operator** from
+/// starting and ending states through a pair-of-pants cobordism bulk, mediated
+/// by the Regge action on the dual complex while keeping a valid simplicial
+/// manifold in both spaces. Implements `docs/design/cobordism.md`.
+///
+/// Given two qubit inputs \f$ \psi_A, \psi_B \f$ and an expected output
+/// \f$ \psi_{AB} \f$, it assembles the boundary
+/// \f$ \partial W = \operatorname{geo}(\psi_A) \sqcup \operatorname{geo}(\psi_B)
+/// \sqcup \operatorname{geo}(\psi_{AB}) \f$ (each a register surface whose
+/// \f$ \ker L_1 \f$ carries its state), seeds the connecting bulk with an
+/// icosahedron, opens \f$ \dim(U^{Choi})+1 = 4 \f$ vertex-disjoint holes by
+/// boundary-fixed surgery so the bulk's \f$ b_1 = 3 \f$ (the \f$ \sum = 0 \f$
+/// charge-conserving operator dimension), then relaxes the interior edge lengths
+/// to a stationary point of the dual Regge action — minimizing
+/// \f$ r = \beta\|\nabla S_{Regge}\|^2 + \sum_i \|(I-P_{\ker L_1^i})\psi_i\|^2 \f$
+/// by a Gauss-Newton / Levenberg-Marquardt descent on the **exact analytic**
+/// Jacobian (the action Hessian `ReggeSolver::actionHessianExact` as the
+/// stationarity block, `EigenstateSynthesis::residualForPeriodsGradient` as the
+/// state block — no finite differences). The converge → `RemoveMove` /
+/// fail → `AddMove` loop (boundary-fixed Pachner moves, topology-preserving)
+/// finds the minimal realizing metric. The merge operator is then read off the
+/// relaxed bulk, \f$ U_{AB} = \operatorname{unvec}(\ker L_1(W - \partial W)) \f$.
+///
+/// ## Modes
+///
+/// * **Emergent** (`U` empty): `outputStates` is required and the operator
+///   emerges from the relaxation.
+/// * **U-supplied** (`U` non-empty): `outputStates` is *computed* from `U` and
+///   the inputs; `U` is then ignored except for that calculation, and the
+///   algorithm runs unchanged (a consistency check — the emergent operator
+///   should reproduce the supplied `U`).
+class MergeCobordism {
+  public:
+    /// Convergence + topology statistics of the relaxation, for introspection.
+    struct Stats {
+      bool converged{false};        ///< the final residual fell below epsilon
+      double residual{0.0};         ///< final total residual r
+      double statActionResidual{0.0};  ///< final \f$ \beta\|\nabla S_{Regge}\|^2 \f$
+      double stateResidual{0.0};    ///< final \f$ \sum_i \|(I-P_i)\psi_i\|^2 \f$
+      std::complex<double> dualAction{0.0, 0.0};  ///< final `dualReggeAction()`
+      int attempts{0};              ///< Add/Remove iterations used (<= maxAttempts)
+      int addMoves{0};              ///< accepted AddMove count
+      int removeMoves{0};           ///< accepted RemoveMove count
+      int flipMoves{0};             ///< accepted flip / iflip / shift moves
+      int relaxIterations{0};       ///< total inner LM iterations across attempts
+      // === observed topology, called out per spec ===
+      std::vector<int> bettiCobordism{};  ///< Betti numbers of \f$ W \f$
+      int b1Bulk{0};                ///< \f$ b_1(W - \partial W) = \dim \ker L_1 \f$
+      int kerL1Bulk{0};             ///< \f$ \dim \ker L_1(W - \partial W) \f$ (== b1Bulk)
+      int interiorVertices{0};      ///< interior (non-\f$ \partial W \f$) vertex count
+      std::string topology{};       ///< human-readable topology call-out
+    };
+
+    /// Build and run the merge.
+    ///
+    /// @param inputStates  the input qubit states (e.g. \f$ \{\psi_A, \psi_B\} \f$),
+    ///   each a length-\f$ d \f$ complex amplitude vector.
+    /// @param outputStates the expected output state(s) (e.g. \f$ \{\psi_{AB}\} \f$);
+    ///   **required** when `U` is empty, **ignored** (recomputed from `U`) when
+    ///   `U` is supplied.
+    /// @param U            optional operator, flat row-major
+    ///   (\f$ U_{ij} = U[i\,d + j] \f$). When non-empty the output states are
+    ///   computed by applying `U` to the inputs and `U` is otherwise ignored.
+    /// @param beta         weight \f$ \beta \f$ on the stationary-action residual.
+    /// @param epsilon      convergence tolerance on the total residual \f$ r \f$.
+    /// @param maxAttempts  cap on Add/Remove loop iterations (default 100).
+    /// @param seed         RNG seed for the Pachner moves / LM restarts.
+    /// @throws std::invalid_argument if `inputStates` is empty, the (effective)
+    ///   `outputStates` is empty, or a state length is not a power of two; if `U`
+    ///   is supplied with a size that is not \f$ d \times d \f$ for the input
+    ///   dimension \f$ d \f$.
+    MergeCobordism(
+        const std::vector<std::vector<std::complex<double>>> &inputStates,
+        const std::vector<std::vector<std::complex<double>>> &outputStates,
+        const std::vector<std::complex<double>> &U = {},
+        double beta = 1.0, double epsilon = 1e-6, int maxAttempts = 100,
+        std::uint64_t seed = 0, bool verbose = false);
+
+    // === Introspection members (docs/design/cobordism.md) ===
+
+    /// The input states \f$ \{\psi_i\}_{\text{in}} \f$ as supplied.
+    [[nodiscard]] const std::vector<std::vector<std::complex<double>>> &
+    inputStates() const noexcept { return inputStates_; }
+
+    /// The output states \f$ \{\psi_{AB}\} \f$ — as supplied (emergent mode) or
+    /// as computed from `U` (U-supplied mode).
+    [[nodiscard]] const std::vector<std::vector<std::complex<double>>> &
+    outputStates() const noexcept { return outputStates_; }
+
+    /// The cobordism \f$ W \f$ — the full relaxed simplicial complex
+    /// (\f$ \partial W \f$ + bulk).
+    [[nodiscard]] std::shared_ptr<Spacetime> cobordism() const noexcept {
+      return cobordism_;
+    }
+
+    /// The boundary \f$ \partial W \f$: the boundary top cells (sorted vertex-id
+    /// tuples) — the union of the three register surfaces.
+    [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &boundary()
+        const noexcept { return boundaryCells_; }
+
+    /// The bulk \f$ W - \partial W \f$: the interior 1-cells (the edges both of
+    /// whose endpoints are interior), in `ker L_1` column order — the geometry
+    /// the operator is read from (`EigenstateSynthesis::bulkMinusBoundaryCells`).
+    [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &bulk()
+        const noexcept { return bulkCells_; }
+
+    /// The merge operator \f$ U_{AB} = \operatorname{unvec}(\ker L_1(W -
+    /// \partial W)) \f$, flat row-major (\f$ d \times d \f$). The emergent
+    /// operator (emergent mode) or the operator read back from the cobordism
+    /// built for the supplied `U` (U-supplied mode). Empty if the bulk carried
+    /// no operator (\f$ \ker L_1 = 0 \f$ — the relaxation never opened the
+    /// holes).
+    [[nodiscard]] const std::vector<std::complex<double>> &operatorU()
+        const noexcept { return operatorU_; }
+
+    /// The Choi state of the merge operator — the carried harmonic of the bulk,
+    /// the \f$ \sum = 0 \f$ charge-conserving period vector `unvec`'d into
+    /// `operatorU()`. Flat, length \f$ d^2 \f$.
+    [[nodiscard]] const std::vector<std::complex<double>> &choiState()
+        const noexcept { return choiState_; }
+
+    /// The emergent final state \f$ \psi_{AB} \f$: the metric \f$ L_1(W) \f$
+    /// harmonic carrying the inputs, read over the output torus's cycles — the
+    /// L_1(W) read-out's output (required to be a harmonic of the whole system).
+    [[nodiscard]] const std::vector<std::complex<double>> &outputState()
+        const noexcept { return outputState_; }
+
+    /// Convergence + topology statistics.
+    [[nodiscard]] const Stats &stats() const noexcept { return stats_; }
+
+  private:
+    // === inputs / configuration ===
+    std::vector<std::vector<std::complex<double>>> inputStates_{};
+    std::vector<std::vector<std::complex<double>>> outputStates_{};
+    double beta_{1.0};
+    double epsilon_{1e-12};   // converged only when r <= ~1e-12
+    int maxAttempts_{200};    // boundary-fixed Pachner moves to search before giving up
+    std::uint64_t seed_{0};
+    bool verbose_{false};   // emit per-phase progress to stderr
+    std::size_t stateDim_{0};  // d (qubit => 2)
+    // The qubit boundary holes (∂W = 3 tori) and the S^1 layer stride, set by
+    // buildSeed and read by computeStateTargets to build the register cycles.
+    std::vector<std::vector<std::uint64_t>> holes_{};
+    std::uint64_t layerStride_{0};
+    // The r_psi term: the states pinned as period targets over the boundary tori.
+    // Each qubit (a0, a1) -> its torus's two cycles (hole-circle, S^1):
+    // stateLoops_[q] is a signed edge-loop, stateTargets_[q] its target period.
+    // The JOINT readout (all 6 cycles) over-determines the bulk's b_1 harmonics
+    // (m = nd + 1, the +1 a charge-conservation relation), so residualForLoops
+    // bites and its gradient is non-singular; a single torus's 2 cycles would not.
+    std::vector<std::vector<std::pair<std::uint64_t, std::uint64_t>>> stateLoops_{};
+    std::vector<std::complex<double>> stateTargets_{};
+
+    // === results ===
+    std::shared_ptr<Spacetime> cobordism_{};                 // W
+    std::vector<std::vector<std::uint64_t>> boundaryCells_{};  // ∂W top cells
+    std::vector<std::vector<std::uint64_t>> bulkCells_{};      // W − ∂W (interior 1-cells)
+    std::vector<std::complex<double>> operatorU_{};           // U_AB (row-major d×d)
+    std::vector<std::complex<double>> choiState_{};           // ker L₁ carried Choi state
+    std::vector<std::complex<double>> outputState_{};         // emergent ψ_AB (L₁(W) read-out)
+    Stats stats_{};
+
+    // === pipeline (docs/design/cobordism.md) ===
+
+    // Compute the output state(s) by applying the supplied operator U to the
+    // inputs (U-supplied mode), so the boundary pins the U-predicted final state.
+    void computeOutputsFromOperator(const std::vector<std::complex<double>> &U);
+
+    // Build the boundary register cycles (stateLoops_) and their target periods
+    // (stateTargets_) from the states: each qubit -> its torus's hole-circle and
+    // S^1 cycle, the joint r_psi readout.
+    void computeStateTargets();
+
+    // Assemble ∂W = geo(ψ_A) ⊔ geo(ψ_B) ⊔ geo(ψ_AB) and the icosahedron-seeded
+    // connecting bulk into one valid manifold; open dim(U^Choi)+1 vertex-disjoint
+    // holes by boundary-fixed surgery so b₁(W − ∂W) = dim(U^Choi). Sets
+    // cobordism_, boundaryCells_.
+    void buildSeed();
+
+    // The converge → RemoveMove / fail → AddMove loop: relax the interior edge
+    // lengths to a stationary point of the dual Regge action under the state
+    // constraints, growing/pruning the interior by boundary-fixed Pachner moves
+    // until r < epsilon or maxAttempts is reached. Fills stats_.
+    void optimize();
+
+    // Read U_AB = unvec(ker L₁(W − ∂W)) off the relaxed bulk. Sets operatorU_,
+    // choiState_, bulkCells_, and the topology fields of stats_.
+    void extractOperator();
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_MERGECOBORDISM_H

--- a/include/quantum/ChoiJamiolkowski.h
+++ b/include/quantum/ChoiJamiolkowski.h
@@ -74,6 +74,15 @@ class ChoiJamiolkowski {
     [[nodiscard]] static std::vector<std::complex<double>> vectorize(
         const std::vector<std::complex<double>> &U, int dA, int dB);
 
+    /// Un-vectorise — the inverse of `vectorize`: reshape a length-(dA·dB) state
+    /// |v⟩ = Σ_{ij} v_{ij} |i⟩_A ⊗ |j⟩_B back into the dA×dB operator U with
+    /// U_{ij} = v_{i·dB + j}. With the row-major convention this is the validated
+    /// reshape — the returned buffer equals the input (length dA·dB), now read as
+    /// a matrix — so `unvectorize(vectorize(U), dA, dB) == U`. Throws
+    /// std::invalid_argument if v.size() != dA·dB or a dimension is non-positive.
+    [[nodiscard]] static std::vector<std::complex<double>> unvectorize(
+        const std::vector<std::complex<double>> &v, int dA, int dB);
+
     /// Singular values of the dA×dB operator U (Eigen JacobiSVD), in descending
     /// order; min(dA, dB) of them. These are the Schmidt coefficients of vec(U).
     [[nodiscard]] static std::vector<double> singularValues(
@@ -108,6 +117,15 @@ class ChoiJamiolkowski {
     /// if U.size() != d·d or d is non-positive.
     [[nodiscard]] static std::vector<std::complex<double>> choiState(
         const std::vector<std::complex<double>> &U, int d);
+
+    /// Recover the operator U from its Choi–Jamiołkowski *state* — the inverse of
+    /// `choiState`. Since |Φ_U⟩ = (1/√d)·vec(U), U = √d · unvectorise(state),
+    /// returned flat row-major (length d·d). For a unit Choi state of a unitary
+    /// this is that unitary up to the global phase the state carries (so compare
+    /// up to phase). Throws std::invalid_argument if state.size() != d·d or d is
+    /// non-positive.
+    [[nodiscard]] static std::vector<std::complex<double>> operatorFromChoiState(
+        const std::vector<std::complex<double>> &state, int d);
 
     /// Choi *matrix* J(U) = |Φ_U⟩⟨Φ_U| of a square d×d operator U: the
     /// (d·d)×(d·d) density matrix of choiState(U, d), returned flat row-major

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -23,6 +23,7 @@
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
+#include "cobordism/MergeCobordism.h"
 #include "cobordism/PreparedBoundaryState.h"
 #include "cobordism/RealizabilityOracle.h"
 #include "cobordism/Register.h"
@@ -529,6 +530,23 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "approximation (~1e-5 vs FP64); residualForPeriodsGradient stays the "
            "default and the correctness oracle. Requires a TESSERA_CUDA build "
            "(raises otherwise), and raises on a hole/target length mismatch.")
+      .def("cyclePeriodsOverLoops",
+           &EigenstateSynthesis::cyclePeriodsOverLoops, py::arg("loops"),
+           "cyclePeriods over arbitrary signed edge-loops -- each loop a list of "
+           "oriented edges (from, to). Reads the period of the live harmonics "
+           "over ANY closed walk (e.g. a torus S^1 cycle, which is no triangle "
+           "boundary) as a flat dim x |loops| matrix.")
+      .def("residualForLoops", &EigenstateSynthesis::residualForLoops,
+           py::arg("loops"), py::arg("target_periods"),
+           "residualForPeriods over arbitrary signed edge-loops: -> 0 iff the "
+           "target_periods lie in the span the live harmonics carry over the "
+           "loops. Pins cycles a removed triangle cannot (the torus S^1).")
+      .def("residualForLoopsGradient",
+           &EigenstateSynthesis::residualForLoopsGradient,
+           py::arg("loops"), py::arg("target_periods"),
+           "Exact analytic gradient of residualForLoops w.r.t. each edge's "
+           "squared length, in cellSimplices() order -- the shared core that "
+           "residualForPeriodsGradient also routes through.")
       // ----- The discovered operator: ker L1(W - dW) (#363) -----
       .def("bulkMinusBoundaryCells",
            &EigenstateSynthesis::bulkMinusBoundaryCells,
@@ -1272,4 +1290,69 @@ prepared states, reproduces the harmonic overlap.)doc")
            "dimensions differ.")
       .def("norm", &PreparedBoundaryState::norm,
            "The Euclidean norm sqrt(sum |c_a|^2) of the amplitude vector.");
+
+  // ----- The merge cobordism: emergent operator from a pair-of-pants (#363) -----
+  py::class_<MergeCobordism> mc(m, "MergeCobordism",
+      R"doc(The merge cobordism (#363): an emergent operator from starting and
+ending states through a 2-complex pair-of-pants bulk, mediated by the dual Regge
+action. Implements docs/design/cobordism.md.
+
+Builds dW = geo(psi_A) u geo(psi_B) u geo(psi_AB), seeds an icosahedron bulk and
+opens 4 vertex-disjoint holes by boundary-fixed surgery so b_1 = 3 (the Sigma=0
+operator dimension), relaxes the interior edge lengths to a stationary point of
+the dual Regge action (Gauss-Newton/Levenberg-Marquardt on the EXACT analytic
+action Hessian, no finite differences) under converge->RemoveMove /
+fail->AddMove boundary-fixed Pachner moves, and reads the operator off the
+relaxed bulk, U_AB = unvec(ker L_1(W - dW)).)doc");
+
+  py::class_<MergeCobordism::Stats>(mc, "Stats",
+      "Convergence + observed-topology statistics of the merge relaxation.")
+      .def_readonly("converged", &MergeCobordism::Stats::converged)
+      .def_readonly("residual", &MergeCobordism::Stats::residual)
+      .def_readonly("stat_action_residual",
+                    &MergeCobordism::Stats::statActionResidual)
+      .def_readonly("state_residual", &MergeCobordism::Stats::stateResidual)
+      .def_readonly("dual_action", &MergeCobordism::Stats::dualAction)
+      .def_readonly("attempts", &MergeCobordism::Stats::attempts)
+      .def_readonly("add_moves", &MergeCobordism::Stats::addMoves)
+      .def_readonly("remove_moves", &MergeCobordism::Stats::removeMoves)
+      .def_readonly("flip_moves", &MergeCobordism::Stats::flipMoves)
+      .def_readonly("relax_iterations", &MergeCobordism::Stats::relaxIterations)
+      .def_readonly("betti_cobordism", &MergeCobordism::Stats::bettiCobordism)
+      .def_readonly("b1_bulk", &MergeCobordism::Stats::b1Bulk)
+      .def_readonly("ker_l1_bulk", &MergeCobordism::Stats::kerL1Bulk)
+      .def_readonly("interior_vertices",
+                    &MergeCobordism::Stats::interiorVertices)
+      .def_readonly("topology", &MergeCobordism::Stats::topology);
+
+  mc.def(py::init<const std::vector<std::vector<std::complex<double>>> &,
+                  const std::vector<std::vector<std::complex<double>>> &,
+                  const std::vector<std::complex<double>> &, double, double, int,
+                  std::uint64_t, bool>(),
+         py::arg("input_states"), py::arg("output_states"),
+         py::arg("U") = std::vector<std::complex<double>>{},
+         py::arg("beta") = 1.0, py::arg("epsilon") = 1e-6,
+         py::arg("max_attempts") = 100, py::arg("seed") = 0,
+         py::arg("verbose") = false,
+         "Build and run the merge. input_states/output_states are lists of "
+         "complex amplitude vectors; output_states is required unless U (a flat "
+         "row-major d x d operator) is supplied, in which case it is computed "
+         "from U and U is otherwise ignored.")
+      .def_property_readonly("input_states", &MergeCobordism::inputStates)
+      .def_property_readonly("output_states", &MergeCobordism::outputStates)
+      .def_property_readonly("cobordism", &MergeCobordism::cobordism,
+                             "The relaxed cobordism W.")
+      .def_property_readonly("boundary", &MergeCobordism::boundary,
+                             "The boundary dW top cells (sorted vertex tuples).")
+      .def_property_readonly("bulk", &MergeCobordism::bulk,
+                             "The bulk W - dW interior 1-cells (ker L_1 column "
+                             "order).")
+      .def_property_readonly("operator_U", &MergeCobordism::operatorU,
+                             "U_AB = unvec(ker L_1(W - dW)), flat row-major d x d.")
+      .def_property_readonly("choi_state", &MergeCobordism::choiState,
+                             "The carried Choi state (Sigma=0 period vector).")
+      .def_property_readonly("output_state", &MergeCobordism::outputState,
+                             "Emergent psi_AB: the metric L_1(W) harmonic carrying "
+                             "the inputs, read over the output cycles.")
+      .def_property_readonly("stats", &MergeCobordism::stats);
 }

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -529,6 +529,27 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "approximation (~1e-5 vs FP64); residualForPeriodsGradient stays the "
            "default and the correctness oracle. Requires a TESSERA_CUDA build "
            "(raises otherwise), and raises on a hole/target length mismatch.")
+      // ----- The discovered operator: ker L1(W - dW) (#363) -----
+      .def("bulkMinusBoundaryCells",
+           &EigenstateSynthesis::bulkMinusBoundaryCells,
+           "The interior 1-cells of W - dW (edges both of whose endpoints are "
+           "interior vertices, on no dW face), as sorted (u,v) tuples in "
+           "canonical ChainComplex C_1 order -- the column ordering of "
+           "bulkMinusBoundaryHarmonicMatrix. Empty for a bare (un-grown) "
+           "cobordism (all boundary, no interior bulk).")
+      .def("bulkMinusBoundaryHarmonicMatrix",
+           &EigenstateSynthesis::bulkMinusBoundaryHarmonicMatrix,
+           py::arg("tol") = 1e-9,
+           "ker L1(W - dW): the harmonic 1-forms of the combinatorial "
+           "(unit-weight, signature-blind) Hodge Laplacian L1 of the bulk with "
+           "the full dW subcomplex deleted (the subcomplex induced on the "
+           "interior vertices). Restricts the integer boundary maps d1, d2 to "
+           "the interior cells and eigendecomposes L1 = d1^T d1 + d2 d2^T, "
+           "returning the |lambda| < tol eigenvectors stacked as the ROWS of a "
+           "flat row-major (dim ker L1) x len(bulkMinusBoundaryCells()) complex "
+           "array (ascending eigenvalue). The geometry the discovered operator "
+           "is read from -- surgery must first grow the interior so this is "
+           "nonzero. Read fresh from the live complex.")
       // ----- Surgery: the topology-changing interior remove move (#196) -----
       .def("interiorTopCells", &EigenstateSynthesis::interiorTopCells,
            "The interior top cells (all-interior vertices, on no dW face) as "

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -981,10 +981,19 @@ std::vector<cd> EigenstateSynthesis::carriedRepresentative(
         "EigenstateSynthesis::carriedRepresentative: " +
         std::to_string(targetPeriods.size()) + " target periods for " +
         std::to_string(holes.size()) + " holes");
-  const RegisterReadout ro = assembleRegisterReadout(holes);
+  return carriedFromReadout(assembleRegisterReadout(holes), targetPeriods);
+}
+
+std::vector<cd> EigenstateSynthesis::carriedFromReadout(
+    const RegisterReadout &ro, const std::vector<cd> &targetPeriods) const {
   const std::size_t n = order_;
-  const std::size_t m = holes.size();
+  const std::size_t m = ro.leakColumns.size();
   if (n == 0) return {};
+  if (targetPeriods.size() != m)
+    throw std::runtime_error(
+        "EigenstateSynthesis::carriedFromReadout: " +
+        std::to_string(targetPeriods.size()) + " target periods for " +
+        std::to_string(m) + " cycles");
 
   // The minimum-norm least-squares projection onto the carried period rows
   // (what numpy.linalg.lstsq returns): c = (P^T)^+ target via the SVD.
@@ -1003,7 +1012,7 @@ std::vector<cd> EigenstateSynthesis::carriedRepresentative(
   }
 
   // The carried representative plus the minimal leak: psi = sum_r c_r h_r,
-  // then each hole's uncarried remainder lands on its leak column, so the
+  // then each cycle's uncarried remainder lands on its leak column, so the
   // cochain's periods are exactly the targets.
   std::vector<cd> psi(n, cd(0.0, 0.0));
   for (std::size_t r = 0; r < ro.dim; ++r) {
@@ -1019,6 +1028,98 @@ std::vector<cd> EigenstateSynthesis::carriedRepresentative(
   return psi;
 }
 
+EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleReadoutOverLoops(
+    const std::vector<EdgeLoop> &loops) const {
+  RegisterReadout out;
+  const std::size_t n = order_;
+  out.H = HodgeLaplacian(st_).harmonicMatrix(k_, 1e-9, /*metric=*/true);
+  if (n == 0) {
+    if (!loops.empty())
+      throw std::runtime_error(
+          "EigenstateSynthesis::assembleReadoutOverLoops: the complex has no "
+          "k-cells to carry periods");
+    return out;
+  }
+  if (out.H.size() % n != 0)
+    throw std::runtime_error(
+        "EigenstateSynthesis::assembleReadoutOverLoops: the harmonic matrix "
+        "width " + std::to_string(out.H.size()) +
+        " is not a multiple of the captured operator dimension " +
+        std::to_string(n));
+  out.dim = out.H.size() / n;
+  std::map<std::vector<std::uint64_t>, std::size_t> col;
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i) col[cellOrdering_[i]] = i;
+  const std::size_t m = loops.size();
+  out.P.assign(out.dim * m, cd(0.0, 0.0));
+  out.leakColumns.reserve(m);
+  for (std::size_t q = 0; q < m; ++q) {
+    if (loops[q].empty())
+      throw std::runtime_error(
+          "EigenstateSynthesis::assembleReadoutOverLoops: loop " +
+          std::to_string(q) + " is empty");
+    bool first = true;
+    for (const OrientedEdge &oe : loops[q]) {
+      const std::uint64_t a = oe.first, b = oe.second;
+      const std::vector<std::uint64_t> e = {std::min(a, b), std::max(a, b)};
+      const auto it = col.find(e);
+      if (it == col.end())
+        throw std::runtime_error(
+            "EigenstateSynthesis::assembleReadoutOverLoops: loop edge (" +
+            std::to_string(a) + "," + std::to_string(b) +
+            ") is not a k-cell of the complex");
+      const double s = (a < b) ? 1.0 : -1.0;
+      if (first) {
+        out.leakColumns.push_back(it->second);
+        first = false;
+      }
+      for (std::size_t r = 0; r < out.dim; ++r)
+        out.P[r * m + q] += s * out.H[r * n + it->second];
+    }
+  }
+  return out;
+}
+
+std::vector<cd> EigenstateSynthesis::cyclePeriodsOverLoops(
+    const std::vector<EdgeLoop> &loops) const {
+  return assembleReadoutOverLoops(loops).P;
+}
+
+double EigenstateSynthesis::residualForLoops(
+    const std::vector<EdgeLoop> &loops,
+    const std::vector<cd> &targetPeriods) const {
+  const std::vector<cd> psi =
+      carriedFromReadout(assembleReadoutOverLoops(loops), targetPeriods);
+  if (psi.empty()) return 0.0;
+  return residual(psi);
+}
+
+std::vector<cd> EigenstateSynthesis::carriedRepresentativeOverLoops(
+    const std::vector<EdgeLoop> &loops, const std::vector<cd> &targetPeriods) const {
+  return carriedFromReadout(assembleReadoutOverLoops(loops), targetPeriods);
+}
+
+std::vector<cd> EigenstateSynthesis::periodsOfCochainOverLoops(
+    const std::vector<cd> &cochain, const std::vector<EdgeLoop> &loops) const {
+  std::map<std::vector<std::uint64_t>, std::size_t> col;
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i) col[cellOrdering_[i]] = i;
+  std::vector<cd> out(loops.size(), cd(0.0, 0.0));
+  for (std::size_t q = 0; q < loops.size(); ++q)
+    for (const OrientedEdge &oe : loops[q]) {
+      const std::vector<std::uint64_t> e = {std::min(oe.first, oe.second),
+                                            std::max(oe.first, oe.second)};
+      const auto it = col.find(e);
+      if (it == col.end())
+        throw std::runtime_error(
+            "EigenstateSynthesis::periodsOfCochainOverLoops: loop edge (" +
+            std::to_string(oe.first) + "," + std::to_string(oe.second) +
+            ") is not a k-cell of the complex");
+      if (it->second < cochain.size())
+        out[q] += (oe.first < oe.second ? cd(1.0, 0.0) : cd(-1.0, 0.0)) *
+                  cochain[it->second];
+    }
+  return out;
+}
+
 double EigenstateSynthesis::residualForPeriods(
     const std::vector<std::vector<std::uint64_t>> &holes,
     const std::vector<cd> &targetPeriods) const {
@@ -1027,8 +1128,8 @@ double EigenstateSynthesis::residualForPeriods(
   return residual(psi);
 }
 
-std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
-    const std::vector<std::vector<std::uint64_t>> &holes,
+std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
+    const std::vector<EdgeLoop> &loops,
     const std::vector<cd> &targetPeriods) const {
   using Eigen::Index;
   using Eigen::MatrixXd;
@@ -1036,13 +1137,13 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
   using Eigen::VectorXd;
   const std::size_t n1 = order_;
   std::vector<double> grad(n1, 0.0);
-  const std::size_t m = holes.size();
+  const std::size_t m = loops.size();
   if (n1 == 0 || m == 0) return grad;
   if (targetPeriods.size() != m)
     throw std::runtime_error(
-        "EigenstateSynthesis::residualForPeriodsGradient: " +
+        "EigenstateSynthesis::periodGradientOverLoops: " +
         std::to_string(targetPeriods.size()) + " target periods for " +
-        std::to_string(m) + " holes");
+        std::to_string(m) + " loops");
   static constexpr double kNullTol = 1e-7;
   const Index N = static_cast<Index>(n1);
 
@@ -1105,19 +1206,24 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
     return it == l2map.end() ? 0.0 : it->second;
   };
 
-  // ---- Q (hole-boundary covector) + each hole's leak column ----
+  // ---- Q (signed edge-loop covector) + each cycle's leak column ----
+  // Generalizes the removed-triangle boundary to any closed walk of oriented
+  // edges: Q(q, edge) += +1 along the stored orientation, -1 against; the leak
+  // is the loop's first edge.
   MatrixXd Q = MatrixXd::Zero(static_cast<Index>(m), N);
   std::vector<std::size_t> leakCol(m);
   for (std::size_t q = 0; q < m; ++q) {
-    const auto &h = holes[q];
-    for (int j = 0; j < 3; ++j) {
-      std::vector<std::uint64_t> facet;
-      for (int i = 0; i < 3; ++i)
-        if (i != j) facet.push_back(h[i]);
-      Q(static_cast<Index>(q), static_cast<Index>(cidx1.at(key(facet[0], facet[1])))) +=
-          (j % 2 == 0 ? 1.0 : -1.0);
+    const EdgeLoop &loop = loops[q];
+    if (loop.empty())
+      throw std::runtime_error(
+          "EigenstateSynthesis::periodGradientOverLoops: loop " +
+          std::to_string(q) + " is empty");
+    leakCol[q] = cidx1.at(key(loop.front().first, loop.front().second));
+    for (const OrientedEdge &oe : loop) {
+      const double s = (oe.first < oe.second) ? 1.0 : -1.0;
+      Q(static_cast<Index>(q),
+        static_cast<Index>(cidx1.at(key(oe.first, oe.second)))) += s;
     }
-    leakCol[q] = cidx1.at(key(h[0], h[1]));
   }
 
   // ---- eigendecomposition of M; harmonic (null) / non-null split ----
@@ -1219,6 +1325,31 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
                (2.0 * rU / nrm) * (p.dot(dpsi)).real();
   }
   return grad;
+}
+
+std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+  // A removed triangle's boundary IS the oriented loop h0 -> h1 -> h2 -> h0
+  // (identical signed covector and leak), so route through the loop core.
+  std::vector<EdgeLoop> loops;
+  loops.reserve(holes.size());
+  for (const auto &h : holes) {
+    if (h.size() != 3)
+      throw std::runtime_error(
+          "EigenstateSynthesis::residualForPeriodsGradient: hole has " +
+          std::to_string(h.size()) + " vertices, expected 3");
+    std::vector<std::uint64_t> s(h);
+    std::sort(s.begin(), s.end());
+    loops.push_back({{s[0], s[1]}, {s[1], s[2]}, {s[2], s[0]}});
+  }
+  return periodGradientOverLoops(loops, targetPeriods);
+}
+
+std::vector<double> EigenstateSynthesis::residualForLoopsGradient(
+    const std::vector<EdgeLoop> &loops,
+    const std::vector<cd> &targetPeriods) const {
+  return periodGradientOverLoops(loops, targetPeriods);
 }
 
 std::vector<double> EigenstateSynthesis::residualForPeriodsGradientGpu(

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -802,6 +802,92 @@ std::pair<bool, std::string> EigenstateSynthesis::dualComplexValid() const {
                   : std::vector<std::vector<std::uint64_t>>{});
 }
 
+// === The discovered operator: ker L₁(W − ∂W) (#363) ===
+
+std::vector<std::vector<std::uint64_t>>
+EigenstateSynthesis::bulkMinusBoundaryCells() const {
+  std::vector<std::vector<std::uint64_t>> out;
+  if (!st_) return out;
+  const std::unordered_set<std::uint64_t> bverts(
+      boundaryVertexIdsSorted_.begin(), boundaryVertexIdsSorted_.end());
+  for (auto &e : ChainComplex::fromSpacetime(*st_).kSimplexVertices(1)) {
+    bool interior = true;
+    for (const std::uint64_t v : e)
+      if (bverts.count(v)) { interior = false; break; }
+    if (interior) out.push_back(e);
+  }
+  return out;
+}
+
+std::vector<cd> EigenstateSynthesis::bulkMinusBoundaryHarmonicMatrix(
+    double tol) const {
+  using Eigen::Index;
+  using Eigen::MatrixXd;
+  if (!st_) return {};
+
+  // W − ∂W is the subcomplex induced on the interior vertices (the ones on no
+  // ∂W face); a cell belongs to it iff all of its vertices are interior. This is
+  // the ticket's "boundary removed" — and ties to its measured "3 interior
+  // vertices carry nothing" (too few interior vertices ⇒ no interior 1-cycle).
+  const std::unordered_set<std::uint64_t> bverts(
+      boundaryVertexIdsSorted_.begin(), boundaryVertexIdsSorted_.end());
+  const auto interiorCell = [&](const std::vector<std::uint64_t> &c) {
+    for (const std::uint64_t v : c)
+      if (bverts.count(v)) return false;
+    return true;
+  };
+
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const auto v0 = cc.kSimplexVertices(0);
+  const auto v1 = cc.kSimplexVertices(1);
+  const auto v2 = cc.kSimplexVertices(2);
+  const std::size_t n0 = v0.size(), n1 = v1.size(), n2 = v2.size();
+  if (n1 == 0) return {};
+
+  // The interior-cell index lists into the full C_k orderings.
+  std::vector<Index> i0, i1, i2;
+  for (std::size_t i = 0; i < n0; ++i)
+    if (interiorCell(v0[i])) i0.push_back(static_cast<Index>(i));
+  for (std::size_t i = 0; i < n1; ++i)
+    if (interiorCell(v1[i])) i1.push_back(static_cast<Index>(i));
+  for (std::size_t i = 0; i < n2; ++i)
+    if (interiorCell(v2[i])) i2.push_back(static_cast<Index>(i));
+  const Index m1 = static_cast<Index>(i1.size());
+  if (m1 == 0) return {};
+
+  // Restrict ∂₁ (n0×n1) and ∂₂ (n1×n2) to the interior rows/columns, then the
+  // combinatorial L₁ = ∂₁ᵀ∂₁ + ∂₂∂₂ᵀ (unit weights — the magnitude,
+  // signature-blind register the merge reads with harmonicMatrix(1,·,False)).
+  const std::vector<long> &d1 = cc.boundaryMatrix(1);
+  const std::vector<long> &d2 = cc.boundaryMatrix(2);
+  MatrixXd D1 = MatrixXd::Zero(static_cast<Index>(i0.size()), m1);
+  for (Index r = 0; r < static_cast<Index>(i0.size()); ++r)
+    for (Index c = 0; c < m1; ++c)
+      D1(r, c) = static_cast<double>(
+          d1[static_cast<std::size_t>(i0[r]) * n1 + static_cast<std::size_t>(i1[c])]);
+  MatrixXd L = D1.transpose() * D1;
+  if (!i2.empty()) {
+    MatrixXd D2 = MatrixXd::Zero(m1, static_cast<Index>(i2.size()));
+    for (Index r = 0; r < m1; ++r)
+      for (Index c = 0; c < static_cast<Index>(i2.size()); ++c)
+        D2(r, c) = static_cast<double>(
+            d2[static_cast<std::size_t>(i1[r]) * n2 + static_cast<std::size_t>(i2[c])]);
+    L += D2 * D2.transpose();
+  }
+
+  // ker L₁ ≅ H₁ of the interior: the |λ| < tol eigenvectors, stacked as rows in
+  // ascending-eigenvalue order (matching HodgeLaplacian::harmonicMatrix).
+  Eigen::SelfAdjointEigenSolver<MatrixXd> eig(L);
+  const Eigen::VectorXd &lam = eig.eigenvalues();
+  const MatrixXd &V = eig.eigenvectors();
+  std::vector<cd> out;
+  for (Index j = 0; j < lam.size(); ++j) {
+    if (std::abs(lam[j]) >= tol) continue;
+    for (Index i = 0; i < m1; ++i) out.push_back(cd(V(i, j), 0.0));
+  }
+  return out;
+}
+
 EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleRegisterReadout(
     const std::vector<std::vector<std::uint64_t>> &holes) const {
   const auto joinIds = [](const std::vector<std::uint64_t> &c) {

--- a/src/cobordism/MergeCobordism.cpp
+++ b/src/cobordism/MergeCobordism.cpp
@@ -440,75 +440,70 @@ void MergeCobordism::buildSeed() {
 }
 
 void MergeCobordism::optimize() {
-  // Two-phase optimization (#363).
-  //
-  // PHASE 1 (combinatorial). At the FIXED seed metric, step through triangulation
-  // space with boundary-fixed Pachner moves and greedily keep only those that
-  // lower the interior Regge stationarity ||grad_I S||^2, rolling the rest back
-  // (the moves are transactional). The dual action S = sum_h |*h| eps_h depends on
-  // the triangulation (which hinges exist, their deficits / dual volumes /
-  // rapidities) at fixed edge lengths, so the moves alone extremize it. Stop when
-  // no move lowers the action (extremized) or the move budget is spent.
-  //
-  // PHASE 2 (metric). On that triangulation, relax the edge lengths to minimize
-  // the FULL residual r = beta||grad S||^2 + r_psi, with NO further moves. The
-  // action stays extremized because beta||grad S||^2 is still a term in r.
+  // Joint search (#363). The dual action is stationary over edge lengths AND
+  // combinatorics jointly, so we cannot extremize one then the other (a fixed
+  // metric makes the move-graph look flat — a combinatorial-first pass accepts
+  // zero moves). Each round instead applies a batch of boundary-fixed Pachner
+  // moves (a walk over all five bistellar types), relaxes the metric against the
+  // FULL residual r = beta||grad S||^2 + r_psi, and scores the relaxed result;
+  // we keep the lowest-residual operator found. A move is only as good as the
+  // metric it can be relaxed into.
   std::mt19937 rng(static_cast<std::uint32_t>(seed_));
 
-  // Interior Regge stationarity residual at the current triangulation + metric.
-  auto actionResidual = [&]() -> double {
-    EigenstateSynthesis es(cobordism_, 1);
-    std::set<std::pair<std::uint64_t, std::uint64_t>> interiorSet;
-    for (const auto &uv : es.interiorEdges()) interiorSet.insert(uv);
-    ReggeSolver solver(cobordism_, MatterConfiguration());
-    const auto g = solver.actionGradientExact();
-    const auto edges = cobordism_->getEdgeList()->toVector();
-    double n2 = 0.0;
-    for (std::size_t i = 0; i < edges.size() && i < g.size(); ++i)
-      if (interiorSet.count(edgeKey(edges[i]))) n2 += std::norm(g[i]);
-    return beta_ * n2;
-  };
-
-  // --- Phase 1: greedy combinatorial action extremization (fixed metric) ---
-  double bestAction = actionResidual();
+  relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_, /*maxIters=*/150,
+                stats_.relaxIterations, verbose_);
+  extractOperator();
+  double best = stats_.residual;
+  std::vector<std::complex<double>> bestU = operatorU_, bestChoi = choiState_;
+  Stats bestSnap = stats_;
   if (verbose_)
-    std::cerr << "[merge] seed action=" << bestAction << " -- phase 1 (combinatorial, up to "
+    std::cerr << "[merge] seed r=" << best << " -- joint search (up to "
               << maxAttempts_ << " rounds)\n";
-  for (int attempt = 0; attempt < maxAttempts_ && bestAction >= epsilon_; ++attempt) {
-    bool improved = false;
-    auto tryMove = [&](auto &mv, int &counter) {
-      if (mv.propose() && mv.apply()) {
-        const double a = actionResidual();
-        if (a < bestAction) { bestAction = a; ++counter; improved = true; }
-        else { mv.rollback(); }  // reject: undo the move
-      }
+
+  for (int attempt = 0; attempt < maxAttempts_ && best >= epsilon_; ++attempt) {
+    auto applyMove = [&](auto &mv, int &counter) {
+      if (mv.propose() && mv.apply()) ++counter;  // a walk: no per-move rollback
     };
     for (int k = 0; k < kMovesPerRound; ++k) {
       const std::uint64_t s = static_cast<std::uint64_t>(rng());
       switch ((attempt * kMovesPerRound + k) % 5) {
-        case 0: { FlipMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); tryMove(mv, stats_.flipMoves); break; }
-        case 1: { IFlipMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); tryMove(mv, stats_.flipMoves); break; }
-        case 2: { ShiftMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); tryMove(mv, stats_.flipMoves); break; }
-        case 3: { AddMove mv(cobordism_.get(), s, true, PachnerMode::PreGeometric, true); tryMove(mv, stats_.addMoves); break; }
-        default: { RemoveMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); tryMove(mv, stats_.removeMoves); break; }
+        case 0: { FlipMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); applyMove(mv, stats_.flipMoves); break; }
+        case 1: { IFlipMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); applyMove(mv, stats_.flipMoves); break; }
+        case 2: { ShiftMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); applyMove(mv, stats_.flipMoves); break; }
+        case 3: { AddMove mv(cobordism_.get(), s, true, PachnerMode::PreGeometric, true); applyMove(mv, stats_.addMoves); break; }
+        default: { RemoveMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); applyMove(mv, stats_.removeMoves); break; }
       }
     }
     stats_.attempts = attempt + 1;
+    relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_, /*maxIters=*/150,
+                  stats_.relaxIterations, verbose_);
+    extractOperator();
     if (verbose_)
-      std::cerr << "[merge phase1] round " << (attempt + 1) << "/" << maxAttempts_
-                << "  action=" << bestAction << "  (flip=" << stats_.flipMoves
-                << " add=" << stats_.addMoves << " rm=" << stats_.removeMoves << ")\n";
-    if (!improved) break;  // no move lowered the action this round — extremized
+      std::cerr << "[merge joint] round " << (attempt + 1) << "/" << maxAttempts_
+                << "  r=" << stats_.residual << "  best=" << best
+                << "  (flip=" << stats_.flipMoves << " add=" << stats_.addMoves
+                << " rm=" << stats_.removeMoves << ")\n";
+    if (stats_.residual < best) {
+      best = stats_.residual;
+      bestU = operatorU_;
+      bestChoi = choiState_;
+      bestSnap = stats_;
+    }
   }
 
-  // --- Phase 2: metric residual minimization, no moves ---
-  if (verbose_)
-    std::cerr << "[merge] phase 1 done (action=" << bestAction
-              << ") -- phase 2 (relax, 400 iters)\n";
-  relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_, /*maxIters=*/400,
-                stats_.relaxIterations, verbose_);
-  extractOperator();  // operator + topology + full residual breakdown
-  stats_.converged = stats_.residual < epsilon_;
+  // Return the lowest-residual operator found; the move counters stay cumulative.
+  stats_.converged = best < epsilon_;
+  operatorU_ = bestU;
+  choiState_ = bestChoi;
+  stats_.residual = bestSnap.residual;
+  stats_.statActionResidual = bestSnap.statActionResidual;
+  stats_.stateResidual = bestSnap.stateResidual;
+  stats_.dualAction = bestSnap.dualAction;
+  stats_.kerL1Bulk = bestSnap.kerL1Bulk;
+  stats_.bettiCobordism = bestSnap.bettiCobordism;
+  stats_.b1Bulk = bestSnap.b1Bulk;
+  stats_.interiorVertices = bestSnap.interiorVertices;
+  stats_.topology = bestSnap.topology;
 }
 
 void MergeCobordism::extractOperator() {

--- a/src/cobordism/MergeCobordism.cpp
+++ b/src/cobordism/MergeCobordism.cpp
@@ -1,0 +1,603 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/MergeCobordism.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <optional>
+#include <random>
+#include <set>
+#include <stdexcept>
+#include <utility>
+
+#include <Eigen/Dense>
+
+#include "cobordism/ChainComplex.h"
+#include "cobordism/EigenstateSynthesis.h"
+#include "matter/MatterConfiguration.h"
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Vertex.h"
+#include "quantum/ChoiJamiolkowski.h"
+#include "simulations/ReggeSolver.h"
+#include "spacetime/Foliation.h"
+#include "spacetime/Metric.h"
+#include "spacetime/Signature.h"
+#include "spacetime/Spacetime.h"
+#include <iostream>
+
+#include "spacetime/pachner/AddMove.h"
+#include "spacetime/pachner/FlipMove.h"
+#include "spacetime/pachner/IFlipMove.h"
+#include "spacetime/pachner/RemoveMove.h"
+#include "spacetime/pachner/ShiftMove.h"
+#include "spacetime/topologies/SimplexBoundarySphere.h"
+#include "spacetime/topologies/SimplicialProduct.h"
+#include "spacetime/topologies/Topology.h"
+
+namespace tessera::cobordism {
+
+using ::tessera::MatterConfiguration;
+using ::tessera::quantum::ChoiJamiolkowski;
+using ::tessera::simulations::ReggeSolver;
+using ::tessera::spacetime::AddMove;
+using ::tessera::spacetime::PachnerMode;
+using ::tessera::spacetime::RemoveMove;
+using ::tessera::spacetime::Spacetime;
+
+namespace {
+
+// === (subdivided T^2 with 3 holes) x S^1 = T^3 minus 3 solid tori (#363) ===
+// dW = 3 tori (the qubit registers, b_1 = 2 each); interior b_1 = 2g + h - 2 = 3
+// for genus g = 1, h = 3 holes (the operator handles). A genus-1 base is required:
+// a sphere base would leave only the S^1 interior (b_1 = 1). The torus cycles are
+// genuine non-contractible cycles a state residual can read.
+
+// One geodesic (1 -> 4) subdivision of a triangulated surface, so a 3-fold
+// vertex-disjoint hole triple exists (the minimal S^1 x S^1 torus has only 2).
+std::vector<std::vector<std::uint64_t>> subdivideFaces(
+    const std::vector<std::vector<std::uint64_t>> &faces) {
+  std::uint64_t nxt = 0;
+  for (const auto &f : faces)
+    for (const auto v : f) nxt = std::max(nxt, v + 1);
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::uint64_t> mid;
+  auto m = [&](std::uint64_t a, std::uint64_t b) -> std::uint64_t {
+    const auto key = std::make_pair(std::min(a, b), std::max(a, b));
+    const auto it = mid.find(key);
+    if (it != mid.end()) return it->second;
+    const std::uint64_t id = nxt++;
+    mid[key] = id;
+    return id;
+  };
+  std::vector<std::vector<std::uint64_t>> out;
+  for (const auto &f : faces) {
+    const std::uint64_t a = f[0], b = f[1], c = f[2];
+    const std::uint64_t ab = m(a, b), bc = m(b, c), ca = m(c, a);
+    std::vector<std::vector<std::uint64_t>> tris = {
+        {a, ab, ca}, {b, bc, ab}, {c, ca, bc}, {ab, bc, ca}};
+    for (auto &s : tris) {
+      std::sort(s.begin(), s.end());
+      out.push_back(s);
+    }
+  }
+  return out;
+}
+
+// The first k pairwise vertex-disjoint faces — the holonomy holes whose
+// boundary circles become the qubit tori (each circle x S^1).
+std::vector<std::vector<std::uint64_t>> disjointHoles(
+    const std::vector<std::vector<std::uint64_t>> &faces, std::size_t k) {
+  std::vector<std::vector<std::uint64_t>> holes;
+  std::set<std::uint64_t> used;
+  for (const auto &f : faces) {
+    if (holes.size() >= k) break;
+    bool overlap = false;
+    for (const auto v : f)
+      if (used.count(v)) { overlap = true; break; }
+    if (!overlap) {
+      holes.push_back(f);
+      for (const auto v : f) used.insert(v);
+    }
+  }
+  return holes;
+}
+
+// The 3 prism tets of (triangle x edge) from layer offset `bot` to `top` — the
+// dimension-generic staircase, looped to make x S^1 rather than x [0,1].
+void appendStaircase(const std::vector<std::vector<std::uint64_t>> &faces,
+                     std::uint64_t bot, std::uint64_t top,
+                     std::set<std::vector<std::uint64_t>> &cells) {
+  for (const auto &f : faces) {
+    const std::uint64_t a = f[0], b = f[1], c = f[2];
+    const std::uint64_t b0[3] = {a + bot, b + bot, c + bot};
+    const std::uint64_t t0[3] = {a + top, b + top, c + top};
+    std::vector<std::vector<std::uint64_t>> tets = {
+        {b0[0], b0[1], b0[2], t0[2]},
+        {b0[0], b0[1], t0[1], t0[2]},
+        {b0[0], t0[0], t0[1], t0[2]}};
+    for (auto &t : tets) {
+      std::sort(t.begin(), t.end());
+      cells.insert(t);
+    }
+  }
+}
+
+// The sorted (min,max) endpoint key of a mesh edge.
+std::pair<std::uint64_t, std::uint64_t> edgeKey(const ::tessera::mesh::Edge *e) {
+  const auto a = e->getSource()->getId();
+  const auto b = e->getTarget()->getId();
+  return {std::min(a, b), std::max(a, b)};
+}
+
+// Betti numbers of a complex (combinatorial, geometry-free).
+std::vector<int> betti(const Spacetime &st) {
+  return ChainComplex::fromSpacetime(st).bettiNumbers();
+}
+
+// One bounded Gauss-Newton / Levenberg-Marquardt descent of the stationary-action
+// residual beta*||grad S||^2 over the interior edge squared-lengths, using the
+// EXACT analytic gradient and Hessian of the dual Regge action (no finite
+// differences). Returns the final beta*||grad S||^2. Leaves the interior edges at
+// the best point found.
+//
+// The least-squares residual is f = grad S (over all edges), its Jacobian w.r.t.
+// the interior edge lengths is the action Hessian H restricted to the interior
+// columns; the GN normal equations (Re(H_I^H H_I) + mu I) delta = -Re(H_I^H g)
+// are the analytic-Jacobian Levenberg-Marquardt step the spec calls for.
+// Boundary-fixed Pachner moves per relaxation round (#363): a batch jumps
+// further through triangulation space before each (expensive) relax, so the
+// combinatorial search covers far more updates between relaxations.
+constexpr int kMovesPerRound = 8;
+
+double relaxInterior(
+    const std::shared_ptr<Spacetime> &st, double beta,
+    const std::vector<std::vector<std::pair<std::uint64_t, std::uint64_t>>> &stateLoops,
+    const std::vector<std::complex<double>> &stateTargets,
+    int maxIters, int &iterCounter, bool verbose = false) {
+  // The free parameters: interior edges (both endpoints off dW). dW is held
+  // fixed, so the Regge stationarity we relax is over these edges only. The
+  // EdgeList order is the order of actionGradientExact / actionHessianExact.
+  EigenstateSynthesis es(st, 1);
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> interiorRank;
+  for (const auto &uv : es.interiorEdges()) interiorRank.emplace(uv, 0);
+  const auto edges = st->getEdgeList()->toVector();
+  std::vector<std::size_t> interiorIdx;   // EdgeList indices of the free edges
+  std::vector<::tessera::mesh::Edge *> interiorEdgePtr;
+  for (std::size_t i = 0; i < edges.size(); ++i) {
+    if (interiorRank.count(edgeKey(edges[i]))) {
+      interiorIdx.push_back(i);
+      interiorEdgePtr.push_back(edges[i]);
+    }
+  }
+  const std::size_t nI = interiorIdx.size();
+
+  // r_psi: the carried-harmonic residual of the pinned states over the boundary
+  // cycles. Reads the live metric, so it tracks the interior relaxation.
+  auto stateCost = [&]() {
+    return stateLoops.empty() ? 0.0
+                              : es.residualForLoops(stateLoops, stateTargets);
+  };
+  // The action residual is the Regge stationarity over the FREE (interior) edges
+  // ONLY: dW is fixed (Dirichlet), so its action gradient is an irreducible
+  // reaction, not part of the interior stationarity — summing it over all edges
+  // would floor r at the boundary's |grad S|^2.
+  auto actionNorm2 = [&]() {
+    ReggeSolver solver(st, MatterConfiguration());
+    const auto g = solver.actionGradientExact();
+    double n2 = 0.0;
+    for (const std::size_t e : interiorIdx) n2 += std::norm(g[e]);
+    return n2;
+  };
+
+  if (nI == 0) return beta * actionNorm2() + stateCost();  // no free edges to relax
+
+  // cellSimplices order (residualForPeriodsGradient) -> interior param index,
+  // so the analytic state-residual gradient folds into the action gradient.
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> paramOf;
+  for (std::size_t c = 0; c < nI; ++c) paramOf[edgeKey(interiorEdgePtr[c])] = c;
+  const auto &cells = es.cellSimplices();
+  std::vector<int> cellToParam(cells.size(), -1);
+  for (std::size_t j = 0; j < cells.size(); ++j) {
+    if (cells[j].size() < 2) continue;
+    const std::pair<std::uint64_t, std::uint64_t> key{
+        std::min(cells[j][0], cells[j][1]), std::max(cells[j][0], cells[j][1])};
+    const auto it = paramOf.find(key);
+    if (it != paramOf.end()) cellToParam[j] = static_cast<int>(it->second);
+  }
+
+  auto cost = [&]() { return beta * actionNorm2() + stateCost(); };
+
+  double mu = 1e-3;
+  double best = cost();
+  for (int it = 0; it < maxIters; ++it, ++iterCounter) {
+    ReggeSolver solver(st, MatterConfiguration());
+    const auto gVec = solver.actionGradientExact();   // |E| complex, EdgeList order
+    const auto hMat = solver.actionHessianExact();     // |E|x|E| complex
+
+    // The interior gradient g_I and the interior-interior Hessian block H_II — the
+    // residual is the stationarity over the FREE edges only (see actionNorm2).
+    Eigen::VectorXcd gI(nI);
+    for (std::size_t c = 0; c < nI; ++c) gI(c) = gVec[interiorIdx[c]];
+    Eigen::MatrixXcd HII(nI, nI);
+    for (std::size_t r = 0; r < nI; ++r)
+      for (std::size_t c = 0; c < nI; ++c)
+        HII(r, c) = hMat[interiorIdx[r]][interiorIdx[c]];
+
+    // Analytic gradient and GN Hessian of beta*||grad_I S||^2 over the interior
+    // lengths, plus the analytic state-residual gradient (cellSimplices order).
+    Eigen::VectorXd grad = (2.0 * beta * (HII.adjoint() * gI)).real();
+    if (!stateLoops.empty()) {
+      const auto rg = es.residualForLoopsGradient(stateLoops, stateTargets);
+      for (std::size_t j = 0; j < rg.size() && j < cellToParam.size(); ++j)
+        if (cellToParam[j] >= 0) grad(cellToParam[j]) += rg[j];
+    }
+    Eigen::MatrixXd B = (2.0 * beta * (HII.adjoint() * HII)).real();
+
+    // Current interior lengths (real squared-lengths; spacelike).
+    Eigen::VectorXd x0(nI);
+    for (std::size_t c = 0; c < nI; ++c)
+      x0(c) = interiorEdgePtr[c]->getSquaredLength().real();
+
+    bool improved = false;
+    for (int ls = 0; ls < 12; ++ls) {  // mu line search
+      Eigen::MatrixXd A = B;
+      for (std::size_t c = 0; c < nI; ++c) A(c, c) += mu * (B(c, c) + 1.0);
+      const Eigen::VectorXd delta = A.ldlt().solve(-grad);
+      Eigen::VectorXd x = x0 + delta;
+      // Emergent causal type: l^2 is free to be positive (spacelike), negative
+      // (timelike), or pass through zero (null) — no clamp. A degenerate/null
+      // step blows the action up, so the line search below rejects it loudly.
+      for (std::size_t c = 0; c < nI; ++c)
+        interiorEdgePtr[c]->setSquaredLength(std::complex<double>(x(c), 0.0));
+      const double trial = cost();
+      if (trial < best) {
+        best = trial;
+        mu = std::max(mu * 0.5, 1e-9);
+        improved = true;
+        break;
+      }
+      mu = std::min(mu * 4.0, 1e9);
+    }
+    if (verbose && (it % 25 == 0 || it + 1 == maxIters || !improved))
+      std::cerr << "[merge phase2] iter " << it << "/" << maxIters
+                << "  r=" << best << "\n";
+    if (!improved) {
+      // restore best point (x0) and stop — no step lowered the residual
+      for (std::size_t c = 0; c < nI; ++c)
+        interiorEdgePtr[c]->setSquaredLength(std::complex<double>(x0(c), 0.0));
+      break;
+    }
+  }
+  return best;
+}
+
+}  // namespace
+
+MergeCobordism::MergeCobordism(
+    const std::vector<std::vector<std::complex<double>>> &inputStates,
+    const std::vector<std::vector<std::complex<double>>> &outputStates,
+    const std::vector<std::complex<double>> &U, double beta, double epsilon,
+    int maxAttempts, std::uint64_t seed, bool verbose)
+    : inputStates_(inputStates),
+      outputStates_(outputStates),
+      beta_(beta),
+      epsilon_(epsilon),
+      maxAttempts_(maxAttempts),
+      seed_(seed),
+      verbose_(verbose) {
+  if (inputStates_.empty())
+    throw std::invalid_argument("MergeCobordism: inputStates is empty");
+  stateDim_ = inputStates_.front().size();
+  if (stateDim_ < 2 || (stateDim_ & (stateDim_ - 1)) != 0)
+    throw std::invalid_argument(
+        "MergeCobordism: state dimension must be a power of two >= 2");
+
+  if (!U.empty()) {
+    // U-supplied mode: compute the output state(s) from U, then ignore U.
+    if (U.size() != stateDim_ * stateDim_)
+      throw std::invalid_argument(
+          "MergeCobordism: U must be a d x d row-major operator");
+    computeOutputsFromOperator(U);
+  }
+  if (outputStates_.empty())
+    throw std::invalid_argument(
+        "MergeCobordism: outputStates is required when U is not supplied");
+
+  buildSeed();
+  computeStateTargets();
+  optimize();  // also reads the operator out (the best round's), via extractOperator
+}
+
+void MergeCobordism::computeOutputsFromOperator(
+    const std::vector<std::complex<double>> &U) {
+  // Apply the (row-major d x d) operator to each input: psi_out = U psi_in. The
+  // boundary then pins the U-predicted final state and the emergent operator is
+  // checked against U.
+  const std::size_t d = stateDim_;
+  outputStates_.clear();
+  for (const auto &psi : inputStates_) {
+    if (psi.size() != d)
+      throw std::invalid_argument("MergeCobordism: ragged input state dimension");
+    std::vector<std::complex<double>> out(d, {0.0, 0.0});
+    for (std::size_t i = 0; i < d; ++i)
+      for (std::size_t j = 0; j < d; ++j) out[i] += U[i * d + j] * psi[j];
+    outputStates_.push_back(std::move(out));
+  }
+}
+
+void MergeCobordism::computeStateTargets() {
+  // dW = 3 tori carry psi_A, psi_B, psi_AB. Each qubit's two components are the
+  // periods over its torus's two cycles: the hole-circle (the removed face's
+  // boundary) and the S^1 (the time loop of a hole vertex). residualForLoops
+  // over ALL six cycles jointly scores how far the bulk is from carrying the
+  // states; the six cycles span b_1(W) = 5 (over-determined by the one
+  // charge-conservation relation, the register's m = nd + 1).
+  stateLoops_.clear();
+  stateTargets_.clear();
+  if (holes_.size() < 3 || layerStride_ == 0) return;
+  std::vector<std::vector<std::complex<double>>> states;
+  for (const auto &s : inputStates_) states.push_back(s);
+  for (const auto &s : outputStates_) states.push_back(s);
+  const std::uint64_t N = layerStride_;
+  const std::size_t nStates = std::min(states.size(), holes_.size());
+  for (std::size_t i = 0; i < nStates; ++i) {
+    std::vector<std::uint64_t> h(holes_[i]);
+    std::sort(h.begin(), h.end());
+    const std::complex<double> a0 = states[i].size() > 0 ? states[i][0] : std::complex<double>(0);
+    const std::complex<double> a1 = states[i].size() > 1 ? states[i][1] : std::complex<double>(0);
+    // cycle 1: the hole-circle (removed face boundary) -> psi_i[0]
+    stateLoops_.push_back({{h[0], h[1]}, {h[1], h[2]}, {h[2], h[0]}});
+    stateTargets_.push_back(a0);
+    // cycle 2: the S^1 (vertical loop of hole vertex h[0]) -> psi_i[1]
+    stateLoops_.push_back(
+        {{h[0], h[0] + N}, {h[0] + N, h[0] + 2 * N}, {h[0] + 2 * N, h[0]}});
+    stateTargets_.push_back(a1);
+  }
+}
+
+void MergeCobordism::buildSeed() {
+  // dW = geo(psi_A) u geo(psi_B) u geo(psi_AB): three qubit registers, each a
+  // torus (b_1 = 2). The bulk between them carries the operator as the interior
+  // handles, ker L_1(W - dW) = d^2 - 1 = 3 for a qubit. Realized as (subdivided
+  // T^2 with 3 holes) x S^1 = T^3 minus the three (hole x S^1) solid tori: the
+  // hole-circles x S^1 are the boundary tori, the genus + S^1 cycles the interior
+  // operator. REGGE (not CDT): edge lengths free, causal type emergent.
+  Signature sig2(2, SignatureType::Lorentzian);
+  auto metric2 = std::make_shared<Metric>(true, sig2);
+  auto s1a = std::make_shared<SimplexBoundarySphere>(1);
+  auto s1b = std::make_shared<SimplexBoundarySphere>(1);
+  std::shared_ptr<Topology> t2 = std::make_shared<SimplicialProduct>(s1a, s1b);
+  auto torus = std::make_shared<Spacetime>(metric2, SpacetimeType::REGGE, 1.0, 1.0,
+                                           Foliation::NONE, t2);
+  torus->build();
+
+  const auto faces =
+      subdivideFaces(ChainComplex::fromSpacetime(*torus).kSimplexVertices(2));
+  const int holeCount = static_cast<int>(stateDim_ * stateDim_) - 1;  // 3 for a qubit
+  const auto holes = disjointHoles(faces, static_cast<std::size_t>(holeCount));
+  if (static_cast<int>(holes.size()) < holeCount)
+    throw std::runtime_error(
+        "MergeCobordism: torus base lacks enough vertex-disjoint holes");
+  const std::set<std::vector<std::uint64_t>> holeSet(holes.begin(), holes.end());
+
+  std::uint64_t N = 0;
+  for (const auto &f : faces)
+    for (const auto v : f) N = std::max(N, v + 1);
+  holes_ = holes;       // the qubit boundary holes, for computeStateTargets
+  layerStride_ = N;     // the S^1 layer stride (vertex-id offset per layer)
+  std::vector<std::vector<std::uint64_t>> holed;  // torus with the holes removed
+  for (const auto &f : faces)
+    if (!holeSet.count(f)) holed.push_back(f);
+
+  // Staircase the holed torus over S^1 (three layers, looped 0 -> N -> 2N -> 0).
+  std::set<std::vector<std::uint64_t>> cellSet;
+  for (std::uint64_t layer = 0; layer < 3; ++layer)
+    appendStaircase(holed, layer * N, ((layer + 1) % 3) * N, cellSet);
+
+  Signature sig3(3, SignatureType::Lorentzian);
+  auto metric3 = std::make_shared<Metric>(true, sig3);
+  cobordism_ = std::make_shared<Spacetime>(metric3, SpacetimeType::REGGE, 1.0, 1.0,
+                                           Foliation::NONE, std::nullopt);
+  std::set<std::uint64_t> verts;
+  for (const auto &c : cellSet)
+    for (const auto v : c) verts.insert(v);
+  std::map<std::uint64_t, ::tessera::mesh::Vertex *> vmap;
+  for (const auto id : verts) vmap[id] = cobordism_->createVertex(id);
+  for (const auto &c : cellSet) {
+    std::vector<::tessera::mesh::Vertex *> vs;
+    vs.reserve(c.size());
+    for (const auto v : c) vs.push_back(vmap[v]);
+    cobordism_->createSimplex(vs);
+  }
+
+  // Seed the metric off the degenerate uniform point. At l^2 = 1 a non-null
+  // metric-Hodge eigenvalue sits at ~0, where the period-residual gradient's
+  // eigenvector perturbation (~ -1/lambda) blows up (|grad| ~ 1e12), so the
+  // first relax step cannot descend. A small seeded spread breaks the
+  // degeneracy (|grad| ~ 1e-6, FD-validated); the relaxation moves freely from
+  // here. l^2 stays positive (spacelike) — the causal type is still emergent.
+  std::mt19937 jrng(static_cast<std::uint32_t>(seed_) ^ 0x9e3779b9u);
+  std::uniform_real_distribution<double> jitter(0.7, 1.3);
+  for (auto *e : cobordism_->getEdgeList()->toVector())
+    e->setSquaredLength(std::complex<double>(jitter(jrng), 0.0));
+
+  // dW = the single-coface triangles: the three qubit tori (54 faces = 3 x T^2).
+  std::map<std::vector<std::uint64_t>, int> cofaceCount;
+  for (const auto &c : cellSet)
+    for (std::size_t i = 0; i < c.size(); ++i) {
+      std::vector<std::uint64_t> tri;
+      tri.reserve(c.size() - 1);
+      for (std::size_t j = 0; j < c.size(); ++j)
+        if (j != i) tri.push_back(c[j]);
+      ++cofaceCount[tri];
+    }
+  boundaryCells_.clear();
+  for (const auto &kv : cofaceCount)
+    if (kv.second == 1) boundaryCells_.push_back(kv.first);
+  stats_.b1Bulk = 0;  // filled after relaxation in extractOperator()
+}
+
+void MergeCobordism::optimize() {
+  // Two-phase optimization (#363).
+  //
+  // PHASE 1 (combinatorial). At the FIXED seed metric, step through triangulation
+  // space with boundary-fixed Pachner moves and greedily keep only those that
+  // lower the interior Regge stationarity ||grad_I S||^2, rolling the rest back
+  // (the moves are transactional). The dual action S = sum_h |*h| eps_h depends on
+  // the triangulation (which hinges exist, their deficits / dual volumes /
+  // rapidities) at fixed edge lengths, so the moves alone extremize it. Stop when
+  // no move lowers the action (extremized) or the move budget is spent.
+  //
+  // PHASE 2 (metric). On that triangulation, relax the edge lengths to minimize
+  // the FULL residual r = beta||grad S||^2 + r_psi, with NO further moves. The
+  // action stays extremized because beta||grad S||^2 is still a term in r.
+  std::mt19937 rng(static_cast<std::uint32_t>(seed_));
+
+  // Interior Regge stationarity residual at the current triangulation + metric.
+  auto actionResidual = [&]() -> double {
+    EigenstateSynthesis es(cobordism_, 1);
+    std::set<std::pair<std::uint64_t, std::uint64_t>> interiorSet;
+    for (const auto &uv : es.interiorEdges()) interiorSet.insert(uv);
+    ReggeSolver solver(cobordism_, MatterConfiguration());
+    const auto g = solver.actionGradientExact();
+    const auto edges = cobordism_->getEdgeList()->toVector();
+    double n2 = 0.0;
+    for (std::size_t i = 0; i < edges.size() && i < g.size(); ++i)
+      if (interiorSet.count(edgeKey(edges[i]))) n2 += std::norm(g[i]);
+    return beta_ * n2;
+  };
+
+  // --- Phase 1: greedy combinatorial action extremization (fixed metric) ---
+  double bestAction = actionResidual();
+  if (verbose_)
+    std::cerr << "[merge] seed action=" << bestAction << " -- phase 1 (combinatorial, up to "
+              << maxAttempts_ << " rounds)\n";
+  for (int attempt = 0; attempt < maxAttempts_ && bestAction >= epsilon_; ++attempt) {
+    bool improved = false;
+    auto tryMove = [&](auto &mv, int &counter) {
+      if (mv.propose() && mv.apply()) {
+        const double a = actionResidual();
+        if (a < bestAction) { bestAction = a; ++counter; improved = true; }
+        else { mv.rollback(); }  // reject: undo the move
+      }
+    };
+    for (int k = 0; k < kMovesPerRound; ++k) {
+      const std::uint64_t s = static_cast<std::uint64_t>(rng());
+      switch ((attempt * kMovesPerRound + k) % 5) {
+        case 0: { FlipMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); tryMove(mv, stats_.flipMoves); break; }
+        case 1: { IFlipMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); tryMove(mv, stats_.flipMoves); break; }
+        case 2: { ShiftMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); tryMove(mv, stats_.flipMoves); break; }
+        case 3: { AddMove mv(cobordism_.get(), s, true, PachnerMode::PreGeometric, true); tryMove(mv, stats_.addMoves); break; }
+        default: { RemoveMove mv(cobordism_.get(), s, PachnerMode::PreGeometric, true); tryMove(mv, stats_.removeMoves); break; }
+      }
+    }
+    stats_.attempts = attempt + 1;
+    if (verbose_)
+      std::cerr << "[merge phase1] round " << (attempt + 1) << "/" << maxAttempts_
+                << "  action=" << bestAction << "  (flip=" << stats_.flipMoves
+                << " add=" << stats_.addMoves << " rm=" << stats_.removeMoves << ")\n";
+    if (!improved) break;  // no move lowered the action this round — extremized
+  }
+
+  // --- Phase 2: metric residual minimization, no moves ---
+  if (verbose_)
+    std::cerr << "[merge] phase 1 done (action=" << bestAction
+              << ") -- phase 2 (relax, 400 iters)\n";
+  relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_, /*maxIters=*/400,
+                stats_.relaxIterations, verbose_);
+  extractOperator();  // operator + topology + full residual breakdown
+  stats_.converged = stats_.residual < epsilon_;
+}
+
+void MergeCobordism::extractOperator() {
+  // The discovered operator: U_AB = unvec(ker L_1(W - dW)). Read the carried
+  // harmonic of the bulk (interior subcomplex) and un-vectorize it into the
+  // d x d operator.
+  EigenstateSynthesis es(cobordism_, 1);
+  bulkCells_ = es.bulkMinusBoundaryCells();
+  const auto H = es.bulkMinusBoundaryHarmonicMatrix();
+  const std::size_t ncols = bulkCells_.size();
+  const std::size_t dim = ncols ? H.size() / ncols : 0;
+
+  stats_.kerL1Bulk = static_cast<int>(dim);
+  const auto bws = betti(*cobordism_);
+  stats_.bettiCobordism = bws;
+  stats_.b1Bulk = (bws.size() > 1) ? bws[1] : 0;
+  // interior vertex count off the synthesizer.
+  stats_.interiorVertices = static_cast<int>(es.interiorVertexCount());
+
+  const std::size_t d = stateDim_;
+  choiState_.clear();
+  operatorU_.clear();
+  outputState_.clear();
+  const std::size_t registerDim = 0;
+
+  // L_1(W) harmonic read-out. The OPERATOR emerges: it rides on the metric Hodge
+  // harmonic of the WHOLE relaxed system that carries ALL the pinned states (so
+  // the relaxed geometry enters it). The states (psi_A, psi_B AND psi_AB) all stay
+  // pinned; the operator is what we read out. (The interior dim ker L_1(W - dW) is
+  // kept as a topology stat above.)
+  if (!stateLoops_.empty()) {
+    const std::vector<std::complex<double>> psi =
+        es.carriedRepresentativeOverLoops(stateLoops_, stateTargets_);
+    if (!psi.empty()) {
+      // The operator's Choi state: the carried metric harmonic on the first d^2
+      // cells (state-dependent via the relaxed metric; a principled cycle-based
+      // Choi is the next refinement).
+      for (std::size_t j = 0; j < d * d && j < psi.size(); ++j)
+        choiState_.push_back(psi[j]);
+    }
+    // Fidelity diagnostic only (NOT the operator): the emergent ending state from
+    // the inputs alone — carry the inputs, read the output cycles — vs the pinned
+    // target psi_AB.
+    const std::size_t nIn = std::min(inputStates_.size() * 2, stateLoops_.size());
+    if (nIn < stateLoops_.size()) {
+      const std::vector<EigenstateSynthesis::EdgeLoop> inLoops(
+          stateLoops_.begin(), stateLoops_.begin() + static_cast<std::ptrdiff_t>(nIn));
+      const std::vector<std::complex<double>> inTargets(
+          stateTargets_.begin(), stateTargets_.begin() + static_cast<std::ptrdiff_t>(nIn));
+      const std::vector<EigenstateSynthesis::EdgeLoop> outLoops(
+          stateLoops_.begin() + static_cast<std::ptrdiff_t>(nIn), stateLoops_.end());
+      const std::vector<std::complex<double>> psiIn =
+          es.carriedRepresentativeOverLoops(inLoops, inTargets);
+      if (!psiIn.empty()) outputState_ = es.periodsOfCochainOverLoops(psiIn, outLoops);
+    }
+  }
+
+  // Promote the carried Choi state to the operator via the Choi-Jamiolkowski
+  // isomorphism (U = sqrt(d) * unvec(state), the inverse of the Choi-state map).
+  if (!choiState_.empty())
+    operatorU_ = ChoiJamiolkowski::operatorFromChoiState(choiState_,
+                                                         static_cast<int>(d));
+
+  // Topology call-out.
+  {
+    std::string t = "W: b = [";
+    for (std::size_t i = 0; i < bws.size(); ++i)
+      t += std::to_string(bws[i]) + (i + 1 < bws.size() ? "," : "");
+    t += "]; ker L1(W-dW) = " + std::to_string(dim) +
+         "; register ker L1(W) over holes = " + std::to_string(registerDim);
+    stats_.topology = t;
+  }
+
+  // Residual read-out, so the combinatorial search can score each triangulation:
+  // the dual Sorkin action stationarity beta||grad S||^2 plus the joint state
+  // residual r_psi, both at the current metric.
+  ReggeSolver residualSolver(cobordism_, MatterConfiguration());
+  const auto gRes = residualSolver.actionGradientExact();
+  std::set<std::pair<std::uint64_t, std::uint64_t>> interiorSet;
+  for (const auto &uv : es.interiorEdges()) interiorSet.insert(uv);
+  const auto resEdges = cobordism_->getEdgeList()->toVector();
+  double actionN2 = 0.0;  // free (interior) edges only — dW is fixed
+  for (std::size_t i = 0; i < resEdges.size() && i < gRes.size(); ++i)
+    if (interiorSet.count(edgeKey(resEdges[i]))) actionN2 += std::norm(gRes[i]);
+  stats_.statActionResidual = beta_ * actionN2;
+  stats_.dualAction = residualSolver.dualReggeAction();
+  stats_.stateResidual =
+      stateLoops_.empty() ? 0.0 : es.residualForLoops(stateLoops_, stateTargets_);
+  stats_.residual = stats_.statActionResidual + stats_.stateResidual;
+}
+
+}  // namespace tessera::cobordism

--- a/src/quantum/Bindings.cpp
+++ b/src/quantum/Bindings.cpp
@@ -836,6 +836,11 @@ operator U has ``U[i*dB + j] = U_{ij}``. Locked conventions:
             py::arg("U"), py::arg("dA"), py::arg("dB"),
             R"doc(Vectorise a dA×dB operator: vec(U) = Σ_{ij} U_{ij} |i⟩⊗|j⟩,
 the length-(dA·dB) row-major flatten.)doc")
+        .def_static("unvectorize", &ChoiJamiolkowski::unvectorize,
+            py::arg("v"), py::arg("dA"), py::arg("dB"),
+            R"doc(Un-vectorise (the inverse of vectorize): reshape a
+length-(dA·dB) state back into the dA×dB operator U_{ij} = v[i·dB + j].
+The validated row-major reshape, so unvectorize(vectorize(U)) == U.)doc")
         .def_static("singularValues", &ChoiJamiolkowski::singularValues,
             py::arg("U"), py::arg("dA"), py::arg("dB"),
             R"doc(Singular values of the dA×dB operator U (descending); the
@@ -856,6 +861,11 @@ conj(psiA_i)·U_{ij}·psiB_j.)doc")
             py::arg("U"), py::arg("d"),
             R"doc(Choi–Jamiołkowski state (U⊗I)|Φ⁺⟩ = (1/√d)·vec(U) of a square
 d×d operator (length d·d, row-major; a unit vector for unitary U).)doc")
+        .def_static("operatorFromChoiState", &ChoiJamiolkowski::operatorFromChoiState,
+            py::arg("state"), py::arg("d"),
+            R"doc(Recover U from its Choi state (the inverse of choiState):
+U = √d · unvectorize(state), flat row-major (length d·d); the original
+operator up to the global phase the state carries.)doc")
         .def_static("choiMatrix", &ChoiJamiolkowski::choiMatrix,
             py::arg("U"), py::arg("d"),
             R"doc(Choi matrix J(U) = |state⟩⟨state| of a square d×d operator

--- a/src/quantum/ChoiJamiolkowski.cpp
+++ b/src/quantum/ChoiJamiolkowski.cpp
@@ -78,6 +78,17 @@ std::vector<std::complex<double>> ChoiJamiolkowski::vectorize(
     return U;
 }
 
+std::vector<std::complex<double>> ChoiJamiolkowski::unvectorize(
+    const std::vector<std::complex<double>> &v, int dA, int dB) {
+    requirePositiveDims(dA, dB, "ChoiJamiolkowski::unvectorize");
+    // The inverse of vectorize: |v⟩ = Σ_{ij} v_{ij} |i⟩_A ⊗ |j⟩_B reshapes to the
+    // operator U_{ij} = v_{i·dB + j}. With the row-major convention the matrix
+    // buffer is the vector buffer, so validate the length (dA·dB) and return it,
+    // now read as a dA×dB operator.
+    asMatrix(v, dA, dB, "ChoiJamiolkowski::unvectorize");
+    return v;
+}
+
 std::vector<double> ChoiJamiolkowski::singularValues(
     const std::vector<std::complex<double>> &U, int dA, int dB) {
     requirePositiveDims(dA, dB, "ChoiJamiolkowski::singularValues");
@@ -144,6 +155,17 @@ std::vector<std::complex<double>> ChoiJamiolkowski::choiState(
     std::vector<std::complex<double>> state = U;
     for (auto &z : state) z *= inv;
     return state;
+}
+
+std::vector<std::complex<double>> ChoiJamiolkowski::operatorFromChoiState(
+    const std::vector<std::complex<double>> &state, int d) {
+    requirePositiveDims(d, d, "ChoiJamiolkowski::operatorFromChoiState");
+    asMatrix(state, d, d, "ChoiJamiolkowski::operatorFromChoiState");
+    // choiState gives (1/√d)·vec(U); invert by U = √d · unvectorise(state).
+    const double scale = std::sqrt(static_cast<double>(d));
+    std::vector<std::complex<double>> U = state;
+    for (auto &z : U) z *= scale;
+    return U;
 }
 
 std::vector<std::complex<double>> ChoiJamiolkowski::choiMatrix(


### PR DESCRIPTION
## Summary

The single canonical entry point for every interaction/evolution —
`MergeCobordism(initialStates, finalState)` — so welding and other heuristics
outside the gated optimization are structurally impossible. Implemented in C++.
Scope of this PR: the **canonical interface + the operator-recovery gating
verification**. The proton target (tripartite W_ABC → color singlet) is a
follow-on.

The three-way recovery (the object to implement):

| object | source |
|---|---|
| initial states | the boundary `∂W = ⊔ᵢ geo(ψᵢ)` |
| **operator** (Choi state) | `ker L₁(W − ∂W)`, reshaped (ChoiJamiolkowski un-vectorize) = `U` |
| final state | `ker L₁(W)`, accepted iff it matches `finalState` within ε |

Verification-first: per the ticket, the `operator = ker L₁(W − ∂W)` formulation
goes into the spec/docs/code **only once the gating verification passes**. If it
floors, that's reported as the finding.

## Landed so far
- `EigenstateSynthesis::bulkMinusBoundaryHarmonicMatrix` / `bulkMinusBoundaryCells`
  — `ker L₁` of the bulk with the full `∂W` subcomplex deleted (induced subcomplex
  on interior vertices). Reproduces the ticket's bare-merge measurement exactly
  (3 interior vertices → dim ker L₁ = 0).
- `ChoiJamiolkowski::unvectorize` / `operatorFromChoiState` — the literal
  "un-vectorize" reshape, inverses of `vectorize` / `choiState`.

## Test plan (the gating verification, d=2 qubit first, then d=3 color)
- [ ] grow the interior via the reliable gated surgery so `ker L₁(W − ∂W) ≠ 0`
- [ ] `reshape(harmonic eigenvector) == U` for a known non-identity charge-conserving `U`
- [ ] initial states read from `∂W`, final state from `ker L₁(W)`
- [ ] a non-charge-conserving operator is **not** carried (floors)
- [ ] (after green) wire the recovery into the canonical `MergeCobordism` C++ class

## Open item under discussion
The bare merge has 0 interior top cells, so the composed stellar subdivision can't
grow it and `growInterior` is unreliable here. Reliably building a 3D bulk interior
with an internal 1-cycle (so `ker L₁(W − ∂W) ≠ 0`) is the load-bearing step — being
worked out before the reshape==U check.

Closes #363.
