### PR TITLE
MergeCobordism: rebuild a clean minimal base for the #380 epic

### DIFF
--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -166,6 +166,12 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} Register.h
 ```
+```{doxygenfile} MergeCobordism.h
+```
+```{doxygenfile} TopologyBuilder.h
+```
+```{doxygenfile} TorusOperatorTopology.h
+```
 
 ## Quantum
 

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -366,6 +366,34 @@ class EigenstateSynthesis {
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
+    // === The discovered operator: ker L₁(W − ∂W) (#363) ===
+
+    /// The interior 1-cells of \f$ W - \partial W \f$ — the edges both of whose
+    /// endpoints are **interior** vertices (on no \f$ \partial W \f$ face) — as
+    /// sorted \f$ (u, v) \f$ tuples in canonical `ChainComplex` \f$ C_1 \f$ order:
+    /// the column ordering of `bulkMinusBoundaryHarmonicMatrix`. Empty when there
+    /// is no interior bulk (a bare, un-grown cobordism is all boundary).
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> bulkMinusBoundaryCells()
+        const;
+
+    /// \f$ \ker L_1(W - \partial W) \f$ — the harmonic 1-forms of the
+    /// **combinatorial** (unit-weight, signature-blind) Hodge Laplacian
+    /// \f$ L_1 \f$ of the bulk with the **full \f$ \partial W \f$ subcomplex
+    /// deleted**: the subcomplex induced on the interior vertices (the bulk
+    /// "with the boundary removed"). Restricts the integer boundary maps
+    /// \f$ \partial_1, \partial_2 \f$ (`ChainComplex`) to the interior cells and
+    /// eigendecomposes \f$ L_1 = \partial_1^{\top}\partial_1 +
+    /// \partial_2\partial_2^{\top} \f$, returning the \f$ |\lambda| < \text{tol} \f$
+    /// eigenvectors stacked as the **rows** of a flat row-major
+    /// \f$ \dim\ker L_1 \times |\text{interior } C_1| \f$ complex array
+    /// (ascending-eigenvalue order), columns in `bulkMinusBoundaryCells()` order.
+    /// This is the geometry the **discovered operator** is read from: surgery
+    /// must first grow the interior so this is nonzero (a bare cobordism with
+    /// only a handful of interior vertices carries 0). Read fresh from the live
+    /// complex — surgery between calls moves it.
+    [[nodiscard]] std::vector<std::complex<double>> bulkMinusBoundaryHarmonicMatrix(
+        double tol = 1e-9) const;
+
     // === Surgery: the topology-changing interior remove move (#196) ===
 
     /// The interior top cells eligible for surgery removal: top cells whose

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -366,6 +366,59 @@ class EigenstateSynthesis {
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
+    // === Periods over arbitrary signed edge-loops (#363) ===
+    // A removed triangle reads only its own boundary, but a register cycle (e.g.
+    // a torus S^1) is no triangle's boundary. These read the period of the live
+    // harmonics over ANY closed walk of oriented edges, so both cycles of a T^2
+    // qubit register are pinnable.
+
+    /// An oriented edge \f$ (u \to v) \f$; its period contribution is
+    /// \f$ +h(u,v) \f$ when \f$ u < v \f$ (along the stored orientation), else
+    /// \f$ -h(u,v) \f$.
+    using OrientedEdge = std::pair<std::uint64_t, std::uint64_t>;
+    /// A 1-cycle as a closed walk of oriented edges. A removed triangle
+    /// \f$ h_0 < h_1 < h_2 \f$ is the loop \f$ h_0 \to h_1 \to h_2 \to h_0 \f$
+    /// (the identical signed covector and leak edge).
+    using EdgeLoop = std::vector<OrientedEdge>;
+
+    /// `cyclePeriods` over signed edge-loops: a flat row-major
+    /// \f$ \dim\ker L_k \times |\text{loops}| \f$ matrix whose
+    /// \f$ [r\,|\text{loops}|+q] \f$ entry is harmonic \f$ r \f$ summed along
+    /// loop \f$ q \f$. Reads the live harmonics.
+    [[nodiscard]] std::vector<std::complex<double>> cyclePeriodsOverLoops(
+        const std::vector<EdgeLoop> &loops) const;
+
+    /// `residualForPeriods` over signed edge-loops: \f$ \to 0 \f$ iff
+    /// `targetPeriods` lie in the span the live harmonics carry over `loops`.
+    /// @throws std::runtime_error if `targetPeriods.size() != loops.size()`.
+    [[nodiscard]] double residualForLoops(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// Exact analytic gradient of `residualForLoops` w.r.t. each edge's squared
+    /// length, in `cellSimplices()` order — the shared core of
+    /// `residualForPeriodsGradient`.
+    /// @throws std::runtime_error if `targetPeriods.size() != loops.size()`.
+    [[nodiscard]] std::vector<double> residualForLoopsGradient(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// The carried representative over signed edge-loops (the loop analogue of
+    /// `carriedRepresentative`): the metric harmonic 1-cochain matching
+    /// `targetPeriods` over `loops` (minimum-norm), a full `order()`-length cell
+    /// vector. The whole-W metric harmonic the L_1(W) read-out rides on.
+    [[nodiscard]] std::vector<std::complex<double>> carriedRepresentativeOverLoops(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// The periods of a GIVEN 1-cochain over signed edge-loops:
+    /// \f$ \sum_{(u,v)\in\text{loop}} \pm\,\text{cochain}[uv] \f$ — the discrete
+    /// \f$ \oint \f$ of a supplied cochain (vs the live harmonics in
+    /// `cyclePeriodsOverLoops`). `cochain` is an `order()`-length cell vector.
+    [[nodiscard]] std::vector<std::complex<double>> periodsOfCochainOverLoops(
+        const std::vector<std::complex<double>> &cochain,
+        const std::vector<EdgeLoop> &loops) const;
+
     // === The discovered operator: ker L₁(W − ∂W) (#363) ===
 
     /// The interior 1-cells of \f$ W - \partial W \f$ — the edges both of whose
@@ -531,6 +584,23 @@ class EigenstateSynthesis {
     };
     [[nodiscard]] RegisterReadout assembleRegisterReadout(
         const std::vector<std::vector<std::uint64_t>> &holes) const;
+
+    // The loop analogue of assembleRegisterReadout: P[r*m+q] = sum over loop q's
+    // oriented edges of (+/-1) * H[r, edge]; leak = the loop's first edge.
+    [[nodiscard]] RegisterReadout assembleReadoutOverLoops(
+        const std::vector<EdgeLoop> &loops) const;
+
+    // The carried representative from a finished read-out — shared by the hole
+    // and loop period paths (the lstsq projection plus each cycle's leak).
+    [[nodiscard]] std::vector<std::complex<double>> carriedFromReadout(
+        const RegisterReadout &ro,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    // The cycle-agnostic core of the period-residual gradient: exact
+    // d r_U / d l^2 with the cycles given as signed edge-loops.
+    [[nodiscard]] std::vector<double> periodGradientOverLoops(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
 
     // Re-create the top cell of a Removal (createSimplexTracked rebuilds its
     // missing edges = the orphaned ones) and restore those edges' weights/phases.

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -13,12 +13,14 @@
 #include <vector>
 
 #include "cobordism/HodgeLaplacian.h"
+#include "mesh/Edge.h"
 
 // === tessera subsystem ns fwd-decls ===
 namespace tessera::mesh { class Edge; class Vertex; class Simplex; }
 namespace tessera::spacetime { class Spacetime; }
 namespace tessera::cobordism {
 using namespace ::tessera::spacetime;
+using ::tessera::mesh::Edge;
 
 /// # EigenstateSynthesis
 ///
@@ -372,14 +374,13 @@ class EigenstateSynthesis {
     // harmonics over ANY closed walk of oriented edges, so both cycles of a T^2
     // qubit register are pinnable.
 
-    /// An oriented edge \f$ (u \to v) \f$; its period contribution is
-    /// \f$ +h(u,v) \f$ when \f$ u < v \f$ (along the stored orientation), else
-    /// \f$ -h(u,v) \f$.
-    using OrientedEdge = std::pair<std::uint64_t, std::uint64_t>;
-    /// A 1-cycle as a closed walk of oriented edges. A removed triangle
-    /// \f$ h_0 < h_1 < h_2 \f$ is the loop \f$ h_0 \to h_1 \to h_2 \to h_0 \f$
-    /// (the identical signed covector and leak edge).
-    using EdgeLoop = std::vector<OrientedEdge>;
+    /// A 1-cycle as a closed walk of directed `Edge`s: each edge's
+    /// `getSource() -> getTarget()` is the traversal step, contributing
+    /// \f$ +h(u,v) \f$ when \f$ u < v \f$ (source id < target id) else
+    /// \f$ -h(u,v) \f$. A removed triangle \f$ h_0 < h_1 < h_2 \f$ is the loop
+    /// \f$ h_0 \to h_1 \to h_2 \to h_0 \f$ (the identical signed covector and
+    /// leak edge). Only the endpoints are read; the edges' lengths are unused.
+    using EdgeLoop = std::vector<Edge>;
 
     /// `cyclePeriods` over signed edge-loops: a flat row-major
     /// \f$ \dim\ker L_k \times |\text{loops}| \f$ matrix whose

--- a/include/cobordism/MergeCobordism.h
+++ b/include/cobordism/MergeCobordism.h
@@ -61,6 +61,8 @@ class MergeCobordism {
     ///   are computed from it and `U` is otherwise ignored.
     /// @param beta         weight on the stationary-action residual.
     /// @param epsilon      convergence tolerance on the total residual.
+    /// @param maxIters     interior-relaxation iteration budget (LM steps). The
+    ///   production default is 400; tests pass a small value for speed.
     /// @param seed         RNG seed for the metric jitter.
     /// @param topology     the cobordism topology; null => TorusOperatorTopology.
     /// @param verbose      emit per-iteration relax progress to stderr.
@@ -68,7 +70,7 @@ class MergeCobordism {
         const std::vector<std::vector<std::complex<double>>> &inputStates,
         const std::vector<std::vector<std::complex<double>>> &outputStates,
         const std::vector<std::complex<double>> &U = {}, double beta = 1.0,
-        double epsilon = 1e-6, std::uint64_t seed = 0,
+        double epsilon = 1e-6, int maxIters = 400, std::uint64_t seed = 0,
         std::shared_ptr<TopologyBuilder> topology = nullptr, bool verbose = false);
 
     [[nodiscard]] const std::vector<std::vector<std::complex<double>>> &
@@ -103,6 +105,7 @@ class MergeCobordism {
     std::vector<std::vector<std::complex<double>>> outputStates_{};
     double beta_{1.0};
     double epsilon_{1e-6};
+    int maxIters_{400};
     std::uint64_t seed_{0};
     std::size_t stateDim_{0};
     bool verbose_{false};

--- a/include/cobordism/MergeCobordism.h
+++ b/include/cobordism/MergeCobordism.h
@@ -110,7 +110,7 @@ class MergeCobordism {
 
     // r_psi: the states pinned as period targets over the boundary cycles the
     // topology's readout() supplies.
-    std::vector<std::vector<std::pair<std::uint64_t, std::uint64_t>>> stateLoops_{};
+    std::vector<TopologyBuilder::EdgeLoop> stateLoops_{};
     std::vector<std::complex<double>> stateTargets_{};
 
     // === results ===

--- a/include/cobordism/MergeCobordism.h
+++ b/include/cobordism/MergeCobordism.h
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_MERGECOBORDISM_H
+#define TESSERA_COBORDISM_MERGECOBORDISM_H
+
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cobordism/TopologyBuilder.h"
+
+namespace tessera::spacetime { class Spacetime; }
+
+namespace tessera::cobordism {
+using ::tessera::spacetime::Spacetime;
+
+/// # MergeCobordism
+///
+/// The canonical merge primitive (#363): an **emergent operator** built from
+/// input/output qubit states through a cobordism bulk, mediated by the dual
+/// Lorentzian Regge action while keeping a valid simplicial manifold.
+///
+/// The topology is supplied by a `TopologyBuilder` (#378) — defaulting to the
+/// \f$ (T^2 - 3\,\text{holes}) \times S^1 \f$ operator topology — which builds
+/// \f$ W \f$ and supplies the per-state read-out cycles. The interior edge
+/// lengths are relaxed to a stationary point of the dual Regge action under the
+/// state-pinning residual (`r = \beta\|\nabla S\|^2 + r_\psi`) by a Gauss-Newton
+/// / Levenberg-Marquardt descent on the **exact analytic** Jacobian, using the
+/// **sparse** action Hessian (`actionHessianExactSparse`). The operator is then
+/// read off the relaxed bulk.
+///
+/// ## Modes
+/// * **Emergent** (`U` empty): `outputStates` is required; the operator emerges.
+/// * **U-supplied**: `outputStates` is computed from `U` and the inputs; `U` is
+///   then ignored (a consistency check — the emergent operator should reproduce
+///   the supplied `U`).
+class MergeCobordism {
+  public:
+    /// Convergence + topology statistics of the relaxation.
+    struct Stats {
+      bool converged{false};            ///< the final residual fell below epsilon
+      double residual{0.0};             ///< final total residual r
+      double statActionResidual{0.0};   ///< final \f$ \beta\|\nabla S\|^2 \f$
+      double stateResidual{0.0};        ///< final \f$ r_\psi \f$
+      std::complex<double> dualAction{0.0, 0.0};  ///< final `dualReggeAction()`
+      int relaxIterations{0};           ///< inner LM iterations used
+      std::vector<int> bettiCobordism{};  ///< Betti numbers of \f$ W \f$
+      int b1Bulk{0};                    ///< \f$ b_1(W - \partial W) \f$
+      int kerL1Bulk{0};                 ///< \f$ \dim \ker L_1(W - \partial W) \f$
+      int interiorVertices{0};          ///< interior (non-\f$ \partial W \f$) vertices
+      std::string topology{};           ///< the TopologyBuilder's name
+    };
+
+    /// Build and run the merge.
+    /// @param inputStates  the input qubit states, each a length-\f$ d \f$ vector.
+    /// @param outputStates the expected output state(s); required when `U` empty.
+    /// @param U            optional operator, flat row-major; when set the outputs
+    ///   are computed from it and `U` is otherwise ignored.
+    /// @param beta         weight on the stationary-action residual.
+    /// @param epsilon      convergence tolerance on the total residual.
+    /// @param seed         RNG seed for the metric jitter.
+    /// @param topology     the cobordism topology; null => TorusOperatorTopology.
+    /// @param verbose      emit per-iteration relax progress to stderr.
+    MergeCobordism(
+        const std::vector<std::vector<std::complex<double>>> &inputStates,
+        const std::vector<std::vector<std::complex<double>>> &outputStates,
+        const std::vector<std::complex<double>> &U = {}, double beta = 1.0,
+        double epsilon = 1e-6, std::uint64_t seed = 0,
+        std::shared_ptr<TopologyBuilder> topology = nullptr, bool verbose = false);
+
+    [[nodiscard]] const std::vector<std::vector<std::complex<double>>> &
+    inputStates() const noexcept { return inputStates_; }
+    [[nodiscard]] const std::vector<std::vector<std::complex<double>>> &
+    outputStates() const noexcept { return outputStates_; }
+
+    /// The cobordism \f$ W \f$ (relaxed boundary + bulk).
+    [[nodiscard]] std::shared_ptr<Spacetime> cobordism() const noexcept {
+      return cobordism_;
+    }
+    /// The boundary \f$ \partial W \f$ top-cells.
+    [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &boundary()
+        const noexcept { return boundaryCells_; }
+    /// The bulk \f$ W - \partial W \f$ interior 1-cells (ker L_1 column order).
+    [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &bulk()
+        const noexcept { return bulkCells_; }
+    /// The merge operator \f$ U_{AB} = \operatorname{unvec}(\ker L_1(W-\partial W)) \f$,
+    /// flat row-major \f$ d\times d \f$.
+    [[nodiscard]] const std::vector<std::complex<double>> &operatorU()
+        const noexcept { return operatorU_; }
+    /// The Choi state of the merge operator (the carried \f$ \sum=0 \f$ period
+    /// vector), flat length \f$ d^2 \f$.
+    [[nodiscard]] const std::vector<std::complex<double>> &choiState()
+        const noexcept { return choiState_; }
+
+    [[nodiscard]] const Stats &stats() const noexcept { return stats_; }
+
+  private:
+    // === inputs / configuration ===
+    std::vector<std::vector<std::complex<double>>> inputStates_{};
+    std::vector<std::vector<std::complex<double>>> outputStates_{};
+    double beta_{1.0};
+    double epsilon_{1e-6};
+    std::uint64_t seed_{0};
+    std::size_t stateDim_{0};
+    bool verbose_{false};
+    std::shared_ptr<TopologyBuilder> topology_{};
+
+    // r_psi: the states pinned as period targets over the boundary cycles the
+    // topology's readout() supplies.
+    std::vector<std::vector<std::pair<std::uint64_t, std::uint64_t>>> stateLoops_{};
+    std::vector<std::complex<double>> stateTargets_{};
+
+    // === results ===
+    std::shared_ptr<Spacetime> cobordism_{};
+    std::vector<std::vector<std::uint64_t>> boundaryCells_{};
+    std::vector<std::vector<std::uint64_t>> bulkCells_{};
+    std::vector<std::complex<double>> operatorU_{};
+    std::vector<std::complex<double>> choiState_{};
+    Stats stats_{};
+
+    // === pipeline ===
+    // Compute the output state(s) by applying U to the inputs (U-supplied mode).
+    void computeOutputsFromOperator(const std::vector<std::complex<double>> &U);
+    // The boundary read-out cycles + target periods, from topology_->readout().
+    void computeStateTargets();
+    // Build W via topology_->build(); sets cobordism_, boundaryCells_.
+    void buildSeed();
+    // Relax the interior edge lengths to a stationary point of the dual Regge
+    // action under the state constraints (GN/LM, sparse Hessian). Fills stats_.
+    void optimize();
+    // Read U_AB off the relaxed bulk. Sets operatorU_, choiState_, bulkCells_,
+    // and the topology fields of stats_.
+    void extractOperator();
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_MERGECOBORDISM_H

--- a/include/cobordism/TopologyBuilder.h
+++ b/include/cobordism/TopologyBuilder.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_TOPOLOGYBUILDER_H
+#define TESSERA_COBORDISM_TOPOLOGYBUILDER_H
+
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tessera::spacetime { class Spacetime; }
+
+namespace tessera::cobordism {
+using ::tessera::spacetime::Spacetime;
+
+/// # TopologyBuilder
+///
+/// Pluggable cobordism topology for `MergeCobordism` (#378). A builder
+/// constructs the complex \f$ W \f$ (boundary \f$ \partial W \f$ + bulk) and
+/// supplies the per-state read-out cycles, so `MergeCobordism` is agnostic to
+/// the topology — our \f$ (T^2 - 3\,\text{holes}) \times S^1 \f$ operator
+/// topology vs a \#353-style register rep topology, etc. The two encode
+/// different objects (a qubit operator vs a color rep), so the read-out travels
+/// with the topology rather than being hard-coded in the merge.
+///
+/// Usage is stateful: `build()` constructs \f$ W \f$ and may cache internal data
+/// (holes, strides) that `readout()` then consumes — so call `build()` first.
+class TopologyBuilder {
+  public:
+    /// A signed edge-loop: ordered (source, target) vertex-id pairs whose
+    /// orientation gives each edge's sign in the discrete \f$ \oint \f$.
+    using EdgeLoop = std::vector<std::pair<std::uint64_t, std::uint64_t>>;
+
+    virtual ~TopologyBuilder() = default;
+
+    /// Build \f$ W \f$ (boundary + bulk) for a state dimension \f$ d \f$.
+    /// Populates `boundaryCells` (the \f$ \partial W \f$ top-cells) and returns
+    /// the Spacetime, with the metric seeded off the degenerate uniform point.
+    /// @param stateDim      the qudit dimension \f$ d \f$ (2 for a qubit).
+    /// @param seed          RNG seed for the metric jitter.
+    /// @param boundaryCells out: the \f$ \partial W \f$ top-cells (sorted ids).
+    [[nodiscard]] virtual std::shared_ptr<Spacetime> build(
+        std::size_t stateDim, std::uint64_t seed,
+        std::vector<std::vector<std::uint64_t>> &boundaryCells) = 0;
+
+    /// The pinned-state read-out: the signed edge-loops over \f$ \partial W \f$
+    /// and their target periods, given the states (inputs followed by outputs).
+    /// Defines what the relaxation pins and what the operator/rep read-out reads.
+    /// Requires a prior `build()`.
+    virtual void readout(
+        const std::vector<std::vector<std::complex<double>>> &states,
+        std::vector<EdgeLoop> &loops,
+        std::vector<std::complex<double>> &targets) const = 0;
+
+    /// The carried-object dimension this topology realizes:
+    /// \f$ \dim \ker L_1(W - \partial W) \f$ (e.g. \f$ d^2 - 1 \f$ for the
+    /// operator topology, \f$ b_1 \f$ on the \f$ \sum=0 \f$ hyperplane for a
+    /// register). Used to size and validate the read-out.
+    [[nodiscard]] virtual std::size_t carriedDim(std::size_t stateDim) const = 0;
+
+    /// Human-readable topology name, for `MergeCobordism::Stats::topology`.
+    [[nodiscard]] virtual std::string name() const = 0;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_TOPOLOGYBUILDER_H

--- a/include/cobordism/TopologyBuilder.h
+++ b/include/cobordism/TopologyBuilder.h
@@ -11,10 +11,13 @@
 #include <utility>
 #include <vector>
 
+#include "mesh/Edge.h"
+
 namespace tessera::spacetime { class Spacetime; }
 
 namespace tessera::cobordism {
 using ::tessera::spacetime::Spacetime;
+using ::tessera::mesh::Edge;
 
 /// # TopologyBuilder
 ///
@@ -30,9 +33,11 @@ using ::tessera::spacetime::Spacetime;
 /// (holes, strides) that `readout()` then consumes — so call `build()` first.
 class TopologyBuilder {
   public:
-    /// A signed edge-loop: ordered (source, target) vertex-id pairs whose
-    /// orientation gives each edge's sign in the discrete \f$ \oint \f$.
-    using EdgeLoop = std::vector<std::pair<std::uint64_t, std::uint64_t>>;
+    /// A signed edge-loop: an ordered closed walk of directed `Edge`s, each
+    /// edge's `getSource() -> getTarget()` giving its sign in the discrete
+    /// \f$ \oint \f$ (the carried-period direction). Built over the mesh's
+    /// vertices in `readout()`.
+    using EdgeLoop = std::vector<Edge>;
 
     virtual ~TopologyBuilder() = default;
 
@@ -49,8 +54,11 @@ class TopologyBuilder {
     /// The pinned-state read-out: the signed edge-loops over \f$ \partial W \f$
     /// and their target periods, given the states (inputs followed by outputs).
     /// Defines what the relaxation pins and what the operator/rep read-out reads.
-    /// Requires a prior `build()`.
+    /// The loops' `Edge`s are built over `cobordism`'s vertices, so this needs
+    /// the `cobordism` returned by a prior `build()`.
+    /// @param cobordism the \f$ W \f$ from `build()`, for the loop edges' vertices.
     virtual void readout(
+        const std::shared_ptr<Spacetime> &cobordism,
         const std::vector<std::vector<std::complex<double>>> &states,
         std::vector<EdgeLoop> &loops,
         std::vector<std::complex<double>> &targets) const = 0;

--- a/include/cobordism/TorusOperatorTopology.h
+++ b/include/cobordism/TorusOperatorTopology.h
@@ -24,6 +24,7 @@ class TorusOperatorTopology : public TopologyBuilder {
         std::vector<std::vector<std::uint64_t>> &boundaryCells) override;
 
     void readout(
+        const std::shared_ptr<Spacetime> &cobordism,
         const std::vector<std::vector<std::complex<double>>> &states,
         std::vector<EdgeLoop> &loops,
         std::vector<std::complex<double>> &targets) const override;

--- a/include/cobordism/TorusOperatorTopology.h
+++ b/include/cobordism/TorusOperatorTopology.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_TORUSOPERATORTOPOLOGY_H
+#define TESSERA_COBORDISM_TORUSOPERATORTOPOLOGY_H
+
+#include "cobordism/TopologyBuilder.h"
+
+namespace tessera::cobordism {
+
+/// # TorusOperatorTopology
+///
+/// The \f$ (T^2 - 3\,\text{holes}) \times S^1 \f$ operator topology: \f$ T^3 \f$
+/// minus three \f$ (\text{hole} \times S^1) \f$ solid tori. \f$ \partial W \f$ is
+/// three register tori (one per state, \f$ b_1 = 2 \f$), and
+/// \f$ \ker L_1(W - \partial W) = d^2 - 1 \f$ is the qubit operator. Each state
+/// pins over its torus's two cycles — the hole-circle and the \f$ S^1 \f$ time
+/// loop — so the read-out is six signed edge-loops jointly (over-determining the
+/// bulk \f$ b_1 \f$ by the one charge-conservation relation).
+class TorusOperatorTopology : public TopologyBuilder {
+  public:
+    [[nodiscard]] std::shared_ptr<Spacetime> build(
+        std::size_t stateDim, std::uint64_t seed,
+        std::vector<std::vector<std::uint64_t>> &boundaryCells) override;
+
+    void readout(
+        const std::vector<std::vector<std::complex<double>>> &states,
+        std::vector<EdgeLoop> &loops,
+        std::vector<std::complex<double>> &targets) const override;
+
+    [[nodiscard]] std::size_t carriedDim(std::size_t stateDim) const override {
+      return stateDim * stateDim - 1;  // ker L_1(W - dW), the Sigma=0 Choi dim
+    }
+
+    [[nodiscard]] std::string name() const override {
+      return "(T^2-3holes)xS^1 operator";
+    }
+
+  private:
+    // Cached by build() for readout(): the three qubit boundary holes (sorted
+    // vertex triples) and the S^1 layer stride (vertex-id offset per S^1 layer).
+    std::vector<std::vector<std::uint64_t>> holes_{};
+    std::uint64_t layerStride_{0};
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_TORUSOPERATORTOPOLOGY_H

--- a/include/mesh/Edge.h
+++ b/include/mesh/Edge.h
@@ -7,10 +7,16 @@
 #include "mesh/Fingerprint.h"
 #include "mesh/ForwardDeclarations.h"
 #include "mesh/EdgeKey.h"
+// walkLoop calls Vertex::getId() non-dependently, so Vertex must be COMPLETE at
+// its definition. Vertex.h only forward-declares Edge, so this include is
+// acyclic.
+#include "mesh/Vertex.h"
 
 #include <complex>
 #include <random>
 #include <memory>
+#include <vector>
+#include <cstdint>
 
 
 // === tessera subsystem ns fwd-decls ===
@@ -181,6 +187,19 @@ class Edge {
     /// Set the U(1) connection phase (radians).  Used by the Hermitian-weighted
     /// Laplacian and its gauge transform to rephase the edge without rebuilding the mesh.
     void setPhase(double p) noexcept { phase = p; }
+
+    /// Walk a closed loop of ordered directed steps (each Edge's
+    /// getSource()->getTarget() is one traversal step). Invokes f(sourceId,
+    /// targetId, sign) per step; sign = +1 if sourceId < targetId (canonical
+    /// orientation) else -1.
+    template <typename F>
+    static void walkLoop(const std::vector<Edge> &loop, F &&f) {
+      for (const Edge &step : loop) {
+        const std::uint64_t u = step.getSource()->getId();
+        const std::uint64_t v = step.getTarget()->getId();
+        f(u, v, (u < v) ? 1.0 : -1.0);
+      }
+    }
 
     /// The Van Raamsdonk metric law: the spacelike signed squared length for a
     /// given mutual information ``I`` — the value to store as ``squaredLength``

--- a/include/quantum/ChoiJamiolkowski.h
+++ b/include/quantum/ChoiJamiolkowski.h
@@ -74,6 +74,15 @@ class ChoiJamiolkowski {
     [[nodiscard]] static std::vector<std::complex<double>> vectorize(
         const std::vector<std::complex<double>> &U, int dA, int dB);
 
+    /// Un-vectorise — the inverse of `vectorize`: reshape a length-(dA·dB) state
+    /// |v⟩ = Σ_{ij} v_{ij} |i⟩_A ⊗ |j⟩_B back into the dA×dB operator U with
+    /// U_{ij} = v_{i·dB + j}. With the row-major convention this is the validated
+    /// reshape — the returned buffer equals the input (length dA·dB), now read as
+    /// a matrix — so `unvectorize(vectorize(U), dA, dB) == U`. Throws
+    /// std::invalid_argument if v.size() != dA·dB or a dimension is non-positive.
+    [[nodiscard]] static std::vector<std::complex<double>> unvectorize(
+        const std::vector<std::complex<double>> &v, int dA, int dB);
+
     /// Singular values of the dA×dB operator U (Eigen JacobiSVD), in descending
     /// order; min(dA, dB) of them. These are the Schmidt coefficients of vec(U).
     [[nodiscard]] static std::vector<double> singularValues(
@@ -108,6 +117,15 @@ class ChoiJamiolkowski {
     /// if U.size() != d·d or d is non-positive.
     [[nodiscard]] static std::vector<std::complex<double>> choiState(
         const std::vector<std::complex<double>> &U, int d);
+
+    /// Recover the operator U from its Choi–Jamiołkowski *state* — the inverse of
+    /// `choiState`. Since |Φ_U⟩ = (1/√d)·vec(U), U = √d · unvectorise(state),
+    /// returned flat row-major (length d·d). For a unit Choi state of a unitary
+    /// this is that unitary up to the global phase the state carries (so compare
+    /// up to phase). Throws std::invalid_argument if state.size() != d·d or d is
+    /// non-positive.
+    [[nodiscard]] static std::vector<std::complex<double>> operatorFromChoiState(
+        const std::vector<std::complex<double>> &state, int d);
 
     /// Choi *matrix* J(U) = |Φ_U⟩⟨Φ_U| of a square d×d operator U: the
     /// (d·d)×(d·d) density matrix of choiState(U, d), returned flat row-major

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -1298,13 +1298,15 @@ prepared states, reproduces the harmonic overlap.)doc")
   mc.def(py::init([](const std::vector<std::vector<std::complex<double>>> &in,
                      const std::vector<std::vector<std::complex<double>>> &out,
                      const std::vector<std::complex<double>> &U, double beta,
-                     double epsilon, std::uint64_t seed, bool verbose) {
-           return std::make_unique<MergeCobordism>(in, out, U, beta, epsilon,
-                                                   seed, nullptr, verbose);
+                     double epsilon, int maxIters, std::uint64_t seed,
+                     bool verbose) {
+           return std::make_unique<MergeCobordism>(
+               in, out, U, beta, epsilon, maxIters, seed, nullptr, verbose);
          }),
          py::arg("input_states"), py::arg("output_states"),
          py::arg("U") = std::vector<std::complex<double>>{},
-         py::arg("beta") = 1.0, py::arg("epsilon") = 1e-6, py::arg("seed") = 0,
+         py::arg("beta") = 1.0, py::arg("epsilon") = 1e-6,
+         py::arg("max_iters") = 400, py::arg("seed") = 0,
          py::arg("verbose") = false,
          "Build and run the merge on the default (T^2-3holes)xS^1 operator "
          "topology. output_states is required unless U (a flat row-major dxd "

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -23,6 +23,7 @@
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
+#include "cobordism/MergeCobordism.h"
 #include "cobordism/PreparedBoundaryState.h"
 #include "cobordism/RealizabilityOracle.h"
 #include "cobordism/Register.h"
@@ -1272,4 +1273,53 @@ prepared states, reproduces the harmonic overlap.)doc")
            "dimensions differ.")
       .def("norm", &PreparedBoundaryState::norm,
            "The Euclidean norm sqrt(sum |c_a|^2) of the amplitude vector.");
+
+  // === MergeCobordism (#363 / #388) ===
+  py::class_<MergeCobordism> mc(m, "MergeCobordism",
+      "The canonical merge primitive: an emergent operator built from input/"
+      "output qubit states through a cobordism bulk, mediated by the dual "
+      "Lorentzian Regge action (relaxed with the sparse analytic Hessian) on a "
+      "TopologyBuilder topology.");
+  py::class_<MergeCobordism::Stats>(mc, "Stats",
+      "Convergence + topology statistics of the relaxation.")
+      .def_readonly("converged", &MergeCobordism::Stats::converged)
+      .def_readonly("residual", &MergeCobordism::Stats::residual)
+      .def_readonly("stat_action_residual",
+                    &MergeCobordism::Stats::statActionResidual)
+      .def_readonly("state_residual", &MergeCobordism::Stats::stateResidual)
+      .def_readonly("dual_action", &MergeCobordism::Stats::dualAction)
+      .def_readonly("relax_iterations", &MergeCobordism::Stats::relaxIterations)
+      .def_readonly("betti_cobordism", &MergeCobordism::Stats::bettiCobordism)
+      .def_readonly("b1_bulk", &MergeCobordism::Stats::b1Bulk)
+      .def_readonly("ker_l1_bulk", &MergeCobordism::Stats::kerL1Bulk)
+      .def_readonly("interior_vertices",
+                    &MergeCobordism::Stats::interiorVertices)
+      .def_readonly("topology", &MergeCobordism::Stats::topology);
+  mc.def(py::init([](const std::vector<std::vector<std::complex<double>>> &in,
+                     const std::vector<std::vector<std::complex<double>>> &out,
+                     const std::vector<std::complex<double>> &U, double beta,
+                     double epsilon, std::uint64_t seed, bool verbose) {
+           return std::make_unique<MergeCobordism>(in, out, U, beta, epsilon,
+                                                   seed, nullptr, verbose);
+         }),
+         py::arg("input_states"), py::arg("output_states"),
+         py::arg("U") = std::vector<std::complex<double>>{},
+         py::arg("beta") = 1.0, py::arg("epsilon") = 1e-6, py::arg("seed") = 0,
+         py::arg("verbose") = false,
+         "Build and run the merge on the default (T^2-3holes)xS^1 operator "
+         "topology. output_states is required unless U (a flat row-major dxd "
+         "operator) is supplied, in which case it is computed from U.")
+      .def_property_readonly("input_states", &MergeCobordism::inputStates)
+      .def_property_readonly("output_states", &MergeCobordism::outputStates)
+      .def_property_readonly("cobordism", &MergeCobordism::cobordism,
+                             "The cobordism W (relaxed boundary + bulk).")
+      .def_property_readonly("boundary", &MergeCobordism::boundary,
+                             "The boundary dW top-cells.")
+      .def_property_readonly("bulk", &MergeCobordism::bulk,
+                             "The bulk W - dW interior 1-cells.")
+      .def_property_readonly("operator_U", &MergeCobordism::operatorU,
+                             "The merge operator (empty until the #6 read-out).")
+      .def_property_readonly("choi_state", &MergeCobordism::choiState,
+                             "The operator's Choi state (empty until #6).")
+      .def_property_readonly("stats", &MergeCobordism::stats);
 }

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -529,6 +529,27 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "approximation (~1e-5 vs FP64); residualForPeriodsGradient stays the "
            "default and the correctness oracle. Requires a TESSERA_CUDA build "
            "(raises otherwise), and raises on a hole/target length mismatch.")
+      // ----- The discovered operator: ker L1(W - dW) (#363) -----
+      .def("bulkMinusBoundaryCells",
+           &EigenstateSynthesis::bulkMinusBoundaryCells,
+           "The interior 1-cells of W - dW (edges both of whose endpoints are "
+           "interior vertices, on no dW face), as sorted (u,v) tuples in "
+           "canonical ChainComplex C_1 order -- the column ordering of "
+           "bulkMinusBoundaryHarmonicMatrix. Empty for a bare (un-grown) "
+           "cobordism (all boundary, no interior bulk).")
+      .def("bulkMinusBoundaryHarmonicMatrix",
+           &EigenstateSynthesis::bulkMinusBoundaryHarmonicMatrix,
+           py::arg("tol") = 1e-9,
+           "ker L1(W - dW): the harmonic 1-forms of the combinatorial "
+           "(unit-weight, signature-blind) Hodge Laplacian L1 of the bulk with "
+           "the full dW subcomplex deleted (the subcomplex induced on the "
+           "interior vertices). Restricts the integer boundary maps d1, d2 to "
+           "the interior cells and eigendecomposes L1 = d1^T d1 + d2 d2^T, "
+           "returning the |lambda| < tol eigenvectors stacked as the ROWS of a "
+           "flat row-major (dim ker L1) x len(bulkMinusBoundaryCells()) complex "
+           "array (ascending eigenvalue). The geometry the discovered operator "
+           "is read from -- surgery must first grow the interior so this is "
+           "nonzero. Read fresh from the live complex.")
       // ----- Surgery: the topology-changing interior remove move (#196) -----
       .def("interiorTopCells", &EigenstateSynthesis::interiorTopCells,
            "The interior top cells (all-interior vertices, on no dW face) as "

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1058,8 +1058,7 @@ EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleReadoutOverLoo
           "EigenstateSynthesis::assembleReadoutOverLoops: loop " +
           std::to_string(q) + " is empty");
     bool first = true;
-    for (const Edge &oe : loops[q]) {
-      const std::uint64_t a = oe.getSource()->getId(), b = oe.getTarget()->getId();
+    Edge::walkLoop(loops[q], [&](std::uint64_t a, std::uint64_t b, double s) {
       const std::vector<std::uint64_t> e = {std::min(a, b), std::max(a, b)};
       const auto it = col.find(e);
       if (it == col.end())
@@ -1067,14 +1066,13 @@ EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleReadoutOverLoo
             "EigenstateSynthesis::assembleReadoutOverLoops: loop edge (" +
             std::to_string(a) + "," + std::to_string(b) +
             ") is not a k-cell of the complex");
-      const double s = (a < b) ? 1.0 : -1.0;
       if (first) {
         out.leakColumns.push_back(it->second);
         first = false;
       }
       for (std::size_t r = 0; r < out.dim; ++r)
         out.P[r * m + q] += s * out.H[r * n + it->second];
-    }
+    });
   }
   return out;
 }
@@ -1104,8 +1102,7 @@ std::vector<cd> EigenstateSynthesis::periodsOfCochainOverLoops(
   for (std::size_t i = 0; i < cellOrdering_.size(); ++i) col[cellOrdering_[i]] = i;
   std::vector<cd> out(loops.size(), cd(0.0, 0.0));
   for (std::size_t q = 0; q < loops.size(); ++q)
-    for (const Edge &oe : loops[q]) {
-      const std::uint64_t a = oe.getSource()->getId(), b = oe.getTarget()->getId();
+    Edge::walkLoop(loops[q], [&](std::uint64_t a, std::uint64_t b, double s) {
       const std::vector<std::uint64_t> e = {std::min(a, b), std::max(a, b)};
       const auto it = col.find(e);
       if (it == col.end())
@@ -1114,9 +1111,8 @@ std::vector<cd> EigenstateSynthesis::periodsOfCochainOverLoops(
             std::to_string(a) + "," + std::to_string(b) +
             ") is not a k-cell of the complex");
       if (it->second < cochain.size())
-        out[q] += (a < b ? cd(1.0, 0.0) : cd(-1.0, 0.0)) *
-                  cochain[it->second];
-    }
+        out[q] += cd(s, 0.0) * cochain[it->second];
+    });
   return out;
 }
 
@@ -1220,12 +1216,10 @@ std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
           std::to_string(q) + " is empty");
     const Edge &fe = loop.front();
     leakCol[q] = cidx1.at(key(fe.getSource()->getId(), fe.getTarget()->getId()));
-    for (const Edge &oe : loop) {
-      const std::uint64_t a = oe.getSource()->getId(), b = oe.getTarget()->getId();
-      const double s = (a < b) ? 1.0 : -1.0;
+    Edge::walkLoop(loop, [&](std::uint64_t a, std::uint64_t b, double s) {
       Q(static_cast<Index>(q),
         static_cast<Index>(cidx1.at(key(a, b)))) += s;
-    }
+    });
   }
 
   // ---- eigendecomposition of M; harmonic (null) / non-null split ----

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -981,10 +981,19 @@ std::vector<cd> EigenstateSynthesis::carriedRepresentative(
         "EigenstateSynthesis::carriedRepresentative: " +
         std::to_string(targetPeriods.size()) + " target periods for " +
         std::to_string(holes.size()) + " holes");
-  const RegisterReadout ro = assembleRegisterReadout(holes);
+  return carriedFromReadout(assembleRegisterReadout(holes), targetPeriods);
+}
+
+std::vector<cd> EigenstateSynthesis::carriedFromReadout(
+    const RegisterReadout &ro, const std::vector<cd> &targetPeriods) const {
   const std::size_t n = order_;
-  const std::size_t m = holes.size();
+  const std::size_t m = ro.leakColumns.size();
   if (n == 0) return {};
+  if (targetPeriods.size() != m)
+    throw std::runtime_error(
+        "EigenstateSynthesis::carriedFromReadout: " +
+        std::to_string(targetPeriods.size()) + " target periods for " +
+        std::to_string(m) + " cycles");
 
   // The minimum-norm least-squares projection onto the carried period rows
   // (what numpy.linalg.lstsq returns): c = (P^T)^+ target via the SVD.
@@ -1003,7 +1012,7 @@ std::vector<cd> EigenstateSynthesis::carriedRepresentative(
   }
 
   // The carried representative plus the minimal leak: psi = sum_r c_r h_r,
-  // then each hole's uncarried remainder lands on its leak column, so the
+  // then each cycle's uncarried remainder lands on its leak column, so the
   // cochain's periods are exactly the targets.
   std::vector<cd> psi(n, cd(0.0, 0.0));
   for (std::size_t r = 0; r < ro.dim; ++r) {
@@ -1019,6 +1028,98 @@ std::vector<cd> EigenstateSynthesis::carriedRepresentative(
   return psi;
 }
 
+EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleReadoutOverLoops(
+    const std::vector<EdgeLoop> &loops) const {
+  RegisterReadout out;
+  const std::size_t n = order_;
+  out.H = HodgeLaplacian(st_).harmonicMatrix(k_, 1e-9, /*metric=*/true);
+  if (n == 0) {
+    if (!loops.empty())
+      throw std::runtime_error(
+          "EigenstateSynthesis::assembleReadoutOverLoops: the complex has no "
+          "k-cells to carry periods");
+    return out;
+  }
+  if (out.H.size() % n != 0)
+    throw std::runtime_error(
+        "EigenstateSynthesis::assembleReadoutOverLoops: the harmonic matrix "
+        "width " + std::to_string(out.H.size()) +
+        " is not a multiple of the captured operator dimension " +
+        std::to_string(n));
+  out.dim = out.H.size() / n;
+  std::map<std::vector<std::uint64_t>, std::size_t> col;
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i) col[cellOrdering_[i]] = i;
+  const std::size_t m = loops.size();
+  out.P.assign(out.dim * m, cd(0.0, 0.0));
+  out.leakColumns.reserve(m);
+  for (std::size_t q = 0; q < m; ++q) {
+    if (loops[q].empty())
+      throw std::runtime_error(
+          "EigenstateSynthesis::assembleReadoutOverLoops: loop " +
+          std::to_string(q) + " is empty");
+    bool first = true;
+    for (const OrientedEdge &oe : loops[q]) {
+      const std::uint64_t a = oe.first, b = oe.second;
+      const std::vector<std::uint64_t> e = {std::min(a, b), std::max(a, b)};
+      const auto it = col.find(e);
+      if (it == col.end())
+        throw std::runtime_error(
+            "EigenstateSynthesis::assembleReadoutOverLoops: loop edge (" +
+            std::to_string(a) + "," + std::to_string(b) +
+            ") is not a k-cell of the complex");
+      const double s = (a < b) ? 1.0 : -1.0;
+      if (first) {
+        out.leakColumns.push_back(it->second);
+        first = false;
+      }
+      for (std::size_t r = 0; r < out.dim; ++r)
+        out.P[r * m + q] += s * out.H[r * n + it->second];
+    }
+  }
+  return out;
+}
+
+std::vector<cd> EigenstateSynthesis::cyclePeriodsOverLoops(
+    const std::vector<EdgeLoop> &loops) const {
+  return assembleReadoutOverLoops(loops).P;
+}
+
+double EigenstateSynthesis::residualForLoops(
+    const std::vector<EdgeLoop> &loops,
+    const std::vector<cd> &targetPeriods) const {
+  const std::vector<cd> psi =
+      carriedFromReadout(assembleReadoutOverLoops(loops), targetPeriods);
+  if (psi.empty()) return 0.0;
+  return residual(psi);
+}
+
+std::vector<cd> EigenstateSynthesis::carriedRepresentativeOverLoops(
+    const std::vector<EdgeLoop> &loops, const std::vector<cd> &targetPeriods) const {
+  return carriedFromReadout(assembleReadoutOverLoops(loops), targetPeriods);
+}
+
+std::vector<cd> EigenstateSynthesis::periodsOfCochainOverLoops(
+    const std::vector<cd> &cochain, const std::vector<EdgeLoop> &loops) const {
+  std::map<std::vector<std::uint64_t>, std::size_t> col;
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i) col[cellOrdering_[i]] = i;
+  std::vector<cd> out(loops.size(), cd(0.0, 0.0));
+  for (std::size_t q = 0; q < loops.size(); ++q)
+    for (const OrientedEdge &oe : loops[q]) {
+      const std::vector<std::uint64_t> e = {std::min(oe.first, oe.second),
+                                            std::max(oe.first, oe.second)};
+      const auto it = col.find(e);
+      if (it == col.end())
+        throw std::runtime_error(
+            "EigenstateSynthesis::periodsOfCochainOverLoops: loop edge (" +
+            std::to_string(oe.first) + "," + std::to_string(oe.second) +
+            ") is not a k-cell of the complex");
+      if (it->second < cochain.size())
+        out[q] += (oe.first < oe.second ? cd(1.0, 0.0) : cd(-1.0, 0.0)) *
+                  cochain[it->second];
+    }
+  return out;
+}
+
 double EigenstateSynthesis::residualForPeriods(
     const std::vector<std::vector<std::uint64_t>> &holes,
     const std::vector<cd> &targetPeriods) const {
@@ -1027,8 +1128,8 @@ double EigenstateSynthesis::residualForPeriods(
   return residual(psi);
 }
 
-std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
-    const std::vector<std::vector<std::uint64_t>> &holes,
+std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
+    const std::vector<EdgeLoop> &loops,
     const std::vector<cd> &targetPeriods) const {
   using Eigen::Index;
   using Eigen::MatrixXd;
@@ -1036,13 +1137,13 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
   using Eigen::VectorXd;
   const std::size_t n1 = order_;
   std::vector<double> grad(n1, 0.0);
-  const std::size_t m = holes.size();
+  const std::size_t m = loops.size();
   if (n1 == 0 || m == 0) return grad;
   if (targetPeriods.size() != m)
     throw std::runtime_error(
-        "EigenstateSynthesis::residualForPeriodsGradient: " +
+        "EigenstateSynthesis::periodGradientOverLoops: " +
         std::to_string(targetPeriods.size()) + " target periods for " +
-        std::to_string(m) + " holes");
+        std::to_string(m) + " loops");
   static constexpr double kNullTol = 1e-7;
   const Index N = static_cast<Index>(n1);
 
@@ -1105,19 +1206,24 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
     return it == l2map.end() ? 0.0 : it->second;
   };
 
-  // ---- Q (hole-boundary covector) + each hole's leak column ----
+  // ---- Q (signed edge-loop covector) + each cycle's leak column ----
+  // Generalizes the removed-triangle boundary to any closed walk of oriented
+  // edges: Q(q, edge) += +1 along the stored orientation, -1 against; the leak
+  // is the loop's first edge.
   MatrixXd Q = MatrixXd::Zero(static_cast<Index>(m), N);
   std::vector<std::size_t> leakCol(m);
   for (std::size_t q = 0; q < m; ++q) {
-    const auto &h = holes[q];
-    for (int j = 0; j < 3; ++j) {
-      std::vector<std::uint64_t> facet;
-      for (int i = 0; i < 3; ++i)
-        if (i != j) facet.push_back(h[i]);
-      Q(static_cast<Index>(q), static_cast<Index>(cidx1.at(key(facet[0], facet[1])))) +=
-          (j % 2 == 0 ? 1.0 : -1.0);
+    const EdgeLoop &loop = loops[q];
+    if (loop.empty())
+      throw std::runtime_error(
+          "EigenstateSynthesis::periodGradientOverLoops: loop " +
+          std::to_string(q) + " is empty");
+    leakCol[q] = cidx1.at(key(loop.front().first, loop.front().second));
+    for (const OrientedEdge &oe : loop) {
+      const double s = (oe.first < oe.second) ? 1.0 : -1.0;
+      Q(static_cast<Index>(q),
+        static_cast<Index>(cidx1.at(key(oe.first, oe.second)))) += s;
     }
-    leakCol[q] = cidx1.at(key(h[0], h[1]));
   }
 
   // ---- eigendecomposition of M; harmonic (null) / non-null split ----
@@ -1219,6 +1325,31 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
                (2.0 * rU / nrm) * (p.dot(dpsi)).real();
   }
   return grad;
+}
+
+std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+  // A removed triangle's boundary IS the oriented loop h0 -> h1 -> h2 -> h0
+  // (identical signed covector and leak), so route through the loop core.
+  std::vector<EdgeLoop> loops;
+  loops.reserve(holes.size());
+  for (const auto &h : holes) {
+    if (h.size() != 3)
+      throw std::runtime_error(
+          "EigenstateSynthesis::residualForPeriodsGradient: hole has " +
+          std::to_string(h.size()) + " vertices, expected 3");
+    std::vector<std::uint64_t> s(h);
+    std::sort(s.begin(), s.end());
+    loops.push_back({{s[0], s[1]}, {s[1], s[2]}, {s[2], s[0]}});
+  }
+  return periodGradientOverLoops(loops, targetPeriods);
+}
+
+std::vector<double> EigenstateSynthesis::residualForLoopsGradient(
+    const std::vector<EdgeLoop> &loops,
+    const std::vector<cd> &targetPeriods) const {
+  return periodGradientOverLoops(loops, targetPeriods);
 }
 
 std::vector<double> EigenstateSynthesis::residualForPeriodsGradientGpu(

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1058,8 +1058,8 @@ EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleReadoutOverLoo
           "EigenstateSynthesis::assembleReadoutOverLoops: loop " +
           std::to_string(q) + " is empty");
     bool first = true;
-    for (const OrientedEdge &oe : loops[q]) {
-      const std::uint64_t a = oe.first, b = oe.second;
+    for (const Edge &oe : loops[q]) {
+      const std::uint64_t a = oe.getSource()->getId(), b = oe.getTarget()->getId();
       const std::vector<std::uint64_t> e = {std::min(a, b), std::max(a, b)};
       const auto it = col.find(e);
       if (it == col.end())
@@ -1104,17 +1104,17 @@ std::vector<cd> EigenstateSynthesis::periodsOfCochainOverLoops(
   for (std::size_t i = 0; i < cellOrdering_.size(); ++i) col[cellOrdering_[i]] = i;
   std::vector<cd> out(loops.size(), cd(0.0, 0.0));
   for (std::size_t q = 0; q < loops.size(); ++q)
-    for (const OrientedEdge &oe : loops[q]) {
-      const std::vector<std::uint64_t> e = {std::min(oe.first, oe.second),
-                                            std::max(oe.first, oe.second)};
+    for (const Edge &oe : loops[q]) {
+      const std::uint64_t a = oe.getSource()->getId(), b = oe.getTarget()->getId();
+      const std::vector<std::uint64_t> e = {std::min(a, b), std::max(a, b)};
       const auto it = col.find(e);
       if (it == col.end())
         throw std::runtime_error(
             "EigenstateSynthesis::periodsOfCochainOverLoops: loop edge (" +
-            std::to_string(oe.first) + "," + std::to_string(oe.second) +
+            std::to_string(a) + "," + std::to_string(b) +
             ") is not a k-cell of the complex");
       if (it->second < cochain.size())
-        out[q] += (oe.first < oe.second ? cd(1.0, 0.0) : cd(-1.0, 0.0)) *
+        out[q] += (a < b ? cd(1.0, 0.0) : cd(-1.0, 0.0)) *
                   cochain[it->second];
     }
   return out;
@@ -1218,11 +1218,13 @@ std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
       throw std::runtime_error(
           "EigenstateSynthesis::periodGradientOverLoops: loop " +
           std::to_string(q) + " is empty");
-    leakCol[q] = cidx1.at(key(loop.front().first, loop.front().second));
-    for (const OrientedEdge &oe : loop) {
-      const double s = (oe.first < oe.second) ? 1.0 : -1.0;
+    const Edge &fe = loop.front();
+    leakCol[q] = cidx1.at(key(fe.getSource()->getId(), fe.getTarget()->getId()));
+    for (const Edge &oe : loop) {
+      const std::uint64_t a = oe.getSource()->getId(), b = oe.getTarget()->getId();
+      const double s = (a < b) ? 1.0 : -1.0;
       Q(static_cast<Index>(q),
-        static_cast<Index>(cidx1.at(key(oe.first, oe.second)))) += s;
+        static_cast<Index>(cidx1.at(key(a, b)))) += s;
     }
   }
 
@@ -1332,6 +1334,14 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
     const std::vector<cd> &targetPeriods) const {
   // A removed triangle's boundary IS the oriented loop h0 -> h1 -> h2 -> h0
   // (identical signed covector and leak), so route through the loop core.
+  auto &vlist = *st_->getVertexList();
+  auto edge = [&](std::uint64_t u, std::uint64_t v) {
+    auto *vu = vlist.get(u), *vv = vlist.get(v);
+    if (!vu || !vv)
+      throw std::runtime_error(
+          "EigenstateSynthesis::residualForPeriodsGradient: hole vertex absent");
+    return Edge(vu, vv, cd(1.0, 0.0));
+  };
   std::vector<EdgeLoop> loops;
   loops.reserve(holes.size());
   for (const auto &h : holes) {
@@ -1341,7 +1351,7 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
           std::to_string(h.size()) + " vertices, expected 3");
     std::vector<std::uint64_t> s(h);
     std::sort(s.begin(), s.end());
-    loops.push_back({{s[0], s[1]}, {s[1], s[2]}, {s[2], s[0]}});
+    loops.push_back({edge(s[0], s[1]), edge(s[1], s[2]), edge(s[2], s[0])});
   }
   return periodGradientOverLoops(loops, targetPeriods);
 }

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -802,6 +802,92 @@ std::pair<bool, std::string> EigenstateSynthesis::dualComplexValid() const {
                   : std::vector<std::vector<std::uint64_t>>{});
 }
 
+// === The discovered operator: ker L₁(W − ∂W) (#363) ===
+
+std::vector<std::vector<std::uint64_t>>
+EigenstateSynthesis::bulkMinusBoundaryCells() const {
+  std::vector<std::vector<std::uint64_t>> out;
+  if (!st_) return out;
+  const std::unordered_set<std::uint64_t> bverts(
+      boundaryVertexIdsSorted_.begin(), boundaryVertexIdsSorted_.end());
+  for (auto &e : ChainComplex::fromSpacetime(*st_).kSimplexVertices(1)) {
+    bool interior = true;
+    for (const std::uint64_t v : e)
+      if (bverts.count(v)) { interior = false; break; }
+    if (interior) out.push_back(e);
+  }
+  return out;
+}
+
+std::vector<cd> EigenstateSynthesis::bulkMinusBoundaryHarmonicMatrix(
+    double tol) const {
+  using Eigen::Index;
+  using Eigen::MatrixXd;
+  if (!st_) return {};
+
+  // W − ∂W is the subcomplex induced on the interior vertices (the ones on no
+  // ∂W face); a cell belongs to it iff all of its vertices are interior. This is
+  // the ticket's "boundary removed" — and ties to its measured "3 interior
+  // vertices carry nothing" (too few interior vertices ⇒ no interior 1-cycle).
+  const std::unordered_set<std::uint64_t> bverts(
+      boundaryVertexIdsSorted_.begin(), boundaryVertexIdsSorted_.end());
+  const auto interiorCell = [&](const std::vector<std::uint64_t> &c) {
+    for (const std::uint64_t v : c)
+      if (bverts.count(v)) return false;
+    return true;
+  };
+
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const auto v0 = cc.kSimplexVertices(0);
+  const auto v1 = cc.kSimplexVertices(1);
+  const auto v2 = cc.kSimplexVertices(2);
+  const std::size_t n0 = v0.size(), n1 = v1.size(), n2 = v2.size();
+  if (n1 == 0) return {};
+
+  // The interior-cell index lists into the full C_k orderings.
+  std::vector<Index> i0, i1, i2;
+  for (std::size_t i = 0; i < n0; ++i)
+    if (interiorCell(v0[i])) i0.push_back(static_cast<Index>(i));
+  for (std::size_t i = 0; i < n1; ++i)
+    if (interiorCell(v1[i])) i1.push_back(static_cast<Index>(i));
+  for (std::size_t i = 0; i < n2; ++i)
+    if (interiorCell(v2[i])) i2.push_back(static_cast<Index>(i));
+  const Index m1 = static_cast<Index>(i1.size());
+  if (m1 == 0) return {};
+
+  // Restrict ∂₁ (n0×n1) and ∂₂ (n1×n2) to the interior rows/columns, then the
+  // combinatorial L₁ = ∂₁ᵀ∂₁ + ∂₂∂₂ᵀ (unit weights — the magnitude,
+  // signature-blind register the merge reads with harmonicMatrix(1,·,False)).
+  const std::vector<long> &d1 = cc.boundaryMatrix(1);
+  const std::vector<long> &d2 = cc.boundaryMatrix(2);
+  MatrixXd D1 = MatrixXd::Zero(static_cast<Index>(i0.size()), m1);
+  for (Index r = 0; r < static_cast<Index>(i0.size()); ++r)
+    for (Index c = 0; c < m1; ++c)
+      D1(r, c) = static_cast<double>(
+          d1[static_cast<std::size_t>(i0[r]) * n1 + static_cast<std::size_t>(i1[c])]);
+  MatrixXd L = D1.transpose() * D1;
+  if (!i2.empty()) {
+    MatrixXd D2 = MatrixXd::Zero(m1, static_cast<Index>(i2.size()));
+    for (Index r = 0; r < m1; ++r)
+      for (Index c = 0; c < static_cast<Index>(i2.size()); ++c)
+        D2(r, c) = static_cast<double>(
+            d2[static_cast<std::size_t>(i1[r]) * n2 + static_cast<std::size_t>(i2[c])]);
+    L += D2 * D2.transpose();
+  }
+
+  // ker L₁ ≅ H₁ of the interior: the |λ| < tol eigenvectors, stacked as rows in
+  // ascending-eigenvalue order (matching HodgeLaplacian::harmonicMatrix).
+  Eigen::SelfAdjointEigenSolver<MatrixXd> eig(L);
+  const Eigen::VectorXd &lam = eig.eigenvalues();
+  const MatrixXd &V = eig.eigenvectors();
+  std::vector<cd> out;
+  for (Index j = 0; j < lam.size(); ++j) {
+    if (std::abs(lam[j]) >= tol) continue;
+    for (Index i = 0; i < m1; ++i) out.push_back(cd(V(i, j), 0.0));
+  }
+  return out;
+}
+
 EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleRegisterReadout(
     const std::vector<std::vector<std::uint64_t>> &holes) const {
   const auto joinIds = [](const std::vector<std::uint64_t> &c) {

--- a/src/cobordism/MergeCobordism.cpp
+++ b/src/cobordism/MergeCobordism.cpp
@@ -53,7 +53,7 @@ std::vector<int> betti(const Spacetime &st) {
 // interior edges at the best point found.
 double relaxInterior(
     const std::shared_ptr<Spacetime> &st, double beta,
-    const std::vector<std::vector<std::pair<std::uint64_t, std::uint64_t>>> &stateLoops,
+    const std::vector<EigenstateSynthesis::EdgeLoop> &stateLoops,
     const std::vector<std::complex<double>> &stateTargets,
     int maxIters, int &iterCounter, bool verbose = false) {
   EigenstateSynthesis es(st, 1);
@@ -225,7 +225,7 @@ void MergeCobordism::computeStateTargets() {
   states.reserve(inputStates_.size() + outputStates_.size());
   for (const auto &s : inputStates_) states.push_back(s);
   for (const auto &s : outputStates_) states.push_back(s);
-  topology_->readout(states, stateLoops_, stateTargets_);
+  topology_->readout(cobordism_, states, stateLoops_, stateTargets_);
 }
 
 void MergeCobordism::buildSeed() {

--- a/src/cobordism/MergeCobordism.cpp
+++ b/src/cobordism/MergeCobordism.cpp
@@ -173,11 +173,13 @@ MergeCobordism::MergeCobordism(
     const std::vector<std::vector<std::complex<double>>> &inputStates,
     const std::vector<std::vector<std::complex<double>>> &outputStates,
     const std::vector<std::complex<double>> &U, double beta, double epsilon,
-    std::uint64_t seed, std::shared_ptr<TopologyBuilder> topology, bool verbose)
+    int maxIters, std::uint64_t seed, std::shared_ptr<TopologyBuilder> topology,
+    bool verbose)
     : inputStates_(inputStates),
       outputStates_(outputStates),
       beta_(beta),
       epsilon_(epsilon),
+      maxIters_(maxIters),
       seed_(seed),
       verbose_(verbose),
       topology_(topology ? std::move(topology)
@@ -238,7 +240,7 @@ void MergeCobordism::optimize() {
   // combinatorial move-search: the relaxed seed triangulation is a local optimum
   // (every boundary-fixed Pachner move only raised the residual in testing), so
   // the relax alone determines the geometry. [#388]
-  relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_, /*maxIters=*/400,
+  relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_, maxIters_,
                 stats_.relaxIterations, verbose_);
   extractOperator();
   stats_.converged = stats_.residual < epsilon_;

--- a/src/cobordism/MergeCobordism.cpp
+++ b/src/cobordism/MergeCobordism.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/MergeCobordism.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <utility>
+
+#include <Eigen/Dense>
+#include <Eigen/SparseCore>
+
+#include "cobordism/ChainComplex.h"
+#include "cobordism/EigenstateSynthesis.h"
+#include "cobordism/TorusOperatorTopology.h"
+#include "matter/MatterConfiguration.h"
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Vertex.h"
+#include "simulations/ReggeSolver.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+using ::tessera::MatterConfiguration;
+using ::tessera::simulations::ReggeSolver;
+using ::tessera::spacetime::Spacetime;
+
+namespace {
+
+// The sorted (min,max) endpoint key of a mesh edge.
+std::pair<std::uint64_t, std::uint64_t> edgeKey(const ::tessera::mesh::Edge *e) {
+  const auto a = e->getSource()->getId();
+  const auto b = e->getTarget()->getId();
+  return {std::min(a, b), std::max(a, b)};
+}
+
+// Betti numbers of a complex (combinatorial, geometry-free).
+std::vector<int> betti(const Spacetime &st) {
+  return ChainComplex::fromSpacetime(st).bettiNumbers();
+}
+
+// One bounded Gauss-Newton / Levenberg-Marquardt descent of the total residual
+// r = beta*||grad_I S||^2 + r_psi over the interior edge squared-lengths, using
+// the EXACT analytic gradient and the SPARSE analytic Hessian of the dual Regge
+// action (actionHessianExactSparse, #381 — assembled at O(nnz), the interior
+// block extracted from it). dW is held fixed (Dirichlet), so the Regge
+// stationarity is over interior edges only. Returns the final r; leaves the
+// interior edges at the best point found.
+double relaxInterior(
+    const std::shared_ptr<Spacetime> &st, double beta,
+    const std::vector<std::vector<std::pair<std::uint64_t, std::uint64_t>>> &stateLoops,
+    const std::vector<std::complex<double>> &stateTargets,
+    int maxIters, int &iterCounter, bool verbose = false) {
+  EigenstateSynthesis es(st, 1);
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> interiorRank;
+  for (const auto &uv : es.interiorEdges()) interiorRank.emplace(uv, 0);
+  const auto edges = st->getEdgeList()->toVector();
+  std::vector<std::size_t> interiorIdx;
+  std::vector<::tessera::mesh::Edge *> interiorEdgePtr;
+  for (std::size_t i = 0; i < edges.size(); ++i) {
+    if (interiorRank.count(edgeKey(edges[i]))) {
+      interiorIdx.push_back(i);
+      interiorEdgePtr.push_back(edges[i]);
+    }
+  }
+  const std::size_t nI = interiorIdx.size();
+
+  // r_psi: the carried-harmonic residual of the pinned states over the boundary
+  // cycles, read against the live metric so it tracks the relaxation.
+  auto stateCost = [&]() {
+    return stateLoops.empty() ? 0.0
+                              : es.residualForLoops(stateLoops, stateTargets);
+  };
+  // The action residual is the Regge stationarity over the FREE (interior) edges
+  // only: dW is fixed, so its action gradient is an irreducible Dirichlet
+  // reaction, not part of the interior stationarity.
+  auto actionNorm2 = [&]() {
+    ReggeSolver solver(st, MatterConfiguration());
+    const auto g = solver.actionGradientExact();
+    double n2 = 0.0;
+    for (const std::size_t e : interiorIdx) n2 += std::norm(g[e]);
+    return n2;
+  };
+
+  if (nI == 0) return beta * actionNorm2() + stateCost();
+
+  // cellSimplices order (residualForLoopsGradient) -> interior param index, so
+  // the analytic state-residual gradient folds into the action gradient.
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> paramOf;
+  for (std::size_t c = 0; c < nI; ++c) paramOf[edgeKey(interiorEdgePtr[c])] = c;
+  const auto &cells = es.cellSimplices();
+  std::vector<int> cellToParam(cells.size(), -1);
+  for (std::size_t j = 0; j < cells.size(); ++j) {
+    if (cells[j].size() < 2) continue;
+    const std::pair<std::uint64_t, std::uint64_t> key{
+        std::min(cells[j][0], cells[j][1]), std::max(cells[j][0], cells[j][1])};
+    const auto it = paramOf.find(key);
+    if (it != paramOf.end()) cellToParam[j] = static_cast<int>(it->second);
+  }
+
+  auto cost = [&]() { return beta * actionNorm2() + stateCost(); };
+
+  double mu = 1e-3;
+  double best = cost();
+  for (int it = 0; it < maxIters; ++it, ++iterCounter) {
+    ReggeSolver solver(st, MatterConfiguration());
+    const auto gVec = solver.actionGradientExact();          // |E| complex
+    const auto hSparse = solver.actionHessianExactSparse();  // |E|x|E| sparse
+
+    // The interior gradient g_I and the interior-interior Hessian block H_II,
+    // extracted from the sparse Hessian (no dense |E|^2 assembly).
+    Eigen::VectorXcd gI(nI);
+    for (std::size_t c = 0; c < nI; ++c) gI(c) = gVec[interiorIdx[c]];
+    Eigen::MatrixXcd HII(nI, nI);
+    for (std::size_t r = 0; r < nI; ++r)
+      for (std::size_t c = 0; c < nI; ++c)
+        HII(r, c) = hSparse.coeff(static_cast<Eigen::Index>(interiorIdx[r]),
+                                  static_cast<Eigen::Index>(interiorIdx[c]));
+
+    // Analytic gradient and GN Hessian of beta*||grad_I S||^2 over the interior
+    // lengths, plus the analytic state-residual gradient (cellSimplices order).
+    Eigen::VectorXd grad = (2.0 * beta * (HII.adjoint() * gI)).real();
+    if (!stateLoops.empty()) {
+      const auto rg = es.residualForLoopsGradient(stateLoops, stateTargets);
+      for (std::size_t j = 0; j < rg.size() && j < cellToParam.size(); ++j)
+        if (cellToParam[j] >= 0) grad(cellToParam[j]) += rg[j];
+    }
+    Eigen::MatrixXd B = (2.0 * beta * (HII.adjoint() * HII)).real();
+
+    Eigen::VectorXd x0(nI);
+    for (std::size_t c = 0; c < nI; ++c)
+      x0(c) = interiorEdgePtr[c]->getSquaredLength().real();
+
+    bool improved = false;
+    for (int ls = 0; ls < 12; ++ls) {  // mu line search
+      Eigen::MatrixXd A = B;
+      for (std::size_t c = 0; c < nI; ++c) A(c, c) += mu * (B(c, c) + 1.0);
+      const Eigen::VectorXd delta = A.ldlt().solve(-grad);
+      Eigen::VectorXd x = x0 + delta;
+      // Emergent causal type: l^2 is free (spacelike/null/timelike), no clamp; a
+      // degenerate step blows the action up and the line search rejects it.
+      for (std::size_t c = 0; c < nI; ++c)
+        interiorEdgePtr[c]->setSquaredLength(std::complex<double>(x(c), 0.0));
+      const double trial = cost();
+      if (trial < best) {
+        best = trial;
+        mu = std::max(mu * 0.5, 1e-9);
+        improved = true;
+        break;
+      }
+      mu = std::min(mu * 4.0, 1e9);
+    }
+    if (verbose && (it % 25 == 0 || it + 1 == maxIters || !improved))
+      std::cerr << "[merge relax] iter " << it << "/" << maxIters << "  r=" << best
+                << "\n";
+    if (!improved) {  // restore best point and stop
+      for (std::size_t c = 0; c < nI; ++c)
+        interiorEdgePtr[c]->setSquaredLength(std::complex<double>(x0(c), 0.0));
+      break;
+    }
+  }
+  return best;
+}
+
+}  // namespace
+
+MergeCobordism::MergeCobordism(
+    const std::vector<std::vector<std::complex<double>>> &inputStates,
+    const std::vector<std::vector<std::complex<double>>> &outputStates,
+    const std::vector<std::complex<double>> &U, double beta, double epsilon,
+    std::uint64_t seed, std::shared_ptr<TopologyBuilder> topology, bool verbose)
+    : inputStates_(inputStates),
+      outputStates_(outputStates),
+      beta_(beta),
+      epsilon_(epsilon),
+      seed_(seed),
+      verbose_(verbose),
+      topology_(topology ? std::move(topology)
+                         : std::make_shared<TorusOperatorTopology>()) {
+  if (inputStates_.empty())
+    throw std::invalid_argument("MergeCobordism: inputStates is empty");
+  stateDim_ = inputStates_.front().size();
+  if (stateDim_ < 2 || (stateDim_ & (stateDim_ - 1)) != 0)
+    throw std::invalid_argument(
+        "MergeCobordism: state dimension must be a power of two >= 2");
+
+  if (!U.empty()) {
+    // U-supplied: compute the output state(s) from U, then ignore U.
+    if (U.size() != stateDim_ * stateDim_)
+      throw std::invalid_argument(
+          "MergeCobordism: U must be a d x d row-major operator");
+    computeOutputsFromOperator(U);
+  }
+  if (outputStates_.empty())
+    throw std::invalid_argument(
+        "MergeCobordism: outputStates is required when U is not supplied");
+
+  buildSeed();
+  computeStateTargets();
+  optimize();
+}
+
+void MergeCobordism::computeOutputsFromOperator(
+    const std::vector<std::complex<double>> &U) {
+  const std::size_t d = stateDim_;
+  outputStates_.clear();
+  for (const auto &psi : inputStates_) {
+    if (psi.size() != d)
+      throw std::invalid_argument("MergeCobordism: ragged input state dimension");
+    std::vector<std::complex<double>> out(d, {0.0, 0.0});
+    for (std::size_t i = 0; i < d; ++i)
+      for (std::size_t j = 0; j < d; ++j) out[i] += U[i * d + j] * psi[j];
+    outputStates_.push_back(std::move(out));
+  }
+}
+
+void MergeCobordism::computeStateTargets() {
+  // The states (inputs then outputs) pinned over the topology's read-out cycles.
+  std::vector<std::vector<std::complex<double>>> states;
+  states.reserve(inputStates_.size() + outputStates_.size());
+  for (const auto &s : inputStates_) states.push_back(s);
+  for (const auto &s : outputStates_) states.push_back(s);
+  topology_->readout(states, stateLoops_, stateTargets_);
+}
+
+void MergeCobordism::buildSeed() {
+  cobordism_ = topology_->build(stateDim_, seed_, boundaryCells_);
+}
+
+void MergeCobordism::optimize() {
+  // Relax the interior edge lengths to a stationary point of the dual Regge
+  // action under the state-pinning residual r = beta||grad S||^2 + r_psi. No
+  // combinatorial move-search: the relaxed seed triangulation is a local optimum
+  // (every boundary-fixed Pachner move only raised the residual in testing), so
+  // the relax alone determines the geometry. [#388]
+  relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_, /*maxIters=*/400,
+                stats_.relaxIterations, verbose_);
+  extractOperator();
+  stats_.converged = stats_.residual < epsilon_;
+}
+
+void MergeCobordism::extractOperator() {
+  EigenstateSynthesis es(cobordism_, 1);
+  bulkCells_ = es.bulkMinusBoundaryCells();
+  const auto H = es.bulkMinusBoundaryHarmonicMatrix();
+  const std::size_t ncols = bulkCells_.size();
+  const std::size_t dim = ncols ? H.size() / ncols : 0;
+
+  // === topology stats ===
+  stats_.kerL1Bulk = static_cast<int>(dim);
+  const auto bws = betti(*cobordism_);
+  stats_.bettiCobordism = bws;
+  stats_.b1Bulk = (bws.size() > 1) ? bws[1] : 0;
+  stats_.interiorVertices = static_cast<int>(es.interiorVertexCount());
+  stats_.topology = topology_->name() + "  ker L1(W-dW)=" + std::to_string(dim);
+
+  // === operator read-out — DEFERRED to #6 (operator-recovery verdict) ===
+  // The principled map ker L_1(W) -> U^Choi (the cycle-Choi correspondence) is
+  // the #6 work; the clean base deliberately does NOT carry the old first-d^2
+  // placeholder. choiState_/operatorU_ stay empty until #6 lands.
+  choiState_.clear();
+  operatorU_.clear();
+
+  // === residual read-out: beta*||grad_I S||^2 + r_psi at the relaxed metric ===
+  ReggeSolver residualSolver(cobordism_, MatterConfiguration());
+  const auto gRes = residualSolver.actionGradientExact();
+  std::set<std::pair<std::uint64_t, std::uint64_t>> interiorSet;
+  for (const auto &uv : es.interiorEdges()) interiorSet.insert(uv);
+  const auto resEdges = cobordism_->getEdgeList()->toVector();
+  double actionN2 = 0.0;  // free (interior) edges only — dW is fixed
+  for (std::size_t i = 0; i < resEdges.size() && i < gRes.size(); ++i)
+    if (interiorSet.count(edgeKey(resEdges[i]))) actionN2 += std::norm(gRes[i]);
+  stats_.statActionResidual = beta_ * actionN2;
+  stats_.dualAction = residualSolver.dualReggeAction();
+  stats_.stateResidual =
+      stateLoops_.empty() ? 0.0 : es.residualForLoops(stateLoops_, stateTargets_);
+  stats_.residual = stats_.statActionResidual + stats_.stateResidual;
+}
+
+}  // namespace tessera::cobordism

--- a/src/cobordism/TorusOperatorTopology.cpp
+++ b/src/cobordism/TorusOperatorTopology.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/TorusOperatorTopology.h"
+
+#include <algorithm>
+#include <map>
+#include <optional>
+#include <random>
+#include <set>
+#include <stdexcept>
+#include <utility>
+
+#include "cobordism/ChainComplex.h"
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Vertex.h"
+#include "spacetime/Foliation.h"
+#include "spacetime/Metric.h"
+#include "spacetime/Signature.h"
+#include "spacetime/Spacetime.h"
+#include "spacetime/topologies/SimplexBoundarySphere.h"
+#include "spacetime/topologies/SimplicialProduct.h"
+#include "spacetime/topologies/Topology.h"
+
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+namespace {
+
+// One geodesic (1 -> 4) subdivision of a triangulated surface, so a 3-fold
+// vertex-disjoint hole triple exists (the minimal S^1 x S^1 torus has only 2).
+std::vector<std::vector<std::uint64_t>> subdivideFaces(
+    const std::vector<std::vector<std::uint64_t>> &faces) {
+  std::uint64_t nxt = 0;
+  for (const auto &f : faces)
+    for (const auto v : f) nxt = std::max(nxt, v + 1);
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::uint64_t> mid;
+  auto m = [&](std::uint64_t a, std::uint64_t b) -> std::uint64_t {
+    const auto key = std::make_pair(std::min(a, b), std::max(a, b));
+    const auto it = mid.find(key);
+    if (it != mid.end()) return it->second;
+    const std::uint64_t id = nxt++;
+    mid[key] = id;
+    return id;
+  };
+  std::vector<std::vector<std::uint64_t>> out;
+  for (const auto &f : faces) {
+    const std::uint64_t a = f[0], b = f[1], c = f[2];
+    const std::uint64_t ab = m(a, b), bc = m(b, c), ca = m(c, a);
+    std::vector<std::vector<std::uint64_t>> tris = {
+        {a, ab, ca}, {b, bc, ab}, {c, ca, bc}, {ab, bc, ca}};
+    for (auto &s : tris) {
+      std::sort(s.begin(), s.end());
+      out.push_back(s);
+    }
+  }
+  return out;
+}
+
+// The first k pairwise vertex-disjoint faces — the holonomy holes whose
+// boundary circles become the qubit tori (each circle x S^1).
+std::vector<std::vector<std::uint64_t>> disjointHoles(
+    const std::vector<std::vector<std::uint64_t>> &faces, std::size_t k) {
+  std::vector<std::vector<std::uint64_t>> holes;
+  std::set<std::uint64_t> used;
+  for (const auto &f : faces) {
+    if (holes.size() >= k) break;
+    bool overlap = false;
+    for (const auto v : f)
+      if (used.count(v)) { overlap = true; break; }
+    if (!overlap) {
+      holes.push_back(f);
+      for (const auto v : f) used.insert(v);
+    }
+  }
+  return holes;
+}
+
+// The 3 prism tets of (triangle x edge) from layer offset `bot` to `top` — the
+// dimension-generic staircase, looped to make x S^1 rather than x [0,1].
+void appendStaircase(const std::vector<std::vector<std::uint64_t>> &faces,
+                     std::uint64_t bot, std::uint64_t top,
+                     std::set<std::vector<std::uint64_t>> &cells) {
+  for (const auto &f : faces) {
+    const std::uint64_t a = f[0], b = f[1], c = f[2];
+    const std::uint64_t b0[3] = {a + bot, b + bot, c + bot};
+    const std::uint64_t t0[3] = {a + top, b + top, c + top};
+    std::vector<std::vector<std::uint64_t>> tets = {
+        {b0[0], b0[1], b0[2], t0[2]},
+        {b0[0], b0[1], t0[1], t0[2]},
+        {b0[0], t0[0], t0[1], t0[2]}};
+    for (auto &t : tets) {
+      std::sort(t.begin(), t.end());
+      cells.insert(t);
+    }
+  }
+}
+
+}  // namespace
+
+std::shared_ptr<Spacetime> TorusOperatorTopology::build(
+    std::size_t stateDim, std::uint64_t seed,
+    std::vector<std::vector<std::uint64_t>> &boundaryCells) {
+  // dW = three qubit registers, each a torus (b_1 = 2). The bulk carries the
+  // operator as the interior handles, ker L_1(W - dW) = d^2 - 1. Realized as
+  // (subdivided T^2 with 3 holes) x S^1 = T^3 minus three (hole x S^1) solid
+  // tori. REGGE (not CDT): edge lengths free, causal type emergent.
+  Signature sig2(2, SignatureType::Lorentzian);
+  auto metric2 = std::make_shared<Metric>(true, sig2);
+  auto s1a = std::make_shared<SimplexBoundarySphere>(1);
+  auto s1b = std::make_shared<SimplexBoundarySphere>(1);
+  std::shared_ptr<Topology> t2 = std::make_shared<SimplicialProduct>(s1a, s1b);
+  auto torus = std::make_shared<Spacetime>(metric2, SpacetimeType::REGGE, 1.0, 1.0,
+                                           Foliation::NONE, t2);
+  torus->build();
+
+  const auto faces =
+      subdivideFaces(ChainComplex::fromSpacetime(*torus).kSimplexVertices(2));
+  const int holeCount = static_cast<int>(stateDim * stateDim) - 1;  // 3 for a qubit
+  const auto holes = disjointHoles(faces, static_cast<std::size_t>(holeCount));
+  if (static_cast<int>(holes.size()) < holeCount)
+    throw std::runtime_error(
+        "TorusOperatorTopology: torus base lacks enough vertex-disjoint holes");
+  const std::set<std::vector<std::uint64_t>> holeSet(holes.begin(), holes.end());
+
+  std::uint64_t N = 0;
+  for (const auto &f : faces)
+    for (const auto v : f) N = std::max(N, v + 1);
+  holes_ = holes;     // cache for readout(): the qubit boundary holes
+  layerStride_ = N;   // cache for readout(): the S^1 layer stride
+  std::vector<std::vector<std::uint64_t>> holed;  // torus with the holes removed
+  for (const auto &f : faces)
+    if (!holeSet.count(f)) holed.push_back(f);
+
+  // Staircase the holed torus over S^1 (three layers, looped 0 -> N -> 2N -> 0).
+  std::set<std::vector<std::uint64_t>> cellSet;
+  for (std::uint64_t layer = 0; layer < 3; ++layer)
+    appendStaircase(holed, layer * N, ((layer + 1) % 3) * N, cellSet);
+
+  Signature sig3(3, SignatureType::Lorentzian);
+  auto metric3 = std::make_shared<Metric>(true, sig3);
+  auto cobordism = std::make_shared<Spacetime>(metric3, SpacetimeType::REGGE, 1.0,
+                                               1.0, Foliation::NONE, std::nullopt);
+  std::set<std::uint64_t> verts;
+  for (const auto &c : cellSet)
+    for (const auto v : c) verts.insert(v);
+  std::map<std::uint64_t, ::tessera::mesh::Vertex *> vmap;
+  for (const auto id : verts) vmap[id] = cobordism->createVertex(id);
+  for (const auto &c : cellSet) {
+    std::vector<::tessera::mesh::Vertex *> vs;
+    vs.reserve(c.size());
+    for (const auto v : c) vs.push_back(vmap[v]);
+    cobordism->createSimplex(vs);
+  }
+
+  // Seed the metric off the degenerate uniform point. At l^2 = 1 a non-null
+  // metric-Hodge eigenvalue sits at ~0, where the period-residual gradient
+  // blows up; a small seeded spread breaks the degeneracy. l^2 stays positive
+  // (spacelike) — the causal type is still emergent.
+  std::mt19937 jrng(static_cast<std::uint32_t>(seed) ^ 0x9e3779b9u);
+  std::uniform_real_distribution<double> jitter(0.7, 1.3);
+  for (auto *e : cobordism->getEdgeList()->toVector())
+    e->setSquaredLength(std::complex<double>(jitter(jrng), 0.0));
+
+  // dW = the single-coface triangles: the three qubit tori.
+  std::map<std::vector<std::uint64_t>, int> cofaceCount;
+  for (const auto &c : cellSet)
+    for (std::size_t i = 0; i < c.size(); ++i) {
+      std::vector<std::uint64_t> tri;
+      tri.reserve(c.size() - 1);
+      for (std::size_t j = 0; j < c.size(); ++j)
+        if (j != i) tri.push_back(c[j]);
+      ++cofaceCount[tri];
+    }
+  boundaryCells.clear();
+  for (const auto &kv : cofaceCount)
+    if (kv.second == 1) boundaryCells.push_back(kv.first);
+  return cobordism;
+}
+
+void TorusOperatorTopology::readout(
+    const std::vector<std::vector<std::complex<double>>> &states,
+    std::vector<EdgeLoop> &loops,
+    std::vector<std::complex<double>> &targets) const {
+  // Each state's two qubit components are the periods over its torus's two
+  // cycles: the hole-circle (the removed face's boundary) and the S^1 (the time
+  // loop of a hole vertex). The six cycles jointly over-determine the bulk b_1.
+  loops.clear();
+  targets.clear();
+  if (holes_.size() < 3 || layerStride_ == 0) return;
+  const std::uint64_t N = layerStride_;
+  const std::size_t nStates = std::min(states.size(), holes_.size());
+  for (std::size_t i = 0; i < nStates; ++i) {
+    std::vector<std::uint64_t> h(holes_[i]);
+    std::sort(h.begin(), h.end());
+    const std::complex<double> a0 =
+        states[i].size() > 0 ? states[i][0] : std::complex<double>(0);
+    const std::complex<double> a1 =
+        states[i].size() > 1 ? states[i][1] : std::complex<double>(0);
+    // cycle 1: the hole-circle (removed face boundary) -> psi_i[0]
+    loops.push_back({{h[0], h[1]}, {h[1], h[2]}, {h[2], h[0]}});
+    targets.push_back(a0);
+    // cycle 2: the S^1 (vertical loop of hole vertex h[0]) -> psi_i[1]
+    loops.push_back(
+        {{h[0], h[0] + N}, {h[0] + N, h[0] + 2 * N}, {h[0] + 2 * N, h[0]}});
+    targets.push_back(a1);
+  }
+}
+
+}  // namespace tessera::cobordism

--- a/src/cobordism/TorusOperatorTopology.cpp
+++ b/src/cobordism/TorusOperatorTopology.cpp
@@ -77,26 +77,6 @@ std::vector<std::vector<std::uint64_t>> disjointHoles(
   return holes;
 }
 
-// The 3 prism tets of (triangle x edge) from layer offset `bot` to `top` — the
-// dimension-generic staircase, looped to make x S^1 rather than x [0,1].
-void appendStaircase(const std::vector<std::vector<std::uint64_t>> &faces,
-                     std::uint64_t bot, std::uint64_t top,
-                     std::set<std::vector<std::uint64_t>> &cells) {
-  for (const auto &f : faces) {
-    const std::uint64_t a = f[0], b = f[1], c = f[2];
-    const std::uint64_t b0[3] = {a + bot, b + bot, c + bot};
-    const std::uint64_t t0[3] = {a + top, b + top, c + top};
-    std::vector<std::vector<std::uint64_t>> tets = {
-        {b0[0], b0[1], b0[2], t0[2]},
-        {b0[0], b0[1], t0[1], t0[2]},
-        {b0[0], t0[0], t0[1], t0[2]}};
-    for (auto &t : tets) {
-      std::sort(t.begin(), t.end());
-      cells.insert(t);
-    }
-  }
-}
-
 }  // namespace
 
 std::shared_ptr<Spacetime> TorusOperatorTopology::build(
@@ -124,19 +104,26 @@ std::shared_ptr<Spacetime> TorusOperatorTopology::build(
         "TorusOperatorTopology: torus base lacks enough vertex-disjoint holes");
   const std::set<std::vector<std::uint64_t>> holeSet(holes.begin(), holes.end());
 
-  std::uint64_t N = 0;
-  for (const auto &f : faces)
-    for (const auto v : f) N = std::max(N, v + 1);
   holes_ = holes;     // cache for readout(): the qubit boundary holes
-  layerStride_ = N;   // cache for readout(): the S^1 layer stride
   std::vector<std::vector<std::uint64_t>> holed;  // torus with the holes removed
   for (const auto &f : faces)
     if (!holeSet.count(f)) holed.push_back(f);
+  std::uint64_t N = 0;  // per-layer vertex stride (matches Spacetime::prismCells)
+  for (const auto &f : holed)
+    for (const auto v : f) N = std::max(N, v + 1);
+  layerStride_ = N;   // cache for readout(): the S^1 layer stride
 
-  // Staircase the holed torus over S^1 (three layers, looped 0 -> N -> 2N -> 0).
+  // (holed torus) x S^1 via the canonical prism (Spacetime::prismCells), then
+  // glue the top layer (ids >= 3N) back to the bottom to close the S^1.
   std::set<std::vector<std::uint64_t>> cellSet;
-  for (std::uint64_t layer = 0; layer < 3; ++layer)
-    appendStaircase(holed, layer * N, ((layer + 1) % 3) * N, cellSet);
+  const std::uint64_t topOff = N * 3;  // three layers, stride N
+  for (const auto &cell : Spacetime::prismCells(holed, /*layers=*/3)) {
+    std::vector<std::uint64_t> c;
+    c.reserve(cell.size());
+    for (const auto v : cell) c.push_back(v >= topOff ? v - topOff : v);
+    std::sort(c.begin(), c.end());
+    cellSet.insert(std::move(c));
+  }
 
   Signature sig3(3, SignatureType::Lorentzian);
   auto metric3 = std::make_shared<Metric>(true, sig3);

--- a/src/cobordism/TorusOperatorTopology.cpp
+++ b/src/cobordism/TorusOperatorTopology.cpp
@@ -167,6 +167,7 @@ std::shared_ptr<Spacetime> TorusOperatorTopology::build(
 }
 
 void TorusOperatorTopology::readout(
+    const std::shared_ptr<Spacetime> &cobordism,
     const std::vector<std::vector<std::complex<double>>> &states,
     std::vector<EdgeLoop> &loops,
     std::vector<std::complex<double>> &targets) const {
@@ -175,8 +176,18 @@ void TorusOperatorTopology::readout(
   // loop of a hole vertex). The six cycles jointly over-determine the bulk b_1.
   loops.clear();
   targets.clear();
-  if (holes_.size() < 3 || layerStride_ == 0) return;
+  if (holes_.size() < 3 || layerStride_ == 0 || !cobordism) return;
   const std::uint64_t N = layerStride_;
+  auto &vlist = *cobordism->getVertexList();
+  // A directed step (u -> v) as a fresh Edge over W's vertices; l^2 = 1 is a
+  // placeholder (the period read-out uses only the endpoints, not the length).
+  auto edge = [&](std::uint64_t u, std::uint64_t v) {
+    ::tessera::mesh::Vertex *vu = vlist.get(u), *vv = vlist.get(v);
+    if (!vu || !vv)
+      throw std::runtime_error(
+          "TorusOperatorTopology::readout: loop vertex absent from W");
+    return ::tessera::mesh::Edge(vu, vv, std::complex<double>(1.0, 0.0));
+  };
   const std::size_t nStates = std::min(states.size(), holes_.size());
   for (std::size_t i = 0; i < nStates; ++i) {
     std::vector<std::uint64_t> h(holes_[i]);
@@ -186,11 +197,11 @@ void TorusOperatorTopology::readout(
     const std::complex<double> a1 =
         states[i].size() > 1 ? states[i][1] : std::complex<double>(0);
     // cycle 1: the hole-circle (removed face boundary) -> psi_i[0]
-    loops.push_back({{h[0], h[1]}, {h[1], h[2]}, {h[2], h[0]}});
+    loops.push_back({edge(h[0], h[1]), edge(h[1], h[2]), edge(h[2], h[0])});
     targets.push_back(a0);
     // cycle 2: the S^1 (vertical loop of hole vertex h[0]) -> psi_i[1]
-    loops.push_back(
-        {{h[0], h[0] + N}, {h[0] + N, h[0] + 2 * N}, {h[0] + 2 * N, h[0]}});
+    loops.push_back({edge(h[0], h[0] + N), edge(h[0] + N, h[0] + 2 * N),
+                     edge(h[0] + 2 * N, h[0])});
     targets.push_back(a1);
   }
 }

--- a/src/observables/WilsonLoop.cpp
+++ b/src/observables/WilsonLoop.cpp
@@ -377,17 +377,34 @@ WilsonResult WilsonLoop::evaluateU1Connection(
     const int n = static_cast<int>(cycle.size());
     if (n < 2) return {};  // need at least one edge
 
-    double total = 0.0;
+    // Each consecutive pair cycle[i] -> cycle[i+1] (mod n) is one directed
+    // traversal step, walked through the shared Edge::walkLoop primitive. The
+    // step Edges carry a dummy unit length; only their endpoints are read. A
+    // small id -> VertexPtr lookup recovers the mesh edge inside the walk.
+    std::vector<Edge> steps;
+    steps.reserve(static_cast<std::size_t>(n));
+    std::unordered_map<std::uint64_t, VertexPtr> byId;
     for (int i = 0; i < n; ++i) {
-        VertexPtr a = cycle[i];
-        VertexPtr b = cycle[(i + 1) % n];
-        EdgePtr e = edgeBetween(a, b);
-        if (!e) return {};  // open path — not a closed 1-skeleton cycle
-        // +phase along the stored source→target orientation, −phase reversed.
-        const bool forward = (e->getSource()->getId() == a->getId() &&
-                              e->getTarget()->getId() == b->getId());
-        total += forward ? e->getPhase() : -e->getPhase();
+        steps.emplace_back(cycle[i], cycle[(i + 1) % n],
+                           std::complex<double>(1.0, 0.0));
+        byId[cycle[i]->getId()] = cycle[i];
     }
+
+    double total = 0.0;
+    bool open = false;
+    Edge::walkLoop(steps, [&](std::uint64_t u, std::uint64_t v, double sign) {
+        if (open) return;
+        EdgePtr e = edgeBetween(byId[u], byId[v]);
+        if (!e) { open = true; return; }  // open path — not a closed cycle
+        // +phase along the stored source→target orientation, −phase reversed.
+        // The canonical-orientation `sign` folds the edge's stored orientation
+        // back to the cycle's u->v direction: sign * stored == (forward ? +1 :
+        // -1), so this is algebraically identical to the old forward test.
+        const double stored =
+            (e->getSource()->getId() < e->getTarget()->getId()) ? 1.0 : -1.0;
+        total += sign * stored * e->getPhase();
+    });
+    if (open) return {};  // open path — not a closed 1-skeleton cycle
 
     WilsonResult r;
     r.loopSize = n;

--- a/src/quantum/Bindings.cpp
+++ b/src/quantum/Bindings.cpp
@@ -836,6 +836,11 @@ operator U has ``U[i*dB + j] = U_{ij}``. Locked conventions:
             py::arg("U"), py::arg("dA"), py::arg("dB"),
             R"doc(Vectorise a dA×dB operator: vec(U) = Σ_{ij} U_{ij} |i⟩⊗|j⟩,
 the length-(dA·dB) row-major flatten.)doc")
+        .def_static("unvectorize", &ChoiJamiolkowski::unvectorize,
+            py::arg("v"), py::arg("dA"), py::arg("dB"),
+            R"doc(Un-vectorise (the inverse of vectorize): reshape a
+length-(dA·dB) state back into the dA×dB operator U_{ij} = v[i·dB + j].
+The validated row-major reshape, so unvectorize(vectorize(U)) == U.)doc")
         .def_static("singularValues", &ChoiJamiolkowski::singularValues,
             py::arg("U"), py::arg("dA"), py::arg("dB"),
             R"doc(Singular values of the dA×dB operator U (descending); the
@@ -856,6 +861,11 @@ conj(psiA_i)·U_{ij}·psiB_j.)doc")
             py::arg("U"), py::arg("d"),
             R"doc(Choi–Jamiołkowski state (U⊗I)|Φ⁺⟩ = (1/√d)·vec(U) of a square
 d×d operator (length d·d, row-major; a unit vector for unitary U).)doc")
+        .def_static("operatorFromChoiState", &ChoiJamiolkowski::operatorFromChoiState,
+            py::arg("state"), py::arg("d"),
+            R"doc(Recover U from its Choi state (the inverse of choiState):
+U = √d · unvectorize(state), flat row-major (length d·d); the original
+operator up to the global phase the state carries.)doc")
         .def_static("choiMatrix", &ChoiJamiolkowski::choiMatrix,
             py::arg("U"), py::arg("d"),
             R"doc(Choi matrix J(U) = |state⟩⟨state| of a square d×d operator

--- a/src/quantum/ChoiJamiolkowski.cpp
+++ b/src/quantum/ChoiJamiolkowski.cpp
@@ -78,6 +78,17 @@ std::vector<std::complex<double>> ChoiJamiolkowski::vectorize(
     return U;
 }
 
+std::vector<std::complex<double>> ChoiJamiolkowski::unvectorize(
+    const std::vector<std::complex<double>> &v, int dA, int dB) {
+    requirePositiveDims(dA, dB, "ChoiJamiolkowski::unvectorize");
+    // The inverse of vectorize: |v⟩ = Σ_{ij} v_{ij} |i⟩_A ⊗ |j⟩_B reshapes to the
+    // operator U_{ij} = v_{i·dB + j}. With the row-major convention the matrix
+    // buffer is the vector buffer, so validate the length (dA·dB) and return it,
+    // now read as a dA×dB operator.
+    asMatrix(v, dA, dB, "ChoiJamiolkowski::unvectorize");
+    return v;
+}
+
 std::vector<double> ChoiJamiolkowski::singularValues(
     const std::vector<std::complex<double>> &U, int dA, int dB) {
     requirePositiveDims(dA, dB, "ChoiJamiolkowski::singularValues");
@@ -144,6 +155,17 @@ std::vector<std::complex<double>> ChoiJamiolkowski::choiState(
     std::vector<std::complex<double>> state = U;
     for (auto &z : state) z *= inv;
     return state;
+}
+
+std::vector<std::complex<double>> ChoiJamiolkowski::operatorFromChoiState(
+    const std::vector<std::complex<double>> &state, int d) {
+    requirePositiveDims(d, d, "ChoiJamiolkowski::operatorFromChoiState");
+    asMatrix(state, d, d, "ChoiJamiolkowski::operatorFromChoiState");
+    // choiState gives (1/√d)·vec(U); invert by U = √d · unvectorise(state).
+    const double scale = std::sqrt(static_cast<double>(d));
+    std::vector<std::complex<double>> U = state;
+    for (auto &z : U) z *= scale;
+    return U;
 }
 
 std::vector<std::complex<double>> ChoiJamiolkowski::choiMatrix(

--- a/tests/cobordism/test_merge_cobordism_operator_python.py
+++ b/tests/cobordism/test_merge_cobordism_operator_python.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""The clean C++ MergeCobordism (#388): ``tessera.cobordism.MergeCobordism``.
+
+An emergent merge operator built from input/output qubit states through the
+``(T^2 - 3 holes) x S^1`` operator topology, relaxed to a stationary point of
+the dual Lorentzian Regge action under the state-pinning residual. These tests
+pin the clean base's contract:
+
+  * the topology it builds and the carried operator dimension
+    ``ker L1(W - dW) = d^2 - 1`` (= 3 for a qubit),
+  * the boundary / bulk / interior structure (all combinatorial, so exact and
+    seed-independent),
+  * that the relaxation descends from the bare seed to the intrinsic
+    ``delta-S = 0`` floor, decomposes as ``beta*||grad S||^2 + r_psi``, and is
+    deterministic for a fixed seed.
+
+Distinct from ``test_merge_cobordism_python.py``, which tests the older Python
+pair-of-pants example ``examples/cobordism/merge_cobordism.py`` (ker L1 = 2).
+"""
+
+import math
+import unittest
+
+import tessera
+
+# d = 2 qubit: two input states on the boundary, one output. Built once and
+# shared -- the 400-iteration relaxation is the expensive part.
+_IN = [[1 + 0j, 0 + 0j], [0 + 0j, 1 + 0j]]
+_OUT = [[1 + 0j, 0 + 0j]]
+# A short relaxation budget keeps the suite runnable: the structural invariants
+# are set after buildSeed (budget-independent), and the descent is steep early
+# -- 30 LM steps already drop the residual ~300x from the bare seed. Production
+# uses max_iters=400 (the delta-S=0 floor); the full-relax byte-identical
+# descent is pinned by the period smoke, not here.
+_ITERS = 30
+_M = tessera.cobordism.MergeCobordism(_IN, _OUT, max_iters=_ITERS, seed=0)
+_S = _M.stats
+
+
+class TopologyStructureTest(unittest.TestCase):
+    """The (T^2-3holes)xS^1 operator topology and its carried dimensions.
+    Everything here is combinatorial -- seed-independent and exact."""
+
+    def test_topology_name(self):
+        self.assertTrue(_S.topology.startswith("(T^2-3holes)xS^1 operator"))
+        self.assertIn("ker L1(W-dW)=3", _S.topology)
+
+    def test_carried_operator_dimension(self):
+        # ker L1(W - dW) = d^2 - 1 = 3 for a qubit (the Sigma=0 Choi dim).
+        self.assertEqual(_S.ker_l1_bulk, 3)
+
+    def test_bulk_first_betti(self):
+        self.assertEqual(_S.b1_bulk, 5)
+
+    def test_interior_vertex_count(self):
+        self.assertEqual(_S.interior_vertices, 81)
+
+    def test_boundary_and_bulk_cell_counts(self):
+        self.assertEqual(len(_M.boundary), 54)
+        self.assertEqual(len(_M.bulk), 483)
+
+    def test_cobordism_spacetime_is_populated(self):
+        W = _M.cobordism
+        # interior + boundary vertices, all present in W.
+        self.assertGreater(W.getVertexList().size(), _S.interior_vertices)
+        self.assertGreater(len(W.getSimplices()), 0)
+
+    def test_betti_array_consistent(self):
+        b = _S.betti_cobordism
+        self.assertGreaterEqual(len(b), 2)
+        self.assertGreaterEqual(b[0], 1)        # at least one component
+        self.assertEqual(b[1], _S.b1_bulk)      # b1_bulk is read off betti[1]
+
+
+class RelaxationTest(unittest.TestCase):
+    """The dual-Regge relaxation descends to the delta-S = 0 stationary floor."""
+
+    def test_descends_well_below_seed(self):
+        # the bare seed starts at r ~ 162; 30 LM steps drop it below 1.
+        self.assertLess(_S.residual, 1.0)
+
+    def test_floors_above_zero(self):
+        # delta-S = 0 is a stationary point, not a minimum -- r does not vanish.
+        self.assertGreater(_S.residual, 0.0)
+
+    def test_residual_decomposes(self):
+        # beta = 1: r = beta*||grad S||^2 + r_psi.
+        self.assertAlmostEqual(
+            _S.residual, _S.stat_action_residual + _S.state_residual, places=9)
+
+    def test_states_are_pinned_hard(self):
+        # r_psi is the (hard) state-pinning term; it sits near zero.
+        self.assertLess(_S.state_residual, 1e-2)
+
+    def test_runs_the_iteration_budget(self):
+        self.assertEqual(_S.relax_iterations, _ITERS)
+
+    def test_not_converged_below_epsilon(self):
+        # the floor (~0.075) is above the 1e-6 tolerance, so converged is False.
+        self.assertFalse(_S.converged)
+
+    def test_dual_action_is_finite(self):
+        # The dual Regge action is well-defined (finite) at the relaxed metric.
+        # We deliberately do NOT assert Im == 0: the action is complex by
+        # construction (Lorentzian / Sorkin) and the imaginary part is real
+        # physics (spacelike-hinge boosts). It happens to come out ~0 for this
+        # all-spacelike emergent seed, but pinning Im == 0 would bake in a
+        # Euclidean expectation and forbid a genuine timelike emergence -- so we
+        # require only finiteness, leaving Im free.
+        self.assertTrue(math.isfinite(_S.dual_action.real))
+        self.assertTrue(math.isfinite(_S.dual_action.imag))
+
+
+class StatePassThroughTest(unittest.TestCase):
+    """Inputs/outputs are preserved verbatim (emergent mode)."""
+
+    def test_input_states_preserved(self):
+        self.assertEqual(_M.input_states, _IN)
+
+    def test_output_states_preserved(self):
+        self.assertEqual(_M.output_states, _OUT)
+
+
+class OperatorRecoveryDeferredTest(unittest.TestCase):
+    """Operator read-out is deferred to #6; the accessors are empty for now.
+    Update this test when ``reshape(ker L1(W-dW)) == U`` lands."""
+
+    def test_operator_u_empty(self):
+        self.assertEqual(len(_M.operator_U), 0)
+
+    def test_choi_state_empty(self):
+        self.assertEqual(len(_M.choi_state), 0)
+
+
+class DeterminismTest(unittest.TestCase):
+    """A fixed seed gives a bit-identical relaxation (reproducible)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.m2 = tessera.cobordism.MergeCobordism(_IN, _OUT, max_iters=_ITERS, seed=0)
+
+    def test_same_seed_same_residual(self):
+        self.assertEqual(self.m2.stats.residual, _S.residual)
+
+    def test_same_seed_same_structure(self):
+        self.assertEqual(self.m2.stats.ker_l1_bulk, _S.ker_l1_bulk)
+        self.assertEqual(self.m2.stats.interior_vertices, _S.interior_vertices)
+        self.assertEqual(len(self.m2.bulk), len(_M.bulk))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Rebuild the bare-minimum `MergeCobordism` on a clean branch off `main`, shedding the experimental scruff that accumulated on the feat branch (#364), so the #380 epic builds on a clean foundation. Scope (keep/shed/audit) in #388.

First commit cherry-picks the clean deps (`ker L₁(W−∂W)` harmonic + `ChoiJamiolkowski::unvectorize`, `8a7cb44`). The MergeCobordism core follows: one `TopologyBuilder` (our `(T²−3holes)×S¹`), boundary pinning, interior relax against the dual Regge action with the **sparse Hessian** (`actionHessianExactSparse`, #381), and a *principled* read-out — no two-phase, no blind move-search, no first-`d²` placeholder.

## Test plan
- [x] clean worktree off main + clean deps cherry-picked
- [ ] reimplement MergeCobordism core (seam + sparse-Hessian relax + principled read-out)
- [ ] port loop methods + bindings; build
- [ ] smoke: seed-relax residual reproduces the feat baseline (~0.1) on the bare seed
- [ ] decide #364's fate (supersede/close)

Closes #388.