### PR TITLE
feat(cobordism): reproduce #353 proton-from-quarks via the C++ MergeCobordism (#379)

### DIFF
--- a/include/cobordism/RegisterTopology.h
+++ b/include/cobordism/RegisterTopology.h
@@ -13,27 +13,35 @@ namespace tessera::cobordism {
 
 /// # RegisterTopology
 ///
-/// The \#353-style color register topology, built **without welding** (the
-/// default `MergeCobordism` topology). The merge \f$ \psi_A, \psi_B \to \psi_R \f$
-/// is three holed-icosahedron register blocks — each \f$ S^2 - 3\,\text{holes} \f$,
-/// \f$ b_1 = 2 \f$ on the \f$ \sum = 0 \f$ hyperplane (the \f$ S_3 \f$ standard
-/// rep, the color singlet \f$ [1, \omega, \omega^2] \f$) — laid with **disjoint**
-/// vertex ids and joined input→result by additive **tubes** (the six lateral
-/// triangles of a triangular prism between two triangular hole-circles).
+/// The \#353-style color register topology (the default `MergeCobordism`
+/// topology). The holed icosahedron (\f$ S^2 - 3 \f$ color holes, \f$ b_1 = 2 \f$
+/// on the \f$ \sum = 0 \f$ hyperplane — the \f$ S_3 \f$ standard rep, the color
+/// singlet \f$ [1, \omega, \omega^2] \f$) is extruded over a **3-layer staircase**
+/// (`Spacetime::prismCells`) into one connected 3-complex with
+/// \f$ b_1(W) = 2 \f$: **one shared color register** across the three blocks
+/// (block A = layer 0, B = layer 1, R = layer 2). That \f$ b_1 = 2 \f$ is the
+/// confinement — a \f$ \sum \neq 0 \f$ (colored) config cannot be carried, so its
+/// realizability residual floors, while a \f$ \sum = 0 \f$ (color-neutral) config
+/// realizes (reproducing #353's realizability map / S₃ gauge invariance).
 ///
-/// Connecting by tubes, never by *identifying* a shared block, is what keeps the
-/// merge a genuine trivalent manifold: the result \f$ R \f$ is a real lobe of one
-/// connected complex, not the buried middle slice the \#353 `merge_cobordism.py`
-/// weld produces (a `P x I` transport whose `dualComplexValid` passes only
-/// because that gate misses the codim-3 pinch). `build()` asserts a manifold gate
-/// — `dualComplexValid` **plus** every edge in \f$ \leq 2 \f$ triangles — and
-/// throws if the seed is non-manifold, so a weld cannot recur.
+/// The continuous staircase is a genuine valid manifold — every triangle in
+/// \f$ \leq 2 \f$ tets, `dualComplexValid` — **not** the welded shared-block
+/// construction (a `P x I` transport that buries the result); `build()` asserts
+/// the manifold gate and throws on a non-manifold seed.
 ///
 /// Read-out: the color hole-circles only (no \f$ S^1 \f$). Each block's three
-/// hole-circle periods carry that state's three color amplitudes. The carried
-/// object is a color rep, so `MergeCobordism` reads a rep, not an operator.
+/// hole-circle periods carry that state's three color amplitudes, with the target
+/// periods pre-multiplied by the induced-orientation covector `kColorSign`
+/// (the #353 `SIGN_BLOCK`) so the carried condition is \f$ \text{sign} \cdot
+/// \psi = 0 \f$. The carried object is a color rep, so `MergeCobordism` reads a
+/// rep, not an operator.
 class RegisterTopology : public TopologyBuilder {
   public:
+    /// The induced-orientation covector on the three color holes
+    /// (`endSignCovector` of the icosahedron color holes; the #353 `SIGN_BLOCK`
+    /// `(+1, +1, -1)`). Target periods are pre-multiplied by it in `readout()`.
+    static const int kColorSign[3];
+
     [[nodiscard]] std::shared_ptr<Spacetime> build(
         std::size_t stateDim, std::uint64_t seed,
         std::vector<std::vector<std::uint64_t>> &boundaryCells) override;
@@ -56,7 +64,7 @@ class RegisterTopology : public TopologyBuilder {
     void validateStateDim(std::size_t d) const override;
 
     [[nodiscard]] std::string name() const override {
-      return "register (S^2-3holes color blocks, tube-joined)";
+      return "register ((S^2-3color-holes) x [0,2] staircase, b1=2)";
     }
 
   private:

--- a/src/cobordism/RegisterTopology.cpp
+++ b/src/cobordism/RegisterTopology.cpp
@@ -35,89 +35,24 @@ std::vector<Face> icosahedron() {
   return faces;
 }
 
-// One geodesic (1 -> 4) subdivision of a triangulated surface: each triangle
-// splits into four on its edge midpoints (fresh midpoint ids after the max).
-// Gives the level-1 register seed (42 vertices) — room for three color holes
-// plus the connection ports as pairwise vertex-disjoint faces.
-std::vector<Face> subdivideFaces(const std::vector<Face> &faces) {
-  std::uint64_t nxt = 0;
-  for (const auto &f : faces)
-    for (const auto v : f) nxt = std::max(nxt, v + 1);
-  std::map<std::pair<std::uint64_t, std::uint64_t>, std::uint64_t> mid;
-  auto m = [&](std::uint64_t a, std::uint64_t b) -> std::uint64_t {
-    const auto key = std::make_pair(std::min(a, b), std::max(a, b));
-    const auto it = mid.find(key);
-    if (it != mid.end()) return it->second;
-    const std::uint64_t id = nxt++;
-    mid[key] = id;
-    return id;
-  };
-  std::vector<Face> out;
-  for (const auto &f : faces) {
-    const std::uint64_t a = f[0], b = f[1], c = f[2];
-    const std::uint64_t ab = m(a, b), bc = m(b, c), ca = m(c, a);
-    std::vector<Face> tris = {{a, ab, ca}, {b, bc, ab}, {c, ca, bc}, {ab, bc, ca}};
-    for (auto &s : tris) {
-      std::sort(s.begin(), s.end());
-      out.push_back(s);
-    }
-  }
-  return out;
-}
-
-// The first k pairwise vertex-disjoint faces of `faces`.
-std::vector<Face> disjointHoles(const std::vector<Face> &faces, std::size_t k) {
-  std::vector<Face> holes;
-  std::set<std::uint64_t> used;
-  for (const auto &f : faces) {
-    if (holes.size() >= k) break;
-    bool overlap = false;
-    for (const auto v : f)
-      if (used.count(v)) { overlap = true; break; }
-    if (!overlap) {
-      holes.push_back(f);
-      for (const auto v : f) used.insert(v);
-    }
-  }
+// The three holonomy-class (color) holes: three pairwise vertex-disjoint
+// icosahedron faces (the #353 `_CLASS_HOLES`). Removing them opens the b_1 = 2
+// color register on the Sigma = 0 hyperplane (the S_3 standard rep). Order is
+// load-bearing: it pairs with the induced-orientation sign (+1, +1, -1) below.
+std::vector<Face> classHoles() {
+  std::vector<Face> holes = {{0, 1, 2}, {3, 7, 8}, {4, 9, 5}};
+  for (auto &h : holes) std::sort(h.begin(), h.end());
   return holes;
 }
 
-// Shift every vertex id of a face list by `off` (a distinct block).
-std::vector<Face> shift(const std::vector<Face> &faces, std::uint64_t off) {
-  std::vector<Face> out;
-  out.reserve(faces.size());
-  for (const auto &f : faces) {
-    Face g;
-    g.reserve(f.size());
-    for (const auto v : f) g.push_back(v + off);
-    std::sort(g.begin(), g.end());
-    out.push_back(std::move(g));
-  }
-  return out;
-}
-
-// The six lateral triangles of the triangular prism between sorted triangles
-// t0=(a,b,c) and t1=(a',b',c'), corresponded by sorted order. This ADDS
-// triangles to join two hole-circles into a tube — it never identifies the two
-// blocks' cells, so no weld is created.
-std::vector<Face> tube(const Face &t0, const Face &t1) {
-  const std::uint64_t a = t0[0], b = t0[1], c = t0[2];
-  const std::uint64_t a2 = t1[0], b2 = t1[1], c2 = t1[2];
-  const std::uint64_t quads[3][4] = {
-      {a, b, b2, a2}, {b, c, c2, b2}, {c, a, a2, c2}};
-  std::vector<Face> out;
-  for (const auto &q : quads) {
-    Face t = {q[0], q[1], q[2]};
-    std::sort(t.begin(), t.end());
-    out.push_back(t);
-    Face u = {q[0], q[2], q[3]};
-    std::sort(u.begin(), u.end());
-    out.push_back(u);
-  }
-  return out;
-}
-
 }  // namespace
+
+// The induced-orientation covector on the three color holes — `endSignCovector`
+// of the icosahedron `classHoles()` — equal to the #353 `SIGN_BLOCK`. The carried
+// (Sigma = 0) condition is `sign . periods == 0`, so a state's target periods
+// must be pre-multiplied by it; feeding raw components mis-floors the color
+// singlet [1, omega, omega^2] (whose plain-sum is 0 but raw n.a != 0).
+const int RegisterTopology::kColorSign[3] = {1, 1, -1};
 
 void RegisterTopology::validateStateDim(std::size_t d) const {
   if (d != 3)
@@ -129,73 +64,79 @@ void RegisterTopology::validateStateDim(std::size_t d) const {
 std::shared_ptr<Spacetime> RegisterTopology::build(
     std::size_t /*stateDim*/, std::uint64_t seed,
     std::vector<std::vector<std::uint64_t>> &boundaryCells) {
-  // Three register blocks A, B, R (one per state: two inputs + one result), each
-  // a holed icosahedron, with disjoint vertex ids; input blocks join the result
-  // block by additive tubes (A->R, B->R). The level-1 subdivided icosahedron has
-  // room for three color holes + the ports as vertex-disjoint faces.
-  const auto seedFaces = subdivideFaces(icosahedron());
-  std::uint64_t stride = 0;
-  for (const auto &f : seedFaces)
-    for (const auto v : f) stride = std::max(stride, v + 1);
+  // The #353 color-register merge, built NON-WELDED: the holed icosahedron
+  // (S^2 - 3 color holes, b_1 = 2 on the Sigma=0 hyperplane) extruded over a
+  // 3-layer staircase (Spacetime::prismCells), giving one connected 3-complex
+  // with b_1(W) = 2 — ONE shared color register across the three blocks (the
+  // confinement: a Sigma != 0 config cannot be carried). The three blocks are
+  // the three vertex layers (stride N): block A = layer 0, B = layer 1,
+  // R (result) = layer 2; each layer's three color hole-circles are the read-out
+  // cycles. b_1 = 2 (not the tube-merge's b_1 = 8) is what reproduces #353's
+  // realizability map; the continuous staircase is a valid manifold (every
+  // triangle in <= 2 tets, dualComplexValid) — never the welded shared-block
+  // construction (which is a P x I transport that buries the result).
+  const auto ico = icosahedron();
+  const auto holes = classHoles();
+  const std::set<Face> holeSet(holes.begin(), holes.end());
+  std::vector<Face> holed;  // icosahedron with the 3 color holes removed (b_1=2)
+  for (const auto &f : ico)
+    if (!holeSet.count(f)) holed.push_back(f);
 
-  constexpr std::size_t kBlocks = 3;        // A, B, R
-  constexpr std::size_t kResult = 2;        // R is the third block
-  std::vector<std::vector<Face>> ports(kBlocks);
-  std::vector<std::set<Face>> omitted(kBlocks);  // holes + ports (not laid)
-  blockHoles_.assign(kBlocks, {});
-  for (std::size_t b = 0; b < kBlocks; ++b) {
-    const std::size_t nPorts = (b == kResult) ? 2 : 1;  // R joins both inputs
-    const std::size_t need = 3 + nPorts;
-    const auto blockFaces = shift(seedFaces, static_cast<std::uint64_t>(b) * stride);
-    const auto picks = disjointHoles(blockFaces, need);
-    if (picks.size() < need)
-      throw std::runtime_error(
-          "RegisterTopology: register seed lacks enough vertex-disjoint faces "
-          "for the color holes and connection ports");
-    for (std::size_t i = 0; i < 3; ++i) blockHoles_[b].push_back(picks[i]);
-    for (std::size_t i = 3; i < need; ++i) ports[b].push_back(picks[i]);
-    for (const auto &f : picks) omitted[b].insert(f);
+  std::uint64_t N = 0;  // per-layer vertex stride (matches Spacetime::prismCells)
+  for (const auto &f : holed)
+    for (const auto v : f) N = std::max(N, v + 1);
+
+  // (holed icosahedron) x [0,2]: a 3-layer staircase of tets (NOT looped — an
+  // interval, so the two end caps + the hole-tubes are the boundary).
+  const auto prism = Spacetime::prismCells(holed, /*layers=*/2);
+  std::vector<std::vector<std::uint64_t>> cells;
+  cells.reserve(prism.size());
+  for (auto c : prism) {
+    std::sort(c.begin(), c.end());
+    cells.push_back(std::move(c));
   }
 
-  // Assemble: each block's faces (minus its holes and ports) + one tube per
-  // input->result connection.
-  std::set<Face> cellSet;
-  for (std::size_t b = 0; b < kBlocks; ++b) {
-    const auto blockFaces = shift(seedFaces, static_cast<std::uint64_t>(b) * stride);
-    for (const auto &f : blockFaces)
-      if (!omitted[b].count(f)) cellSet.insert(f);
-  }
-  for (const auto &t : tube(ports[0][0], ports[kResult][0])) cellSet.insert(t);
-  for (const auto &t : tube(ports[1][0], ports[kResult][1])) cellSet.insert(t);
-
-  // === manifold gate: no weld (every edge in <= 2 triangles) ===
-  std::map<std::pair<std::uint64_t, std::uint64_t>, int> edgeCoface;
-  for (const auto &c : cellSet)
-    for (std::size_t i = 0; i < c.size(); ++i)
-      for (std::size_t j = i + 1; j < c.size(); ++j)
-        ++edgeCoface[{std::min(c[i], c[j]), std::max(c[i], c[j])}];
-  for (const auto &kv : edgeCoface)
-    if (kv.second > 2)
-      throw std::runtime_error(
-          "RegisterTopology: non-manifold seed (an edge has > 2 cofaces) — the "
-          "construction welded two blocks");
-
-  std::vector<std::vector<std::uint64_t>> cellList(cellSet.begin(), cellSet.end());
-  auto cobordism = Spacetime::fromCells(2, cellList, 1.0, 0.0);
+  auto cobordism = Spacetime::fromCells(3, cells, 1.0, 0.0);
 
   // Seed the metric off the degenerate uniform point (break the l^2 = 1
   // degeneracy so the first relax step can descend), as the operator seed does.
+  // REGGE: causal type emergent.
   std::mt19937 jrng(static_cast<std::uint32_t>(seed) ^ 0x9e3779b9u);
   std::uniform_real_distribution<double> jitter(0.7, 1.3);
   for (auto *e : cobordism->getEdgeList()->toVector())
     e->setSquaredLength(std::complex<double>(jitter(jrng), 0.0));
 
-  // dW = the boundary 1-cells: edges in exactly one triangle (the opened color
-  // hole-circles; the ports are tube-filled, hence interior).
+  // The per-block (per-layer) color holes, in fixed class-hole order so they pair
+  // with kColorSign: block A = layer 0, B = layer 1, R = layer 2.
+  blockHoles_.assign(3, {});
+  for (std::size_t blk = 0; blk < 3; ++blk) {
+    const std::uint64_t off = static_cast<std::uint64_t>(blk) * N;
+    for (const auto &h : holes) {
+      Face shifted;
+      shifted.reserve(h.size());
+      for (const auto v : h) shifted.push_back(v + off);
+      blockHoles_[blk].push_back(std::move(shifted));
+    }
+  }
+
+  // dW = the single-coface triangles (the two end caps + the hole-tube walls);
+  // also the manifold gate: every triangle must sit in <= 2 tets (no weld).
+  std::map<Face, int> cofaceCount;
+  for (const auto &c : cells)
+    for (std::size_t i = 0; i < c.size(); ++i) {
+      Face tri;
+      tri.reserve(c.size() - 1);
+      for (std::size_t j = 0; j < c.size(); ++j)
+        if (j != i) tri.push_back(c[j]);
+      ++cofaceCount[tri];
+    }
   boundaryCells.clear();
-  for (const auto &kv : edgeCoface)
-    if (kv.second == 1)
-      boundaryCells.push_back({kv.first.first, kv.first.second});
+  for (const auto &kv : cofaceCount) {
+    if (kv.second > 2)
+      throw std::runtime_error(
+          "RegisterTopology: non-manifold seed (a triangle has > 2 cofaces)");
+    if (kv.second == 1) boundaryCells.push_back(kv.first);
+  }
 
   // === manifold gate: dualComplexValid (rigorous for n <= 3) ===
   const auto valid = EigenstateSynthesis(cobordism, 1).dualComplexValid();
@@ -214,7 +155,10 @@ void RegisterTopology::readout(
     std::vector<std::complex<double>> &targets) const {
   // Each block's three color hole-circles carry that state's three color
   // amplitudes (no S^1). The hole-circle of a sorted triangle (a<b<c) is the
-  // signed walk a -> b -> c -> a.
+  // signed walk a -> b -> c -> a; the target periods are PRE-MULTIPLIED by the
+  // induced-orientation covector kColorSign (the #353 SIGN_BLOCK), so the carried
+  // condition is sign . psi = 0 (the color singlet [1, omega, omega^2] realizes;
+  // raw components would mis-floor it).
   loops.clear();
   targets.clear();
   if (blockHoles_.empty() || !cobordism) return;
@@ -232,8 +176,9 @@ void RegisterTopology::readout(
       Face h(blockHoles_[s][k]);
       std::sort(h.begin(), h.end());
       loops.push_back({edge(h[0], h[1]), edge(h[1], h[2]), edge(h[2], h[0])});
-      targets.push_back(k < states[s].size() ? states[s][k]
-                                             : std::complex<double>(0));
+      const std::complex<double> a =
+          k < states[s].size() ? states[s][k] : std::complex<double>(0);
+      targets.push_back(static_cast<double>(kColorSign[k % 3]) * a);
     }
   }
 }

--- a/tests/cobordism/test_proton_realizability_python.py
+++ b/tests/cobordism/test_proton_realizability_python.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""#353 proton-from-quarks color realizability, via the C++ register (#379).
+
+#353's Stage 1 — the color-configuration **realizability map** (confinement) and
+**S₃ gauge invariance** — runs on the carried color register `cob.Register`
+(an icosahedron S² with three holonomy holes; ker L₁ = b₁ = 2, the S₃ standard
+rep on the Σ=0 hyperplane). These tests reproduce that map through the C++
+primitive:
+
+  * **confinement**: a color-neutral (Σ=0) configuration realizes (residual →
+    machine zero); a colored (Σ≠0) configuration floors (the confinement floor)
+    — a ~25-order-of-magnitude split;
+  * **S₃ (color-relabel = Weyl gauge) invariance**: the residual is identical
+    under all 6 permutations of the three color holes;
+  * the color singlet `[1, ω, ω²]` (plain-sum 0) realizes — exercising the
+    induced-orientation sign convention (`reg.sign`), without which it mis-floors.
+
+The merge / emergent-result side (#353 Stage 3) is covered by
+`test_register_merge_353_python.py`.
+"""
+
+import cmath
+import importlib.util
+import itertools
+import os
+import sys
+import unittest
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXAMPLES = os.path.join(_HERE, "..", "..", "examples", "cobordism")
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_EXAMPLES, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_SG = _load("spectral_gate_realizability")
+_W = cmath.exp(2j * cmath.pi / 3)
+
+# #353 realize/floor thresholds (spectral_gate_realizability REALIZE / CERT_FLOOR).
+_REALIZE = 1e-9
+_CERT_FLOOR = 1e-2
+
+# Color configs: neutral (Σ=0, realize) vs colored (Σ≠0, floor = confinement).
+_NEUTRAL = {
+    "meson R-Gbar [1,-1,0]": [1, -1, 0],
+    "meson G-Bbar [0,1,-1]": [0, 1, -1],
+    "baryon real [1,1,-2]": [1, 1, -2],
+    "singlet Z3 [1,w,w^2]": [1, _W, _W * _W],
+}
+_COLORED = {
+    "quark R [1,0,0]": [1, 0, 0],
+    "quark G [0,1,0]": [0, 1, 0],
+    "diquark RG [1,1,0]": [1, 1, 0],
+    "symmetric RGB [1,1,1]": [1, 1, 1],
+}
+
+
+def _residual(reg, cfg):
+    """#353 score(): the realizability residual in the oriented period frame —
+    reg.spectral_residual(reg.sign * periods)."""
+    raw = np.asarray(reg.sign, dtype=complex) * np.asarray(cfg, dtype=complex)
+    return reg.spectral_residual(list(raw))
+
+
+# The verified icosahedron / 3-color-hole register (built in C++ via cob.Register).
+_REG = _SG.Register()
+
+
+class RegisterIsTheColorRegisterTest(unittest.TestCase):
+    def test_b1_is_two_on_sigma_zero(self):
+        # ker L₁ = b₁ = 2 = the S₃ standard rep (rank(P)=2: a genuine register).
+        self.assertEqual(_REG.dim, 2)
+        self.assertEqual(_REG.rank, 2)
+
+    def test_sign_is_the_induced_covector(self):
+        # P @ n = 0: the induced-orientation covector symmetrizes to Σ=0.
+        self.assertEqual(len(_REG.sign), 3)
+
+
+class RealizabilityMapTest(unittest.TestCase):
+    """Confinement: Σ=0 realizes, Σ≠0 floors (the #353 color realizability map)."""
+
+    def test_color_neutral_configs_realize(self):
+        for name, cfg in _NEUTRAL.items():
+            with self.subTest(cfg=name):
+                self.assertLess(_residual(_REG, cfg), _REALIZE, name)
+
+    def test_singlet_realizes_with_sign_convention(self):
+        # [1,ω,ω²] has plain-sum 0 and MUST realize; it only does in the oriented
+        # frame (reg.sign), the smoking-gun for the induced-sign convention.
+        self.assertLess(_residual(_REG, [1, _W, _W * _W]), _REALIZE)
+
+    def test_colored_configs_floor_confinement(self):
+        for name, cfg in _COLORED.items():
+            with self.subTest(cfg=name):
+                self.assertGreater(_residual(_REG, cfg), _CERT_FLOOR, name)
+
+    def test_realize_floor_split_is_enormous(self):
+        worst_neutral = max(_residual(_REG, c) for c in _NEUTRAL.values())
+        best_colored = min(_residual(_REG, c) for c in _COLORED.values())
+        self.assertGreater(best_colored / max(worst_neutral, 1e-300), 1e6)
+
+
+class S3GaugeInvarianceTest(unittest.TestCase):
+    """The residual is identical under all 6 color-relabel (S₃ / Weyl) perms."""
+
+    def test_singlet_is_s3_invariant(self):
+        base = [1, _W, _W * _W]
+        residuals = [_residual(_REG, [base[i] for i in p])
+                     for p in itertools.permutations(range(3))]
+        self.assertLess(max(residuals) - min(residuals), 1e-6)
+
+    def test_colored_floors_under_every_relabel(self):
+        # Confinement is gauge-invariant: a colored config floors (> CERT_FLOOR)
+        # under EVERY color relabel. (The floor VALUE varies — permuting [1,1,0]
+        # gives distinct colored states RG/RB/GB — so this asserts "floors", not
+        # "floors equally"; only Σ=0 states are S₃-invariant in value, above.)
+        base = [1, 1, 0]
+        for p in itertools.permutations(range(3)):
+            cfg = [base[i] for i in p]
+            self.assertGreater(_residual(_REG, cfg), _CERT_FLOOR, str(p))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_register_merge_353_python.py
+++ b/tests/cobordism/test_register_merge_353_python.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""#353 color confinement + emergent result through the C++ MergeCobordism (#379).
+
+The reworked `RegisterTopology` is the #353 color register built as a
+**b₁=2 holed-icosahedron staircase** (`(S²−3 color holes) × [0,2]`): one shared
+color register across the three blocks. That b₁=2 is the confinement — a colored
+(Σ≠0) configuration cannot be carried, so its realizability residual floors,
+while a color-neutral (Σ=0) configuration realizes. (The earlier tube-merge was
+b₁=8 and carried *any* config — no confinement.) These tests pin, through the
+canonical C++ `MergeCobordism`:
+
+  * the topology is a valid manifold with **b₁=2** (not 8);
+  * **confinement**: neutral/singlet states score orders below colored states;
+  * the color singlet `[1,ω,ω²]` realizes (the induced-sign `kColorSign` fix —
+    raw components would mis-floor it);
+  * **S₃ gauge invariance** of the score;
+  * the **emergent result block** is read after relaxation (never inserted); the
+    two-pair bipartite merge is *not* a color singlet (|σ_R| ≫ 0) — #353's
+    documented result that the proton needs three pairs (the #382 tripartite/
+    sequence merge), not a single bipartite merge.
+
+The exact (~1e-29) realizability map lives on `cob.Register` /
+`residualForPeriods`; through the merge the loop encoding (`residualForLoops`)
+gives a softer neutral floor (~1e-2), but the confinement *split* is the same.
+"""
+
+import cmath
+import itertools
+import unittest
+
+import tessera
+
+cob = tessera.cobordism
+_W = cmath.exp(2j * cmath.pi / 3)
+
+_NEUTRAL = {"[1,-1,0]": [1, -1, 0], "[1,0,-1]": [1, 0, -1],
+            "singlet [1,w,w^2]": [1, _W, _W * _W]}
+_COLORED = {"[1,0,0]": [1, 0, 0], "[1,1,0]": [1, 1, 0], "[1,1,1]": [1, 1, 1]}
+
+
+def _merge(states_in, states_out, max_iters=0):
+    return cob.MergeCobordism(states_in, states_out, max_iters=max_iters, seed=0,
+                              topology=cob.RegisterTopology())
+
+
+def _score(cfg):
+    # Pin the config on the register blocks; the post-build r_U (state_residual)
+    # is the realizability score. max_iters=0 => bare metric (the confinement is
+    # a topology property, max_iters-independent), so this is fast and exact.
+    return _merge([cfg], [cfg]).stats.state_residual
+
+
+# Built once for the structural assertions (topology is max_iters-independent).
+_M = _merge([[1, -1, 0]], [[1, -1, 0]])
+
+
+class TopologyIsB1EqualsTwoTest(unittest.TestCase):
+    def test_name_is_the_b1_2_staircase(self):
+        self.assertIn("register", _M.stats.topology)
+        self.assertIn("b1=2", _M.stats.topology)
+
+    def test_betti_is_b1_two(self):
+        # b₁(W)=2: one shared color register (the confinement), not the b₁=8 tube.
+        betti = list(_M.stats.betti_cobordism)
+        self.assertEqual(betti[0], 1)
+        self.assertEqual(betti[1], 2)
+
+
+class ConfinementThroughTheMergeTest(unittest.TestCase):
+    """Neutral/singlet realize (low r_U); colored floor — the confinement split."""
+
+    def test_neutral_below_colored(self):
+        worst_neutral = max(_score(c) for c in _NEUTRAL.values())
+        best_colored = min(_score(c) for c in _COLORED.values())
+        self.assertLess(worst_neutral, 1.0, "neutral should be small")
+        self.assertGreater(best_colored, 5.0, "colored should floor")
+        self.assertGreater(best_colored / worst_neutral, 50.0)
+
+    def test_singlet_realizes_not_floored(self):
+        # The sign fix: [1,ω,ω²] scores like a neutral pair, NOT like a colored
+        # state. Without kColorSign it would floor (raw n·a ≠ 0).
+        self.assertLess(_score([1, _W, _W * _W]), 1.0)
+        self.assertGreater(min(_score(c) for c in _COLORED.values()), 5.0)
+
+
+class S3GaugeInvarianceThroughTheMergeTest(unittest.TestCase):
+    def test_singlet_score_is_s3_invariant(self):
+        base = [1, _W, _W * _W]
+        scores = [_score([base[i] for i in p])
+                  for p in itertools.permutations(range(3))]
+        self.assertLess(max(scores) - min(scores), 1e-6)
+
+
+class EmergentResultBlockTest(unittest.TestCase):
+    """The result block emerges after relaxation (never inserted); the two-pair
+    merge is not a singlet (the proton needs three pairs — #382)."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Merge two neutral q-qbar pairs; read the emergent result over the R
+        # block's color cycles (a short relaxation suffices for the structure).
+        cls.m = _merge([[1, -1, 0], [1, 0, -1]], [[1, _W, _W * _W]], max_iters=40)
+
+    def test_output_state_is_a_color_triple(self):
+        self.assertEqual(len(self.m.output_state), 3)
+
+    def test_operator_is_deferred_empty(self):
+        # Register read-out is a color rep, not an operator (operator deferred).
+        self.assertEqual(len(self.m.operator_U), 0)
+
+    def test_two_pair_merge_is_not_a_singlet(self):
+        # |σ_R| is O(1), not < 1e-3: the bipartite (2-pair) merge does NOT yield a
+        # color singlet — #353's finding that the proton needs the 3-pair merge.
+        sigma_r = abs(sum(self.m.output_state))
+        self.assertGreater(sigma_r, 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_register_topology_python.py
+++ b/tests/cobordism/test_register_topology_python.py
@@ -7,13 +7,15 @@
 default is now the color `RegisterTopology` (the #353 register), selectable
 against the `(T^2-3holes)xS^1` `TorusOperatorTopology`.
 
-`RegisterTopology` lays three holed-icosahedron color blocks (A, B, R) with
-disjoint vertex ids, joined input->result by additive *tubes*. Connecting by
-tubes — never by *identifying* a shared block — keeps the merge a genuine
-trivalent manifold, NOT the #353 `merge_cobordism.py` weld (a `P x I` transport
-with a buried result). These tests pin that the register seed is a valid,
-non-welded manifold and that the topology is selectable with a topology-specific
-state dimension (register: d=3; operator: a power of two).
+`RegisterTopology` extrudes the holed icosahedron (S²−3 color holes, b₁=2 on the
+Σ=0 hyperplane) over a 3-layer staircase into one connected 3-complex with
+**b₁(W)=2** — one shared color register across the three blocks (#379). That b₁=2
+is the #353 confinement (a Σ≠0 config cannot be carried). It is a valid manifold
+(every triangle in ≤2 tets, dualComplexValid) — not the welded shared-block
+construction. These tests pin the topology + the selectable seam with a
+topology-specific state dimension (register: d=3; operator: a power of two); the
+color realizability map / S₃ invariance / emergent result are in
+`test_register_merge_353_python.py` and `test_proton_realizability_python.py`.
 """
 
 import cmath
@@ -60,26 +62,26 @@ class RegisterIsDefaultTest(unittest.TestCase):
         self.assertIn("register", _M.stats.topology)
 
 
-class RegisterIsAValidNonWeldedManifoldTest(unittest.TestCase):
-    def test_no_edge_in_more_than_two_triangles(self):
-        # The weld signature is an edge in > 2 triangles. Tubes only ADD
-        # triangles, so the register stays a 2-manifold (each edge in 1 or 2).
-        faces = _top_cells(_M.cobordism, 2)
-        self.assertGreater(len(faces), 0)
-        self.assertLessEqual(_max_facet_coface(faces), 2)
+class RegisterIsAValidManifoldTest(unittest.TestCase):
+    def test_no_triangle_in_more_than_two_tets(self):
+        # The weld signature is a (codim-1) triangle in > 2 tets. The continuous
+        # staircase is a clean 3-manifold (each triangle in 1 or 2 tets).
+        tets = _top_cells(_M.cobordism, 3)
+        self.assertGreater(len(tets), 0)
+        self.assertLessEqual(_max_facet_coface(tets), 2)
 
     def test_dual_complex_gate_passes(self):
         ok, why = cob.EigenstateSynthesis(_M.cobordism, 1).dualComplexValid()
         self.assertTrue(ok, why)
 
-    def test_connected_with_nine_holes(self):
-        # Three icosa blocks tube-joined into one connected complex; opening the
-        # nine color holes (3 per block) gives S^2 minus 9 disks: b0=1, b1=8.
+    def test_connected_b1_is_two(self):
+        # One connected complex (b0=1) with b1=2: the single shared color register
+        # (the #353 confinement), NOT the b1=8 of independent per-block holes.
         betti = list(_M.stats.betti_cobordism)
         self.assertEqual(betti[0], 1)
-        self.assertEqual(betti[1], 8)
+        self.assertEqual(betti[1], 2)
 
-    def test_boundary_is_the_color_hole_circles(self):
+    def test_boundary_is_nonempty(self):
         self.assertGreater(len(_M.boundary), 0)
 
 


### PR DESCRIPTION
## Summary

Reproduce #353's proton-from-quarks construction through the canonical C++
`MergeCobordism`, confirming the general primitive subsumes the Python
`build_merge_from_inputs` + `StationaryActionRelaxer` path.

**Key finding (and fix):** #378's register topology was `b₁=8` (three color
blocks joined by tubes, homologically independent), which carried *any* config —
**no confinement**. #353's confinement is intrinsically a `b₁=2` property (one
*shared* color register). So this PR reworks `RegisterTopology` to the
**holed-icosahedron `b₁=2` staircase** (`(S²−3 color holes) × [0,2]` via
`prismCells`) — a valid manifold (every triangle in ≤2 tets, `dualComplexValid`),
**not** the welded shared-block construction. It also fixes the read-out **sign
convention** (`kColorSign=(+1,+1,−1)`, the #353 `SIGN_BLOCK`) so the color singlet
`[1,ω,ω²]` realizes instead of mis-flooring.

## What's reproduced
- **Realizability map / confinement** — exact on the C++ `cob.Register` (b₁=2):
  color-neutral (Σ=0) realizes ~`1e-29` (< `REALIZE`), colored (Σ≠0) floors
  ~`0.5–8` (> `CERT_FLOOR`), a ~25-order split.
- **S₃ gauge (color-relabel) invariance** — the residual is identical under all
  6 permutations (Σ=0 states); colored states floor under every relabel.
- **Confinement through the merge** — the reworked b₁=2 `MergeCobordism` register
  gives a clean neutral/singlet ≪ colored split (vs the old b₁=8: no split).
- **Emergent result block** — read after relaxation (never inserted). The
  **two-pair bipartite merge is not a color singlet** (`|σ_R|~1`), reproducing
  #353's documented result that the proton needs the **three-pair** merge (#382).

## Test plan
- [x] `cob.Register` exact realizability map + S₃ (`test_proton_realizability_python.py`)
- [x] b₁=2 register topology is a valid manifold; confinement + S₃ + emergent result through `MergeCobordism` (`test_register_merge_353_python.py`)
- [x] `test_register_topology_python.py` updated for the b₁=2 staircase (was b₁=8 tube)
- [x] operator suite + Python-example merge still pass (no regression)
- [ ] full pytest suite green on CI

## Notes
- The exact (~1e-29) map is via `residualForPeriods`/`cob.Register`; through the
  merge the loop encoding (`residualForLoops`) gives a softer neutral floor
  (~1e-2) but the same confinement split — documented in the merge test.
- This revises the merged #378 register topology (b₁=8 → b₁=2), within #379's
  scope (make the C++ primitive subsume #353). Welding question resolved: the
  b₁=2 register is a genuine valid manifold, no hand-identified simplices.

Closes #379. Part of the #380 epic; the proton (3-pair merge) is #382.
