### PR TITLE
feat(cobordism): E and B from the temporal/spatial split (#417)

### DIFF
--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -575,6 +575,55 @@ class EigenstateSynthesis {
     [[nodiscard]] std::pair<bool, std::string> stellarSubdivideInterior(
         const std::vector<std::uint64_t> &cell);
 
+    // === Charge sector: the E/B split of the field strength F ∈ Ω² (#417) ===
+    // The field-strength is a 2-cochain F ∈ Ω². On a Lorentzian complex each
+    // plaquette has a causal type, so F splits by it: the ELECTRIC part lives on
+    // plaquettes carrying a timelike edge (one temporal leg, the discrete F_{0i});
+    // the MAGNETIC part on purely-spacelike plaquettes (all-spatial, F_{ij}). This
+    // is a read-out on the live degree-2 complex — it only classifies cells by
+    // `Edge::isTimelike()` and partitions a supplied F, never mutating geometry.
+
+    /// The electric/magnetic split of a field-strength 2-cochain `F` by the causal
+    /// type of each plaquette. `electric` is `F` on plaquettes with a timelike edge
+    /// (zero elsewhere); `magnetic` is `F` on purely-spacelike plaquettes (zero
+    /// elsewhere); so `electric + magnetic == F` componentwise. `electricCells` /
+    /// `magneticCells` are the disjoint, complete index lists into
+    /// `cellSimplices()` (degree-2). A plaquette is electric iff any of its three
+    /// edges in the live complex is `Edge::isTimelike()`, else magnetic.
+    struct FieldStrengthSplit {
+      std::vector<std::complex<double>> electric;  // F on timelike-leg plaquettes
+      std::vector<std::complex<double>> magnetic;  // F on purely-spacelike ones
+      std::vector<std::size_t> electricCells;      // E indices into cellSimplices()
+      std::vector<std::size_t> magneticCells;      // B indices into cellSimplices()
+    };
+
+    /// Split a field-strength 2-cochain `F` (an `order()`-length cochain in the
+    /// degree-2 `cellSimplices()` order) into its electric (timelike-leg) and
+    /// magnetic (purely-spacelike) parts by the causal type of each plaquette's
+    /// edges (`Edge::isTimelike()` on the live complex). The returned `electric`
+    /// and `magnetic` are `order()`-length cochains agreeing with `F` on their own
+    /// support and zero elsewhere (`electric + magnetic == F`), plus the disjoint
+    /// index lists `electricCells` / `magneticCells` (their union is all cells).
+    /// @throws std::runtime_error if `degree() != 2`, if `F.size() != order()`, or
+    ///   if a plaquette's edge is missing from the complex.
+    [[nodiscard]] FieldStrengthSplit fieldStrengthSplit(
+        const std::vector<std::complex<double>> &F) const;
+
+    /// The curvature 2-cochain \f$ F = dA \f$ built from a carried U(1) connection
+    /// 1-cochain `A` by discrete coboundary: on each degree-2 cell \f$ (a,b,c) \f$
+    /// (sorted) \f$ F = A(a,b) + A(b,c) - A(a,c) \f$, the induced-orientation signed
+    /// edge sum the period read-out uses (`cyclePeriods`,
+    /// `examples/cobordism/proton_observables.py:55-56`). `A` is a degree-1 cochain
+    /// indexed in the canonical `ChainComplex` 1-cell order (length = the number of
+    /// 1-cells/edges, i.e. `EigenstateSynthesis(st, 1).order()`); this instance is
+    /// degree 2 and returns an `order()`-length 2-cochain. Because \f$ d\circ d = 0 \f$
+    /// the result is gauge-invariant: a pure gauge \f$ A \to A + d\chi \f$ leaves
+    /// `F` (hence its E/B split) unchanged.
+    /// @throws std::runtime_error if `degree() != 2`, if `A.size()` is not the
+    ///   number of 1-cells, or if a 2-cell's edge is not a 1-cell of the complex.
+    [[nodiscard]] std::vector<std::complex<double>> curvatureFromConnection(
+        const std::vector<std::complex<double>> &A) const;
+
   private:
     std::shared_ptr<Spacetime> st_;
     int k_{0};  // the Hodge degree of L_k that apply()/residual() score against

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -337,7 +337,7 @@ Euclidean spectrum/kernel.)doc")
            "all-spacelike complex.");
 
   // ----- §4b eigenstate synthesis: residual + parameter access (#133) -----
