### PR TITLE
chore(ci): test only Python 3.13 (drop the build matrix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.13"]
     env:
       TESSERA_CUDA: "0"
       # The runner box is shared (other self-hosted runners + interactive use);


### PR DESCRIPTION
## Summary

Reduce `build.yml`'s `matrix.python-version` from `["3.11", "3.12", "3.13"]` to
`["3.13"]` — one build + full test suite per run instead of three. The full
suite behaves the same on every supported interpreter, so the extra versions
tripled self-hosted runner load (and full-suite wall-clock ×3) without adding
signal. Single-entry matrix kept so the `pip install (py3.13)` job name and
templating are unchanged.

## Test plan
- [ ] Exactly one job (`pip install (py3.13)`) runs on the self-hosted runner.
- [ ] Build + full `pytest tests/` suite pass.

Closes #383.