### PR TITLE
feat(cobordism): switch MergeCobordism's 2nd objective term to the realizability r_U, with selectable r_ψ

### DIFF
--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -420,6 +420,60 @@ class EigenstateSynthesis {
         const std::vector<std::complex<double>> &cochain,
         const std::vector<EdgeLoop> &loops) const;
 
+    // === The hard period-pin r_ψ (the realizability alternative, #377) ===
+    // `residualForLoops`/`residualForPeriods` (r_U) build the EXACT-period state
+    // (a minimal leak) and score its NON-harmonicity \f$ \|L\psi-\lambda\psi\|^2 \f$.
+    // These instead keep the carried object a PURE harmonic and score the period
+    // GAP it cannot match, \f$ r_\psi = \|P^{\top}c - \text{target}\|^2 \f$ with
+    // \f$ c \f$ the least-squares fit — the §5.0 hard period-pin (#353's `r_ψ`).
+    // Same zero set as r_U (\f$ \to 0 \f$ iff the target lies in the carried
+    // period span), different off-zero shape and gradient. Selectable in
+    // `MergeCobordism` for comparison; r_U is the default.
+
+    /// The hard period-pin residual over signed edge-loops:
+    /// \f$ r_\psi = \|\,P^{\top} c - \text{target}\,\|^2 \f$, where the columns of
+    /// \f$ P^{\top} \f$ are the live harmonics' periods over `loops` and
+    /// \f$ c = (P^{\top})^{+}\,\text{target} \f$ is their least-squares fit — the
+    /// squared norm of the part of `targetPeriods` no pure harmonic can carry.
+    /// \f$ \to 0 \f$ iff the target lies in the carried period span (the same
+    /// realizable set as `residualForLoops`), floored otherwise; **no leak**, so
+    /// the carried object stays a pure harmonic (vs r_U's exact-period state).
+    /// @throws std::runtime_error if `targetPeriods.size() != loops.size()`.
+    [[nodiscard]] double periodGapForLoops(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// Exact analytic gradient \f$ \partial r_\psi / \partial l^2_e \f$ of
+    /// `periodGapForLoops` w.r.t. each edge's squared length, in `cellSimplices()`
+    /// order. The least-squares optimality \f$ P^{\top\!}\,r = 0 \f$ (envelope
+    /// theorem) kills the \f$ \partial c \f$ term, so
+    /// \f$ \partial r_\psi = 2\,\Re\big(r^{\dagger}\,(Q\,\partial U_n)\,c\big) \f$
+    /// — only the harmonic-subspace perturbation \f$ \partial U_n \f$ enters
+    /// (no leak, no \f$ \partial\psi \f$ chain). Same first-order eigenvector
+    /// perturbation machinery as `residualForLoopsGradient`. \f$ O(n_1^3) \f$.
+    /// @throws std::runtime_error if `targetPeriods.size() != loops.size()`.
+    [[nodiscard]] std::vector<double> periodGapForLoopsGradient(
+        const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// `periodGapForLoops` over removed-triangle holes (the r_ψ analogue of
+    /// `residualForPeriods`): each hole is a 3-vertex tuple whose oriented
+    /// boundary \f$ h_0\to h_1\to h_2\to h_0 \f$ is the loop. Convenience +
+    /// Python entry point.
+    /// @throws std::runtime_error if `targetPeriods.size() != holes.size()` or a
+    ///   hole has \f$ \ne 3 \f$ vertices.
+    [[nodiscard]] double periodGapForPeriods(
+        const std::vector<std::vector<std::uint64_t>> &holes,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    /// The analytic gradient of `periodGapForPeriods` (holes routed to
+    /// `periodGapForLoopsGradient`), in `cellSimplices()` order.
+    /// @throws std::runtime_error if `targetPeriods.size() != holes.size()` or a
+    ///   hole has \f$ \ne 3 \f$ vertices.
+    [[nodiscard]] std::vector<double> periodGapForPeriodsGradient(
+        const std::vector<std::vector<std::uint64_t>> &holes,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
     // === The discovered operator: ker L₁(W − ∂W) (#363) ===
 
     /// The interior 1-cells of \f$ W - \partial W \f$ — the edges both of whose
@@ -602,6 +656,12 @@ class EigenstateSynthesis {
     [[nodiscard]] std::vector<double> periodGradientOverLoops(
         const std::vector<EdgeLoop> &loops,
         const std::vector<std::complex<double>> &targetPeriods) const;
+
+    // Each removed-triangle hole (a 3-vertex tuple) as the oriented boundary loop
+    // h0 -> h1 -> h2 -> h0, so the holes period-gap methods reuse the loop core.
+    [[nodiscard]] std::vector<EdgeLoop> holeLoops(
+        const std::vector<std::vector<std::uint64_t>> &holes,
+        const char *who) const;
 
     // Re-create the top cell of a Removal (createSimplexTracked rebuilds its
     // missing edges = the orphaned ones) and restore those edges' weights/phases.

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -645,6 +645,14 @@ class EigenstateSynthesis {
     [[nodiscard]] RegisterReadout assembleReadoutOverLoops(
         const std::vector<EdgeLoop> &loops) const;
 
+    // The minimum-norm least-squares fit of targetPeriods onto the carried
+    // period rows P^T (c = (P^T)^+ target via the SVD) — the single projection
+    // both the carried representative (r_U) and the period gap (r_psi) ride on, so
+    // their realizable zero sets coincide. Length ro.dim (empty when ro.dim == 0).
+    [[nodiscard]] std::vector<std::complex<double>> lstsqOverReadout(
+        const RegisterReadout &ro,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
     // The carried representative from a finished read-out — shared by the hole
     // and loop period paths (the lstsq projection plus each cycle's leak).
     [[nodiscard]] std::vector<std::complex<double>> carriedFromReadout(

--- a/include/cobordism/MergeCobordism.h
+++ b/include/cobordism/MergeCobordism.h
@@ -27,7 +27,7 @@ using ::tessera::spacetime::Spacetime;
 /// \f$ (T^2 - 3\,\text{holes}) \times S^1 \f$ operator topology — which builds
 /// \f$ W \f$ and supplies the per-state read-out cycles. The interior edge
 /// lengths are relaxed to a stationary point of the dual Regge action under the
-/// state-pinning residual (`r = \beta\|\nabla S\|^2 + r_\psi`) by a Gauss-Newton
+/// state-pinning residual (`r = \beta\|\nabla S\|^2 + r_state`) by a Gauss-Newton
 /// / Levenberg-Marquardt descent on the **exact analytic** Jacobian, using the
 /// **sparse** action Hessian (`actionHessianExactSparse`). The operator is then
 /// read off the relaxed bulk.
@@ -37,14 +37,34 @@ using ::tessera::spacetime::Spacetime;
 /// * **U-supplied**: `outputStates` is computed from `U` and the inputs; `U` is
 ///   then ignored (a consistency check — the emergent operator should reproduce
 ///   the supplied `U`).
+///
+/// ## State-residual term \f$ r_\text{state} \f$ (#377, selectable)
+/// The matter/state term defaults to the #353 **realizability** residual
+/// \f$ r_U \f$ (`EigenstateSynthesis::residualForLoops`): it holds the state's
+/// target periods **exactly** (a minimal leak) and scores the non-harmonicity
+/// \f$ \|L\psi-\lambda\psi\|^2 \f$ — \f$ \to 0 \f$ for a realizable (e.g.
+/// \f$ \sum = 0 \f$) state, floored otherwise (confinement). The legacy **hard
+/// period-pin** \f$ r_\psi \f$ (`EigenstateSynthesis::periodGapForLoops`, the
+/// carried-vs-target period gap \f$ \|P^{\top}c-\text{target}\|^2 \f$ with the
+/// carried object a pure harmonic) is selectable via `StateResidualMode` for
+/// comparison. Both share the realizable zero set; they differ off-zero.
 class MergeCobordism {
   public:
+    /// The matter/state term \f$ r_\text{state} \f$ the relaxation pins against.
+    enum class StateResidualMode {
+      Realizability,  ///< \f$ r_U \f$ (default): hold the periods exact, score the
+                      ///< state's non-harmonicity (`residualForLoops`).
+      PeriodPin,      ///< \f$ r_\psi \f$: pure-harmonic carried-vs-target period
+                      ///< gap (`periodGapForLoops`).
+    };
+
     /// Convergence + topology statistics of the relaxation.
     struct Stats {
       bool converged{false};            ///< the final residual fell below epsilon
       double residual{0.0};             ///< final total residual r
       double statActionResidual{0.0};   ///< final \f$ \beta\|\nabla S\|^2 \f$
-      double stateResidual{0.0};        ///< final \f$ r_\psi \f$
+      double stateResidual{0.0};        ///< final \f$ r_\text{state} \f$ (the
+                                        ///< selected term: r_U or r_psi)
       std::complex<double> dualAction{0.0, 0.0};  ///< final `dualReggeAction()`
       int relaxIterations{0};           ///< inner LM iterations used
       std::vector<int> bettiCobordism{};  ///< Betti numbers of \f$ W \f$
@@ -52,6 +72,7 @@ class MergeCobordism {
       int kerL1Bulk{0};                 ///< \f$ \dim \ker L_1(W - \partial W) \f$
       int interiorVertices{0};          ///< interior (non-\f$ \partial W \f$) vertices
       std::string topology{};           ///< the TopologyBuilder's name
+      std::string stateMode{};          ///< the selected r_state term ("r_U" / "r_psi")
     };
 
     /// Build and run the merge.
@@ -66,12 +87,15 @@ class MergeCobordism {
     /// @param seed         RNG seed for the metric jitter.
     /// @param topology     the cobordism topology; null => TorusOperatorTopology.
     /// @param verbose      emit per-iteration relax progress to stderr.
+    /// @param stateMode    the \f$ r_\text{state} \f$ term — `Realizability`
+    ///   (\f$ r_U \f$, default) or `PeriodPin` (\f$ r_\psi \f$, for comparison).
     MergeCobordism(
         const std::vector<std::vector<std::complex<double>>> &inputStates,
         const std::vector<std::vector<std::complex<double>>> &outputStates,
         const std::vector<std::complex<double>> &U = {}, double beta = 1.0,
         double epsilon = 1e-6, int maxIters = 400, std::uint64_t seed = 0,
-        std::shared_ptr<TopologyBuilder> topology = nullptr, bool verbose = false);
+        std::shared_ptr<TopologyBuilder> topology = nullptr, bool verbose = false,
+        StateResidualMode stateMode = StateResidualMode::Realizability);
 
     [[nodiscard]] const std::vector<std::vector<std::complex<double>>> &
     inputStates() const noexcept { return inputStates_; }
@@ -110,9 +134,10 @@ class MergeCobordism {
     std::size_t stateDim_{0};
     bool verbose_{false};
     std::shared_ptr<TopologyBuilder> topology_{};
+    StateResidualMode stateMode_{StateResidualMode::Realizability};
 
-    // r_psi: the states pinned as period targets over the boundary cycles the
-    // topology's readout() supplies.
+    // r_state: the states pinned as period targets over the boundary cycles the
+    // topology's readout() supplies (scored by r_U or r_psi per stateMode_).
     std::vector<TopologyBuilder::EdgeLoop> stateLoops_{};
     std::vector<std::complex<double>> stateTargets_{};
 

--- a/include/cobordism/MergeCobordism.h
+++ b/include/cobordism/MergeCobordism.h
@@ -43,7 +43,7 @@ using ::tessera::spacetime::Spacetime;
 /// \f$ r_U \f$ (`EigenstateSynthesis::residualForLoops`): it holds the state's
 /// target periods **exactly** (a minimal leak) and scores the non-harmonicity
 /// \f$ \|L\psi-\lambda\psi\|^2 \f$ — \f$ \to 0 \f$ for a realizable (e.g.
-/// \f$ \sum = 0 \f$) state, floored otherwise (confinement). The legacy **hard
+/// \f$ \sum = 0 \f$) state, floored otherwise (confinement). The **hard
 /// period-pin** \f$ r_\psi \f$ (`EigenstateSynthesis::periodGapForLoops`, the
 /// carried-vs-target period gap \f$ \|P^{\top}c-\text{target}\|^2 \f$ with the
 /// carried object a pure harmonic) is selectable via `StateResidualMode` for

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -530,6 +530,26 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "approximation (~1e-5 vs FP64); residualForPeriodsGradient stays the "
            "default and the correctness oracle. Requires a TESSERA_CUDA build "
            "(raises otherwise), and raises on a hole/target length mismatch.")
+      // ----- The hard period-pin r_psi (the realizability alternative, #377) -----
+      .def("periodGapForPeriods", &EigenstateSynthesis::periodGapForPeriods,
+           py::arg("holes"), py::arg("target_periods"),
+           "The hard period-pin r_psi over the holes' cycles: r_psi = "
+           "||P^T c - target||^2, where the columns of P^T are the live "
+           "harmonics' periods over the holes and c is their least-squares fit "
+           "-- the squared norm of the part of target_periods no pure harmonic "
+           "can carry. Unlike residualForPeriods (r_U), the carried object stays "
+           "a pure harmonic (NO leak). -> 0 iff the targets lie in the carried "
+           "period span (the same realizable set as r_U), floored otherwise. "
+           "Raises on a hole/target length mismatch or a malformed hole.")
+      .def("periodGapForPeriodsGradient",
+           &EigenstateSynthesis::periodGapForPeriodsGradient,
+           py::arg("holes"), py::arg("target_periods"),
+           "The exact analytic gradient d r_psi / d l^2 of periodGapForPeriods, "
+           "in cellSimplices() (k=1 cell) order. By least-squares optimality "
+           "(A^T r = 0, the envelope theorem) only the harmonic-subspace "
+           "perturbation enters: d r_psi = 2 Re( r^H (Q dUn) c ) -- no leak, no "
+           "dpsi chain. Raises on a hole/target length mismatch or a malformed "
+           "hole.")
       // ----- The discovered operator: ker L1(W - dW) (#363) -----
       .def("bulkMinusBoundaryCells",
            &EigenstateSynthesis::bulkMinusBoundaryCells,
@@ -1280,6 +1300,14 @@ prepared states, reproduces the harmonic overlap.)doc")
       "output qubit states through a cobordism bulk, mediated by the dual "
       "Lorentzian Regge action (relaxed with the sparse analytic Hessian) on a "
       "TopologyBuilder topology.");
+  py::enum_<MergeCobordism::StateResidualMode>(mc, "StateResidualMode",
+      "The matter/state term r_state the relaxation pins against.")
+      .value("Realizability", MergeCobordism::StateResidualMode::Realizability,
+             "r_U (default): hold the periods exact, score the state's "
+             "non-harmonicity (residualForLoops).")
+      .value("PeriodPin", MergeCobordism::StateResidualMode::PeriodPin,
+             "r_psi: the pure-harmonic carried-vs-target period gap "
+             "(periodGapForLoops).");
   py::class_<MergeCobordism::Stats>(mc, "Stats",
       "Convergence + topology statistics of the relaxation.")
       .def_readonly("converged", &MergeCobordism::Stats::converged)
@@ -1294,23 +1322,29 @@ prepared states, reproduces the harmonic overlap.)doc")
       .def_readonly("ker_l1_bulk", &MergeCobordism::Stats::kerL1Bulk)
       .def_readonly("interior_vertices",
                     &MergeCobordism::Stats::interiorVertices)
-      .def_readonly("topology", &MergeCobordism::Stats::topology);
+      .def_readonly("topology", &MergeCobordism::Stats::topology)
+      .def_readonly("state_mode", &MergeCobordism::Stats::stateMode,
+                    "The selected r_state term: 'r_U' or 'r_psi'.");
   mc.def(py::init([](const std::vector<std::vector<std::complex<double>>> &in,
                      const std::vector<std::vector<std::complex<double>>> &out,
                      const std::vector<std::complex<double>> &U, double beta,
                      double epsilon, int maxIters, std::uint64_t seed,
-                     bool verbose) {
+                     bool verbose, MergeCobordism::StateResidualMode stateMode) {
            return std::make_unique<MergeCobordism>(
-               in, out, U, beta, epsilon, maxIters, seed, nullptr, verbose);
+               in, out, U, beta, epsilon, maxIters, seed, nullptr, verbose,
+               stateMode);
          }),
          py::arg("input_states"), py::arg("output_states"),
          py::arg("U") = std::vector<std::complex<double>>{},
          py::arg("beta") = 1.0, py::arg("epsilon") = 1e-6,
          py::arg("max_iters") = 400, py::arg("seed") = 0,
          py::arg("verbose") = false,
+         py::arg("state_mode") = MergeCobordism::StateResidualMode::Realizability,
          "Build and run the merge on the default (T^2-3holes)xS^1 operator "
          "topology. output_states is required unless U (a flat row-major dxd "
-         "operator) is supplied, in which case it is computed from U.")
+         "operator) is supplied, in which case it is computed from U. state_mode "
+         "selects the r_state term: Realizability (r_U, default) or PeriodPin "
+         "(r_psi, for comparison).")
       .def_property_readonly("input_states", &MergeCobordism::inputStates)
       .def_property_readonly("output_states", &MergeCobordism::outputStates)
       .def_property_readonly("cobordism", &MergeCobordism::cobordism,

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -995,37 +995,45 @@ std::vector<cd> EigenstateSynthesis::carriedFromReadout(
         std::to_string(targetPeriods.size()) + " target periods for " +
         std::to_string(m) + " cycles");
 
-  // The minimum-norm least-squares projection onto the carried period rows
-  // (what numpy.linalg.lstsq returns): c = (P^T)^+ target via the SVD.
-  Eigen::VectorXcd t(static_cast<Eigen::Index>(m));
-  for (std::size_t q = 0; q < m; ++q)
-    t[static_cast<Eigen::Index>(q)] = targetPeriods[q];
-  Eigen::VectorXcd c(static_cast<Eigen::Index>(ro.dim));
-  if (ro.dim > 0) {
-    Eigen::MatrixXcd Pt(static_cast<Eigen::Index>(m),
-                        static_cast<Eigen::Index>(ro.dim));
-    for (std::size_t q = 0; q < m; ++q)
-      for (std::size_t r = 0; r < ro.dim; ++r)
-        Pt(static_cast<Eigen::Index>(q), static_cast<Eigen::Index>(r)) =
-            ro.P[r * m + q];
-    c = Pt.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(t);
-  }
+  // The minimum-norm least-squares projection onto the carried period rows.
+  const std::vector<cd> c = lstsqOverReadout(ro, targetPeriods);
 
   // The carried representative plus the minimal leak: psi = sum_r c_r h_r,
   // then each cycle's uncarried remainder lands on its leak column, so the
   // cochain's periods are exactly the targets.
   std::vector<cd> psi(n, cd(0.0, 0.0));
   for (std::size_t r = 0; r < ro.dim; ++r) {
-    const cd cr = c[static_cast<Eigen::Index>(r)];
+    const cd cr = c[r];
     for (std::size_t i = 0; i < n; ++i) psi[i] += cr * ro.H[r * n + i];
   }
   for (std::size_t q = 0; q < m; ++q) {
     cd carried(0.0, 0.0);
-    for (std::size_t r = 0; r < ro.dim; ++r)
-      carried += c[static_cast<Eigen::Index>(r)] * ro.P[r * m + q];
+    for (std::size_t r = 0; r < ro.dim; ++r) carried += c[r] * ro.P[r * m + q];
     psi[ro.leakColumns[q]] += targetPeriods[q] - carried;
   }
   return psi;
+}
+
+std::vector<cd> EigenstateSynthesis::lstsqOverReadout(
+    const RegisterReadout &ro, const std::vector<cd> &targetPeriods) const {
+  // c = (P^T)^+ target (minimum-norm least squares, what numpy.linalg.lstsq
+  // returns): the SVD projection of the targets onto the carried period rows.
+  // Shared by carriedFromReadout (r_U's leak'd state) and periodGapForLoops
+  // (r_psi's period gap), so the two terms fit onto the same carried space.
+  const std::size_t m = ro.leakColumns.size();
+  if (ro.dim == 0) return {};
+  Eigen::VectorXcd t(static_cast<Eigen::Index>(m));
+  for (std::size_t q = 0; q < m; ++q)
+    t[static_cast<Eigen::Index>(q)] = targetPeriods[q];
+  Eigen::MatrixXcd Pt(static_cast<Eigen::Index>(m),
+                      static_cast<Eigen::Index>(ro.dim));
+  for (std::size_t q = 0; q < m; ++q)
+    for (std::size_t r = 0; r < ro.dim; ++r)
+      Pt(static_cast<Eigen::Index>(q), static_cast<Eigen::Index>(r)) =
+          ro.P[r * m + q];
+  const Eigen::VectorXcd c =
+      Pt.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(t);
+  return std::vector<cd>(c.data(), c.data() + c.size());
 }
 
 EigenstateSynthesis::RegisterReadout EigenstateSynthesis::assembleReadoutOverLoops(
@@ -1158,30 +1166,20 @@ double EigenstateSynthesis::periodGapForLoops(
         std::to_string(m) + " loops");
   if (m == 0) return 0.0;
   const RegisterReadout ro = assembleReadoutOverLoops(loops);
-  // No harmonic carried: none of the target is reachable -> the gap is all of it.
-  if (ro.dim == 0) {
-    double g = 0.0;
-    for (const cd &t : targetPeriods) g += std::norm(t);
-    return g;
+  // The carried object stays a PURE harmonic (no leak): least-squares-fit the
+  // target onto the carried period rows (lstsqOverReadout — the SAME projection
+  // r_U's carriedFromReadout uses, so the two terms share the realizable zero
+  // set) and return the squared norm of the remainder no harmonic can reach,
+  // ||carried - target||^2 = ||P^T c - target||^2. When ro.dim == 0 nothing is
+  // carried and the gap is the whole target (c is empty -> carried = 0).
+  const std::vector<cd> c = lstsqOverReadout(ro, targetPeriods);
+  double gap = 0.0;
+  for (std::size_t q = 0; q < m; ++q) {
+    cd carried(0.0, 0.0);
+    for (std::size_t r = 0; r < ro.dim; ++r) carried += c[r] * ro.P[r * m + q];
+    gap += std::norm(carried - targetPeriods[q]);
   }
-  // P^T (m x dim): the live harmonics' periods over the loops. The carried object
-  // stays a PURE harmonic (no leak): least-squares-fit the target onto P^T's
-  // column space and return the squared norm of the unreachable remainder. The
-  // min-norm SVD fit is the same projection convention carriedFromReadout uses
-  // for r_U (so the two terms share the realizable zero set) and that
-  // periodGapForLoopsGradient differentiates.
-  Eigen::MatrixXcd Pt(static_cast<Eigen::Index>(m),
-                      static_cast<Eigen::Index>(ro.dim));
-  for (std::size_t q = 0; q < m; ++q)
-    for (std::size_t r = 0; r < ro.dim; ++r)
-      Pt(static_cast<Eigen::Index>(q), static_cast<Eigen::Index>(r)) =
-          ro.P[r * m + q];
-  Eigen::VectorXcd t(static_cast<Eigen::Index>(m));
-  for (std::size_t q = 0; q < m; ++q)
-    t[static_cast<Eigen::Index>(q)] = targetPeriods[q];
-  const Eigen::VectorXcd c =
-      Pt.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(t);
-  return (Pt * c - t).squaredNorm();
+  return gap;
 }
 
 double EigenstateSynthesis::periodGapForPeriods(
@@ -1593,26 +1591,9 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
     const std::vector<cd> &targetPeriods) const {
   // A removed triangle's boundary IS the oriented loop h0 -> h1 -> h2 -> h0
   // (identical signed covector and leak), so route through the loop core.
-  auto &vlist = *st_->getVertexList();
-  auto edge = [&](std::uint64_t u, std::uint64_t v) {
-    auto *vu = vlist.get(u), *vv = vlist.get(v);
-    if (!vu || !vv)
-      throw std::runtime_error(
-          "EigenstateSynthesis::residualForPeriodsGradient: hole vertex absent");
-    return Edge(vu, vv, cd(1.0, 0.0));
-  };
-  std::vector<EdgeLoop> loops;
-  loops.reserve(holes.size());
-  for (const auto &h : holes) {
-    if (h.size() != 3)
-      throw std::runtime_error(
-          "EigenstateSynthesis::residualForPeriodsGradient: hole has " +
-          std::to_string(h.size()) + " vertices, expected 3");
-    std::vector<std::uint64_t> s(h);
-    std::sort(s.begin(), s.end());
-    loops.push_back({edge(s[0], s[1]), edge(s[1], s[2]), edge(s[2], s[0])});
-  }
-  return periodGradientOverLoops(loops, targetPeriods);
+  return periodGradientOverLoops(
+      holeLoops(holes, "EigenstateSynthesis::residualForPeriodsGradient"),
+      targetPeriods);
 }
 
 std::vector<double> EigenstateSynthesis::residualForLoopsGradient(

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1166,7 +1166,10 @@ double EigenstateSynthesis::periodGapForLoops(
   }
   // P^T (m x dim): the live harmonics' periods over the loops. The carried object
   // stays a PURE harmonic (no leak): least-squares-fit the target onto P^T's
-  // column space and return the squared norm of the unreachable remainder.
+  // column space and return the squared norm of the unreachable remainder. The
+  // min-norm SVD fit is the same projection convention carriedFromReadout uses
+  // for r_U (so the two terms share the realizable zero set) and that
+  // periodGapForLoopsGradient differentiates.
   Eigen::MatrixXcd Pt(static_cast<Eigen::Index>(m),
                       static_cast<Eigen::Index>(ro.dim));
   for (std::size_t q = 0; q < m; ++q)
@@ -1397,7 +1400,13 @@ std::vector<double> EigenstateSynthesis::periodGapForLoopsGradient(
   // A = Q Un and c the least-squares fit, NOT the leak'd state's non-harmonicity.
   // Least-squares optimality A^T r = 0 (envelope theorem) drops the dc term, so
   // d r_psi / d l^2 = 2 Re( r^H (Q dUn) c ) -- no leak, no dpsi chain.
+  //
+  // NB the M / eigensplit / per-edge-dM machinery below is DELIBERATELY duplicated
+  // from periodGradientOverLoops: that r_U gradient is frozen (FD- and GPU-mirror
+  // verified), so a shared helper would have to edit do-not-change code. Keep the
+  // two copies in sync; test_period_gap_python.py FD-guards this one.
   using Eigen::Index;
+  using Eigen::MatrixXcd;
   using Eigen::MatrixXd;
   using Eigen::VectorXcd;
   using Eigen::VectorXd;
@@ -1500,12 +1509,20 @@ std::vector<double> EigenstateSynthesis::periodGapForLoopsGradient(
   for (Index r = 0; r < nnd; ++r) invlam[r] = -1.0 / lam[nnIdx[r]];
 
   // ---- the least-squares fit c and the period-gap residual r = A c - target ----
+  // Rank-robust min-norm fit (Jacobi SVD), matching periodGapForLoops's value so
+  // the analytic gradient stays consistent with the function it differentiates,
+  // and so a column-rank-deficient A (carried harmonic count nd > read-out cycle
+  // count m, or dependent/zero-period harmonics) yields the min-norm solution
+  // rather than the NaN a singular (A^T A)^{-1} would give. The optimality
+  // A^T r = 0 holds for ANY least-squares solution, so the envelope theorem
+  // (the dropped dc term) is unaffected by the min-norm choice.
   VectorXcd target(static_cast<Index>(m));
   for (std::size_t q = 0; q < m; ++q) target[static_cast<Index>(q)] = targetPeriods[q];
   const MatrixXd A = Q * Un;                            // m x nd
-  const MatrixXd AtAi = (A.transpose() * A).inverse();  // nd x nd
-  const VectorXcd c = (AtAi * A.transpose()).cast<cd>() * target;  // nd
-  const VectorXcd r = A.cast<cd>() * c - target;        // m; A^T r = 0 (optimality)
+  const MatrixXcd Ac = A.cast<cd>();
+  const VectorXcd c =
+      Ac.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(target);  // nd
+  const VectorXcd r = Ac * c - target;                 // m; A^T r = 0 (optimality)
 
   // ---- per-edge analytic gradient d r_psi / d l^2 (low-rank dM + perturbation) ----
   for (std::size_t je = 0; je < n1; ++je) {

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1124,6 +1124,71 @@ double EigenstateSynthesis::residualForPeriods(
   return residual(psi);
 }
 
+std::vector<EigenstateSynthesis::EdgeLoop> EigenstateSynthesis::holeLoops(
+    const std::vector<std::vector<std::uint64_t>> &holes, const char *who) const {
+  auto &vlist = *st_->getVertexList();
+  auto edge = [&](std::uint64_t u, std::uint64_t v) {
+    auto *vu = vlist.get(u), *vv = vlist.get(v);
+    if (!vu || !vv)
+      throw std::runtime_error(std::string(who) + ": hole vertex absent");
+    return Edge(vu, vv, cd(1.0, 0.0));
+  };
+  std::vector<EdgeLoop> loops;
+  loops.reserve(holes.size());
+  for (const auto &h : holes) {
+    if (h.size() != 3)
+      throw std::runtime_error(std::string(who) + ": hole has " +
+                               std::to_string(h.size()) +
+                               " vertices, expected 3");
+    std::vector<std::uint64_t> s(h);
+    std::sort(s.begin(), s.end());
+    loops.push_back({edge(s[0], s[1]), edge(s[1], s[2]), edge(s[2], s[0])});
+  }
+  return loops;
+}
+
+double EigenstateSynthesis::periodGapForLoops(
+    const std::vector<EdgeLoop> &loops,
+    const std::vector<cd> &targetPeriods) const {
+  const std::size_t m = loops.size();
+  if (targetPeriods.size() != m)
+    throw std::runtime_error(
+        "EigenstateSynthesis::periodGapForLoops: " +
+        std::to_string(targetPeriods.size()) + " target periods for " +
+        std::to_string(m) + " loops");
+  if (m == 0) return 0.0;
+  const RegisterReadout ro = assembleReadoutOverLoops(loops);
+  // No harmonic carried: none of the target is reachable -> the gap is all of it.
+  if (ro.dim == 0) {
+    double g = 0.0;
+    for (const cd &t : targetPeriods) g += std::norm(t);
+    return g;
+  }
+  // P^T (m x dim): the live harmonics' periods over the loops. The carried object
+  // stays a PURE harmonic (no leak): least-squares-fit the target onto P^T's
+  // column space and return the squared norm of the unreachable remainder.
+  Eigen::MatrixXcd Pt(static_cast<Eigen::Index>(m),
+                      static_cast<Eigen::Index>(ro.dim));
+  for (std::size_t q = 0; q < m; ++q)
+    for (std::size_t r = 0; r < ro.dim; ++r)
+      Pt(static_cast<Eigen::Index>(q), static_cast<Eigen::Index>(r)) =
+          ro.P[r * m + q];
+  Eigen::VectorXcd t(static_cast<Eigen::Index>(m));
+  for (std::size_t q = 0; q < m; ++q)
+    t[static_cast<Eigen::Index>(q)] = targetPeriods[q];
+  const Eigen::VectorXcd c =
+      Pt.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(t);
+  return (Pt * c - t).squaredNorm();
+}
+
+double EigenstateSynthesis::periodGapForPeriods(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+  return periodGapForLoops(
+      holeLoops(holes, "EigenstateSynthesis::periodGapForPeriods"),
+      targetPeriods);
+}
+
 std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
     const std::vector<EdgeLoop> &loops,
     const std::vector<cd> &targetPeriods) const {
@@ -1321,6 +1386,189 @@ std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
                (2.0 * rU / nrm) * (p.dot(dpsi)).real();
   }
   return grad;
+}
+
+std::vector<double> EigenstateSynthesis::periodGapForLoopsGradient(
+    const std::vector<EdgeLoop> &loops,
+    const std::vector<cd> &targetPeriods) const {
+  // The hard-pin sibling of periodGradientOverLoops (r_U): same first-order
+  // eigenvector-perturbation setup (M = L1, harmonic split Un/Unn, the per-edge
+  // low-rank dM, dUn), but the score is the period GAP r_psi = ||A c - t||^2 with
+  // A = Q Un and c the least-squares fit, NOT the leak'd state's non-harmonicity.
+  // Least-squares optimality A^T r = 0 (envelope theorem) drops the dc term, so
+  // d r_psi / d l^2 = 2 Re( r^H (Q dUn) c ) -- no leak, no dpsi chain.
+  using Eigen::Index;
+  using Eigen::MatrixXd;
+  using Eigen::VectorXcd;
+  using Eigen::VectorXd;
+  const std::size_t n1 = order_;
+  std::vector<double> grad(n1, 0.0);
+  const std::size_t m = loops.size();
+  if (n1 == 0 || m == 0) return grad;
+  if (targetPeriods.size() != m)
+    throw std::runtime_error(
+        "EigenstateSynthesis::periodGapForLoopsGradient: " +
+        std::to_string(targetPeriods.size()) + " target periods for " +
+        std::to_string(m) + " loops");
+  static constexpr double kNullTol = 1e-7;
+  const Index N = static_cast<Index>(n1);
+
+  // ---- chain complex, weights, and the metric Laplacian M = L1 ----
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const std::vector<std::vector<std::uint64_t>> &cells1 = cellSimplices();
+  const auto tris = cc.kSimplexVertices(2);
+  const std::size_t n2 = tris.size();
+  const std::vector<long> &d1flat = cc.boundaryMatrix(1);  // n0 x n1
+  const std::vector<long> &d2flat = cc.boundaryMatrix(2);  // n1 x n2
+  const std::size_t n0 = d1flat.size() / n1;
+  const HodgeLaplacian hl(st_);
+  const std::vector<double> W1v = hl.weights(1);  // n1
+  const std::vector<double> W2v = hl.weights(2);  // n2
+  const std::vector<cd> Lflat = hl.laplacian(1, /*metric=*/true, /*lorentzian=*/false);
+
+  MatrixXd M(N, N);
+  for (std::size_t i = 0; i < n1; ++i)
+    for (std::size_t j = 0; j < n1; ++j)
+      M(static_cast<Index>(i), static_cast<Index>(j)) = Lflat[i * n1 + j].real();
+  VectorXd W1(N), D1d(N), D1pd(N);  // W1, 1/sqrt(W1), sqrt(W1)
+  for (std::size_t i = 0; i < n1; ++i) {
+    W1[static_cast<Index>(i)] = W1v[i];
+    D1pd[static_cast<Index>(i)] = std::sqrt(W1v[i]);
+    D1d[static_cast<Index>(i)] = 1.0 / std::sqrt(W1v[i]);
+  }
+  MatrixXd d1m(static_cast<Index>(n0), N);
+  for (std::size_t v = 0; v < n0; ++v)
+    for (std::size_t c = 0; c < n1; ++c)
+      d1m(static_cast<Index>(v), static_cast<Index>(c)) =
+          static_cast<double>(d1flat[v * n1 + c]);
+  MatrixXd d2m(N, static_cast<Index>(n2));
+  for (std::size_t c = 0; c < n1; ++c)
+    for (std::size_t t = 0; t < n2; ++t)
+      d2m(static_cast<Index>(c), static_cast<Index>(t)) =
+          static_cast<double>(d2flat[c * n2 + t]);
+  const MatrixXd K1 = d1m.transpose() * d1m;  // n1 x n1
+  VectorXd W2inv(static_cast<Index>(n2));
+  for (std::size_t t = 0; t < n2; ++t) W2inv[static_cast<Index>(t)] = 1.0 / W2v[t];
+  const MatrixXd K2 = d2m * W2inv.asDiagonal() * d2m.transpose();  // n1 x n1
+
+  // ---- index maps: cell -> index, edge -> l^2, edge -> incident triangles ----
+  auto key = [](std::uint64_t a, std::uint64_t b) {
+    return std::pair<std::uint64_t, std::uint64_t>(std::min(a, b), std::max(a, b));
+  };
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> cidx1;
+  for (std::size_t i = 0; i < n1; ++i) cidx1[key(cells1[i][0], cells1[i][1])] = i;
+  std::map<std::pair<std::uint64_t, std::uint64_t>, double> l2map;
+  for (auto *e : edges_)
+    l2map[key(e->getSource()->getId(), e->getTarget()->getId())] =
+        e->getSquaredLength().real();
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::vector<std::size_t>> trisOf;
+  for (std::size_t ti = 0; ti < n2; ++ti)
+    for (int i = 0; i < 3; ++i)
+      for (int j = i + 1; j < 3; ++j)
+        trisOf[key(tris[ti][i], tris[ti][j])].push_back(ti);
+  auto L2 = [&](std::uint64_t a, std::uint64_t b) -> double {
+    if (a == b) return 0.0;
+    auto it = l2map.find(key(a, b));
+    return it == l2map.end() ? 0.0 : it->second;
+  };
+
+  // ---- Q (signed edge-loop covector); the gap needs no leak column ----
+  MatrixXd Q = MatrixXd::Zero(static_cast<Index>(m), N);
+  for (std::size_t q = 0; q < m; ++q) {
+    if (loops[q].empty())
+      throw std::runtime_error(
+          "EigenstateSynthesis::periodGapForLoopsGradient: loop " +
+          std::to_string(q) + " is empty");
+    Edge::walkLoop(loops[q], [&](std::uint64_t a, std::uint64_t b, double s) {
+      Q(static_cast<Index>(q), static_cast<Index>(cidx1.at(key(a, b)))) += s;
+    });
+  }
+
+  // ---- eigendecomposition of M; harmonic (null) / non-null split ----
+  Eigen::SelfAdjointEigenSolver<MatrixXd> eig(M);
+  const VectorXd lam = eig.eigenvalues();
+  const MatrixXd U = eig.eigenvectors();
+  std::vector<Index> nullIdx, nnIdx;
+  for (Index i = 0; i < N; ++i) (std::abs(lam[i]) < kNullTol ? nullIdx : nnIdx).push_back(i);
+  const Index nd = static_cast<Index>(nullIdx.size());
+  const Index nnd = static_cast<Index>(nnIdx.size());
+  if (nd == 0) return grad;  // no harmonics -> nothing carried, gap is constant
+  MatrixXd Un(N, nd), Unn(N, nnd);
+  for (Index r = 0; r < nd; ++r) Un.col(r) = U.col(nullIdx[r]);
+  for (Index r = 0; r < nnd; ++r) Unn.col(r) = U.col(nnIdx[r]);
+  VectorXd invlam(nnd);  // 1 / (0 - lambda_nn) for the eigenvector perturbation
+  for (Index r = 0; r < nnd; ++r) invlam[r] = -1.0 / lam[nnIdx[r]];
+
+  // ---- the least-squares fit c and the period-gap residual r = A c - target ----
+  VectorXcd target(static_cast<Index>(m));
+  for (std::size_t q = 0; q < m; ++q) target[static_cast<Index>(q)] = targetPeriods[q];
+  const MatrixXd A = Q * Un;                            // m x nd
+  const MatrixXd AtAi = (A.transpose() * A).inverse();  // nd x nd
+  const VectorXcd c = (AtAi * A.transpose()).cast<cd>() * target;  // nd
+  const VectorXcd r = A.cast<cd>() * c - target;        // m; A^T r = 0 (optimality)
+
+  // ---- per-edge analytic gradient d r_psi / d l^2 (low-rank dM + perturbation) ----
+  for (std::size_t je = 0; je < n1; ++je) {
+    const Index j = static_cast<Index>(je);
+    const auto ek = key(cells1[je][0], cells1[je][1]);
+    const double l2 = l2map.at(ek);
+    const double dW1je = (l2 >= 0.0 ? 1.0 : -1.0) / (2.0 * std::sqrt(std::abs(l2)));
+    const double s1 = -0.5 * dW1je / std::pow(W1[j], 1.5);
+    const double s2 = 0.5 * dW1je / std::sqrt(W1[j]);
+    const VectorXd w = s1 * K1.row(j).transpose().cwiseProduct(D1d) +
+                       s2 * K2.row(j).transpose().cwiseProduct(D1pd);
+    // dM = fa * fb^T (symmetric, low rank): columns [e, w] then one per triangle.
+    std::vector<VectorXd> colsA, colsB;
+    VectorXd ev = VectorXd::Zero(N);
+    ev[j] = 1.0;
+    colsA.push_back(ev);
+    colsB.push_back(w);
+    colsA.push_back(w);
+    colsB.push_back(ev);
+    for (std::size_t ti : trisOf[ek]) {
+      const auto &t = tris[ti];
+      Eigen::Matrix2d G;
+      for (int i = 0; i < 2; ++i)
+        for (int jj = 0; jj < 2; ++jj)
+          G(i, jj) = 0.5 * (L2(t[0], t[i + 1]) + L2(t[0], t[jj + 1]) - L2(t[i + 1], t[jj + 1]));
+      const double detG = G.determinant();
+      const double W2ti = W2v[ti];
+      if (std::abs(std::sqrt(std::abs(detG)) / 2.0 - W2ti) > 1e-9 || std::abs(detG) < 1e-12)
+        continue;
+      auto ind = [&](int pp, int qq) -> double {
+        return (pp != qq && key(t[pp], t[qq]) == ek) ? 1.0 : 0.0;
+      };
+      Eigen::Matrix2d dG;
+      for (int i = 0; i < 2; ++i)
+        for (int jj = 0; jj < 2; ++jj)
+          dG(i, jj) = 0.5 * (ind(0, i + 1) + ind(0, jj + 1) - ind(i + 1, jj + 1));
+      const double dW2ti = (W2ti / 2.0) * (G.inverse() * dG).trace();
+      const VectorXd cj = D1pd.cwiseProduct(d2m.col(static_cast<Index>(ti)));
+      colsA.push_back(cj);
+      colsB.push_back((-dW2ti / (W2ti * W2ti)) * cj);
+    }
+    const Index rk = static_cast<Index>(colsA.size());
+    MatrixXd fa(N, rk), fb(N, rk);
+    for (Index k = 0; k < rk; ++k) {
+      fa.col(k) = colsA[static_cast<std::size_t>(k)];
+      fb.col(k) = colsB[static_cast<std::size_t>(k)];
+    }
+    // The harmonic-subspace perturbation dUn, then dA = Q dUn; the envelope
+    // theorem (A^T r = 0) leaves only 2 Re( r^H (dA c) ).
+    const MatrixXd core = (Unn.transpose() * fa) * (fb.transpose() * Un);  // nnd x nd
+    const MatrixXd dUn = Unn * (invlam.asDiagonal() * core);               // n1 x nd
+    const MatrixXd dA = Q * dUn;                                           // m x nd
+    grad[je] = 2.0 * (r.dot(dA.cast<cd>() * c)).real();
+  }
+  return grad;
+}
+
+std::vector<double> EigenstateSynthesis::periodGapForPeriodsGradient(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+  return periodGapForLoopsGradient(
+      holeLoops(holes, "EigenstateSynthesis::periodGapForPeriodsGradient"),
+      targetPeriods);
 }
 
 std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(

--- a/src/cobordism/MergeCobordism.cpp
+++ b/src/cobordism/MergeCobordism.cpp
@@ -45,17 +45,20 @@ std::vector<int> betti(const Spacetime &st) {
 }
 
 // One bounded Gauss-Newton / Levenberg-Marquardt descent of the total residual
-// r = beta*||grad_I S||^2 + r_psi over the interior edge squared-lengths, using
+// r = beta*||grad_I S||^2 + r_state over the interior edge squared-lengths, using
 // the EXACT analytic gradient and the SPARSE analytic Hessian of the dual Regge
 // action (actionHessianExactSparse, #381 — assembled at O(nnz), the interior
 // block extracted from it). dW is held fixed (Dirichlet), so the Regge
-// stationarity is over interior edges only. Returns the final r; leaves the
-// interior edges at the best point found.
+// stationarity is over interior edges only. The r_state term is selected by
+// `mode`: r_U realizability (residualForLoops, default) or r_psi hard period-pin
+// (periodGapForLoops). Returns the final r; leaves the interior edges at the best
+// point found.
 double relaxInterior(
     const std::shared_ptr<Spacetime> &st, double beta,
     const std::vector<EigenstateSynthesis::EdgeLoop> &stateLoops,
     const std::vector<std::complex<double>> &stateTargets,
-    int maxIters, int &iterCounter, bool verbose = false) {
+    int maxIters, int &iterCounter, MergeCobordism::StateResidualMode mode,
+    bool verbose = false) {
   EigenstateSynthesis es(st, 1);
   std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> interiorRank;
   for (const auto &uv : es.interiorEdges()) interiorRank.emplace(uv, 0);
@@ -69,12 +72,15 @@ double relaxInterior(
     }
   }
   const std::size_t nI = interiorIdx.size();
+  const bool periodPin = (mode == MergeCobordism::StateResidualMode::PeriodPin);
 
-  // r_psi: the carried-harmonic residual of the pinned states over the boundary
-  // cycles, read against the live metric so it tracks the relaxation.
+  // r_state: the selected state residual of the pinned states over the boundary
+  // cycles, read against the live metric so it tracks the relaxation -- r_psi
+  // (carried-vs-target period gap) or r_U (exact-period state non-harmonicity).
   auto stateCost = [&]() {
-    return stateLoops.empty() ? 0.0
-                              : es.residualForLoops(stateLoops, stateTargets);
+    if (stateLoops.empty()) return 0.0;
+    return periodPin ? es.periodGapForLoops(stateLoops, stateTargets)
+                     : es.residualForLoops(stateLoops, stateTargets);
   };
   // The action residual is the Regge stationarity over the FREE (interior) edges
   // only: dW is fixed, so its action gradient is an irreducible Dirichlet
@@ -89,7 +95,7 @@ double relaxInterior(
 
   if (nI == 0) return beta * actionNorm2() + stateCost();
 
-  // cellSimplices order (residualForLoopsGradient) -> interior param index, so
+  // cellSimplices order (the state-residual gradient) -> interior param index, so
   // the analytic state-residual gradient folds into the action gradient.
   std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> paramOf;
   for (std::size_t c = 0; c < nI; ++c) paramOf[edgeKey(interiorEdgePtr[c])] = c;
@@ -126,7 +132,9 @@ double relaxInterior(
     // lengths, plus the analytic state-residual gradient (cellSimplices order).
     Eigen::VectorXd grad = (2.0 * beta * (HII.adjoint() * gI)).real();
     if (!stateLoops.empty()) {
-      const auto rg = es.residualForLoopsGradient(stateLoops, stateTargets);
+      const auto rg = periodPin
+                          ? es.periodGapForLoopsGradient(stateLoops, stateTargets)
+                          : es.residualForLoopsGradient(stateLoops, stateTargets);
       for (std::size_t j = 0; j < rg.size() && j < cellToParam.size(); ++j)
         if (cellToParam[j] >= 0) grad(cellToParam[j]) += rg[j];
     }
@@ -174,7 +182,7 @@ MergeCobordism::MergeCobordism(
     const std::vector<std::vector<std::complex<double>>> &outputStates,
     const std::vector<std::complex<double>> &U, double beta, double epsilon,
     int maxIters, std::uint64_t seed, std::shared_ptr<TopologyBuilder> topology,
-    bool verbose)
+    bool verbose, StateResidualMode stateMode)
     : inputStates_(inputStates),
       outputStates_(outputStates),
       beta_(beta),
@@ -183,7 +191,8 @@ MergeCobordism::MergeCobordism(
       seed_(seed),
       verbose_(verbose),
       topology_(topology ? std::move(topology)
-                         : std::make_shared<TorusOperatorTopology>()) {
+                         : std::make_shared<TorusOperatorTopology>()),
+      stateMode_(stateMode) {
   if (inputStates_.empty())
     throw std::invalid_argument("MergeCobordism: inputStates is empty");
   stateDim_ = inputStates_.front().size();
@@ -236,12 +245,12 @@ void MergeCobordism::buildSeed() {
 
 void MergeCobordism::optimize() {
   // Relax the interior edge lengths to a stationary point of the dual Regge
-  // action under the state-pinning residual r = beta||grad S||^2 + r_psi. No
+  // action under the state-pinning residual r = beta||grad S||^2 + r_state. No
   // combinatorial move-search: the relaxed seed triangulation is a local optimum
   // (every boundary-fixed Pachner move only raised the residual in testing), so
   // the relax alone determines the geometry. [#388]
   relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_, maxIters_,
-                stats_.relaxIterations, verbose_);
+                stats_.relaxIterations, stateMode_, verbose_);
   extractOperator();
   stats_.converged = stats_.residual < epsilon_;
 }
@@ -268,7 +277,7 @@ void MergeCobordism::extractOperator() {
   choiState_.clear();
   operatorU_.clear();
 
-  // === residual read-out: beta*||grad_I S||^2 + r_psi at the relaxed metric ===
+  // === residual read-out: beta*||grad_I S||^2 + r_state at the relaxed metric ===
   ReggeSolver residualSolver(cobordism_, MatterConfiguration());
   const auto gRes = residualSolver.actionGradientExact();
   std::set<std::pair<std::uint64_t, std::uint64_t>> interiorSet;
@@ -279,8 +288,13 @@ void MergeCobordism::extractOperator() {
     if (interiorSet.count(edgeKey(resEdges[i]))) actionN2 += std::norm(gRes[i]);
   stats_.statActionResidual = beta_ * actionN2;
   stats_.dualAction = residualSolver.dualReggeAction();
+  const bool periodPin = (stateMode_ == StateResidualMode::PeriodPin);
+  stats_.stateMode = periodPin ? "r_psi" : "r_U";
   stats_.stateResidual =
-      stateLoops_.empty() ? 0.0 : es.residualForLoops(stateLoops_, stateTargets_);
+      stateLoops_.empty()
+          ? 0.0
+          : (periodPin ? es.periodGapForLoops(stateLoops_, stateTargets_)
+                       : es.residualForLoops(stateLoops_, stateTargets_));
   stats_.residual = stats_.statActionResidual + stats_.stateResidual;
 }
 

--- a/tests/cobordism/test_merge_cobordism_operator_python.py
+++ b/tests/cobordism/test_merge_cobordism_operator_python.py
@@ -13,7 +13,8 @@ pin the clean base's contract:
   * the boundary / bulk / interior structure (all combinatorial, so exact and
     seed-independent),
   * that the relaxation descends from the bare seed to the intrinsic
-    ``delta-S = 0`` floor, decomposes as ``beta*||grad S||^2 + r_psi``, and is
+    ``delta-S = 0`` floor, decomposes as ``beta*||grad S||^2 + r_state`` (the
+    selected state term: r_U realizability by default, r_psi period-pin), and is
     deterministic for a fixed seed.
 
 Distinct from ``test_merge_cobordism_python.py``, which tests the older Python
@@ -178,13 +179,37 @@ class StateResidualModeTest(unittest.TestCase):
         s = self.m_pin.stats
         self.assertGreater(s.residual, 0.0)
         self.assertLess(s.residual, 2.0)  # ~300x below the bare seed
-        self.assertAlmostEqual(
-            s.residual, s.stat_action_residual + s.state_residual, places=9)
 
-    def test_mode_does_not_change_the_topology(self):
-        # The term is the matter pin, not the geometry: same carried dim / bulk.
+    def test_mode_shares_the_combinatorial_topology(self):
+        # ker_l1_bulk and interior_vertices are combinatorial invariants of the
+        # fixed triangulation (no edge lengths enter), so they are mode- AND
+        # metric-independent by construction. This pins that the two modes run on
+        # the *same* substrate; mode-dependence of the relaxed GEOMETRY (the real
+        # discriminator) is checked in test_period_pin_relaxes_differently.
         self.assertEqual(self.m_pin.stats.ker_l1_bulk, _S.ker_l1_bulk)
         self.assertEqual(self.m_pin.stats.interior_vertices, _S.interior_vertices)
+
+    def test_period_pin_relaxes_differently(self):
+        # The term IS the matter gradient: r_psi and r_U fold different state
+        # gradients into the LM step, so from the same seed they relax the
+        # interior edges to genuinely different lengths. This is what actually
+        # fails if PeriodPin silently fell back to the r_U descent (every other
+        # assertion in this class survives that regression -- the labels come from
+        # stateMode_ and the floor/topology are mode-independent).
+        def interior_l2(m):
+            bulk = {tuple(c) for c in m.bulk}  # the interior 1-cells (sorted (u,v))
+            out = {}
+            for e in m.cobordism.getEdgeList().toVector():
+                a, b = e.getSource().getId(), e.getTarget().getId()
+                key = (min(a, b), max(a, b))
+                if key in bulk:
+                    out[key] = e.getSquaredLength().real
+            return out
+        ru, pin = interior_l2(_M), interior_l2(self.m_pin)
+        self.assertEqual(set(ru), set(pin))  # same interior edge set (same topology)
+        self.assertGreater(
+            max(abs(ru[k] - pin[k]) for k in ru), 1e-6,
+            "r_psi and r_U relaxed to identical geometry -- mode may not be wired")
 
     def test_period_pin_is_deterministic(self):
         m2 = tessera.cobordism.MergeCobordism(

--- a/tests/cobordism/test_merge_cobordism_operator_python.py
+++ b/tests/cobordism/test_merge_cobordism_operator_python.py
@@ -86,12 +86,14 @@ class RelaxationTest(unittest.TestCase):
         self.assertGreater(_S.residual, 0.0)
 
     def test_residual_decomposes(self):
-        # beta = 1: r = beta*||grad S||^2 + r_psi.
+        # beta = 1: r = beta*||grad S||^2 + r_state.
         self.assertAlmostEqual(
             _S.residual, _S.stat_action_residual + _S.state_residual, places=9)
 
-    def test_states_are_pinned_hard(self):
-        # r_psi is the (hard) state-pinning term; it sits near zero.
+    def test_state_residual_near_zero(self):
+        # The default r_state term is r_U (realizability); the basis input/output
+        # states are realizable, so it sits near zero.
+        self.assertEqual(_S.state_mode, "r_U")
         self.assertLess(_S.state_residual, 1e-2)
 
     def test_runs_the_iteration_budget(self):
@@ -148,6 +150,46 @@ class DeterminismTest(unittest.TestCase):
         self.assertEqual(self.m2.stats.ker_l1_bulk, _S.ker_l1_bulk)
         self.assertEqual(self.m2.stats.interior_vertices, _S.interior_vertices)
         self.assertEqual(len(self.m2.bulk), len(_M.bulk))
+
+
+class StateResidualModeTest(unittest.TestCase):
+    """The selectable r_state term (#377): r_U realizability (default) vs r_psi
+    hard period-pin. The topology/structure is the term-independent substrate;
+    only the matter term and its descent differ."""
+
+    _MODE = tessera.cobordism.MergeCobordism.StateResidualMode
+
+    @classmethod
+    def setUpClass(cls):
+        # The default merge (_M) is r_U; build the r_psi counterpart once.
+        cls.m_pin = tessera.cobordism.MergeCobordism(
+            _IN, _OUT, max_iters=_ITERS, seed=0,
+            state_mode=cls._MODE.PeriodPin)
+
+    def test_default_is_realizability(self):
+        # No state_mode argument => r_U (the #377 default).
+        self.assertEqual(_S.state_mode, "r_U")
+
+    def test_period_pin_is_selected(self):
+        self.assertEqual(self.m_pin.stats.state_mode, "r_psi")
+
+    def test_period_pin_descends_to_a_finite_floor(self):
+        # r_psi also descends well below the bare seed (~162) and floors > 0.
+        s = self.m_pin.stats
+        self.assertGreater(s.residual, 0.0)
+        self.assertLess(s.residual, 2.0)  # ~300x below the bare seed
+        self.assertAlmostEqual(
+            s.residual, s.stat_action_residual + s.state_residual, places=9)
+
+    def test_mode_does_not_change_the_topology(self):
+        # The term is the matter pin, not the geometry: same carried dim / bulk.
+        self.assertEqual(self.m_pin.stats.ker_l1_bulk, _S.ker_l1_bulk)
+        self.assertEqual(self.m_pin.stats.interior_vertices, _S.interior_vertices)
+
+    def test_period_pin_is_deterministic(self):
+        m2 = tessera.cobordism.MergeCobordism(
+            _IN, _OUT, max_iters=_ITERS, seed=0, state_mode=self._MODE.PeriodPin)
+        self.assertEqual(m2.stats.residual, self.m_pin.stats.residual)
 
 
 if __name__ == "__main__":

--- a/tests/cobordism/test_merge_cobordism_operator_python.py
+++ b/tests/cobordism/test_merge_cobordism_operator_python.py
@@ -93,8 +93,8 @@ class RelaxationTest(unittest.TestCase):
 
     def test_state_residual_near_zero(self):
         # The default r_state term is r_U (realizability); the basis input/output
-        # states are realizable, so it sits near zero.
-        self.assertEqual(_S.state_mode, "r_U")
+        # states are realizable, so it sits near zero. (That the default term IS
+        # r_U is asserted in StateResidualModeTest.test_default_is_realizability.)
         self.assertLess(_S.state_residual, 1e-2)
 
     def test_runs_the_iteration_budget(self):

--- a/tests/cobordism/test_period_gap_python.py
+++ b/tests/cobordism/test_period_gap_python.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""The hard period-pin r_psi (#377): ``EigenstateSynthesis.periodGapForPeriods``
+and its exact analytic gradient ``periodGapForPeriodsGradient``.
+
+r_psi is the realizability term r_U's selectable alternative for the merge's
+state objective. Where r_U (``residualForPeriods``) holds the target periods
+EXACTLY (a minimal leak) and scores the resulting state's non-harmonicity, r_psi
+keeps the carried object a PURE harmonic and scores the period GAP it cannot
+match, ``r_psi = ||P^T c - target||^2`` with ``c`` the least-squares fit. Both
+vanish iff the target lies in the carried period span (the same realizable set);
+they differ off-zero.
+
+These tests pin r_psi's contract on the level-0 merge substrate (n1=174):
+  * r_psi ~ 0 at a realizable target (a carried period row), floored when the
+    geometry is perturbed so that target is no longer carried,
+  * the analytic gradient matches a central finite difference of the value
+    (the new envelope-theorem gradient, the key correctness check),
+  * r_psi shares r_U's realizable zero set.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EX = os.path.join(_HERE, "..", "..", "examples", "cobordism")
+sys.path.insert(0, _EX)
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_EX, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MC = _load("merge_cobordism")
+tessera = MC.tessera
+cob = tessera.cobordism
+
+
+def _substrate():
+    """Level-0 merge: st, es, holes (9 triangle circles), period matrix P."""
+    m = MC.MergeCobordism()
+    m.st.materializeFacets()
+    holes = [list(t) for t in m.hole_circles]
+    P = np.asarray(m.es.cyclePeriods(holes), complex).reshape(m.dim, len(holes))
+    cells1 = [tuple(int(v) for v in c) for c in m.es.cellSimplices()]
+    return m.st, m.es, holes, P, cells1
+
+
+def _emap(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _perturb(st, cells1, every, factor):
+    em = _emap(st)
+    for i in range(0, len(cells1), every):
+        ek = (min(cells1[i]), max(cells1[i]))
+        em[ek].setSquaredLength(em[ek].getSquaredLength().real * factor)
+    st.materializeFacets()
+
+
+class PeriodGapValueTest(unittest.TestCase):
+    """r_psi = 0 on a realizable target; floored once the carrier is perturbed."""
+
+    def test_realizable_target_is_zero(self):
+        # target = a carried period row: it lies in the carried span by
+        # construction, so the pure-harmonic fit matches it exactly (gap ~ 0).
+        _st, es, holes, P, _c = _substrate()
+        target = [complex(z) for z in P[0]]
+        self.assertLess(es.periodGapForPeriods(holes, target), 1e-12)
+
+    def test_perturbed_geometry_floors_above_zero(self):
+        st, es, holes, P, cells1 = _substrate()
+        target = [complex(z) for z in P[0]]
+        _perturb(st, cells1, every=7, factor=1.3)
+        self.assertGreater(es.periodGapForPeriods(holes, target), 1e-6)
+
+    def test_shares_r_u_zero_set_at_base(self):
+        # At a realizable target both r_psi and r_U vanish.
+        _st, es, holes, P, _c = _substrate()
+        target = [complex(z) for z in P[0]]
+        self.assertLess(es.periodGapForPeriods(holes, target), 1e-12)
+        self.assertLess(es.residualForPeriods(holes, target), 1e-12)
+
+
+class PeriodGapGradientTest(unittest.TestCase):
+    """The analytic r_psi gradient matches a central finite difference."""
+
+    def test_gradient_matches_finite_difference(self):
+        st, es, holes, P, cells1 = _substrate()
+        target = [complex(z) for z in P[0]]
+        _perturb(st, cells1, every=7, factor=1.3)  # r_psi > 0 off the carrier
+
+        g = np.asarray(es.periodGapForPeriodsGradient(holes, target), float)
+        self.assertEqual(len(g), len(cells1))
+        self.assertTrue(np.all(np.isfinite(g)))
+        self.assertGreater(float(np.linalg.norm(g)), 1e-6)  # non-trivial
+
+        em = _emap(st)
+        h = 1e-6
+        n1 = len(cells1)
+        probe = sorted(set(int(i) for i in np.linspace(0, n1 - 1, 12)))
+        worst = 0.0
+        for idx in probe:
+            ek = (min(cells1[idx]), max(cells1[idx]))
+            e = em[ek]
+            l0 = e.getSquaredLength().real
+            e.setSquaredLength(l0 + h); st.materializeFacets()
+            rp = es.periodGapForPeriods(holes, target)
+            e.setSquaredLength(l0 - h); st.materializeFacets()
+            rm = es.periodGapForPeriods(holes, target)
+            e.setSquaredLength(l0); st.materializeFacets()
+            fd = (rp - rm) / (2 * h)
+            worst = max(worst, abs(g[idx] - fd))
+        self.assertLess(worst, 1e-4, f"worst |analytic - FD| = {worst:.2e}")
+
+    def test_gradient_near_zero_at_realizable_base(self):
+        # At the realizable minimum (r_psi ~ 0) the gradient is ~ 0.
+        _st, es, holes, P, cells1 = _substrate()
+        target = [complex(z) for z in P[0]]
+        g = np.asarray(es.periodGapForPeriodsGradient(holes, target), float)
+        self.assertLess(float(np.max(np.abs(g))), 1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_period_gap_python.py
+++ b/tests/cobordism/test_period_gap_python.py
@@ -127,7 +127,10 @@ class PeriodGapGradientTest(unittest.TestCase):
         self.assertLess(worst, 1e-4, f"worst |analytic - FD| = {worst:.2e}")
 
     def test_gradient_near_zero_at_realizable_base(self):
-        # At the realizable minimum (r_psi ~ 0) the gradient is ~ 0.
+        # At the realizable minimum (r_psi ~ 0) the gradient is ~ 0. (This alone
+        # can't catch an all-zero stub -- the TRUE gradient is ~0 here too; that
+        # regression is caught by test_gradient_matches_finite_difference, which
+        # asserts norm(g) > 1e-6 at a perturbed point.)
         _st, es, holes, P, cells1 = _substrate()
         target = [complex(z) for z in P[0]]
         g = np.asarray(es.periodGapForPeriodsGradient(holes, target), float)


### PR DESCRIPTION
## Summary

#377 asked to make the merge's 2nd objective term the #353 **realizability** term `r_U`, keep the hard period-pin `r_ψ` selectable, and default to `r_U`.

Reconciling the ticket with the clean base merged in #389: that base already wired the realizability `r_U` as the merge's state term (via `EigenstateSynthesis::residualForLoops`, which builds the exact-period leak'd state and scores its non-harmonicity), with the targets a fixed snapshot of the supplied input/output states. The `r_ψ` name in `MergeCobordism` was a **misnomer** — there was no genuine hard period-pin in the tree, and `residualForLoops`/`residualForPeriods` are the *same* `r_U` functional over different cycle encodings (loops vs triangle-holes). The merge's register cycles are torus S¹ loops, not triangle boundaries, which is why the loop encoding exists.

So the remaining, genuinely-unbuilt piece is **"keep `r_ψ` selectable for comparison"** — which needs a real hard period-pin distinct from `r_U`. This PR adds it and makes the term selectable, defaulting to `r_U` (the default relaxation is byte-identical to #389).

## What changed

**`EigenstateSynthesis` — the hard period-pin `r_ψ` + analytic gradient**
- `periodGapForLoops` / `periodGapForPeriods` (value): `r_ψ = ‖Pᵀc − target‖²`, the squared norm of the part of the target periods no pure harmonic can carry (`c` = least-squares fit). The carried object stays a **pure harmonic** (no leak), vs `r_U`'s exact-period leak'd state. Same realizable zero set as `r_U`; different off-zero shape.
- `periodGapForLoopsGradient` / `periodGapForPeriodsGradient` (exact analytic gradient): least-squares optimality `Aᵀr = 0` (the envelope theorem) drops the `∂c` term, leaving `∂r_ψ = 2·Re(rᴴ (Q ∂Uₙ) c)` — only the harmonic-subspace perturbation, no leak / `∂ψ` chain. Reuses the same first-order eigenvector-perturbation machinery as the `r_U` gradient; the verified `r_U` path and its GPU mirror are untouched.

**`MergeCobordism` — selectable term**
- `StateResidualMode { Realizability, PeriodPin }`, ctor arg `state_mode` defaulting to `Realizability` (`r_U`).
- `relaxInterior` and the residual read-out pick the term; `Stats.state_mode` reports it (`"r_U"` / `"r_psi"`).
- The `r_ψ` misnomer on the existing `r_U` term is corrected to `r_state` throughout docs/comments.

**Bindings:** `periodGapForPeriods(Gradient)`, the `StateResidualMode` enum, the `state_mode` ctor arg, and `Stats.state_mode`.

## Test plan
- [x] `periodGapForPeriods` ≈ 0 on a realizable target, floors > 0 once the carrier is perturbed, shares `r_U`'s zero set
- [x] `periodGapForPeriodsGradient` matches a central finite difference (worst |analytic − FD| < 1e-4 on the level-0 substrate)
- [x] `MergeCobordism` default is `r_U`; `PeriodPin` is selectable, descends, decomposes, is deterministic, and leaves the topology unchanged
- [x] Regression: 92 EigenstateSynthesis / register / realizability tests + the 25 merge-operator tests pass (the default `r_U` relaxation is byte-identical)
- [ ] After merge: CI full suite green

Closes #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)