-  py::class_<EigenstateSynthesis>(m, "EigenstateSynthesis",
+  auto eigenstateSynthesis = py::class_<EigenstateSynthesis>(m, "EigenstateSynthesis",
       R"doc(§4b inverse eigenvector problem on a fixed complex, degree-k.
 
 Scores how close the complex's current Hermitian edge weights make a target
@@ -623,7 +623,57 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "acceptance the bulk's edges are re-pinned uniform (squaredLength 1, "
            "phase 0) — the unit cochain metric the register/fill seeds are built "
            "with, held by construction rather than by the createSimplexTracked "
-           "time-rule coincidence on all-same-time seeds.");
+           "time-rule coincidence on all-same-time seeds.")
+      // ----- Charge sector: the E/B split of F in Omega^2 (#417) -----
+      .def("curvatureFromConnection",
+           &EigenstateSynthesis::curvatureFromConnection, py::arg("A"),
+           "The curvature 2-cochain F = dA from a U(1) connection 1-cochain A by "
+           "discrete coboundary: on each sorted degree-2 cell (a,b,c), F = "
+           "A(a,b) + A(b,c) - A(a,c), the induced-orientation signed edge sum the "
+           "period read-out uses (cyclePeriods). A is a degree-1 cochain in the "
+           "canonical ChainComplex 1-cell order (length = the number of edges, "
+           "i.e. EigenstateSynthesis(st, 1).order()); this instance is degree 2 "
+           "and returns an order()-length 2-cochain. Gauge-invariant (d.d = 0): a "
+           "pure gauge A -> A + d chi leaves F unchanged. Raises if degree() != 2, "
+           "if len(A) is not the number of 1-cells, or if a 2-cell edge is "
+           "missing.")
+      .def("fieldStrengthSplit", &EigenstateSynthesis::fieldStrengthSplit,
+           py::arg("F"),
+           "The electric/magnetic split of a field-strength 2-cochain F by the "
+           "causal type of each plaquette: electric = F on plaquettes carrying a "
+           "timelike edge (one temporal leg, the discrete F_{0i}); magnetic = F "
+           "on purely-spacelike plaquettes (F_{ij}). Returns a FieldStrengthSplit "
+           "whose electric/magnetic are order()-length cochains (agreeing with F "
+           "on their own support, zero elsewhere, so electric + magnetic == F) "
+           "and whose electricCells/magneticCells are the disjoint, complete "
+           "index lists into cellSimplices(). A plaquette is electric iff any of "
+           "its three edges is Edge.isTimelike() on the live complex. Raises if "
+           "degree() != 2, if len(F) != order(), or if a plaquette edge is "
+           "missing.");
+
+  // The result of fieldStrengthSplit (#417): the E/B partition of F in Omega^2.
+  py::class_<EigenstateSynthesis::FieldStrengthSplit>(
+      eigenstateSynthesis, "FieldStrengthSplit",
+      "The E/B split of a field-strength 2-cochain F by plaquette causal type "
+      "(EigenstateSynthesis.fieldStrengthSplit): electric (timelike-leg "
+      "plaquettes), magnetic (purely-spacelike plaquettes), and their disjoint "
+      "index lists into cellSimplices(). electric + magnetic == F.")
+      .def_readonly("electric",
+                    &EigenstateSynthesis::FieldStrengthSplit::electric,
+                    "F on plaquettes with a timelike leg (zero elsewhere); an "
+                    "order()-length 2-cochain.")
+      .def_readonly("magnetic",
+                    &EigenstateSynthesis::FieldStrengthSplit::magnetic,
+                    "F on purely-spacelike plaquettes (zero elsewhere); an "
+                    "order()-length 2-cochain.")
+      .def_readonly("electricCells",
+                    &EigenstateSynthesis::FieldStrengthSplit::electricCells,
+                    "Indices into cellSimplices() of the electric (timelike-leg) "
+                    "plaquettes.")
+      .def_readonly("magneticCells",
+                    &EigenstateSynthesis::FieldStrengthSplit::magneticCells,
+                    "Indices into cellSimplices() of the magnetic "
+                    "(purely-spacelike) plaquettes.");
 
   // ----- The carried spectral register V = ker L_1 (#303) -----
   py::class_<Register>(m, "Register",

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -984,6 +984,110 @@ std::vector<cd> EigenstateSynthesis::carriedRepresentative(
   return carriedFromReadout(assembleRegisterReadout(holes), targetPeriods);
 }
 
+// === Charge sector: the E/B split of the field strength F ∈ Ω² (#417) ===
+
+std::vector<cd> EigenstateSynthesis::curvatureFromConnection(
+    const std::vector<cd> &A) const {
+  if (k_ != 2)
+    throw std::runtime_error(
+        "EigenstateSynthesis::curvatureFromConnection: requires a degree-2 "
+        "instance (the field strength F is a 2-cochain); this instance is "
+        "degree " +
+        std::to_string(k_));
+  // The connection A is a degree-1 cochain in the canonical ChainComplex 1-cell
+  // order — map each sorted edge (u,v) to its index so the per-plaquette signed
+  // edge sum can read A by edge.
+  const auto edges1 = ChainComplex::fromSpacetime(*st_).kSimplexVertices(1);
+  if (A.size() != edges1.size())
+    throw std::runtime_error(
+        "EigenstateSynthesis::curvatureFromConnection: the connection has " +
+        std::to_string(A.size()) + " components; the complex has " +
+        std::to_string(edges1.size()) + " 1-cells (edges)");
+  std::map<std::vector<std::uint64_t>, std::size_t> edgeIdx;
+  for (std::size_t i = 0; i < edges1.size(); ++i) edgeIdx[edges1[i]] = i;
+
+  // F = dA on each sorted 2-cell (a,b,c): the induced-orientation signed edge sum
+  // +A(a,b) + A(b,c) - A(a,c) — facet (drop v_j) carries (-1)^j, the same boundary
+  // convention cyclePeriods uses (drop a -> +(b,c), drop b -> -(a,c), drop c ->
+  // +(a,b)).
+  std::vector<cd> F(order_, cd(0.0, 0.0));
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i) {
+    const auto &cell = cellOrdering_[i];  // sorted (a,b,c)
+    if (cell.size() != 3)
+      throw std::runtime_error(
+          "EigenstateSynthesis::curvatureFromConnection: a degree-2 cell has " +
+          std::to_string(cell.size()) + " vertices (expected 3)");
+    const std::vector<std::vector<std::uint64_t>> facets = {
+        {cell[0], cell[1]}, {cell[1], cell[2]}, {cell[0], cell[2]}};
+    const double sign[3] = {1.0, 1.0, -1.0};  // +(a,b) +(b,c) -(a,c)
+    for (std::size_t j = 0; j < 3; ++j) {
+      const auto it = edgeIdx.find(facets[j]);
+      if (it == edgeIdx.end())
+        throw std::runtime_error(
+            "EigenstateSynthesis::curvatureFromConnection: edge (" +
+            std::to_string(facets[j][0]) + "," + std::to_string(facets[j][1]) +
+            ") of a 2-cell is not a 1-cell of the complex");
+      F[i] += sign[j] * A[it->second];
+    }
+  }
+  return F;
+}
+
+EigenstateSynthesis::FieldStrengthSplit EigenstateSynthesis::fieldStrengthSplit(
+    const std::vector<cd> &F) const {
+  if (k_ != 2)
+    throw std::runtime_error(
+        "EigenstateSynthesis::fieldStrengthSplit: requires a degree-2 instance "
+        "(the field strength F is a 2-cochain); this instance is degree " +
+        std::to_string(k_));
+  if (F.size() != order_)
+    throw std::runtime_error(
+        "EigenstateSynthesis::fieldStrengthSplit: F has " +
+        std::to_string(F.size()) + " components; the degree-2 operator has " +
+        std::to_string(order_) + " cells");
+
+  // Map each sorted edge (u,v) to its live Edge* so each plaquette's causal type
+  // is read off Edge::isTimelike() — the sanctioned causal test (Im(length) != 0).
+  std::map<std::pair<std::uint64_t, std::uint64_t>, ::tessera::mesh::Edge *> em;
+  for (auto *e : edges_) {
+    const std::uint64_t a = e->getSource()->getId();
+    const std::uint64_t b = e->getTarget()->getId();
+    em[{std::min(a, b), std::max(a, b)}] = e;
+  }
+
+  FieldStrengthSplit split;
+  split.electric.assign(order_, cd(0.0, 0.0));
+  split.magnetic.assign(order_, cd(0.0, 0.0));
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i) {
+    const auto &cell = cellOrdering_[i];  // sorted (a,b,c)
+    const std::pair<std::uint64_t, std::uint64_t> facets[3] = {
+        {cell[0], cell[1]}, {cell[1], cell[2]}, {cell[0], cell[2]}};
+    // Electric iff any leg is timelike (one temporal index, the discrete F_{0i});
+    // else purely-spacelike = magnetic (F_{ij}).
+    bool electric = false;
+    for (const auto &f : facets) {
+      const auto it = em.find(f);
+      if (it == em.end())
+        throw std::runtime_error(
+            "EigenstateSynthesis::fieldStrengthSplit: edge (" +
+            std::to_string(f.first) + "," + std::to_string(f.second) +
+            ") of a 2-cell is not an edge of the complex");
+      if (it->second->isTimelike()) {
+        electric = true;
+        break;
+      }
+    }
+    if (electric) {
+      split.electric[i] = F[i];
+      split.electricCells.push_back(i);
+    } else {
+      split.magnetic[i] = F[i];
+      split.magneticCells.push_back(i);
+    }
+  }
+  return split;
+}
+
 std::vector<cd> EigenstateSynthesis::carriedFromReadout(
     const RegisterReadout &ro, const std::vector<cd> &targetPeriods) const {
   const std::size_t n = order_;

--- a/tests/cobordism/test_field_strength_split.py
+++ b/tests/cobordism/test_field_strength_split.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""E and B from the temporal/spatial split of the field-strength 2-cochain (#417).
+
+The field strength is a 2-cochain ``F in Omega^2``. Split it by the causal type of
+each plaquette: the ELECTRIC part lives on plaquettes carrying a timelike edge (one
+temporal leg, the discrete ``F_{0i}``); the MAGNETIC part on purely-spacelike
+plaquettes (``F_{ij}``). The source is ``F = dA``, the discrete coboundary of the
+carried U(1) connection 1-cochain ``A`` -- the same induced-orientation signed edge
+sum the period read-out rides on (``examples/cobordism/proton_observables.py:55-56``).
+
+The seed is the W_ABC junction (``TripartiteRegisterTopology``): a static
+(all-spacelike, uniform ``l^2 = 1``) build has every plaquette magnetic; a Lorentzian
+flux (``set_lorentzian_worldlines`` -> the cross-layer/forward-time edges timelike)
+makes the cross-layer plaquettes electric. The split tracks the causal structure.
+
+This is an observable-only read-out: ``fieldStrengthSplit`` / ``curvatureFromConnection``
+classify cells by ``Edge.isTimelike()`` and partition a supplied ``F`` -- they never
+mutate the geometry.
+"""
+
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+# Three color-neutral q-qbar pairs (Sigma = 0 each): the carriable W_ABC inputs.
+_NEUTRAL_PAIRS = [[1, -1, 0], [1, 0, -1], [0, 1, -1]]
+# Fixed RNG seed (no wall-clock, no global seed) -- determinism (G7).
+_SEED = 417
+
+
+def _build(lorentzian=None):
+    """Build (no relax) the W_ABC junction; `lorentzian` (a negative l^2) sets the
+    cross-layer worldline edges timelike for the flux regime."""
+    trt = cob.TripartiteRegisterTopology()
+    if lorentzian is not None:
+        trt.set_lorentzian_worldlines(lorentzian)
+    return cob.TransportCobordism(_NEUTRAL_PAIRS, max_iters=0, seed=0, topology=trt)
+
+
+def _edge_order(st):
+    """(map sorted-edge -> index, n_edges): the degree-1 cell order curvatureFromConnection
+    indexes A in (== EigenstateSynthesis(st, 1).cellSimplices())."""
+    es1 = cob.EigenstateSynthesis(st, 1)
+    idx = {(min(c), max(c)): i for i, c in enumerate(es1.cellSimplices())}
+    return idx, es1.order()
+
+
+def _vertex_ids(st):
+    return [c[0] for c in cob.EigenstateSynthesis(st, 0).cellSimplices()]
+
+
+def _rng_cochain(rng, n):
+    return list(rng.standard_normal(n) + 1j * rng.standard_normal(n))
+
+
+def _edge_isolated_timelike_map(st):
+    """sorted-edge (a,b) -> Edge.isTimelike(), read straight off the live EdgeList:
+    the independent Python re-classification the C++ split is cross-checked against."""
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e.isTimelike()
+    return out
+
+
+def _python_electric_cells(st, es2):
+    """The set of degree-2 cell indices with >= 1 timelike edge, recomputed in pure
+    Python -- the cross-check, not a copy of the C++ result."""
+    tl = _edge_isolated_timelike_map(st)
+    elec = set()
+    for i, (a, b, c) in enumerate(es2.cellSimplices()):
+        if tl[(a, b)] or tl[(b, c)] or tl[(a, c)]:
+            elec.add(i)
+    return elec
+
+
+def _edge_metric_snapshot(st):
+    """Every edge's (Re l^2, Im l^2) -- the bit-for-bit geometry an observable-only
+    read-out must leave untouched."""
+    return [(e.getSquaredLength().real, e.getSquaredLength().imag)
+            for e in st.getEdgeList().toVector()]
+
+
+class FieldStrengthSplitStaticTest(unittest.TestCase):
+    """Static (all-spacelike) seed -> E identically zero, B carries everything."""
+
+    def test_static_seed_is_purely_magnetic(self):
+        m = _build()
+        st = m.cobordism
+        es2 = cob.EigenstateSynthesis(st, 2)
+        _, n_edges = _edge_order(st)
+        rng = np.random.default_rng(_SEED)
+        A = _rng_cochain(rng, n_edges)
+        F = es2.curvatureFromConnection(A)
+        self.assertEqual(len(F), es2.order())
+
+        split = es2.fieldStrengthSplit(F)
+        # E is empty: no plaquette has a timelike leg on the static seed.
+        self.assertEqual(list(split.electricCells), [])
+        # ||E|| is bit-zero (every component a real zero, not within a tolerance).
+        self.assertEqual(np.linalg.norm(split.electric), 0.0)
+        # B carries the entire structure, supported on all order() cells.
+        self.assertEqual(len(split.magneticCells), es2.order())
+        self.assertTrue(np.allclose(split.magnetic, F, atol=1e-12))
+
+    def test_static_partition_is_complete(self):
+        m = _build()
+        es2 = cob.EigenstateSynthesis(m.cobordism, 2)
+        _, n_edges = _edge_order(m.cobordism)
+        rng = np.random.default_rng(_SEED)
+        F = es2.curvatureFromConnection(_rng_cochain(rng, n_edges))
+        split = es2.fieldStrengthSplit(F)
+        total = np.array(split.electric) + np.array(split.magnetic)
+        self.assertTrue(np.allclose(total, F, atol=1e-12))
+
+
+class FieldStrengthSplitFluxTest(unittest.TestCase):
+    """Timelike flux -> ||E|| > 0, the split tracks the causal type."""
+
+    def test_flux_makes_worldlines_timelike(self):
+        st = _build(-0.3).cobordism
+        n_timelike = sum(1 for v in _edge_isolated_timelike_map(st).values() if v)
+        self.assertGreater(n_timelike, 0)
+
+    def test_flux_has_nonzero_electric_tracking_causal_type(self):
+        m = _build(-0.3)
+        st = m.cobordism
+        es2 = cob.EigenstateSynthesis(st, 2)
+        _, n_edges = _edge_order(st)
+        rng = np.random.default_rng(_SEED)
+        F = es2.curvatureFromConnection(_rng_cochain(rng, n_edges))
+        split = es2.fieldStrengthSplit(F)
+
+        # ||E|| strictly nonzero, well above round-off.
+        self.assertGreater(np.linalg.norm(split.electric), 1e-9)
+        # electricCells == the cells with a timelike leg, recomputed independently.
+        self.assertEqual(set(split.electricCells), _python_electric_cells(st, es2))
+        # disjoint + complete partition of the order() cells.
+        e_set, m_set = set(split.electricCells), set(split.magneticCells)
+        self.assertEqual(e_set & m_set, set())
+        self.assertEqual(e_set | m_set, set(range(es2.order())))
+
+    def test_flux_partition_is_complete(self):
+        m = _build(-0.3)
+        es2 = cob.EigenstateSynthesis(m.cobordism, 2)
+        _, n_edges = _edge_order(m.cobordism)
+        rng = np.random.default_rng(_SEED)
+        F = es2.curvatureFromConnection(_rng_cochain(rng, n_edges))
+        split = es2.fieldStrengthSplit(F)
+        total = np.array(split.electric) + np.array(split.magnetic)
+        self.assertTrue(np.allclose(total, F, atol=1e-12))
+
+
+class CurvatureFromConnectionTest(unittest.TestCase):
+    """F = dA: the coboundary signed edge sum and its gauge invariance."""
+
+    def test_coboundary_on_a_single_triangle(self):
+        # One triangle (0,1,2): F = A(0,1) + A(1,2) - A(0,2), the induced-orientation
+        # signed edge sum (drop v_0 -> +(1,2), drop v_1 -> -(0,2), drop v_2 -> +(0,1)).
+        st = tessera.Spacetime.fromCells(2, [[0, 1, 2]], 1.0, 0.0)
+        es2 = cob.EigenstateSynthesis(st, 2)
+        self.assertEqual(es2.order(), 1)
+        idx, n_edges = _edge_order(st)
+        self.assertEqual(n_edges, 3)
+        A = [0.0] * 3
+        A[idx[(0, 1)]] = 2.0 + 1.0j
+        A[idx[(1, 2)]] = -0.5 + 3.0j
+        A[idx[(0, 2)]] = 1.0 - 1.0j
+        F = es2.curvatureFromConnection(A)
+        expected = A[idx[(0, 1)]] + A[idx[(1, 2)]] - A[idx[(0, 2)]]
+        self.assertAlmostEqual(F[0], expected, places=12)
+
+    def test_gauge_invariance(self):
+        # A' = A + d chi (the discrete gradient chi(b) - chi(a) on edge (a,b)); since
+        # d.d = 0, F = dA is unchanged, so E and B are unchanged.
+        m = _build(-0.3)
+        st = m.cobordism
+        es2 = cob.EigenstateSynthesis(st, 2)
+        idx, n_edges = _edge_order(st)
+        rng = np.random.default_rng(_SEED)
+        A = _rng_cochain(rng, n_edges)
+
+        chi = {v: complex(rng.standard_normal(), rng.standard_normal())
+               for v in _vertex_ids(st)}
+        A_prime = list(A)
+        for (a, b), i in idx.items():
+            A_prime[i] = A[i] + (chi[b] - chi[a])  # edges are sorted, a < b
+
+        F = es2.curvatureFromConnection(A)
+        F_prime = es2.curvatureFromConnection(A_prime)
+        self.assertTrue(np.allclose(F_prime, F, atol=1e-10))
+
+        s, sp = es2.fieldStrengthSplit(F), es2.fieldStrengthSplit(F_prime)
+        self.assertTrue(np.allclose(sp.electric, s.electric, atol=1e-10))
+        self.assertTrue(np.allclose(sp.magnetic, s.magnetic, atol=1e-10))
+
+
+class FieldStrengthSplitErrorPathTest(unittest.TestCase):
+    """Size / degree guards raise RuntimeError."""
+
+    def test_wrong_F_size_raises(self):
+        es2 = cob.EigenstateSynthesis(_build().cobordism, 2)
+        with self.assertRaises(RuntimeError):
+            es2.fieldStrengthSplit([0.0] * (es2.order() + 1))
+
+    def test_non_degree_2_instance_raises(self):
+        st = _build().cobordism
+        es1 = cob.EigenstateSynthesis(st, 1)
+        with self.assertRaises(RuntimeError):
+            es1.fieldStrengthSplit([0.0] * es1.order())
+        with self.assertRaises(RuntimeError):
+            es1.curvatureFromConnection([0.0] * es1.order())
+
+    def test_wrong_A_size_raises(self):
+        st = _build().cobordism
+        es2 = cob.EigenstateSynthesis(st, 2)
+        _, n_edges = _edge_order(st)
+        with self.assertRaises(RuntimeError):
+            es2.curvatureFromConnection([0.0] * (n_edges + 1))
+
+
+class ObservableOnlyRegressionTest(unittest.TestCase):
+    """The reader is read-only: it leaves the junction geometry/topology unchanged."""
+
+    def test_reader_does_not_perturb_the_geometry(self):
+        m = _build(-0.3)
+        st = m.cobordism
+        # G4 TOPOLOGY: b1 == 11 and the dual complex is valid on the seed.
+        self.assertEqual(list(m.stats.betti_cobordism)[1], 11)
+        self.assertTrue(cob.EigenstateSynthesis(st, 1).dualComplexValid()[0])
+
+        before = _edge_metric_snapshot(st)
+        es2 = cob.EigenstateSynthesis(st, 2)
+        _, n_edges = _edge_order(st)
+        rng = np.random.default_rng(_SEED)
+        F = es2.curvatureFromConnection(_rng_cochain(rng, n_edges))
+        es2.fieldStrengthSplit(F)
+        after = _edge_metric_snapshot(st)
+        # bit-for-bit identical -- the read-out mutated nothing it should only read.
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Add the charge-sector E/B read-out from epic #410: split the field-strength
2-cochain `F ∈ Ω²` of a relaxed cobordism into its **electric** and **magnetic**
parts by the **causal type of each plaquette**.

- `E` = 2-cells (plaquettes) carrying a **timelike** edge (one temporal leg — the
  discrete `F_{0i}`).
- `B` = **purely-spacelike** plaquettes (`F_{ij}`).

Two new methods on the existing `EigenstateSynthesis` (constructed at degree
`k = 2`), with pybind bindings — no parallel class, no free functions:

- `curvatureFromConnection(A)` — the source `F = dA`: on each sorted 2-cell
  `(a,b,c)`, `F = A(a,b) + A(b,c) − A(a,c)`, the induced-orientation signed edge sum
  the period read-out already uses (`cyclePeriods`,
  `proton_observables.py:55-56`). `A` is a degree-1 cochain in the canonical
  `ChainComplex` 1-cell order (`len(A) == EigenstateSynthesis(st, 1).order()`).
  Gauge-invariant (`d∘d = 0`).
- `fieldStrengthSplit(F)` — returns a `FieldStrengthSplit` with `electric` /
  `magnetic` (`order()`-length cochains, `electric + magnetic == F`) and the
  disjoint, complete index lists `electricCells` / `magneticCells`. A plaquette is
  electric iff any of its three edges is `Edge::isTimelike()` on the live complex.

This is **observable-only**: both methods read the relaxed geometry and never
mutate it.

## Tests

`tests/cobordism/test_field_strength_split.py` (11 tests, all green locally) pin
the acceptance criteria on the W_ABC junction (`TripartiteRegisterTopology`):

- **Static seed → E ≡ 0, B carries everything.** Uniform `l²=1` build:
  `electricCells == []`, `‖electric‖ == 0.0` (bit-zero), `magnetic == F` on all
  `order()` cells.
- **Timelike flux → ‖E‖ > 0, tracking causal type.** `set_lorentzian_worldlines`
  makes the cross-layer worldline edges timelike; `‖electric‖ > 1e-9` and
  `set(electricCells)` equals the timelike-leg cells recomputed independently in
  Python; partition is disjoint + complete.
- **Partition completeness** (both regimes) to `1e-12`.
- **`F = dA` gauge invariance:** `A' = A + dχ` leaves `F`, `E`, `B` unchanged.
- **Coboundary check** on a single triangle (`A(a,b)+A(b,c)−A(a,c)`).
- **Error paths** (`F.size()`, non-degree-2 instance, `A.size()`).
- **Observable-only regression:** the reader leaves the edge metric bit-for-bit
  unchanged; `b1 == 11` and `dualComplexValid` hold on the seed.

## Notes for review

- The ticket's references to `Spacetime::symmetricStackCells` /
  `test_epic410_invariants.py` / stored proton goldens do not exist on `main`;
  the W_ABC junction on `main` is still the `prismCells` (×I) interior, and
  `set_lorentzian_worldlines` sets exactly its cross-layer (forward-time) edges
  timelike — the static-vs-flux knob the ticket needs. The E/B split is
  interior-shape-independent (it only reads `Edge::isTimelike()`), so the seed is
  built via the canonical `TripartiteRegisterTopology` path. The observable-only
  regression is asserted inline (geometry bit-for-bit unchanged) rather than
  against a non-existent shared invariants module.
- `EigenstateSynthesis.h` already has its `{doxygenfile}` entry in
  `docs/source/cpp_api.md` (no new public header).

Closes #417. Part of #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
