### PR TITLE
feat(cobordism): register topology (#353 color) as the default merge topology

### DIFF
--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -172,6 +172,8 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} TorusOperatorTopology.h
 ```
+```{doxygenfile} RegisterTopology.h
+```
 
 ## Quantum
 

--- a/include/cobordism/MergeCobordism.h
+++ b/include/cobordism/MergeCobordism.h
@@ -24,7 +24,8 @@ using ::tessera::spacetime::Spacetime;
 /// Lorentzian Regge action while keeping a valid simplicial manifold.
 ///
 /// The topology is supplied by a `TopologyBuilder` (#378) — defaulting to the
-/// \f$ (T^2 - 3\,\text{holes}) \times S^1 \f$ operator topology — which builds
+/// \#353-style color `RegisterTopology` (select `TorusOperatorTopology` for the
+/// \f$ (T^2 - 3\,\text{holes}) \times S^1 \f$ qubit operator) — which builds
 /// \f$ W \f$ and supplies the per-state read-out cycles. The interior edge
 /// lengths are relaxed to a stationary point of the dual Regge action under the
 /// state-pinning residual (`r = \beta\|\nabla S\|^2 + r_\psi`) by a Gauss-Newton
@@ -64,7 +65,9 @@ class MergeCobordism {
     /// @param maxIters     interior-relaxation iteration budget (LM steps). The
     ///   production default is 400; tests pass a small value for speed.
     /// @param seed         RNG seed for the metric jitter.
-    /// @param topology     the cobordism topology; null => TorusOperatorTopology.
+    /// @param topology     the cobordism topology; null => RegisterTopology (the
+    ///   \#353-style color register default). The admissible state dimension is
+    ///   topology-specific (register: \f$ d = 3 \f$; operator: a power of two).
     /// @param verbose      emit per-iteration relax progress to stderr.
     MergeCobordism(
         const std::vector<std::vector<std::complex<double>>> &inputStates,

--- a/include/cobordism/RegisterTopology.h
+++ b/include/cobordism/RegisterTopology.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_REGISTERTOPOLOGY_H
+#define TESSERA_COBORDISM_REGISTERTOPOLOGY_H
+
+#include <cstdint>
+#include <vector>
+
+#include "cobordism/TopologyBuilder.h"
+
+namespace tessera::cobordism {
+
+/// # RegisterTopology
+///
+/// The \#353-style color register topology, built **without welding** (the
+/// default `MergeCobordism` topology). The merge \f$ \psi_A, \psi_B \to \psi_R \f$
+/// is three holed-icosahedron register blocks — each \f$ S^2 - 3\,\text{holes} \f$,
+/// \f$ b_1 = 2 \f$ on the \f$ \sum = 0 \f$ hyperplane (the \f$ S_3 \f$ standard
+/// rep, the color singlet \f$ [1, \omega, \omega^2] \f$) — laid with **disjoint**
+/// vertex ids and joined input→result by additive **tubes** (the six lateral
+/// triangles of a triangular prism between two triangular hole-circles).
+///
+/// Connecting by tubes, never by *identifying* a shared block, is what keeps the
+/// merge a genuine trivalent manifold: the result \f$ R \f$ is a real lobe of one
+/// connected complex, not the buried middle slice the \#353 `merge_cobordism.py`
+/// weld produces (a `P x I` transport whose `dualComplexValid` passes only
+/// because that gate misses the codim-3 pinch). `build()` asserts a manifold gate
+/// — `dualComplexValid` **plus** every edge in \f$ \leq 2 \f$ triangles — and
+/// throws if the seed is non-manifold, so a weld cannot recur.
+///
+/// Read-out: the color hole-circles only (no \f$ S^1 \f$). Each block's three
+/// hole-circle periods carry that state's three color amplitudes. The carried
+/// object is a color rep, so `MergeCobordism` reads a rep, not an operator.
+class RegisterTopology : public TopologyBuilder {
+  public:
+    [[nodiscard]] std::shared_ptr<Spacetime> build(
+        std::size_t stateDim, std::uint64_t seed,
+        std::vector<std::vector<std::uint64_t>> &boundaryCells) override;
+
+    void readout(
+        const std::shared_ptr<Spacetime> &cobordism,
+        const std::vector<std::vector<std::complex<double>>> &states,
+        std::vector<EdgeLoop> &loops,
+        std::vector<std::complex<double>> &targets) const override;
+
+    [[nodiscard]] std::size_t carriedDim(std::size_t /*stateDim*/) const override {
+      return 2;  // the S_3 standard rep (b_1 = 2 on the Sigma=0 hyperplane)
+    }
+
+    /// The color register is \f$ d = 3 \f$ (the color triple on \f$ \sum=0 \f$).
+    void validateStateDim(std::size_t d) const override;
+
+    [[nodiscard]] std::string name() const override {
+      return "register (S^2-3holes color blocks, tube-joined)";
+    }
+
+  private:
+    // Cached by build() for readout(): the per-block color holes (sorted vertex
+    // triples), blocks in [A, B, R] order.
+    std::vector<std::vector<std::vector<std::uint64_t>>> blockHoles_{};
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_REGISTERTOPOLOGY_H

--- a/include/cobordism/TopologyBuilder.h
+++ b/include/cobordism/TopologyBuilder.h
@@ -7,6 +7,7 @@
 #include <complex>
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -68,6 +69,18 @@ class TopologyBuilder {
     /// operator topology, \f$ b_1 \f$ on the \f$ \sum=0 \f$ hyperplane for a
     /// register). Used to size and validate the read-out.
     [[nodiscard]] virtual std::size_t carriedDim(std::size_t stateDim) const = 0;
+
+    /// Validate the state amplitude dimension \f$ d \f$ for this topology, so the
+    /// admissible dimension travels with the topology rather than being baked
+    /// into `MergeCobordism`. The default requires a power of two \f$ \geq 2 \f$
+    /// (the qubit/Choi operator topology); a register overrides it (\f$ d = 3 \f$,
+    /// the color triple on the \f$ \sum = 0 \f$ hyperplane).
+    /// @throws std::invalid_argument if \f$ d \f$ is not admissible.
+    virtual void validateStateDim(std::size_t d) const {
+      if (d < 2 || (d & (d - 1)) != 0)
+        throw std::invalid_argument(
+            "MergeCobordism: state dimension must be a power of two >= 2");
+    }
 
     /// Human-readable topology name, for `MergeCobordism::Stats::topology`.
     [[nodiscard]] virtual std::string name() const = 0;

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -27,7 +27,10 @@
 #include "cobordism/PreparedBoundaryState.h"
 #include "cobordism/RealizabilityOracle.h"
 #include "cobordism/Register.h"
+#include "cobordism/RegisterTopology.h"
 #include "cobordism/Spectrum.h"
+#include "cobordism/TopologyBuilder.h"
+#include "cobordism/TorusOperatorTopology.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
 
 namespace py = pybind11;
@@ -1274,6 +1277,31 @@ prepared states, reproduces the harmonic overlap.)doc")
       .def("norm", &PreparedBoundaryState::norm,
            "The Euclidean norm sqrt(sum |c_a|^2) of the amplitude vector.");
 
+  // === TopologyBuilder seam (#378): the selectable MergeCobordism topology ===
+  py::class_<TopologyBuilder, std::shared_ptr<TopologyBuilder>>(
+      m, "TopologyBuilder",
+      "Pluggable cobordism topology for MergeCobordism (#378): builds W and "
+      "supplies the per-state read-out cycles, so the read-out (a qubit operator "
+      "vs a color rep) travels with the topology.")
+      .def("name", &TopologyBuilder::name)
+      .def("carried_dim", &TopologyBuilder::carriedDim, py::arg("state_dim"),
+           "dim ker L1(W - dW) this topology realizes.")
+      .def("validate_state_dim", &TopologyBuilder::validateStateDim, py::arg("d"),
+           "Throw unless d is admissible (operator: a power of two >= 2; "
+           "register: 3).");
+  py::class_<TorusOperatorTopology, TopologyBuilder,
+             std::shared_ptr<TorusOperatorTopology>>(
+      m, "TorusOperatorTopology",
+      "The (T^2-3holes)xS^1 qubit-operator topology: dW = 3 tori, 6 boundary "
+      "cycles (2 per state), ker L1(W - dW) = d^2 - 1.")
+      .def(py::init<>());
+  py::class_<RegisterTopology, TopologyBuilder, std::shared_ptr<RegisterTopology>>(
+      m, "RegisterTopology",
+      "The #353-style color register (the default): holed-icosahedron color "
+      "blocks joined by additive tubes (never a welded shared block), color "
+      "hole-circle read-out, no S^1; d = 3.")
+      .def(py::init<>());
+
   // === MergeCobordism (#363 / #388) ===
   py::class_<MergeCobordism> mc(m, "MergeCobordism",
       "The canonical merge primitive: an emergent operator built from input/"
@@ -1299,18 +1327,23 @@ prepared states, reproduces the harmonic overlap.)doc")
                      const std::vector<std::vector<std::complex<double>>> &out,
                      const std::vector<std::complex<double>> &U, double beta,
                      double epsilon, int maxIters, std::uint64_t seed,
-                     bool verbose) {
+                     std::shared_ptr<TopologyBuilder> topology, bool verbose) {
            return std::make_unique<MergeCobordism>(
-               in, out, U, beta, epsilon, maxIters, seed, nullptr, verbose);
+               in, out, U, beta, epsilon, maxIters, seed, std::move(topology),
+               verbose);
          }),
          py::arg("input_states"), py::arg("output_states"),
          py::arg("U") = std::vector<std::complex<double>>{},
          py::arg("beta") = 1.0, py::arg("epsilon") = 1e-6,
          py::arg("max_iters") = 400, py::arg("seed") = 0,
+         py::arg("topology") = std::shared_ptr<TopologyBuilder>{},
          py::arg("verbose") = false,
-         "Build and run the merge on the default (T^2-3holes)xS^1 operator "
-         "topology. output_states is required unless U (a flat row-major dxd "
-         "operator) is supplied, in which case it is computed from U.")
+         "Build and run the merge. topology selects the cobordism topology "
+         "(default: RegisterTopology, the #353-style color register; pass "
+         "TorusOperatorTopology for the (T^2-3holes)xS^1 qubit operator). The "
+         "admissible state dimension is topology-specific (register: d=3; "
+         "operator: a power of two). output_states is required unless U (a flat "
+         "row-major dxd operator) is supplied, in which case it is computed from U.")
       .def_property_readonly("input_states", &MergeCobordism::inputStates)
       .def_property_readonly("output_states", &MergeCobordism::outputStates)
       .def_property_readonly("cobordism", &MergeCobordism::cobordism,

--- a/src/cobordism/MergeCobordism.cpp
+++ b/src/cobordism/MergeCobordism.cpp
@@ -16,6 +16,7 @@
 
 #include "cobordism/ChainComplex.h"
 #include "cobordism/EigenstateSynthesis.h"
+#include "cobordism/RegisterTopology.h"
 #include "cobordism/TorusOperatorTopology.h"
 #include "matter/MatterConfiguration.h"
 #include "mesh/Edge.h"
@@ -183,13 +184,13 @@ MergeCobordism::MergeCobordism(
       seed_(seed),
       verbose_(verbose),
       topology_(topology ? std::move(topology)
-                         : std::make_shared<TorusOperatorTopology>()) {
+                         : std::make_shared<RegisterTopology>()) {
   if (inputStates_.empty())
     throw std::invalid_argument("MergeCobordism: inputStates is empty");
   stateDim_ = inputStates_.front().size();
-  if (stateDim_ < 2 || (stateDim_ & (stateDim_ - 1)) != 0)
-    throw std::invalid_argument(
-        "MergeCobordism: state dimension must be a power of two >= 2");
+  // The admissible state dimension travels with the topology (operator: a power
+  // of two; register: the color triple d = 3).
+  topology_->validateStateDim(stateDim_);
 
   if (!U.empty()) {
     // U-supplied: compute the output state(s) from U, then ignore U.

--- a/src/cobordism/RegisterTopology.cpp
+++ b/src/cobordism/RegisterTopology.cpp
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/RegisterTopology.h"
+
+#include <algorithm>
+#include <map>
+#include <random>
+#include <set>
+#include <stdexcept>
+
+#include "cobordism/EigenstateSynthesis.h"
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Vertex.h"
+#include "mesh/VertexList.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+namespace {
+
+using Face = std::vector<std::uint64_t>;
+
+// The 20 faces of the regular icosahedron (12 vertices), the genus-0 (S^2)
+// register seed (the same seed the #353 register uses).
+std::vector<Face> icosahedron() {
+  std::vector<Face> faces = {
+      {0, 1, 2},   {0, 2, 3},   {0, 3, 4},  {0, 4, 5},  {0, 5, 1},
+      {1, 5, 10},  {1, 10, 6},  {1, 6, 2},  {2, 6, 7},  {2, 7, 3},
+      {3, 7, 8},   {3, 8, 4},   {4, 8, 9},  {4, 9, 5},  {5, 9, 10},
+      {6, 10, 11}, {7, 6, 11},  {8, 7, 11}, {9, 8, 11}, {10, 9, 11}};
+  for (auto &f : faces) std::sort(f.begin(), f.end());
+  return faces;
+}
+
+// One geodesic (1 -> 4) subdivision of a triangulated surface: each triangle
+// splits into four on its edge midpoints (fresh midpoint ids after the max).
+// Gives the level-1 register seed (42 vertices) — room for three color holes
+// plus the connection ports as pairwise vertex-disjoint faces.
+std::vector<Face> subdivideFaces(const std::vector<Face> &faces) {
+  std::uint64_t nxt = 0;
+  for (const auto &f : faces)
+    for (const auto v : f) nxt = std::max(nxt, v + 1);
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::uint64_t> mid;
+  auto m = [&](std::uint64_t a, std::uint64_t b) -> std::uint64_t {
+    const auto key = std::make_pair(std::min(a, b), std::max(a, b));
+    const auto it = mid.find(key);
+    if (it != mid.end()) return it->second;
+    const std::uint64_t id = nxt++;
+    mid[key] = id;
+    return id;
+  };
+  std::vector<Face> out;
+  for (const auto &f : faces) {
+    const std::uint64_t a = f[0], b = f[1], c = f[2];
+    const std::uint64_t ab = m(a, b), bc = m(b, c), ca = m(c, a);
+    std::vector<Face> tris = {{a, ab, ca}, {b, bc, ab}, {c, ca, bc}, {ab, bc, ca}};
+    for (auto &s : tris) {
+      std::sort(s.begin(), s.end());
+      out.push_back(s);
+    }
+  }
+  return out;
+}
+
+// The first k pairwise vertex-disjoint faces of `faces`.
+std::vector<Face> disjointHoles(const std::vector<Face> &faces, std::size_t k) {
+  std::vector<Face> holes;
+  std::set<std::uint64_t> used;
+  for (const auto &f : faces) {
+    if (holes.size() >= k) break;
+    bool overlap = false;
+    for (const auto v : f)
+      if (used.count(v)) { overlap = true; break; }
+    if (!overlap) {
+      holes.push_back(f);
+      for (const auto v : f) used.insert(v);
+    }
+  }
+  return holes;
+}
+
+// Shift every vertex id of a face list by `off` (a distinct block).
+std::vector<Face> shift(const std::vector<Face> &faces, std::uint64_t off) {
+  std::vector<Face> out;
+  out.reserve(faces.size());
+  for (const auto &f : faces) {
+    Face g;
+    g.reserve(f.size());
+    for (const auto v : f) g.push_back(v + off);
+    std::sort(g.begin(), g.end());
+    out.push_back(std::move(g));
+  }
+  return out;
+}
+
+// The six lateral triangles of the triangular prism between sorted triangles
+// t0=(a,b,c) and t1=(a',b',c'), corresponded by sorted order. This ADDS
+// triangles to join two hole-circles into a tube — it never identifies the two
+// blocks' cells, so no weld is created.
+std::vector<Face> tube(const Face &t0, const Face &t1) {
+  const std::uint64_t a = t0[0], b = t0[1], c = t0[2];
+  const std::uint64_t a2 = t1[0], b2 = t1[1], c2 = t1[2];
+  const std::uint64_t quads[3][4] = {
+      {a, b, b2, a2}, {b, c, c2, b2}, {c, a, a2, c2}};
+  std::vector<Face> out;
+  for (const auto &q : quads) {
+    Face t = {q[0], q[1], q[2]};
+    std::sort(t.begin(), t.end());
+    out.push_back(t);
+    Face u = {q[0], q[2], q[3]};
+    std::sort(u.begin(), u.end());
+    out.push_back(u);
+  }
+  return out;
+}
+
+}  // namespace
+
+void RegisterTopology::validateStateDim(std::size_t d) const {
+  if (d != 3)
+    throw std::invalid_argument(
+        "MergeCobordism (register topology): state dimension must be 3 (the "
+        "color triple on the Sigma=0 hyperplane)");
+}
+
+std::shared_ptr<Spacetime> RegisterTopology::build(
+    std::size_t /*stateDim*/, std::uint64_t seed,
+    std::vector<std::vector<std::uint64_t>> &boundaryCells) {
+  // Three register blocks A, B, R (one per state: two inputs + one result), each
+  // a holed icosahedron, with disjoint vertex ids; input blocks join the result
+  // block by additive tubes (A->R, B->R). The level-1 subdivided icosahedron has
+  // room for three color holes + the ports as vertex-disjoint faces.
+  const auto seedFaces = subdivideFaces(icosahedron());
+  std::uint64_t stride = 0;
+  for (const auto &f : seedFaces)
+    for (const auto v : f) stride = std::max(stride, v + 1);
+
+  constexpr std::size_t kBlocks = 3;        // A, B, R
+  constexpr std::size_t kResult = 2;        // R is the third block
+  std::vector<std::vector<Face>> ports(kBlocks);
+  std::vector<std::set<Face>> omitted(kBlocks);  // holes + ports (not laid)
+  blockHoles_.assign(kBlocks, {});
+  for (std::size_t b = 0; b < kBlocks; ++b) {
+    const std::size_t nPorts = (b == kResult) ? 2 : 1;  // R joins both inputs
+    const std::size_t need = 3 + nPorts;
+    const auto blockFaces = shift(seedFaces, static_cast<std::uint64_t>(b) * stride);
+    const auto picks = disjointHoles(blockFaces, need);
+    if (picks.size() < need)
+      throw std::runtime_error(
+          "RegisterTopology: register seed lacks enough vertex-disjoint faces "
+          "for the color holes and connection ports");
+    for (std::size_t i = 0; i < 3; ++i) blockHoles_[b].push_back(picks[i]);
+    for (std::size_t i = 3; i < need; ++i) ports[b].push_back(picks[i]);
+    for (const auto &f : picks) omitted[b].insert(f);
+  }
+
+  // Assemble: each block's faces (minus its holes and ports) + one tube per
+  // input->result connection.
+  std::set<Face> cellSet;
+  for (std::size_t b = 0; b < kBlocks; ++b) {
+    const auto blockFaces = shift(seedFaces, static_cast<std::uint64_t>(b) * stride);
+    for (const auto &f : blockFaces)
+      if (!omitted[b].count(f)) cellSet.insert(f);
+  }
+  for (const auto &t : tube(ports[0][0], ports[kResult][0])) cellSet.insert(t);
+  for (const auto &t : tube(ports[1][0], ports[kResult][1])) cellSet.insert(t);
+
+  // === manifold gate: no weld (every edge in <= 2 triangles) ===
+  std::map<std::pair<std::uint64_t, std::uint64_t>, int> edgeCoface;
+  for (const auto &c : cellSet)
+    for (std::size_t i = 0; i < c.size(); ++i)
+      for (std::size_t j = i + 1; j < c.size(); ++j)
+        ++edgeCoface[{std::min(c[i], c[j]), std::max(c[i], c[j])}];
+  for (const auto &kv : edgeCoface)
+    if (kv.second > 2)
+      throw std::runtime_error(
+          "RegisterTopology: non-manifold seed (an edge has > 2 cofaces) — the "
+          "construction welded two blocks");
+
+  std::vector<std::vector<std::uint64_t>> cellList(cellSet.begin(), cellSet.end());
+  auto cobordism = Spacetime::fromCells(2, cellList, 1.0, 0.0);
+
+  // Seed the metric off the degenerate uniform point (break the l^2 = 1
+  // degeneracy so the first relax step can descend), as the operator seed does.
+  std::mt19937 jrng(static_cast<std::uint32_t>(seed) ^ 0x9e3779b9u);
+  std::uniform_real_distribution<double> jitter(0.7, 1.3);
+  for (auto *e : cobordism->getEdgeList()->toVector())
+    e->setSquaredLength(std::complex<double>(jitter(jrng), 0.0));
+
+  // dW = the boundary 1-cells: edges in exactly one triangle (the opened color
+  // hole-circles; the ports are tube-filled, hence interior).
+  boundaryCells.clear();
+  for (const auto &kv : edgeCoface)
+    if (kv.second == 1)
+      boundaryCells.push_back({kv.first.first, kv.first.second});
+
+  // === manifold gate: dualComplexValid (rigorous for n <= 3) ===
+  const auto valid = EigenstateSynthesis(cobordism, 1).dualComplexValid();
+  if (!valid.first)
+    throw std::runtime_error(
+        "RegisterTopology: seed failed the dual-complex manifold gate: " +
+        valid.second);
+
+  return cobordism;
+}
+
+void RegisterTopology::readout(
+    const std::shared_ptr<Spacetime> &cobordism,
+    const std::vector<std::vector<std::complex<double>>> &states,
+    std::vector<EdgeLoop> &loops,
+    std::vector<std::complex<double>> &targets) const {
+  // Each block's three color hole-circles carry that state's three color
+  // amplitudes (no S^1). The hole-circle of a sorted triangle (a<b<c) is the
+  // signed walk a -> b -> c -> a.
+  loops.clear();
+  targets.clear();
+  if (blockHoles_.empty() || !cobordism) return;
+  auto &vlist = *cobordism->getVertexList();
+  auto edge = [&](std::uint64_t u, std::uint64_t v) {
+    ::tessera::mesh::Vertex *vu = vlist.get(u), *vv = vlist.get(v);
+    if (!vu || !vv)
+      throw std::runtime_error(
+          "RegisterTopology::readout: loop vertex absent from W");
+    return ::tessera::mesh::Edge(vu, vv, std::complex<double>(1.0, 0.0));
+  };
+  const std::size_t nStates = std::min(states.size(), blockHoles_.size());
+  for (std::size_t s = 0; s < nStates; ++s) {
+    for (std::size_t k = 0; k < blockHoles_[s].size(); ++k) {
+      Face h(blockHoles_[s][k]);
+      std::sort(h.begin(), h.end());
+      loops.push_back({edge(h[0], h[1]), edge(h[1], h[2]), edge(h[2], h[0])});
+      targets.push_back(k < states[s].size() ? states[s][k]
+                                             : std::complex<double>(0));
+    }
+  }
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_merge_cobordism_operator_python.py
+++ b/tests/cobordism/test_merge_cobordism_operator_python.py
@@ -35,7 +35,11 @@ _OUT = [[1 + 0j, 0 + 0j]]
 # uses max_iters=400 (the delta-S=0 floor); the full-relax byte-identical
 # descent is pinned by the period smoke, not here.
 _ITERS = 30
-_M = tessera.cobordism.MergeCobordism(_IN, _OUT, max_iters=_ITERS, seed=0)
+# The default topology is now the #353-style RegisterTopology (#378); select the
+# (T^2-3holes)xS^1 operator topology explicitly for this suite.
+_M = tessera.cobordism.MergeCobordism(
+    _IN, _OUT, max_iters=_ITERS, seed=0,
+    topology=tessera.cobordism.TorusOperatorTopology())
 _S = _M.stats
 
 
@@ -139,7 +143,9 @@ class DeterminismTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.m2 = tessera.cobordism.MergeCobordism(_IN, _OUT, max_iters=_ITERS, seed=0)
+        cls.m2 = tessera.cobordism.MergeCobordism(
+            _IN, _OUT, max_iters=_ITERS, seed=0,
+            topology=tessera.cobordism.TorusOperatorTopology())
 
     def test_same_seed_same_residual(self):
         self.assertEqual(self.m2.stats.residual, _S.residual)

--- a/tests/cobordism/test_register_topology_python.py
+++ b/tests/cobordism/test_register_topology_python.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""The #353-style RegisterTopology and the selectable-topology seam (#378).
+
+`MergeCobordism` chooses its cobordism topology behind a `TopologyBuilder`. The
+default is now the color `RegisterTopology` (the #353 register), selectable
+against the `(T^2-3holes)xS^1` `TorusOperatorTopology`.
+
+`RegisterTopology` lays three holed-icosahedron color blocks (A, B, R) with
+disjoint vertex ids, joined input->result by additive *tubes*. Connecting by
+tubes — never by *identifying* a shared block — keeps the merge a genuine
+trivalent manifold, NOT the #353 `merge_cobordism.py` weld (a `P x I` transport
+with a buried result). These tests pin that the register seed is a valid,
+non-welded manifold and that the topology is selectable with a topology-specific
+state dimension (register: d=3; operator: a power of two).
+"""
+
+import cmath
+import unittest
+
+import tessera
+
+cob = tessera.cobordism
+_W = cmath.exp(2j * cmath.pi / 3)
+
+# Color (d=3) states: neutral-pair inputs (plain Sigma=0) + a singlet result.
+_A = [1.0, -1.0, 0.0]
+_B = [1.0, 0.0, -1.0]
+_R = [1.0, _W, _W * _W]
+# Qubit (d=2) state, for the operator topology / the dimension guard.
+_Q = [1.0, 0.0]
+
+
+def _top_cells(st, k):
+    return [tuple(int(v) for v in c)
+            for c in cob.ChainComplex.fromSpacetime(st).kSimplexVertices(k)]
+
+
+def _max_facet_coface(top_cells):
+    """The largest number of top cells sharing any codim-1 facet. A manifold has
+    <= 2 everywhere; a weld (hand-identified blocks) shows > 2."""
+    counts = {}
+    for c in top_cells:
+        vs = sorted(c)
+        for drop in range(len(vs)):
+            facet = tuple(v for i, v in enumerate(vs) if i != drop)
+            counts[facet] = counts.get(facet, 0) + 1
+    return max(counts.values()) if counts else 0
+
+
+# The register relaxation is light (2-D, signature-blind); a tiny iteration
+# budget keeps the suite fast. The topology invariants are seed/budget-independent.
+_M = cob.MergeCobordism([_A, _B], [_R], max_iters=2, seed=0)
+
+
+class RegisterIsDefaultTest(unittest.TestCase):
+    def test_default_topology_is_register(self):
+        # No topology= arg -> the #353-style register.
+        self.assertIn("register", _M.stats.topology)
+
+
+class RegisterIsAValidNonWeldedManifoldTest(unittest.TestCase):
+    def test_no_edge_in_more_than_two_triangles(self):
+        # The weld signature is an edge in > 2 triangles. Tubes only ADD
+        # triangles, so the register stays a 2-manifold (each edge in 1 or 2).
+        faces = _top_cells(_M.cobordism, 2)
+        self.assertGreater(len(faces), 0)
+        self.assertLessEqual(_max_facet_coface(faces), 2)
+
+    def test_dual_complex_gate_passes(self):
+        ok, why = cob.EigenstateSynthesis(_M.cobordism, 1).dualComplexValid()
+        self.assertTrue(ok, why)
+
+    def test_connected_with_nine_holes(self):
+        # Three icosa blocks tube-joined into one connected complex; opening the
+        # nine color holes (3 per block) gives S^2 minus 9 disks: b0=1, b1=8.
+        betti = list(_M.stats.betti_cobordism)
+        self.assertEqual(betti[0], 1)
+        self.assertEqual(betti[1], 8)
+
+    def test_boundary_is_the_color_hole_circles(self):
+        self.assertGreater(len(_M.boundary), 0)
+
+
+class RegisterCarriesTheColorStatesTest(unittest.TestCase):
+    def test_state_pinning_residual_is_finite(self):
+        # The relaxation pins the color states over the hole-circles; r_psi is a
+        # finite, real residual (a couple of iterations already reduce it).
+        self.assertGreaterEqual(_M.stats.state_residual, 0.0)
+        self.assertEqual(_M.stats.residual,
+                         _M.stats.stat_action_residual + _M.stats.state_residual)
+
+
+class TopologySelectionTest(unittest.TestCase):
+    """The topology is user-selectable, with a topology-specific state dim."""
+
+    def test_operator_topology_is_selectable(self):
+        topo = cob.TorusOperatorTopology()
+        self.assertIn("operator", topo.name())
+        self.assertEqual(topo.carried_dim(2), 3)      # d^2 - 1 for a qubit
+        topo.validate_state_dim(2)                     # power of two -> ok
+        with self.assertRaises((ValueError, RuntimeError)):
+            topo.validate_state_dim(3)                 # not a power of two
+
+    def test_register_topology_dim_is_three(self):
+        topo = cob.RegisterTopology()
+        self.assertIn("register", topo.name())
+        topo.validate_state_dim(3)                     # color triple -> ok
+        with self.assertRaises((ValueError, RuntimeError)):
+            topo.validate_state_dim(2)
+
+    def test_register_default_rejects_non_color_dimension(self):
+        # d=2 with the default (register) topology is rejected at construction.
+        with self.assertRaises((ValueError, RuntimeError)):
+            cob.MergeCobordism([_Q, _Q], [_Q], max_iters=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add the second `TopologyBuilder` against the clean #389 seam: **`RegisterTopology`**,
the #353-style color register, and make it the **default** `MergeCobordism`
topology (pass `TorusOperatorTopology` for the `(T²−3holes)×S¹` qubit operator).

> Rebased onto **main** (#389, "clean minimal base for the #380 epic"). The
> earlier draft was built on the unmerged #364 and reinvented an incompatible
> seam; this version implements against main's existing `TopologyBuilder`.

## Not welded (valid manifold)

The register lays three holed-icosahedron color blocks (A, B, R) with **disjoint**
vertex ids and joins each input block to the result by an additive **tube** (the
six lateral triangles of a triangular prism between two hole-circles). Connecting
by tubes — never *identifying* a shared block — keeps the merge a genuine
trivalent manifold: R is a real lobe of one connected complex, not the buried
middle slice the #353 `merge_cobordism.py` weld produces (a `P×I` transport that
slips past `dualComplexValid`). `build()` asserts a manifold gate
(`dualComplexValid` + every edge in ≤2 triangles) and throws on any weld.

## What's in
- `RegisterTopology` — color hole-circle read-out, no S¹; d=3.
- `TopologyBuilder::validateStateDim` (backward-compatible virtual; default a
  power of two, register d=3) — the admissible dim travels with the topology.
- Topology exposed to Python (`TopologyBuilder` / `TorusOperatorTopology` /
  `RegisterTopology` + a `topology=` ctor arg) — #389's binding hardcoded operator.
- Default flipped to register; the operator suite selects `TorusOperatorTopology`
  explicitly.

## Test plan
- [x] register is the default; valid non-welded manifold (max edge-coface ≤2, dualValid, b₀=1/b₁=8)
- [x] register carries the color states; read-out over the color hole-circles (9 = 3/block)
- [x] topology selectable; dim guard topology-specific (register d=3, operator 2^k)
- [x] operator suite still green with explicit topology selection (20 tests)
- [x] register suite green (9 tests)
- [ ] full pytest suite green on CI

Closes #378. Built on **main** (#389). Unblocks #379 (numeric #353 σ_R) / #382 (proton).
