### PR TITLE
feat(cobordism): finer geodesic lattice for the W_ABC junction — resolution/convergence study

### DIFF
--- a/examples/cobordism/finer_lattice_convergence.py
+++ b/examples/cobordism/finer_lattice_convergence.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""Finer geodesic lattice for the W_ABC junction: a resolution/convergence study (#404).
+
+The junction's base is a frequency-N geodesic icosahedron (N=2 is the 42-vertex base
+of #398). The granularity is TUNABLE via `TripartiteRegisterTopology.set_frequency(N)`.
+The ~4e-2 intertwining residual (‖M·P_in − P_out·M‖/‖M‖) at N=2 is a fixed-resolution
+triangulation artifact; refining the lattice should shrink it and drive the singlet
+overlap → 1. This sweeps N and prints the trend.
+
+For each N the COMPLEX is built through the production C++ `set_frequency`; the
+window-cycling symmetry g (not exposed from C++) is reconstructed in Python from the
+icosahedral generators on the SAME frequency-N geometry, and asserted to match the
+cobordism's own window labels.
+
+Run:  python examples/cobordism/finer_lattice_convergence.py
+"""
+
+import cmath
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+_W = cmath.exp(2j * cmath.pi / 3)
+_NEUTRAL = [[1, -1, 0], [1, 0, -1], [0, 1, -1]]
+_ICO = [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 4, 5), (0, 5, 1), (1, 5, 10), (1, 10, 6),
+        (1, 6, 2), (2, 6, 7), (2, 7, 3), (3, 7, 8), (3, 8, 4), (4, 8, 9), (4, 9, 5),
+        (5, 9, 10), (6, 10, 11), (7, 6, 11), (8, 7, 11), (9, 8, 11), (10, 9, 11)]
+_ICO = [tuple(sorted(f)) for f in _ICO]
+_GENS = [[4, 3, 8, 9, 5, 0, 7, 11, 10, 1, 2, 6], [3, 4, 0, 2, 7, 8, 5, 1, 6, 11, 9, 10],
+         [6, 10, 11, 7, 2, 1, 9, 8, 3, 0, 5, 4], [10, 6, 1, 5, 9, 11, 2, 0, 4, 8, 7, 3]]
+_SEEDS = [(2, 0, 1), (1, 6, 10), (0, 3, 4), (3, 2, 7)]
+
+
+def _geodesic(N):
+    """The frequency-N geodesic edge-point map, matching C++ geodesicSphere's
+    face-order numbering. Returns edgePoint(u, v, step) and a reverse lookup."""
+    edge_pts, nxt = {}, [12]
+    for (a, b, c) in _ICO:
+        for (u, v) in [(a, b), (b, c), (c, a)]:
+            e = (min(u, v), max(u, v))
+            if e not in edge_pts:
+                edge_pts[e] = list(range(nxt[0], nxt[0] + N - 1)); nxt[0] += N - 1
+        nxt[0] += (N - 1) * (N - 2) // 2  # face interior block (face-order)
+
+    def edge_point(u, v, step):
+        e = (min(u, v), max(u, v))
+        return edge_pts[e][step - 1 if u == e[0] else N - step - 1]
+
+    rev = {vid: (e, idx) for e, ids in edge_pts.items() for idx, vid in enumerate(ids)}
+    return edge_point, rev
+
+
+def _windows_and_rep(N):
+    """The four A4-orbit windows + the signed reps (P_in, P_out) of the window-cycling
+    symmetry g, reconstructed on the frequency-N geometry."""
+    edge_point, rev = _geodesic(N)
+
+    def lift(perm, vid):
+        if vid < 12:
+            return perm[vid]
+        (e0, e1), idx = rev[vid]
+        return edge_point(perm[e0], perm[e1], idx + 1)
+
+    def apply_h(perm, h):
+        return tuple(sorted(lift(perm, x) for x in h))
+
+    windows = []
+    for w in range(4):
+        v, n1, n2 = _SEEDS[w]
+        seed = tuple(sorted((v, edge_point(v, n1, 1), edge_point(v, n2, 1))))
+        h1 = apply_h(_GENS[w], seed)
+        h2 = apply_h(_GENS[w], h1)
+        windows.append([tuple(sorted(x)) for x in (seed, h1, h2)])
+
+    comp = lambda p, q: [p[q[i]] for i in range(len(q))]
+    group = {tuple(p): p for p in [list(range(12))] + [list(g) for g in _GENS]}
+    changed = True
+    while changed:
+        changed = False
+        for p in list(group.values()):
+            for g in _GENS:
+                r = comp(p, g)
+                if tuple(r) not in group:
+                    group[tuple(r)] = r
+                    changed = True
+    hs = [set(w) for w in windows]
+
+    def winperm(perm):
+        out = []
+        for w in windows:
+            img = {apply_h(perm, h) for h in w}
+            mm = [j for j in range(4) if img == hs[j]]
+            if len(mm) != 1:
+                return None
+            out.append(mm[0])
+        return tuple(out)
+
+    g12 = next(p for p in group.values() if winperm(p) == (1, 2, 0, 3))
+    holes = [h for w in windows for h in w]
+    hidx = {h: i for i, h in enumerate(holes)}
+    sgn3 = lambda t: 1 if ((t[0] > t[1]) + (t[0] > t[2]) + (t[1] > t[2])) % 2 == 0 else -1
+    P = np.zeros((12, 12), complex)
+    for i, h in enumerate(holes):
+        P[hidx[apply_h(g12, h)], i] = sgn3(tuple(lift(g12, x) for x in h))
+    return windows, P[0:9, 0:9], P[9:12, 9:12]
+
+
+def measure(N):
+    """Build the frequency-N junction through the C++ set_frequency and read the
+    intertwining residual + the omega-rep singlet overlap."""
+    t = cob.TripartiteRegisterTopology()
+    t.set_frequency(N)
+    m = cob.TransportCobordism(_NEUTRAL, max_iters=0, seed=0, topology=t)
+    ih = [tuple(sorted(h)) for h in m.input_holes]
+    windows_cpp = [ih[0:3], ih[3:6], ih[6:9], [tuple(sorted(h)) for h in m.result_holes]]
+    windows, p_in, p_out = _windows_and_rep(N)
+    assert all(sorted(windows_cpp[i]) == sorted(windows[i]) for i in range(4)), \
+        f"C++ vs Python window labels disagree at N={N}"
+
+    es = cob.EigenstateSynthesis(m.cobordism, 1)
+    edge = {(min(c), max(c)): i
+            for i, c in enumerate(es.cellSimplices()) if len(c) == 2}
+    holes = [h for w in windows for h in w]
+    M = np.zeros((3, 9), complex)
+    for col in range(9):
+        psi = es.carriedRepresentative([list(holes[col])], [1.0])
+        for k, (a, b, c) in enumerate(holes[9:12]):
+            M[k, col] = psi[edge[(a, b)]] + psi[edge[(b, c)]] - psi[edge[(a, c)]]
+    err = np.linalg.norm(M @ p_in - p_out @ M) / (np.linalg.norm(M) + 1e-30)
+    wv, vin = np.linalg.eig(p_in)
+    wo, vout = np.linalg.eig(p_out)
+    sing = vout[:, int(np.argmin(np.abs(wo - _W)))]
+    ov = lambda u, v: abs(np.vdot(u, v)) / (np.linalg.norm(u) * np.linalg.norm(v) + 1e-30)
+    ovs = [ov(M @ vin[:, k], sing) for k in range(9) if abs(wv[k] - _W) < 1e-6]
+    betti = list(cob.ChainComplex.fromSpacetime(m.cobordism).bettiNumbers())
+    return {"N": N, "verts": m.cobordism.getVertexCount(), "intertwine": err,
+            "overlap_min": min(ovs), "overlap_max": max(ovs),
+            "windows": windows, "betti": betti,
+            "dual_valid": bool(es.dualComplexValid()[0])}
+
+
+def main(freqs=(2, 3, 4)):
+    print("Finer geodesic lattice for W_ABC — convergence (#404)\n")
+    print(f"{'N':>2}  {'cobordism verts':>15}  {'||M Pin - Pout M||/||M||':>26}  "
+          f"{'singlet overlap':>18}")
+    for N in freqs:
+        o = measure(N)
+        print(f"{o['N']:>2}  {o['verts']:>15}  {o['intertwine']:>26.4e}  "
+              f"{o['overlap_min']:.5f}..{o['overlap_max']:.5f}")
+    print("\nLarger N (set_frequency) refines the lattice: the intertwining residual\n"
+          "shrinks and the singlet overlap -> 1. The granularity is tunable.")
+
+
+if __name__ == "__main__":
+    main()

--- a/include/cobordism/TripartiteRegisterTopology.h
+++ b/include/cobordism/TripartiteRegisterTopology.h
@@ -117,11 +117,25 @@ class TripartiteRegisterTopology : public TopologyBuilder {
     /// @param worldlineLsq the timelike squared length for cross-layer edges (<0).
     void setLorentzianWorldlines(double worldlineLsq = -1.0);
 
+    /// Set the geodesic subdivision **frequency** N (the tunable lattice
+    /// granularity, \#404). The base surface is a frequency-N geodesic icosahedron:
+    /// \f$ 12 + 30(N-1) + 20\binom{N-1}{2} \f$ vertices, \f$ 20N^2 \f$ faces. The
+    /// four \f$ A_4 \f$-orbit windows are generated from the symmetry at any N, so
+    /// the construction is unchanged in structure (\f$ N=2 \f$, the default, is the
+    /// \#398 base of 42 vertices); larger N refines the lattice, shrinking the
+    /// intertwining residual and driving the singlet overlap \f$ \to 1 \f$.
+    /// @param frequency the subdivision frequency \f$ N \ge 2 \f$.
+    void setFrequency(int frequency);
+
   private:
     // Lorentzian worldlines (set by setLorentzianWorldlines): when on, build()
     // sets cross-layer edges timelike.
     bool lorentzian_{false};
     double lorentzWorldlineLsq_{-1.0};
+
+    // The geodesic subdivision frequency N (set by setFrequency); default 2 (the
+    // #398 base). Larger N refines the lattice (tunable granularity, #404).
+    int frequency_{2};
 
     // The van Raamsdonk metric seed (set by setEntangledMetric); when unset the
     // build uses the uniform symmetric seed (l^2 = 1).

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -1349,7 +1349,15 @@ prepared states, reproduces the harmonic overlap.)doc")
            "edges are set timelike (l^2 = worldline_lsq < 0), so the dual Regge "
            "action goes complex (Im S != 0) and its harmonics carry the singlet's "
            "omega-phases. Null edges (photons) may emerge under the relax as a "
-           "worldline's l^2 -> 0. Unset => all-spacelike (Riemannian).");
+           "worldline's l^2 -> 0. Unset => all-spacelike (Riemannian).")
+      .def("set_frequency", &TripartiteRegisterTopology::setFrequency,
+           py::arg("frequency"),
+           "Set the geodesic subdivision frequency N (tunable lattice granularity, "
+           "#404): the base is a frequency-N geodesic icosahedron (12 + 30(N-1) + "
+           "20*(N-1)(N-2)/2 vertices, 20 N^2 faces). The four A4-orbit windows are "
+           "generated from the symmetry at any N>=2; N=2 (default) is the #398 base "
+           "of 42 vertices. Larger N refines the lattice, shrinking the intertwining "
+           "residual and driving the singlet overlap -> 1.");
 
   // === MergeCobordism (#363 / #388) ===
   py::class_<MergeCobordism> mc(m, "MergeCobordism",

--- a/src/cobordism/TripartiteRegisterTopology.cpp
+++ b/src/cobordism/TripartiteRegisterTopology.cpp
@@ -34,44 +34,85 @@ std::vector<Face> icosahedron() {
   return faces;
 }
 
-using MidMap = std::map<std::pair<std::uint64_t, std::uint64_t>, std::uint64_t>;
+using EdgeMap =
+    std::map<std::pair<std::uint64_t, std::uint64_t>, std::vector<std::uint64_t>>;
 
-// The 2-frequency geodesic icosahedron and its edge-midpoint map.
+// A frequency-N geodesic icosahedron and its per-edge sub-vertex map.
 struct GeodesicSphere {
-  std::vector<Face> faces;  // 80 sub-triangles (sorted)
-  MidMap mid;               // undirected icosa edge (min,max) -> midpoint vertex id
+  std::vector<Face> faces;  // 20*N^2 sub-triangles (sorted)
+  int frequency;            // N
+  EdgeMap edgePts;          // undirected icosa edge (min,max) -> N-1 ids from min
 };
 
-// 2-frequency geodesic subdivision of the icosahedron: an edge-midpoint vertex
-// per edge (30 new, ids 12..41), each face split into 4. A connected S^2 with 42
-// vertices and 80 faces — enough to host 12 vertex-disjoint hole triangles (the
-// bare icosahedron's 12 vertices admit only 4 disjoint holes; we need 12 = 4
-// windows of 3). Deterministic (no metric/seed dependence). The midpoint map is
-// returned so the symmetric-window generator can lift the C3 rotations.
-GeodesicSphere geodesicTwoSphere() {
+// The step-th sub-vertex (step = 1..N-1) along the icosa edge from u toward v.
+std::uint64_t edgePoint(const EdgeMap &edgePts, int N, std::uint64_t u,
+                        std::uint64_t v, int step) {
+  const std::pair<std::uint64_t, std::uint64_t> e{std::min(u, v), std::max(u, v)};
+  const int idx = (u == e.first) ? step - 1 : N - step - 1;
+  return edgePts.at(e)[static_cast<std::size_t>(idx)];
+}
+
+// Frequency-N geodesic subdivision of the icosahedron: each icosa edge gets N-1
+// sub-vertices and each face is split into N^2 sub-triangles, giving a connected
+// S^2 with 12 + 30(N-1) + 20*(N-1)(N-2)/2 vertices and 20*N^2 faces. N=2 is the
+// 42-vertex/80-face base of #398 (enough to host the 12 vertex-disjoint hole
+// triangles); larger N refines the lattice (the tunable granularity, #404), which
+// shrinks the discretization residual and drives the singlet overlap -> 1. Uses a
+// face-order numbering (edge blocks on first encounter, then the face's interior),
+// so N=2 reproduces geodesicTwoSphere exactly (backward-compatible). Deterministic.
+// The edge map is returned so the window generator lifts the C3 rotations across the
+// subdivision.
+GeodesicSphere geodesicSphere(int N) {
   const auto ico = icosahedron();
-  MidMap mid;
+  EdgeMap edgePts;
   std::uint64_t next = 12;
-  auto midpoint = [&](std::uint64_t a, std::uint64_t b) {
-    const std::pair<std::uint64_t, std::uint64_t> key{std::min(a, b),
-                                                      std::max(a, b)};
-    const auto it = mid.find(key);
-    if (it != mid.end()) return it->second;
-    return mid[key] = next++;
+  auto ensureEdge = [&](std::uint64_t u, std::uint64_t v) {
+    const std::pair<std::uint64_t, std::uint64_t> e{std::min(u, v), std::max(u, v)};
+    if (edgePts.count(e)) return;
+    std::vector<std::uint64_t> ids(static_cast<std::size_t>(N - 1));
+    for (auto &id : ids) id = next++;
+    edgePts.emplace(e, std::move(ids));
+  };
+  // Per-face interior points (barycentric i,j,k all > 0), keyed by (j,k); assigned
+  // in face order AFTER that face's edges (the first-encounter scheme above).
+  std::map<Face, std::map<std::pair<int, int>, std::uint64_t>> interior;
+  for (const auto &f : ico) {
+    ensureEdge(f[0], f[1]);
+    ensureEdge(f[1], f[2]);
+    ensureEdge(f[2], f[0]);
+    std::map<std::pair<int, int>, std::uint64_t> in;
+    for (int j = 1; j < N; ++j)
+      for (int k = 1; k < N - j; ++k) in[{j, k}] = next++;
+    interior[f] = std::move(in);
+  }
+  // P(j,k) in face (a,b,c): barycentric i=N-j-k toward a, j toward b, k toward c.
+  auto gridId = [&](const Face &f, int j, int k) -> std::uint64_t {
+    const std::uint64_t a = f[0], b = f[1], c = f[2];
+    const int i = N - j - k;
+    if (i == N) return a;
+    if (j == N) return b;
+    if (k == N) return c;
+    if (k == 0) return edgePoint(edgePts, N, a, b, j);  // edge a-b
+    if (j == 0) return edgePoint(edgePts, N, a, c, k);  // edge a-c
+    if (i == 0) return edgePoint(edgePts, N, b, c, k);  // edge b-c
+    return interior.at(f).at({j, k});
   };
   std::vector<Face> faces;
-  faces.reserve(ico.size() * 4);
-  for (const auto &f : ico) {
-    const std::uint64_t a = f[0], b = f[1], c = f[2];
-    const std::uint64_t ab = midpoint(a, b), bc = midpoint(b, c),
-                        ca = midpoint(c, a);
-    for (Face sub : {Face{a, ab, ca}, Face{b, bc, ab}, Face{c, ca, bc},
-                     Face{ab, bc, ca}}) {
-      std::sort(sub.begin(), sub.end());
-      faces.push_back(std::move(sub));
-    }
-  }
-  return {std::move(faces), std::move(mid)};
+  faces.reserve(ico.size() * static_cast<std::size_t>(N) * N);
+  for (const auto &f : ico)
+    for (int j = 0; j < N; ++j)
+      for (int k = 0; k < N - j; ++k) {
+        Face up = {gridId(f, j, k), gridId(f, j + 1, k), gridId(f, j, k + 1)};
+        std::sort(up.begin(), up.end());
+        faces.push_back(std::move(up));
+        if (j + k < N - 1) {
+          Face dn = {gridId(f, j + 1, k), gridId(f, j, k + 1),
+                     gridId(f, j + 1, k + 1)};
+          std::sort(dn.begin(), dn.end());
+          faces.push_back(std::move(dn));
+        }
+      }
+  return {std::move(faces), N, std::move(edgePts)};
 }
 
 // The four A4-tetrahedral, C3-symmetric register windows (#398) — one orbit of a
@@ -83,12 +124,15 @@ GeodesicSphere geodesicTwoSphere() {
 // (omega-representation) input transports to the EXACT singlet with manifest S3 —
 // unlike a greedy pick whose windows are geometrically inequivalent.
 //
-// Generated FROM the symmetry (four C3 generators + a seed corner per window +
-// the midpoint lift), so it is correct in whatever vertex numbering
-// geodesicTwoSphere() produces (hardcoding the 12 triples is fragile against the
-// midpoint numbering). Asserts the construction: each window a genuine C3 orbit,
-// all 12 holes real faces, all 36 vertices distinct.
-std::vector<std::vector<Face>> symmetricWindows(const MidMap &mid,
+// Generated FROM the symmetry (four C3 generators + a seed corner per window + the
+// sub-vertex lift), so it is correct at any frequency N and in whatever numbering
+// geodesicSphere() produces (hardcoding the triples is fragile against it). The seed
+// corner sub-triangle at vertex v is {v, the nearest sub-vertex toward each of two
+// neighbours}; the C3 rotation lifts it across the subdivision (a base vertex maps by
+// the permutation; a sub-vertex on edge (p,q) at step s maps to step s on edge
+// (perm[p],perm[q])). Asserts: each window a genuine C3 orbit, all 12 holes real
+// faces, all 36 vertices distinct.
+std::vector<std::vector<Face>> symmetricWindows(const EdgeMap &edgePts, int N,
                                                 const std::set<Face> &faceSet) {
   // The four C3 rotations as 12-vertex permutations: a[w] cycles window w's
   // tetrahedral vertex-orbit (all order 3, orientation-preserving rotations).
@@ -102,22 +146,21 @@ std::vector<std::vector<Face>> symmetricWindows(const MidMap &mid,
   static const std::array<std::array<std::uint64_t, 3>, 4> seed = {{
       {{2, 0, 1}}, {{1, 6, 10}}, {{0, 3, 4}}, {{3, 2, 7}},
   }};
-  auto m = [&](std::uint64_t x, std::uint64_t y) {
-    return mid.at({std::min(x, y), std::max(x, y)});
-  };
-  // Reverse midpoint lookup (id -> the icosa edge it bisects), to lift a vertex
-  // permutation onto the geodesic vertices: a base vertex maps by the
-  // permutation, a midpoint m(p,q) maps to m(perm[p], perm[q]).
-  std::map<std::uint64_t, std::pair<std::uint64_t, std::uint64_t>> rev;
-  for (const auto &kv : mid) rev[kv.second] = kv.first;
+  // Reverse sub-vertex lookup: id -> (its icosa edge, its step index from the edge's
+  // min endpoint), so a vertex permutation lifts onto the subdivision.
+  std::map<std::uint64_t, std::pair<std::pair<std::uint64_t, std::uint64_t>, int>> rev;
+  for (const auto &kv : edgePts)
+    for (std::size_t idx = 0; idx < kv.second.size(); ++idx)
+      rev[kv.second[idx]] = {kv.first, static_cast<int>(idx)};
   auto apply = [&](const std::array<int, 12> &p, Face h) {
     for (auto &v : h) {
       if (v < 12) {
         v = static_cast<std::uint64_t>(p[v]);
       } else {
-        const auto pq = rev.at(v);
-        v = m(static_cast<std::uint64_t>(p[pq.first]),
-              static_cast<std::uint64_t>(p[pq.second]));
+        const auto &er = rev.at(v);  // ((edge min, edge max), step-1)
+        v = edgePoint(edgePts, N, static_cast<std::uint64_t>(p[er.first.first]),
+                      static_cast<std::uint64_t>(p[er.first.second]),
+                      er.second + 1);
       }
     }
     std::sort(h.begin(), h.end());
@@ -127,7 +170,8 @@ std::vector<std::vector<Face>> symmetricWindows(const MidMap &mid,
   std::vector<std::vector<Face>> windows(4);
   std::set<std::uint64_t> used;
   for (int w = 0; w < 4; ++w) {
-    Face s = {seed[w][0], m(seed[w][0], seed[w][1]), m(seed[w][0], seed[w][2])};
+    Face s = {seed[w][0], edgePoint(edgePts, N, seed[w][0], seed[w][1], 1),
+              edgePoint(edgePts, N, seed[w][0], seed[w][2], 1)};
     std::sort(s.begin(), s.end());
     const Face h1 = apply(a[w], s);
     const Face h2 = apply(a[w], h1);
@@ -165,6 +209,14 @@ void TripartiteRegisterTopology::setLorentzianWorldlines(double worldlineLsq) {
   lorentzWorldlineLsq_ = worldlineLsq;
 }
 
+void TripartiteRegisterTopology::setFrequency(int frequency) {
+  if (frequency < 2)
+    throw std::invalid_argument(
+        "TripartiteRegisterTopology: frequency must be >= 2 (N=2 is the base "
+        "that hosts the 12 disjoint holes; larger N refines the lattice)");
+  frequency_ = frequency;
+}
+
 void TripartiteRegisterTopology::validateStateDim(std::size_t d) const {
   if (d != 3)
     throw std::invalid_argument(
@@ -176,13 +228,15 @@ std::shared_ptr<Spacetime> TripartiteRegisterTopology::build(
     std::size_t /*stateDim*/, std::uint64_t /*seed*/,
     std::vector<std::vector<std::uint64_t>> &boundaryCells) {
   // The trivalent W_ABC junction, built NON-WELDED: ONE connected base surface (a
-  // 2-frequency geodesic icosahedron, S^2, 42 vertices) minus 12 vertex-disjoint
-  // hole triangles grouped into FOUR windows of three — A, B, C (inputs) and R
-  // (the emergent result) — extruded x I (prismCells). The four windows are
-  // distinct holes = INDEPENDENT cycles (not stacked layers of one shared
-  // register), so the three inputs do not average; the result is confined to
-  // Sigma=0 by the surface's global Stokes relation (Sigma_R = -Sigma_inputs).
-  const auto sphere = geodesicTwoSphere();
+  // frequency-N geodesic icosahedron, S^2; N=2 -> 42 vertices) minus 12
+  // vertex-disjoint hole triangles grouped into FOUR windows of three — A, B, C
+  // (inputs) and R (the emergent result) — extruded x I (prismCells). The four
+  // windows are distinct holes = INDEPENDENT cycles (not stacked layers of one
+  // shared register), so the three inputs do not average; the result is confined to
+  // Sigma=0 by the surface's global Stokes relation (Sigma_R = -Sigma_inputs). The
+  // frequency is tunable (#404): larger N refines the lattice, shrinking the
+  // discretization residual and driving the singlet overlap -> 1.
+  const auto sphere = geodesicSphere(frequency_);
   const auto &faces = sphere.faces;
   const std::set<Face> faceSet(faces.begin(), faces.end());
 
@@ -191,7 +245,7 @@ std::shared_ptr<Spacetime> TripartiteRegisterTopology::build(
   // and the windows A4-equivalent, so the per-window transport blocks are
   // cyclically related and a color-symmetric input -> the EXACT singlet (manifest
   // S3). Flattened to 12 holes in window order A,B,C,R.
-  const auto windows = symmetricWindows(sphere.mid, faceSet);
+  const auto windows = symmetricWindows(sphere.edgePts, frequency_, faceSet);
   std::vector<Face> holes;
   holes.reserve(12);
   for (const auto &w : windows)

--- a/tests/cobordism/test_finer_lattice_python.py
+++ b/tests/cobordism/test_finer_lattice_python.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""Finer geodesic lattice for the W_ABC junction (#404) — tunable granularity.
+
+The junction base is a frequency-N geodesic icosahedron; the granularity is tunable
+via `TripartiteRegisterTopology.set_frequency(N)`. These tests pin, through the
+production C++ path and the convergence example:
+
+  * N=2 (the default) is backward-compatible with #398 (the four A4-orbit windows are
+    exactly the #398 oracle), and every N gives a valid b1=11 manifold;
+  * the lattice actually refines (more vertices) with N;
+  * refining shrinks the intertwining residual and drives the singlet overlap -> 1;
+  * frequency < 2 is rejected.
+"""
+
+import importlib.util
+import pathlib
+import unittest
+
+import tessera
+
+cob = tessera.cobordism
+
+_EXAMPLE = (pathlib.Path(__file__).resolve().parents[2]
+            / "examples" / "cobordism" / "finer_lattice_convergence.py")
+_spec = importlib.util.spec_from_file_location("finer_lattice_convergence", _EXAMPLE)
+_fl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fl)
+
+_ORACLE = [[(2, 13, 14), (8, 31, 32), (10, 22, 36)],
+           [(1, 23, 24), (4, 19, 34), (7, 30, 39)],
+           [(0, 16, 18), (6, 26, 27), (9, 33, 41)],
+           [(3, 15, 29), (5, 20, 21), (11, 37, 38)]]
+_ORACLE = [[tuple(sorted(h)) for h in w] for w in _ORACLE]
+
+
+class FinerLatticeTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.o2 = _fl.measure(2)   # the #398 base
+        cls.o3 = _fl.measure(3)   # one refinement
+
+    def test_n2_is_backward_compatible_with_398(self):
+        # N=2 (default) reproduces the #398 oracle windows exactly.
+        self.assertTrue(all(sorted(self.o2["windows"][i]) == sorted(_ORACLE[i])
+                            for i in range(4)))
+
+    def test_every_frequency_is_a_valid_b1_11_manifold(self):
+        for o in (self.o2, self.o3):
+            self.assertEqual(o["betti"][1], 11)
+            self.assertTrue(o["dual_valid"])
+
+    def test_finer_lattice_has_more_vertices(self):
+        self.assertGreater(self.o3["verts"], self.o2["verts"])
+
+    def test_refining_shrinks_the_intertwining_residual(self):
+        # The residual is a fixed-resolution artifact; it decreases with N.
+        self.assertLess(self.o3["intertwine"], self.o2["intertwine"])
+
+    def test_singlet_overlap_is_near_one_and_improves(self):
+        self.assertGreater(self.o2["overlap_min"], 0.999)
+        self.assertGreaterEqual(self.o3["overlap_min"], self.o2["overlap_min"] - 1e-6)
+
+    def test_frequency_below_two_is_rejected(self):
+        with self.assertRaises(Exception):
+            cob.TripartiteRegisterTopology().set_frequency(1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make the W_ABC junction's lattice granularity **tunable**. The base generalizes from the 2-frequency geodesic icosahedron (42 vertices, #398) to a **frequency-N** geodesic icosahedron, selected via `TripartiteRegisterTopology.set_frequency(N)` (default N=2). The ~4×10⁻² intertwining residual is a fixed-resolution triangulation artifact; refining the lattice shrinks it and drives the singlet overlap → 1.

### Convergence (through the production `set_frequency` API)

| N | cobordism verts | ‖M·P_in − P_out·M‖/‖M‖ | singlet overlap |
|---|---|---|---|
| 2 | 126 | 4.26e-2 | 0.9991–0.9998 |
| 3 | 276 | 2.09e-2 | 0.9996–**0.99999** |
| 4 | 486 | 1.69e-2 | 0.9997–1.0000 |

The residual halves by N=3 and the singlet is essentially exact — confirming it was a resolution artifact, not symmetry breaking.

## What changed
- `geodesicSphere(N)` — the frequency-N subdivision (12 + 30(N−1) + 20·(N−1)(N−2)/2 verts, 20·N² faces), returning the per-edge sub-vertex map. **Face-order numbering so N=2 reproduces the old base exactly** (backward-compatible).
- `symmetricWindows(edgePts, N, …)` — the same four A₄-orbit windows, generated from the symmetry at any N (C₃ generators + seed corner + the generalized sub-vertex lift), same build-time asserts.
- `setFrequency(N)` + the `set_frequency` pybind binding; N < 2 rejected.

## Test plan
- [x] N=2 (default) windows == the #398 oracle; every N a valid b₁=11 manifold (`dual_valid`)
- [x] finer N has more vertices; the intertwining residual shrinks + overlap → 1
- [x] `set_frequency(1)` rejected
- [x] `examples/cobordism/finer_lattice_convergence.py` (convergence study) + `test_finer_lattice_python.py` (6 tests)
- [x] **#398 junction suite passes unchanged at N=2 default (20/20)** — backward-compatible

Closes #404. Part of the #380 epic; builds on #398/#399.
