### PR TITLE
fix(cobordism): source simplex orientation/sign from the standard formula, not vertex-label sort

### DIFF
--- a/include/cobordism/RegisterTopology.h
+++ b/include/cobordism/RegisterTopology.h
@@ -56,7 +56,8 @@ class RegisterTopology : public TopologyBuilder {
         const std::vector<std::vector<std::complex<double>>> &states,
         std::vector<std::vector<std::uint64_t>> &inputHoles,
         std::vector<std::complex<double>> &inputTargets,
-        std::vector<std::vector<std::uint64_t>> &resultHoles) const override;
+        std::vector<std::vector<std::uint64_t>> &resultHoles,
+        std::vector<int> &resultSigns) const override;
 
     /// The #353 result block EMERGES from the pinned neutral-pair inputs (read
     /// after the relax, not supplied), so MergeCobordism may omit outputStates/U.

--- a/include/cobordism/TopologyBuilder.h
+++ b/include/cobordism/TopologyBuilder.h
@@ -90,17 +90,23 @@ class TopologyBuilder {
     /// @param inputHoles   out: the pinned states' triangle holes (sorted triples).
     /// @param inputTargets out: their target periods (induced-orientation signed).
     /// @param resultHoles  out: the emergent result block's triangle holes (read).
+    /// @param resultSigns  out: the result block's induced-orientation signs
+    ///   (\f$ \pm 1 \f$), applied to the emergent result periods so the read-out is
+    ///   symmetric with the signed input targets and hence relabeling-invariant.
+    ///   Empty means no signing (the read-out keeps the raw per-hole periods).
     virtual void readoutHoles(
         const std::shared_ptr<Spacetime> &cobordism,
         const std::vector<std::vector<std::complex<double>>> &states,
         std::vector<std::vector<std::uint64_t>> &inputHoles,
         std::vector<std::complex<double>> &inputTargets,
-        std::vector<std::vector<std::uint64_t>> &resultHoles) const {
+        std::vector<std::vector<std::uint64_t>> &resultHoles,
+        std::vector<int> &resultSigns) const {
       (void)cobordism;
       (void)states;
       inputHoles.clear();
       inputTargets.clear();
       resultHoles.clear();
+      resultSigns.clear();
     }
 
     /// Whether the result block EMERGES from the pinned inputs alone (the \#353

--- a/include/cobordism/TransportCobordism.h
+++ b/include/cobordism/TransportCobordism.h
@@ -96,6 +96,14 @@ class TransportCobordism {
     [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &resultHoles()
         const noexcept { return resultHoles_; }
 
+    /// The result block's induced-orientation signs (\f$ \pm 1 \f$ per result hole),
+    /// applied to the emergent result periods so the read-out is symmetric with the
+    /// signed input targets (the relabeling-invariant Stokes charge). Empty for a
+    /// topology that supplies no result signing (the raw periods are kept).
+    [[nodiscard]] const std::vector<int> &resultSigns() const noexcept {
+      return resultSigns_;
+    }
+
     [[nodiscard]] const Stats &stats() const noexcept { return stats_; }
 
   private:
@@ -114,6 +122,7 @@ class TransportCobordism {
     std::vector<std::vector<std::uint64_t>> stateHoles_{};
     std::vector<std::complex<double>> holeTargets_{};
     std::vector<std::vector<std::uint64_t>> resultHoles_{};
+    std::vector<int> resultSigns_{};  // result block's induced-orientation signs
 
     // === results ===
     std::shared_ptr<Spacetime> cobordism_{};

--- a/include/cobordism/TripartiteRegisterTopology.h
+++ b/include/cobordism/TripartiteRegisterTopology.h
@@ -70,7 +70,8 @@ class TripartiteRegisterTopology : public TopologyBuilder {
         const std::vector<std::vector<std::complex<double>>> &states,
         std::vector<std::vector<std::uint64_t>> &inputHoles,
         std::vector<std::complex<double>> &inputTargets,
-        std::vector<std::vector<std::uint64_t>> &resultHoles) const override;
+        std::vector<std::vector<std::uint64_t>> &resultHoles,
+        std::vector<int> &resultSigns) const override;
 
     /// The result block (window R) EMERGES from the three pinned inputs; the merge
     /// pins inputs alone and reads the emergent result, so no outputStates/U.

--- a/include/mesh/ForwardDeclarations.h
+++ b/include/mesh/ForwardDeclarations.h
@@ -90,14 +90,14 @@ using VertexIdMap = std::unordered_map<IdType, VertexPtr>;
 using VertexIdToIndex = std::unordered_map<IdType, std::size_t>;
 using VertexIndexToId = std::unordered_map<std::size_t, IdType>;
 
-// SimplexOrientation Structures
-class SimplexOrientation;
-using SimplexOrientationPtr = std::shared_ptr<SimplexOrientation>;
-using SimplexOrientationPtrHash = FingerprintPtrHash<SimplexOrientationPtr>;
-using SimplexOrientationPtrEq = FingerprintPtrEq<SimplexOrientationPtr>;
-using SimplexOrientationHash = FingerprintHash<SimplexOrientation>;
-using SimplexOrientationEq = FingerprintEq<SimplexOrientation>;
-using SimplexOrientationSet = std::unordered_set<SimplexOrientation, SimplexOrientationHash, SimplexOrientationEq>;
+// TemporalOrientation Structures
+class TemporalOrientation;
+using TemporalOrientationPtr = std::shared_ptr<TemporalOrientation>;
+using TemporalOrientationPtrHash = FingerprintPtrHash<TemporalOrientationPtr>;
+using TemporalOrientationPtrEq = FingerprintPtrEq<TemporalOrientationPtr>;
+using TemporalOrientationHash = FingerprintHash<TemporalOrientation>;
+using TemporalOrientationEq = FingerprintEq<TemporalOrientation>;
+using TemporalOrientationSet = std::unordered_set<TemporalOrientation, TemporalOrientationHash, TemporalOrientationEq>;
 
 
 } // namespace tessera::mesh

--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -16,7 +16,7 @@
 #include "Logger.h"
 #include "mesh/EdgeList.h"
 #include "mesh/Fingerprint.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "utils.h"
 
 // === tessera subsystem ns fwd-decls ===
@@ -52,13 +52,13 @@ class Simplex {
   public:
     // ==================== Static Factory Methods ====================
     static Simplex* create(Spacetime *spacetime_, const VertexPtrs &vertices_, const Edges &edges_);
-    static Simplex* create(Spacetime *spacetime_, const VertexPtrs &vertices_, const Edges &edges_, const SimplexOrientation &orientation_);
+    static Simplex* create(Spacetime *spacetime_, const VertexPtrs &vertices_, const Edges &edges_, const TemporalOrientation &orientation_);
     [[nodiscard]] static std::size_t computeNumberOfEdges(std::size_t k);
 
     // ==================== Constructors & Initialization ====================
     /// @param vertices_
     explicit Simplex(Spacetime *spacetime_, const VertexPtrs &vertices_, Edges edges_);
-    Simplex(Spacetime *spacetime_, const VertexPtrs &vertices_, Edges edges_ ,const SimplexOrientation &orientation_);
+    Simplex(Spacetime *spacetime_, const VertexPtrs &vertices_, Edges edges_ ,const TemporalOrientation &orientation_);
 
     std::uint64_t size() const noexcept { return vertices.size(); }
 
@@ -81,9 +81,9 @@ class Simplex {
 
     // ==================== Basic Getters ====================
     /// Each simplex has an associated _orientation_ in the case you're preserving causality with your work. You can
-    /// find specifics of the SimplexOrientation abstractly and concretely/computationally in the documentation for the
-    /// SimplexOrientation
-    [[nodiscard]] const SimplexOrientation &getOrientation() const noexcept { return orientation; }
+    /// find specifics of the TemporalOrientation abstractly and concretely/computationally in the documentation for the
+    /// TemporalOrientation
+    [[nodiscard]] const TemporalOrientation &getOrientation() const noexcept { return orientation; }
 
     /// The earliest time assigned to a vertex in this Simplex.
     /// @returns ti for the Simplex.
@@ -548,7 +548,7 @@ class Simplex {
     void releaseChildren() noexcept;
   private:
     Spacetime *spacetime{nullptr};
-    SimplexOrientation orientation{};
+    TemporalOrientation orientation{};
 
     VertexPtrs vertices{};
 

--- a/include/mesh/TemporalOrientation.h
+++ b/include/mesh/TemporalOrientation.h
@@ -5,8 +5,8 @@
 // Created by andrew on 12/14/25.
 //
 
-#ifndef TESSERA_SIMPLEXORIENTATION_H
-#define TESSERA_SIMPLEXORIENTATION_H
+#ifndef TESSERA_TEMPORALORIENTATION_H
+#define TESSERA_TEMPORALORIENTATION_H
 
 // Note: an old `#include <pybind11/pybind11.h>` was removed here. It was
 // unreferenced inside the file and was dragging Python.h into every TU
@@ -43,7 +43,7 @@ enum class TimeOrientation : uint8_t {
   UNKNOWN = 2
 };
 
-class SimplexOrientation {
+class TemporalOrientation {
   public:
     ///
     /// The orientation of a simplex is determined by how many vertices lie on the initial and final time slice for the
@@ -60,20 +60,20 @@ class SimplexOrientation {
     /// @param ti_ The number of vertices on the initial time slice.
     /// @param tf_ The number of vertices on the final time slice.
     ///
-    SimplexOrientation(uint8_t ti_, uint8_t tf_);
-    SimplexOrientation();
+    TemporalOrientation(uint8_t ti_, uint8_t tf_);
+    TemporalOrientation();
 
-    [[nodiscard]] SimplexOrientation decTf() const;
-    [[nodiscard]] SimplexOrientation decTi() const;
-    [[nodiscard]] SimplexOrientation flip() const;
+    [[nodiscard]] TemporalOrientation decTf() const;
+    [[nodiscard]] TemporalOrientation decTi() const;
+    [[nodiscard]] TemporalOrientation flip() const;
     [[nodiscard]] TimeOrientation getOrientation() const;
     [[nodiscard]] std::pair<uint8_t, uint8_t> numeric() const;
     [[nodiscard]] std::string toString() const noexcept;
-    [[nodiscard]] std::vector<SimplexOrientation> getFacialOrientations() const;
+    [[nodiscard]] std::vector<TemporalOrientation> getFacialOrientations() const;
     [[nodiscard]] uint8_t getK() const; /// A k-simplex has \f$ k+1 \f$ vertices.
     [[nodiscard]] size_t hash() const;
-    bool operator==(const SimplexOrientation &other) const noexcept;
-    static SimplexOrientation orientationOf(const VertexPtrs &vertices);
+    bool operator==(const TemporalOrientation &other) const noexcept;
+    static TemporalOrientation orientationOf(const VertexPtrs &vertices);
     Fingerprint fingerprint;
   private:
     uint8_t ti{0};
@@ -83,4 +83,4 @@ class SimplexOrientation {
 
 }
 
-#endif //TESSERA_SIMPLEXORIENTATION_H
+#endif //TESSERA_TEMPORALORIENTATION_H

--- a/include/spacetime/PachnerMove.h
+++ b/include/spacetime/PachnerMove.h
@@ -13,7 +13,7 @@
 
 #include "mesh/ForwardDeclarations.h"
 #include "mesh/Simplex.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "mesh/Vertex.h"
 #include "spacetime/Spacetime.h"
 
@@ -42,7 +42,7 @@ inline bool isValidCDTOrientation(const VertexPtrs &verts, int d) {
     times.insert(static_cast<std::uint64_t>(v->getTime()));
   }
   if (times.size() != 2) return false;
-  auto orient = SimplexOrientation::orientationOf(verts);
+  auto orient = TemporalOrientation::orientationOf(verts);
   auto [ti, tf] = orient.numeric();
   if ((ti == d && tf == 1) || (ti == 1 && tf == d)) return true;
   if ((ti == d - 1 && tf == 2) || (ti == 2 && tf == d - 1)) return true;
@@ -60,12 +60,12 @@ inline bool isN32Type(const SimplexPtr &s, int d) {
 }
 
 inline bool isN41TypeVerts(const VertexPtrs &verts, int d) {
-  auto [ti, tf] = SimplexOrientation::orientationOf(verts).numeric();
+  auto [ti, tf] = TemporalOrientation::orientationOf(verts).numeric();
   return (ti == d && tf == 1) || (ti == 1 && tf == d);
 }
 
 inline bool isN32TypeVerts(const VertexPtrs &verts, int d) {
-  auto [ti, tf] = SimplexOrientation::orientationOf(verts).numeric();
+  auto [ti, tf] = TemporalOrientation::orientationOf(verts).numeric();
   return (ti == d - 1 && tf == 2) || (ti == 2 && tf == d - 1);
 }
 

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -1514,5 +1514,10 @@ prepared states, reproduces the harmonic overlap.)doc")
       .def_property_readonly("result_holes", &TransportCobordism::resultHoles,
                              "The EMERGENT result block's triangle holes (read, "
                              "never pinned).")
+      .def_property_readonly("result_signs", &TransportCobordism::resultSigns,
+                             "The result block's induced-orientation signs (+-1 per "
+                             "result hole), applied to the emergent result periods so "
+                             "the read-out is symmetric with the signed inputs "
+                             "(relabeling-invariant sigma_R). Empty if unsigned.")
       .def_property_readonly("stats", &TransportCobordism::stats);
 }

--- a/src/cobordism/RegisterTopology.cpp
+++ b/src/cobordism/RegisterTopology.cpp
@@ -153,7 +153,8 @@ void RegisterTopology::readoutHoles(
     const std::vector<std::vector<std::complex<double>>> &states,
     std::vector<std::vector<std::uint64_t>> &inputHoles,
     std::vector<std::complex<double>> &inputTargets,
-    std::vector<std::vector<std::uint64_t>> &resultHoles) const {
+    std::vector<std::vector<std::uint64_t>> &resultHoles,
+    std::vector<int> &resultSigns) const {
   // The EXACT (#353 period) read-out: each block's three color holes are removed
   // triangles whose dual periods carry that state's three color amplitudes (no
   // S^1). The merge scores the PINNED INPUT blocks over residualForPeriods (the
@@ -165,6 +166,8 @@ void RegisterTopology::readoutHoles(
   inputHoles.clear();
   inputTargets.clear();
   resultHoles.clear();
+  resultSigns.clear();  // bipartite register: result left unsigned (behavior
+                        // unchanged; result-sign symmetry is a #410 follow-up).
   if (blockHoles_.empty() || !cobordism) return;
 
   // Pin the supplied states (inputs first); for the #353 inputs -> emergent

--- a/src/cobordism/TransportCobordism.cpp
+++ b/src/cobordism/TransportCobordism.cpp
@@ -61,7 +61,7 @@ void TransportCobordism::computeStateTargets() {
   // topology's exact triangle-hole read-out gives the pinned input holes + their
   // induced-orientation targets, and the first unpinned window (the result block).
   topology_->readoutHoles(cobordism_, inputStates_, stateHoles_, holeTargets_,
-                          resultHoles_);
+                          resultHoles_, resultSigns_);
 }
 
 void TransportCobordism::optimize() {
@@ -99,6 +99,13 @@ void TransportCobordism::readResult() {
     if (m > 0 && P.size() >= m && P.size() % m == 0)
       result_.assign(P.begin(), P.begin() + static_cast<std::ptrdiff_t>(m));
   }
+  // Apply the result block's induced-orientation signs (symmetric with the signed
+  // input targets) so sigma_R = sum(result_) is the relabeling-invariant Stokes
+  // charge, not a bare sum of per-hole sorted-reference periods (#412). Empty signs
+  // (e.g. the bipartite register) leave the raw periods unchanged.
+  if (!resultSigns_.empty() && resultSigns_.size() == result_.size())
+    for (std::size_t k = 0; k < result_.size(); ++k)
+      result_[k] *= static_cast<double>(resultSigns_[k]);
 
   // === residual read-out: beta*||grad_I S||^2 + r_state at the relaxed metric ===
   ReggeSolver residualSolver(cobordism_, MatterConfiguration());

--- a/src/cobordism/TripartiteRegisterTopology.cpp
+++ b/src/cobordism/TripartiteRegisterTopology.cpp
@@ -371,7 +371,8 @@ void TripartiteRegisterTopology::readoutHoles(
     const std::vector<std::vector<std::complex<double>>> &states,
     std::vector<std::vector<std::uint64_t>> &inputHoles,
     std::vector<std::complex<double>> &inputTargets,
-    std::vector<std::vector<std::uint64_t>> &resultHoles) const {
+    std::vector<std::vector<std::uint64_t>> &resultHoles,
+    std::vector<int> &resultSigns) const {
   // The EXACT (#353 period) read-out on distinct windows. Pin the supplied input
   // states on windows A,B,C (one window per state) over residualForPeriods, with
   // each window's own induced-orientation covector signTable_; the first unpinned
@@ -379,6 +380,7 @@ void TripartiteRegisterTopology::readoutHoles(
   inputHoles.clear();
   inputTargets.clear();
   resultHoles.clear();
+  resultSigns.clear();
   if (blockHoles_.empty() || !cobordism) return;
 
   const std::size_t nStates = std::min(states.size(), blockHoles_.size());
@@ -389,8 +391,15 @@ void TripartiteRegisterTopology::readoutHoles(
           k < states[s].size() ? states[s][k] : std::complex<double>(0);
       inputTargets.push_back(static_cast<double>(signTable_[s][k]) * a);
     }
-  if (nStates < blockHoles_.size())
+  if (nStates < blockHoles_.size()) {
     for (const auto &h : blockHoles_[nStates]) resultHoles.push_back(h);
+    // The result block's induced-orientation signs (signTable_[nStates], the same
+    // endSignCovector that signs the inputs), so the emergent result is read in the
+    // SAME global surface orientation as the inputs -- making sigma_R the
+    // relabeling-invariant Stokes charge rather than a bare per-hole-sorted sum.
+    for (std::size_t k = 0; k < blockHoles_[nStates].size(); ++k)
+      resultSigns.push_back(signTable_[nStates][k]);
+  }
 }
 
 }  // namespace tessera::cobordism

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -235,9 +235,9 @@ which to remove).)doc")
       .def("toVector", &EdgeList::toVector, py::return_value_policy::reference,
            "Return all edges as a list.");
   // ========================================
-  // SimplexOrientation
+  // TemporalOrientation
   // ========================================
-  py::class_<SimplexOrientation, std::shared_ptr<SimplexOrientation> >(m, "SimplexOrientation",
+  py::class_<TemporalOrientation, std::shared_ptr<TemporalOrientation> >(m, "TemporalOrientation",
       R"doc(CDT simplex orientation (ti, tf) counting vertices at each time slice.
 
 For a d-simplex spanning times t and t+1:
@@ -248,18 +248,18 @@ For a d-simplex spanning times t and t+1:
 Valid CDT orientations: (d,1), (1,d), (d-1,2), (2,d-1).
 For d=4: (4,1), (1,4), (3,2), (2,3).)doc")
       .def(py::init<uint8_t, uint8_t>(), py::arg("ti"), py::arg("tf"))
-      .def("getOrientation", &SimplexOrientation::getOrientation,
+      .def("getOrientation", &TemporalOrientation::getOrientation,
            "Return the (ti, tf) orientation as a pair.")
-      .def("__hash__", &SimplexOrientation::hash)
-      .def("__eq__", &SimplexOrientation::operator==, py::arg("other"))
-      .def("__str__", &SimplexOrientation::toString)
-      .def("__repr__", &SimplexOrientation::toString)
-      .def("numeric", &SimplexOrientation::numeric,
+      .def("__hash__", &TemporalOrientation::hash)
+      .def("__eq__", &TemporalOrientation::operator==, py::arg("other"))
+      .def("__str__", &TemporalOrientation::toString)
+      .def("__repr__", &TemporalOrientation::toString)
+      .def("numeric", &TemporalOrientation::numeric,
            "Return the orientation as a Python tuple (ti, tf).");
 
-  py::class_<SimplexOrientationHash, std::shared_ptr<SimplexOrientationHash> >(m, "SimplexOrientationHash")
+  py::class_<TemporalOrientationHash, std::shared_ptr<TemporalOrientationHash> >(m, "TemporalOrientationHash")
       .def(py::init<>());
-  py::class_<SimplexOrientationEq, std::shared_ptr<SimplexOrientationEq> >(m, "SimplexOrientationEq")
+  py::class_<TemporalOrientationEq, std::shared_ptr<TemporalOrientationEq> >(m, "TemporalOrientationEq")
       .def(py::init<>());
   // ========================================
   // Simplex

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -4,7 +4,7 @@
 #include "mesh/Vertex.h"
 #include "mesh/Simplex.h"
 #include "mesh/ForwardDeclarations.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "spacetime/Spacetime.h"
 #include "Logger.h"
 #include "utils.h"
@@ -128,7 +128,7 @@ Simplex::Simplex(
   Spacetime *spacetime_,
   const VertexPtrs &vertices_,
   Edges edges_
-) : spacetime(spacetime_), orientation(SimplexOrientation::orientationOf(vertices_)), vertices(vertices_),
+) : spacetime(spacetime_), orientation(TemporalOrientation::orientationOf(vertices_)), vertices(vertices_),
     edges(std::move(edges_)),
     fingerprint({0}) {
 #if TESSERA_ASSERTIONS
@@ -140,7 +140,7 @@ Simplex::Simplex(
   Spacetime *spacetime_,
   const VertexPtrs &vertices_,
   Edges edges_,
-  const SimplexOrientation &orientation_
+  const TemporalOrientation &orientation_
 ) : spacetime(spacetime_), orientation(orientation_), vertices(vertices_), edges(std::move(edges_)),
     fingerprint() {
   for (const auto &v : vertices_) {
@@ -186,7 +186,7 @@ void Simplex::releaseChildren() noexcept {
 Simplex* Simplex::create(Spacetime *spacetime_,
                            const VertexPtrs &vertices_,
                            const Edges &edges_,
-                           const SimplexOrientation &orientation_) {
+                           const TemporalOrientation &orientation_) {
 #if TESSERA_ASSERTIONS
   if (vertices_.empty()) throw std::runtime_error("Simplex is empty");
 #endif

--- a/src/mesh/TemporalOrientation.cpp
+++ b/src/mesh/TemporalOrientation.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 #include "mesh/ForwardDeclarations.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "mesh/Vertex.h"
 
 
@@ -30,61 +30,61 @@ using namespace ::tessera::spacetime;
 using namespace ::tessera::observables;
 using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
-SimplexOrientation::SimplexOrientation(uint8_t ti_, uint8_t tf_)
+TemporalOrientation::TemporalOrientation(uint8_t ti_, uint8_t tf_)
     : ti(ti_), tf(tf_), k(ti_ + tf_ - 1), fingerprint({ti_, tf_}) {
 }
 
-SimplexOrientation::SimplexOrientation()
+TemporalOrientation::TemporalOrientation()
     : ti(0), tf(0), k(0), fingerprint({0, 0}) {
 }
 
-[[nodiscard]] std::pair<uint8_t, uint8_t> SimplexOrientation::numeric() const {
+[[nodiscard]] std::pair<uint8_t, uint8_t> TemporalOrientation::numeric() const {
   return {ti, tf};
 }
 
-[[nodiscard]] size_t SimplexOrientation::hash() const {
+[[nodiscard]] size_t TemporalOrientation::hash() const {
   return fingerprint.fingerprint();
 }
 
 
-[[nodiscard]] SimplexOrientation SimplexOrientation::flip() const {
-  SimplexOrientation o{tf, ti};
+[[nodiscard]] TemporalOrientation TemporalOrientation::flip() const {
+  TemporalOrientation o{tf, ti};
   return o;
 }
 
 [[nodiscard]]
-SimplexOrientation SimplexOrientation::decTi() const {
+TemporalOrientation TemporalOrientation::decTi() const {
   if (ti == 0) return {0, tf};
-  SimplexOrientation o{static_cast<uint8_t>(ti - 1), tf};
+  TemporalOrientation o{static_cast<uint8_t>(ti - 1), tf};
   return o;
 }
 
 [[nodiscard]]
-SimplexOrientation SimplexOrientation::decTf() const {
+TemporalOrientation TemporalOrientation::decTf() const {
   if (tf == 0) return {ti, 0};
-  SimplexOrientation o{ti, static_cast<uint8_t>(tf - 1)};
+  TemporalOrientation o{ti, static_cast<uint8_t>(tf - 1)};
   return o;
 }
 
-[[nodiscard]] std::string SimplexOrientation::toString() const noexcept {
-  return "<SimplexOrientation: (" + std::to_string(ti) + ", " + std::to_string(tf) + ")>";
+[[nodiscard]] std::string TemporalOrientation::toString() const noexcept {
+  return "<TemporalOrientation: (" + std::to_string(ti) + ", " + std::to_string(tf) + ")>";
 }
 
-bool SimplexOrientation::operator==(const SimplexOrientation &other) const noexcept {
+bool TemporalOrientation::operator==(const TemporalOrientation &other) const noexcept {
   return ti == other.ti && tf == other.tf;
 }
 
-[[nodiscard]] TimeOrientation SimplexOrientation::getOrientation() const {
+[[nodiscard]] TimeOrientation TemporalOrientation::getOrientation() const {
   if (ti == tf) return TimeOrientation::UNKNOWN;
   if (ti > tf) return TimeOrientation::PRESENT;
   return TimeOrientation::FUTURE;
 }
 
-[[nodiscard]] std::vector<SimplexOrientation> SimplexOrientation::getFacialOrientations() const {
+[[nodiscard]] std::vector<TemporalOrientation> TemporalOrientation::getFacialOrientations() const {
   if (ti + tf == 0) return {};
   if (ti == 0) return {decTf()};
   if (tf == 0) return {decTi()};
-  std::vector<SimplexOrientation> orientations;
+  std::vector<TemporalOrientation> orientations;
   orientations.reserve(2);
   orientations.push_back(decTi());
   orientations.push_back(decTf());
@@ -92,11 +92,11 @@ bool SimplexOrientation::operator==(const SimplexOrientation &other) const noexc
 }
 
 /// A k-simplex has \f$ k+1 \f$ vertices.
-[[nodiscard]] uint8_t SimplexOrientation::getK() const {
+[[nodiscard]] uint8_t TemporalOrientation::getK() const {
   return k;
 }
 
-SimplexOrientation SimplexOrientation::orientationOf(const VertexPtrs &vertices) {
+TemporalOrientation TemporalOrientation::orientationOf(const VertexPtrs &vertices) {
   // Two-pass: first find min/max times, then count.
   // Single-pass was buggy when the first vertex was at tf, not ti.
   double tMin = std::numeric_limits<double>::max();

--- a/src/simulations/CDT.cpp
+++ b/src/simulations/CDT.cpp
@@ -60,7 +60,7 @@ static bool isValidCDTOrientation(const VertexPtrs &verts, int d) {
   }
   if (times.size() != 2) return false;
 
-  auto orient = SimplexOrientation::orientationOf(verts);
+  auto orient = TemporalOrientation::orientationOf(verts);
   auto [ti, tf] = orient.numeric();
   if ((ti == d && tf == 1) || (ti == 1 && tf == d)) return true;
   if ((ti == d - 1 && tf == 2) || (ti == 2 && tf == d - 1)) return true;

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -23,7 +23,7 @@
 #include "mesh/SimplexFilter.h"
 #include "observables/MIUnits.hpp"
 #include "observables/SparseGraph.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "mesh/ForwardDeclarations.h"
 #include "mesh/EdgeList.h"
 #include "mesh/Edge.h"
@@ -166,7 +166,7 @@ std::pair<SimplexPtr, bool> Spacetime::createSimplex(const std::tuple<uint8_t, u
   if (getMetric()->getSignature()->getSignatureType() != SignatureType::Lorentzian) {
     timelikeSquaredLength = a;  // Euclidean: all edges positive
   }
-  SimplexOrientation orientation = {
+  TemporalOrientation orientation = {
     std::get<0>(numericOrientation),
     std::get<1>(numericOrientation)
   };
@@ -602,7 +602,7 @@ SimplexSet Spacetime::getExternalSimplices() noexcept {
 }
 
 std::vector<SimplexPtr> Spacetime::getSimplicesWithOrientation(std::tuple<uint8_t, uint8_t> orientation) const {
-  SimplexOrientation o{std::get<0>(orientation), std::get<1>(orientation)};
+  TemporalOrientation o{std::get<0>(orientation), std::get<1>(orientation)};
   std::vector<SimplexPtr> result{};
   for (const auto &simplex : simplicesVec) {
     if (simplex->getOrientation() == o) result.push_back(simplex);
@@ -956,7 +956,7 @@ SimplexPtr Spacetime::findSimplexByVerts(
 }
 
 SimplexPtr Spacetime::getRandomSimplexWithOrientation(uint8_t ti, uint8_t tf) {
-  SimplexOrientation target{ti, tf};
+  TemporalOrientation target{ti, tf};
   // Try random sampling first (fast if many match)
   for (int attempt = 0; attempt < 100; ++attempt) {
     auto s = getRandomSimplex();

--- a/src/spacetime/pachner/AddMove.cpp
+++ b/src/spacetime/pachner/AddMove.cpp
@@ -7,7 +7,7 @@
 
 #include "mesh/Edge.h"
 #include "mesh/Simplex.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "mesh/Vertex.h"
 
 // === tessera subsystem ns fwd-decls ===

--- a/src/spacetime/pachner/FlipMove.cpp
+++ b/src/spacetime/pachner/FlipMove.cpp
@@ -7,7 +7,7 @@
 #include <random>
 
 #include "mesh/Simplex.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "mesh/Vertex.h"
 
 // === tessera subsystem ns fwd-decls ===

--- a/src/spacetime/pachner/IFlipMove.cpp
+++ b/src/spacetime/pachner/IFlipMove.cpp
@@ -8,7 +8,7 @@
 
 #include "mesh/Edge.h"
 #include "mesh/Simplex.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "mesh/Vertex.h"
 
 // === tessera subsystem ns fwd-decls ===

--- a/src/spacetime/pachner/RemoveMove.cpp
+++ b/src/spacetime/pachner/RemoveMove.cpp
@@ -9,7 +9,7 @@
 
 #include "mesh/Edge.h"
 #include "mesh/Simplex.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "mesh/Vertex.h"
 
 // === tessera subsystem ns fwd-decls ===

--- a/src/spacetime/pachner/ShiftMove.cpp
+++ b/src/spacetime/pachner/ShiftMove.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 
 #include "mesh/Simplex.h"
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "mesh/Vertex.h"
 
 // === tessera subsystem ns fwd-decls ===

--- a/src/spacetime/topologies/Cylinder.cpp
+++ b/src/spacetime/topologies/Cylinder.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Twin Vector Labs LLC.
 // All rights reserved.
 
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "spacetime/topologies/Cylinder.h"
 #include "spacetime/Spacetime.h"
 #include "utils.h"
@@ -22,7 +22,7 @@ using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
 void Cylinder::build(Spacetime *spacetime, int nSimplices) {
   auto dimensions = spacetime->getMetric()->getSignature()->getDimensions();
-  SimplexOrientation orientation{1, static_cast<std::uint8_t>(dimensions)};
+  TemporalOrientation orientation{1, static_cast<std::uint8_t>(dimensions)};
   spacetime->reserve(nSimplices);
 
   int numLayers = std::max(2, static_cast<int>(std::cbrt(nSimplices)));

--- a/src/spacetime/topologies/Sphere.cpp
+++ b/src/spacetime/topologies/Sphere.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Twin Vector Labs LLC.
 // All rights reserved.
 
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "spacetime/topologies/Sphere.h"
 #include "spacetime/Spacetime.h"
 #include "utils.h"
@@ -22,7 +22,7 @@ using namespace ::tessera::simulations;
 using namespace ::tessera::quantum;
 void Sphere::build(Spacetime *spacetime, int nSimplices) {
   auto dimensions = spacetime->getMetric()->getSignature()->getDimensions();
-  SimplexOrientation orientation{1, static_cast<std::uint8_t>(dimensions)};
+  TemporalOrientation orientation{1, static_cast<std::uint8_t>(dimensions)};
   spacetime->reserve(nSimplices);
 
   int numLayers = std::max(2, static_cast<int>(std::cbrt(nSimplices)));

--- a/src/spacetime/topologies/Toroid.cpp
+++ b/src/spacetime/topologies/Toroid.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Twin Vector Labs LLC.
 // All rights reserved.
 
-#include "mesh/SimplexOrientation.h"
+#include "mesh/TemporalOrientation.h"
 #include "spacetime/topologies/Toroid.h"
 #include "spacetime/Spacetime.h"
 #include "utils.h"

--- a/tests/cobordism/test_orientation_relabeling_invariance.py
+++ b/tests/cobordism/test_orientation_relabeling_invariance.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""Orientation signs come from the standard formula, not vertex-label sort (#412).
+
+The color charge of a window is a SUM of per-hole periods. Read in each hole's own
+sorted-tuple reference orientation, that sum depends on the arbitrary vertex
+NUMBERING: relabeling the base vertices flips an individual hole's term with no
+conjugating partner, scrambling the sum. The fix reads the emergent result in the
+SAME global induced orientation the inputs already use --- the standard spatial
+orientation `ChainComplex::endSignCovector` --- so the signed sum is the geometric
+Stokes charge `Sigma_R = -Sigma_inputs`, a property of the geometry, not the labels.
+
+Note the math: with `sign_k` the induced orientation and `raw_k` the period read in
+hole `k`'s sorted order, `sign_k * raw_k = G * p_k` where `p_k` is the (label-free)
+geometric period and `G` is one global orientation sign for the whole connected
+surface. So `sum_k sign_k * raw_k = G * (geometric charge)` --- invariant under a
+relabeling up to the single global `G`. The raw sum `sum_k raw_k` is not.
+
+(The intertwining residual and singlet overlap were ALREADY relabeling-invariant ---
+bilinear in the transport, so a per-hole sign change conjugates out --- and are left
+untouched.)
+"""
+
+import cmath
+import unittest
+from collections import Counter
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+st = tessera.spacetime
+_W = cmath.exp(2j * cmath.pi / 3)
+_NEUTRAL = [[1, -1, 0], [1, 0, -1], [0, 1, -1]]
+_COLORED = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+_SEED = 412
+
+
+def _build(inputs):
+    return cob.TransportCobordism(inputs, max_iters=0, seed=0,
+                                  topology=cob.TripartiteRegisterTopology())
+
+
+def _geometry(m):
+    """Reconstruct the base surface (the 80 geodesic-2 icosahedron faces), the 12
+    holes, the tetrahedra, and the per-layer stride N from a built junction --- the
+    inputs `endSignCovector` needs, and the cells to rebuild under a relabeling."""
+    tets = [tuple(sorted(v.getId() for v in t.getVertices()))
+            for t in m.cobordism.getTopSimplices()]
+    nverts = max(v for c in tets for v in c) + 1
+    N = nverts // 3  # three prism layers (base x I, two intervals)
+    incidence = Counter()
+    for t in tets:
+        for i in range(4):
+            incidence[tuple(v for j, v in enumerate(t) if j != i)] += 1
+    holed = [list(f) for f, c in incidence.items()
+             if c == 1 and all(v < N for v in f)]  # t=0 cap (the holed base surface)
+    holes = [sorted(h) for h in list(m.input_holes) + list(m.result_holes)]
+    faces = holed + [h for h in holes if list(h) not in holed]
+    return faces, holes, tets, N
+
+
+def _signed_sigma_r(cobordism, input_holes, input_targets, result_holes, result_signs):
+    """The carried color charge Sigma_R: carry the (signed) inputs as an L1 harmonic
+    and read its periods over the result holes, each weighted by its induced sign."""
+    es = cob.EigenstateSynthesis(cobordism, 1)
+    edge = {(min(c), max(c)): i
+            for i, c in enumerate(es.cellSimplices()) if len(c) == 2}
+    psi = es.carriedRepresentative(input_holes, input_targets)
+    total = 0.0 + 0.0j
+    for sign, h in zip(result_signs, result_holes):
+        a, b, c = sorted(h)
+        total += sign * (psi[edge[(a, b)]] + psi[edge[(b, c)]] - psi[edge[(a, c)]])
+    return total
+
+
+class SpatialOrientationPrimitiveTest(unittest.TestCase):
+    """`endSignCovector` is the standard induced spatial orientation, and it is
+    exactly what the production read-out applies."""
+
+    def test_reconstructed_orientation_matches_the_applied_result_signs(self):
+        # Independently recompute the induced orientation over the 12 holes and check
+        # the result block (last three) equals the signs the C++ TransportCobordism
+        # actually applies (m.result_signs == signTable_[R]).
+        m = _build(_NEUTRAL)
+        faces, holes, _tets, _N = _geometry(m)
+        cov = cob.ChainComplex.endSignCovector(
+            [list(f) for f in faces], [list(h) for h in holes])
+        self.assertEqual(len(faces), 80)  # the geodesic-2 icosahedron
+        self.assertEqual(cov[9:12], list(m.result_signs))
+
+    def test_non_orientable_input_throws(self):
+        # A facet with three cofaces is not a pseudomanifold: endSignCovector must
+        # raise, never return a silent covector.
+        bad = [[0, 1, 2], [0, 1, 3], [0, 1, 4]]  # edge (0,1) in three faces
+        with self.assertRaises(Exception):
+            cob.ChainComplex.endSignCovector(bad, [[0, 1, 2]])
+
+
+class ResultSigningTest(unittest.TestCase):
+    """The production read-out applies the result block's induced orientation, so the
+    signed charge is the geometric Stokes charge, not a bare per-hole sorted sum."""
+
+    def test_result_signs_present_and_pm_one(self):
+        m = _build(_NEUTRAL)
+        signs = list(m.result_signs)
+        self.assertEqual(len(signs), 3)
+        self.assertTrue(all(s in (1, -1) for s in signs))
+
+    def test_signed_charge_is_the_neutral_stokes_charge(self):
+        # Neutral inputs (Sigma=0 each) -> signed Sigma_R ~ 0 (confinement), while the
+        # raw (unsigned) sum is O(0.1)-O(1) and NOT the geometric charge.
+        m = _build(_NEUTRAL)
+        faces, holes, _t, _N = _geometry(m)
+        cov = cob.ChainComplex.endSignCovector(
+            [list(f) for f in faces], [list(h) for h in holes])
+        targets = [cov[i] * _NEUTRAL[i // 3][i % 3] for i in range(9)]
+        signed = _signed_sigma_r(m.cobordism, [list(h) for h in holes[:9]],
+                                 targets, [list(h) for h in holes[9:12]], cov[9:12])
+        raw = _signed_sigma_r(m.cobordism, [list(h) for h in holes[:9]],
+                              targets, [list(h) for h in holes[9:12]], [1, 1, 1])
+        self.assertLess(abs(signed), 1e-6)        # the Stokes charge, exactly ~0
+        self.assertGreater(abs(raw), 0.05)        # the unsigned sum is not the charge
+
+    def test_signed_charge_is_the_colored_net_charge(self):
+        # Colored singles (R,G,B): each window Sigma=1, so the signed net charge is 3.
+        m = _build(_COLORED)
+        faces, holes, _t, _N = _geometry(m)
+        cov = cob.ChainComplex.endSignCovector(
+            [list(f) for f in faces], [list(h) for h in holes])
+        targets = [cov[i] * _COLORED[i // 3][i % 3] for i in range(9)]
+        signed = _signed_sigma_r(m.cobordism, [list(h) for h in holes[:9]],
+                                 targets, [list(h) for h in holes[9:12]], cov[9:12])
+        self.assertAlmostEqual(abs(signed), 3.0, delta=1e-6)
+
+    def test_bipartite_register_result_is_left_unsigned(self):
+        # The single (bipartite) register is out of scope and emits no result signs,
+        # so its emergent result is unchanged (behavior preserved).
+        m = cob.TransportCobordism(_NEUTRAL, max_iters=0, seed=0,
+                                   topology=cob.RegisterTopology())
+        self.assertEqual(len(list(m.result_signs)), 0)
+
+
+class RelabelingInvarianceTest(unittest.TestCase):
+    """G6 (this ticket owns it): permuting the base-surface vertex ids and rebuilding
+    the SAME geometry leaves the signed charge invariant (up to one global sign),
+    while the unsigned charge is scrambled."""
+
+    def test_signed_charge_is_relabeling_invariant_raw_is_not(self):
+        m = _build(_COLORED)
+        faces, holes, tets, N = _geometry(m)
+
+        def sigma(cobordism, perm, signed):
+            pi = {v: perm[v] for v in range(len(perm))}
+            pf = [[pi[v] for v in f] for f in faces]
+            ph = [[pi[v] for v in h] for h in holes]
+            cov = cob.ChainComplex.endSignCovector(pf, ph)
+            targets = [cov[i] * _COLORED[i // 3][i % 3] for i in range(9)]
+            rsigns = cov[9:12] if signed else [1, 1, 1]
+            return _signed_sigma_r(cobordism, ph[:9], targets, ph[9:12], rsigns)
+
+        identity = list(range(3 * N))
+        base_signed = abs(sigma(m.cobordism, identity, True))
+        self.assertAlmostEqual(base_signed, 3.0, delta=1e-6)
+
+        rng = np.random.default_rng(_SEED)
+        raw_values = []
+        for _ in range(5):
+            p = rng.permutation(N)
+            perm = [int(p[v % N]) + (v // N) * N for v in range(3 * N)]  # per-layer
+            ptets = [[perm[v] for v in t] for t in tets]
+            pcob = st.Spacetime.fromCells(3, ptets, 1.0, 0.0)  # uniform l^2 = 1
+            signed = abs(sigma(pcob, perm, True))
+            raw = abs(sigma(pcob, perm, False))
+            # SIGNED charge: invariant (up to the single global sign, hence abs).
+            self.assertAlmostEqual(signed, base_signed, delta=1e-6)
+            raw_values.append(round(raw, 4))
+        # RAW charge: label-dependent -- it does NOT stay at the geometric 3.0, and it
+        # is not constant across relabelings (the bug this ticket fixes).
+        self.assertTrue(any(abs(r - 3.0) > 1e-3 for r in raw_values))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_moves_deterministic.py
+++ b/tests/test_moves_deterministic.py
@@ -51,7 +51,7 @@ def _is_valid_cdt_simplex(verts):
     times = {v.getTime() for v in verts}
     if len(times) != 2:
         return False
-    o = tessera.SimplexOrientation(0, 0)  # dummy
+    o = tessera.TemporalOrientation(0, 0)  # dummy
     # Count vertices at each time
     time_list = sorted(times)
     ti_count = sum(1 for v in verts if v.getTime() == time_list[0])

--- a/tests/test_pachner_moves.py
+++ b/tests/test_pachner_moves.py
@@ -404,7 +404,7 @@ class TestActionConsistency(unittest.TestCase):
 # Simplex orientation correctness
 # =====================================================================
 
-class TestSimplexOrientation(unittest.TestCase):
+class TestTemporalOrientation(unittest.TestCase):
     """[RU] Sec. 3: Verify orientation computation from vertex times."""
 
     def _make_simplex(self, times):

--- a/tests/test_temporal_orientation.py
+++ b/tests/test_temporal_orientation.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""The CDT temporal orientation class (renamed from SimplexOrientation, #412).
+
+`TemporalOrientation` is the Ambjorn-Loll causal (time-slice) orientation: the
+`(t_i, t_f)` split = how many of a simplex's vertices lie on the initial vs the
+final time slice. It is purely TEMPORAL -- it carries no spatial +-1 orientation
+sign (that is `ChainComplex::endSignCovector`, the induced spatial orientation).
+The rename disentangles the two notions that were both called "orientation".
+"""
+
+import unittest
+
+import tessera
+
+
+class TemporalOrientationTest(unittest.TestCase):
+    def test_renamed_class_is_exposed(self):
+        self.assertTrue(hasattr(tessera, "TemporalOrientation"))
+        # the old, conflated name is gone
+        self.assertFalse(hasattr(tessera, "SimplexOrientation"))
+
+    def test_constructs_and_reports_the_time_split(self):
+        # (t_i, t_f) = (2 initial-slice vertices, 1 final-slice vertex): a (3,1) CDT
+        # tetrahedron face split.
+        o = tessera.TemporalOrientation(2, 1)
+        self.assertEqual(tuple(o.numeric()), (2, 1))
+
+    def test_orientation_is_purely_temporal(self):
+        # The class encodes only the (t_i, t_f) time-slice split -- the three causal
+        # cases t_i > t_f, t_i == t_f, t_i < t_f -- and carries no spatial sign.
+        for ti, tf in [(2, 1), (1, 1), (1, 2)]:
+            self.assertEqual(tuple(tessera.TemporalOrientation(ti, tf).numeric()),
+                             (ti, tf))
+
+    def test_flip_swaps_initial_and_final(self):
+        o = tessera.TemporalOrientation(3, 1)
+        # equality is by (t_i, t_f); a (3,1) and a (1,3) are distinct orientations.
+        self.assertNotEqual(o, tessera.TemporalOrientation(1, 3))
+        self.assertEqual(o, tessera.TemporalOrientation(3, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make the proton observables (color charge σ, singlet overlap, intertwining residual) **relabeling-invariant**: source every sign-bearing orientation from a consistent induced/geometric orientation rather than from vertex-id `std::sort` parity, so a permutation of the base-surface vertex ids leaves the physics unchanged (up to one consistent global sign). Sign-neutral sorts stay as canonical storage keys, annotated as such.

Implements the orientation-foundation of epic #410. WIP — auditing the exact sign data-flow into the observables before editing (the read-out picks each hole's orientation from its own sorted labels, which a relabeling can flip incoherently; `SimplexOrientation::orientationOf` turned out to be the CDT *temporal* split, not a spatial sign, so the right primitive is being settled).

## Test plan
- [ ] `tests/cobordism/test_orientation_relabeling_invariance.py`: baseline tuple `(σ_A, σ_B, σ_C, σ_R, singlet, residual)` on the default numbering; ≥5 seeded base-vertex relabelings reproduce it up to one consistent global sign (σ_R exact to 1e-14; singlet/residual to 1e-10).
- [ ] G6 relabeling-invariance authored into the shared `tests/cobordism/test_epic410_invariants.py`.
- [ ] No regression: G1–G5/G7/G8 hold on the default numbering; full pytest suite green.
- [ ] Build: `pip install -e ".[dev]"` then `pytest` (throwaway venv in the worktree).

Closes #412.