### PR TITLE
chore(ci): run build + full test suite on self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,22 @@ concurrency:
 jobs:
   pip-install:
     name: pip install (py${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tessera]
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
+    env:
+      TESSERA_CUDA: "0"
+      # The runner box is shared (other self-hosted runners + interactive use);
+      # cap build and math-library parallelism so concurrent matrix jobs stay
+      # good neighbors. Tunable.
+      CMAKE_BUILD_PARALLEL_LEVEL: "8"
+      OMP_NUM_THREADS: "8"
+      OPENBLAS_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      BLIS_NUM_THREADS: "1"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,16 +46,16 @@ jobs:
       # search path — so a green run asserts the build still selects
       # pybind11 >= 3.0 and never falls back to the system v2.
       # liblapack/libblas satisfy the (unconditional) quantum subsystem's
-      # BLAS/LAPACK need.
+      # BLAS/LAPACK need. Skipped on self-hosted, where these are already
+      # installed system-wide and the runner user has no sudo.
       - name: Install system packages (incl. pybind11 v2 regression trap)
+        if: runner.environment == 'github-hosted'
         run: |
           sudo apt-get update
           sudo apt-get install -y pybind11-dev liblapack-dev libblas-dev
 
-      - name: Build and install
-        env:
-          TESSERA_CUDA: "0"
-        run: python -m pip install -e . -v
+      - name: Build and install (with dev extras for the test suite)
+        run: python -m pip install -e ".[dev]" -v
 
       - name: Import smoke test
         working-directory: ${{ runner.temp }}
@@ -56,3 +67,8 @@ jobs:
           assert hasattr(tessera, "quantum"), "tessera.quantum is missing"
           print("quantum subsystem present")
           PY
+
+      # Self-hosted gives us the headroom to run the entire suite (it times out
+      # on GitHub-hosted). Runs from the repo root so pytest discovers tests/.
+      - name: Run full test suite
+        run: python -m pytest tests/ -q

--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -175,6 +175,8 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} TDVPRunner.hpp
 ```
+```{doxygenfile} TDVPIntegrator.hpp
+```
 ```{doxygenfile} Quench.hpp
 ```
 ```{doxygenfile} ChoiJamiolkowski.h
@@ -226,6 +228,8 @@ exclusions to see the entire interface.
 ## GPU / CUDA acceleration
 
 ```{doxygenfile} regge_cuda.h
+```
+```{doxygenfile} eigenstate_cuda.h
 ```
 
 ## Core utilities & infrastructure


### PR DESCRIPTION
## Summary

Point `build.yml` at the self-hosted runners and run the **entire** pytest suite
after the build.

- `runs-on: ubuntu-latest` → `runs-on: [self-hosted, tessera]` (5 runners now
  registered + online on this repo).
- Skip the `apt-get` system-deps step on self-hosted (deps pre-installed; runner
  user has no sudo); kept for github-hosted via `runner.environment` so the
  workflow stays portable.
- Build with `.[dev]` extras, then run `pytest tests/` — the full suite, which
  times out on GitHub-hosted runners.
- Cap build/math parallelism (`CMAKE_BUILD_PARALLEL_LEVEL`, OMP/BLAS thread vars)
  so concurrent matrix jobs stay good neighbors on the shared box; `timeout-minutes: 90`.

## Test plan
- [ ] All 3 matrix jobs dispatch to the `tessera` self-hosted runners.
- [ ] Build succeeds without the apt step (deps present system-wide).
- [ ] Full `pytest tests/` suite runs and passes on each Python version.

Closes #373.