### PR TITLE
feat(cobordism): Dirac-Kähler operator and the conserved current (#415)

### DIFF
--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -140,6 +140,8 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} HodgeLaplacian.h
 ```
+```{doxygenfile} DiracKahler.h
+```
 ```{doxygenfile} IntegerLinalg.h
 ```
 ```{doxygenfile} DijkgraafWitten.h

--- a/include/cobordism/DiracKahler.h
+++ b/include/cobordism/DiracKahler.h
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_DIRACKAHLER_H
+#define TESSERA_COBORDISM_DIRACKAHLER_H
+
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # DiracKahler
+///
+/// The discrete **Dirac-Kahler operator** \f$ D = d + \delta \f$ on the
+/// inhomogeneous cochain complex \f$ \Omega = \bigoplus_{k=0}^{n}\Omega^k \f$ of
+/// a `Spacetime` — the principled, label-independent square root of the
+/// `HodgeLaplacian`. It is the natural **distinguished frame** the deferred
+/// operator read-out (`MergeCobordism::operatorU()`/`choiState()`) lacks, and it
+/// bridges the electric-charge current \f$ j^0 \f$ to the candidate flavor/taste
+/// index (the 4-fold Dirac-Kahler "doubling").
+///
+/// ## The operator
+///
+/// On the **total** cochain space \f$ \Phi \in \bigoplus_k \Omega^k \f$ (flat
+/// dimension \f$ \sum_k |C_k| \f$) the operator is assembled block-by-block from
+/// the same integer boundary maps \f$ \partial_k \f$ (`ChainComplex`) and
+/// diagonal inner-product weights \f$ W_k \f$ (`HodgeLaplacian::weights`) the
+/// `HodgeLaplacian` already uses, in the boundary convention `HodgeLaplacian`
+/// squares (`include/cobordism/HodgeLaplacian.h:31-46,48-68`):
+///
+///  - the **boundary** part \f$ \partial \f$ (degree-lowering) has block
+///    \f$ \Omega^k \to \Omega^{k-1} \f$ equal to \f$ \partial_k \f$
+///    (the integer `ChainComplex::boundaryMatrix(k)`, rows \f$|C_{k-1}|\f$,
+///    cols \f$|C_k|\f$);
+///  - the **codifferential** part \f$ \delta = \partial^* \f$ (degree-raising)
+///    has block \f$ \Omega^{k-1} \to \Omega^k \f$ equal to the metric adjoint
+///    \f$ \partial_k^* = W_k^{-1}\partial_k^{\top}W_{k-1} \f$.
+///
+/// Then, because \f$ \partial^2 = 0 \f$ and \f$ \delta^2 = (\partial^*)^2 = 0 \f$,
+/// the square is **block-diagonal per degree** and reproduces the Hodge Laplacian
+/// exactly:
+/// \f$ (d+\delta)^2 = \delta\partial + \partial\delta = L_k \f$, with
+/// \f$ L_k = W_k^{-1}\partial_k^{\top}W_{k-1}\partial_k
+///       + \partial_{k+1}W_{k+1}^{-1}\partial_{k+1}^{\top}W_k \f$ —
+/// the directly-assembled `HodgeLaplacian` (`signedLaplacian`). On a complex
+/// whose per-degree weights are uniform (e.g. the uniform \f$ l^2=1 \f$ metric,
+/// where \f$ W_k = c_k I \f$) this coincides block-for-block with the symmetric
+/// metric `HodgeLaplacian::laplacian(k, metric=true)`; the `lorentzian` path
+/// reproduces the signed-weight d'Alembertian blocks (\f$ k\ge 1 \f$). The
+/// matrix is rebuilt from the current edge weights on each call (matching the
+/// `HodgeLaplacian` lazy convention).
+///
+/// The \f$ k=0 \f$ block of \f$ D^2 \f$ is the **0-form Hodge Laplacian**
+/// \f$ \partial_1 W_1^{-1}\partial_1^{\top} \f$, which equals
+/// `HodgeLaplacian::laplacian(0)` (the Hermitian U(1)-graph Laplacian \f$ D-A \f$)
+/// only for unit, real edge weights; under the `lorentzian` (signed-weight)
+/// path the graph Laplacian and the signed 0-form d'Alembertian differ, so the
+/// reproduction is asserted over the \f$ k\ge 1 \f$ d'Alembertian blocks there.
+///
+/// ## Clifford / gamma structure and the 4-fold multiplicity
+///
+/// The gamma generators are the **Clifford action of unit 1-cochains** on the
+/// Kahler-Atiyah form fiber \f$ \Lambda(\mathbb{R}^d) \f$ (dimension \f$ 2^d \f$):
+/// \f$ \gamma^a = \varepsilon(e^a) + \eta^{aa}\,\iota(e^a) \f$, exterior
+/// multiplication plus (metric) interior multiplication by the \f$ a \f$-th basis
+/// 1-form. They satisfy the Clifford algebra
+/// \f$ \{\gamma^a,\gamma^b\} = 2\eta^{ab} I \f$ exactly (Euclidean
+/// \f$ \eta=\delta \f$, or the Lorentzian \f$ \mathrm{diag}(-1,+1,\dots) \f$ under
+/// the `lorentzian` flag), and \f$ D = \gamma^\mu\partial_\mu \f$ is the discrete
+/// Dirac operator. The framework spacetime dimension is \f$ d=4 \f$: the fiber is
+/// \f$ 2^4 = 16 \f$-dimensional and decomposes as \f$ 16 = 4\times 4 \f$ —
+/// **4 Dirac spinor components** \f$ \times \f$ **4 degenerate copies**. That
+/// 4-fold "doubling" is the `multiplicity()`, the candidate **flavor/taste
+/// index**.
+///
+/// ## The conserved current \f$ j^0 \f$ (charge density)
+///
+/// The U(1) Noether current of the Dirac-Kahler field is
+/// \f$ j^a = \bar\Phi\,\gamma^a\Phi \f$; its time component
+/// \f$ j^0 = \bar\Phi\,\gamma^0\Phi = \pm\,\Phi^\dagger\Phi \f$ is the **charge
+/// density**, realized per cell as \f$ j^0_c = W_c\,|\Phi_c|^2 \f$ (the
+/// \f$ W \f$-weighted modulus). Summed over a closed slice it integrates to the
+/// carried U(1) charge \f$ \langle\Phi,\Phi\rangle_W \f$; on a single closed
+/// harmonic \f$ \Phi \f$ (a `HodgeLaplacian::harmonicMatrix` row lifted to the
+/// total space) this is the harmonic's carried charge. The eventual Gauss-law
+/// cross-check (the electric-charge-density ticket) compares this to the
+/// period-derived charge; until then the consistency check is that the summed
+/// \f$ j^0 \f$ equals \f$ \langle\Phi,\Phi\rangle_W \f$.
+///
+/// ## Reduced-dimension caveat
+///
+/// The current `S^2 x I` cobordism is **2+1 D** (reduced): the full \f$ 4\times4 \f$
+/// Dirac and the \f$ E \f$/\f$ B \f$ field-strength split need a 3+1 D
+/// \f$ S^3 \f$-spatial-slice mesh. This class assembles \f$ D \f$ and the
+/// \f$ D^2=L \f$ verification generically in \f$ n \f$ D from the mesh, while the
+/// gamma/Clifford framework and `multiplicity()` report the **4D** values (a
+/// fixed property of the Dirac-Kahler framework, not of the reduced mesh).
+class DiracKahler {
+  public:
+    /// Construct over a triangulation. Edge weights are read lazily (at each
+    /// matrix/current query), so the spacetime must outlive the operator; the
+    /// held `shared_ptr` keeps it alive.
+    explicit DiracKahler(std::shared_ptr<Spacetime> st);
+
+    /// The mesh top dimension \f$ n \f$ (largest \f$ k \f$ with a \f$ k \f$-cell),
+    /// or \f$ -1 \f$ for the empty complex.
+    [[nodiscard]] int meshDimension() const;
+
+    /// The total cochain dimension \f$ \sum_{k=0}^{n}|C_k| \f$ — the side length
+    /// of the \f$ D \f$ matrix.
+    [[nodiscard]] std::size_t totalDimension() const;
+
+    /// Block offsets \f$ (o_0,\dots,o_{n+1}) \f$, length \f$ n+2 \f$, with
+    /// \f$ o_k = \sum_{j<k}|C_j| \f$ and \f$ o_{n+1} = \text{totalDimension()} \f$:
+    /// degree-\f$ k \f$ components occupy rows/cols \f$ [o_k, o_{k+1}) \f$ in the
+    /// canonical `ChainComplex` cell order (`kSimplexVertices(k)`).
+    [[nodiscard]] std::vector<std::size_t> blockOffsets() const;
+
+    /// The Dirac-Kahler operator \f$ D = d+\delta \f$ as a flat row-major
+    /// \f$ \text{totalDimension()}^2 \f$ complex array (real entries; imag 0).
+    /// Block \f$ (\Omega^k\to\Omega^{k-1}) = \partial_k \f$ and block
+    /// \f$ (\Omega^{k-1}\to\Omega^k) = W_k^{-1}\partial_k^{\top}W_{k-1} \f$.
+    /// `metric = false` uses unit weights (the combinatorial Dirac operator);
+    /// `lorentzian = true` uses the signed `HodgeLaplacian::weights(k, true)`
+    /// (timelike cells negative), so the square is the signed d'Alembertian.
+    [[nodiscard]] std::vector<std::complex<double>> matrix(
+        bool metric = true, bool lorentzian = false) const;
+
+    /// The square \f$ D^2 \f$ as a flat row-major
+    /// \f$ \text{totalDimension()}^2 \f$ complex array. Block-diagonal per
+    /// degree, each block the degree-\f$ k \f$ `HodgeLaplacian` (see the class
+    /// docstring); the cross-degree blocks vanish (\f$ \partial^2=\delta^2=0 \f$).
+    [[nodiscard]] std::vector<std::complex<double>> square(
+        bool metric = true, bool lorentzian = false) const;
+
+    /// The maximal Frobenius residual \f$ \max_k \| (D^2)_k - L_k \| \f$ between
+    /// the degree-\f$ k \f$ diagonal block of \f$ D^2 \f$ and the independently
+    /// assembled `HodgeLaplacian::laplacian(k, metric, lorentzian)`. Iterated over
+    /// \f$ k = 0..n \f$ for the Euclidean path and \f$ k = 1..n \f$ for the
+    /// `lorentzian` path (the \f$ k=0 \f$ `HodgeLaplacian` is the Hermitian graph
+    /// Laplacian, not the signed 0-form d'Alembertian; see the class docstring).
+    /// ~0 confirms \f$ (d+\delta)^2 = L \f$.
+    [[nodiscard]] double laplacianResidual(
+        bool metric = true, bool lorentzian = false) const;
+
+    /// The framework spacetime dimension \f$ d = 4 \f$ (the 4D Dirac-Kahler
+    /// framework; fixed, independent of the reduced mesh dimension).
+    [[nodiscard]] int frameworkDimension() const;
+
+    /// The Kahler-Atiyah form-fiber dimension \f$ 2^d = 16 \f$ (in 4D): the side
+    /// length of each gamma matrix.
+    [[nodiscard]] std::size_t gammaDimension() const;
+
+    /// The 4-fold Dirac-Kahler **multiplicity** (the "doubling"):
+    /// \f$ 2^{d/2} = 4 \f$ in 4D — the number of degenerate Dirac copies in
+    /// \f$ \Lambda(\mathbb{C}^4) = 16 = 4_{\text{spinor}}\times 4_{\text{taste}} \f$.
+    /// The candidate flavor/taste index. Pinned to 4 in the 4D framework.
+    [[nodiscard]] int multiplicity() const;
+
+    /// The metric signature \f$ \eta \f$ as a flat row-major
+    /// \f$ d\times d \f$ array: Euclidean \f$ \delta_{ab} \f$, or the Lorentzian
+    /// \f$ \mathrm{diag}(-1,+1,+1,+1) \f$ under `lorentzian = true`.
+    [[nodiscard]] std::vector<double> signature(bool lorentzian = false) const;
+
+    /// The \f$ d=4 \f$ gamma generators — the Clifford action of the unit
+    /// 1-cochains on the form fiber \f$ \Lambda(\mathbb{R}^4) \f$ — as a list of
+    /// \f$ \text{gammaDimension()}\times\text{gammaDimension()} \f$ flat
+    /// row-major real matrices \f$ \gamma^a = \varepsilon(e^a)+\eta^{aa}\iota(e^a) \f$.
+    /// They satisfy \f$ \{\gamma^a,\gamma^b\}=2\eta^{ab}I \f$ against
+    /// `signature(lorentzian)`.
+    [[nodiscard]] std::vector<std::vector<std::complex<double>>> gammas(
+        bool lorentzian = false) const;
+
+    /// The Clifford anticommutator residual
+    /// \f$ \max_{a,b}\|\{\gamma^a,\gamma^b\} - 2\eta^{ab}I\|_F \f$ for the
+    /// generators of `gammas(lorentzian)` against `signature(lorentzian)`. ~0.
+    [[nodiscard]] double cliffordResidual(bool lorentzian = false) const;
+
+    /// Lift a degree-\f$ k \f$ cochain `component` (length \f$ |C_k| \f$) into a
+    /// total-space field (length `totalDimension()`), zero in every other degree.
+    /// @throws std::runtime_error if `component` has the wrong length.
+    [[nodiscard]] std::vector<std::complex<double>> lift(
+        int k, const std::vector<std::complex<double>> &component) const;
+
+    /// The per-cell charge density \f$ j^0_c = W_c\,|\Phi_c|^2 \f$ of a total-space
+    /// field `field` (length `totalDimension()`), in the same flat block layout
+    /// (`blockOffsets`). `metric = false` uses unit weights. The time component is
+    /// the (positive) \f$ |\text{volume}| \f$-weighted modulus — the Dirac
+    /// current's \f$ j^0 = \bar\Phi\gamma^0\Phi \f$ in any signature.
+    /// @throws std::runtime_error if `field` has the wrong length.
+    [[nodiscard]] std::vector<double> chargeDensity(
+        const std::vector<std::complex<double>> &field, bool metric = true) const;
+
+    /// The carried U(1) charge \f$ \sum_c j^0_c = \langle\Phi,\Phi\rangle_W \f$ —
+    /// the charge density summed over the slice. On a closed harmonic this is the
+    /// carried charge (the Gauss-law cross-check, deferred to the
+    /// electric-charge-density ticket, compares it to the period-derived charge).
+    /// @throws std::runtime_error if `field` has the wrong length.
+    [[nodiscard]] double charge(
+        const std::vector<std::complex<double>> &field, bool metric = true) const;
+
+  private:
+    std::shared_ptr<Spacetime> st_;
+
+    // Per-degree cell counts |C_k| (length n+1) and the block offsets (length
+    // n+2), built lazily from the ChainComplex on demand.
+    [[nodiscard]] std::vector<std::size_t> cellCounts() const;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_DIRACKAHLER_H

--- a/include/cobordism/DiracKahler.h
+++ b/include/cobordism/DiracKahler.h
@@ -176,6 +176,23 @@ class DiracKahler {
     [[nodiscard]] std::vector<std::vector<std::complex<double>>> gammas(
         bool lorentzian = false) const;
 
+    /// \note **Where the 4x4 irreducible Dirac matrices would slot in.** `gammas()`
+    /// exposes the \f$ 16\times 16 \f$ *Clifford action* on the form fiber (the literal
+    /// "Clifford action of 1-cochains"). That fiber is
+    /// \f$ \Lambda(\mathbb{C}^4)\cong M_4(\mathbb{C}) \f$ — four commuting copies of the
+    /// irreducible \f$ 4\times 4 \f$ Dirac representation, one per `multiplicity()`
+    /// *taste*. To switch approach from the Clifford action to the relativistic Dirac
+    /// matrices, add a sibling accessor here, e.g.
+    /// `diracMatrices(lorentzian)` returning the \f$ 4\times 4 \f$
+    /// \f$ \gamma^\mu \f$ — the image of these same generators under the Chevalley /
+    /// Kahler-Atiyah isomorphism \f$ \Lambda(\mathbb{C}^4)\to M_4(\mathbb{C}) \f$
+    /// (equivalently the restriction of the \f$ 16\times 16 \f$ action to one minimal
+    /// left ideal / taste block) — with a `tasteProjector()` for the four commuting
+    /// copies. The operator \f$ D \f$ and the current \f$ j^0 \f$ are
+    /// representation-independent; only `gammas()` / `gammaDimension()` would change
+    /// (\f$ 16\to 4 \f$) and `multiplicity()` would become the explicit taste
+    /// degeneracy. The Clifford and multiplicity tests pass for either form.
+
     /// The Clifford anticommutator residual
     /// \f$ \max_{a,b}\|\{\gamma^a,\gamma^b\} - 2\eta^{ab}I\|_F \f$ for the
     /// generators of `gammas(lorentzian)` against `signature(lorentzian)`. ~0.

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -20,6 +20,7 @@
 #include "cobordism/Cobordism.h"
 #include "cobordism/CombinatorialDimension.h"
 #include "cobordism/DijkgraafWitten.h"
+#include "cobordism/DiracKahler.h"
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
@@ -335,6 +336,95 @@ Euclidean spectrum/kernel.)doc")
            "representatives, one per column of lorentzianHarmonics (same order). "
            "A value ~0 flags a NULL (lightlike) harmonic; all positive on an "
            "all-spacelike complex.");
+
+  // ----- Dirac-Kahler operator d+delta and the conserved current j^0 (#415) -----
+  py::class_<DiracKahler>(m, "DiracKahler",
+      R"doc(The discrete Dirac-Kahler operator D = d + delta on the inhomogeneous
+cochain complex of a Spacetime — the label-independent square root of the
+HodgeLaplacian, and the distinguished frame the deferred operator read-out lacks.
+
+On the total cochain space Phi in (+)_k Omega^k (flat dim sum_k |C_k|), D is
+assembled block-by-block from the integer boundary maps d_k (ChainComplex) and
+diagonal weights W_k (HodgeLaplacian.weights): the boundary part (degree-lowering)
+block Omega^k -> Omega^{k-1} is d_k; the codifferential part d_k* = W_k^-1 d_k^T
+W_{k-1} (degree-raising) block Omega^{k-1} -> Omega^k. Since d^2 = (d*)^2 = 0 the
+square is block-diagonal per degree and reproduces the HodgeLaplacian:
+(d+delta)^2 = L_k. On uniform per-degree weights (e.g. l^2 = 1, W_k = c_k I) this
+matches the symmetric metric laplacian(k); the lorentzian path reproduces the
+signed d'Alembertian blocks (k>=1). Rebuilt from current edge weights each call.
+
+Clifford/gamma structure: the gammas are the Clifford action of unit 1-cochains on
+the Kahler-Atiyah form fiber Lambda(R^d), gamma^a = eps(e^a) + eta^aa iota(e^a),
+satisfying {gamma^a, gamma^b} = 2 eta^ab I exactly. The framework dimension is d=4:
+the fiber is 2^4 = 16 = 4 (Dirac spinor) x 4 (taste) and multiplicity() = 4 is the
+candidate flavor/taste index. The conserved U(1) current j^a = bar(Phi) gamma^a Phi
+has time component j^0 = W_c |Phi_c|^2 (charge density); summed over a closed slice
+it integrates to the carried charge <Phi,Phi>_W.
+
+Reduced-dimension caveat: the current S^2 x I cobordism is 2+1 D; D and the D^2 = L
+check are generic in n D, while the gamma/Clifford framework and multiplicity report
+the fixed 4D values.)doc")
+      .def(py::init<std::shared_ptr<Spacetime>>(), py::arg("spacetime"),
+           "Build the Dirac-Kahler operator over a triangulation.")
+      .def("meshDimension", &DiracKahler::meshDimension,
+           "The mesh top dimension n (largest k with a k-cell), or -1 if empty.")
+      .def("totalDimension", &DiracKahler::totalDimension,
+           "The total cochain dimension sum_k |C_k| (side length of D).")
+      .def("blockOffsets", &DiracKahler::blockOffsets,
+           "Block offsets (o_0..o_{n+1}), o_k = sum_{j<k} |C_j|: degree-k "
+           "components occupy [o_k, o_{k+1}) in canonical ChainComplex cell order.")
+      .def("matrix", &DiracKahler::matrix, py::arg("metric") = true,
+           py::arg("lorentzian") = false,
+           "The operator D = d+delta as a flat row-major totalDimension^2 complex "
+           "array (real; imag 0). metric=False uses unit weights (combinatorial); "
+           "lorentzian=True uses signed weights (the square is the d'Alembertian).")
+      .def("square", &DiracKahler::square, py::arg("metric") = true,
+           py::arg("lorentzian") = false,
+           "The square D^2 as a flat row-major totalDimension^2 complex array: "
+           "block-diagonal per degree, each block the degree-k HodgeLaplacian; "
+           "cross-degree blocks vanish (d^2 = delta^2 = 0).")
+      .def("laplacianResidual", &DiracKahler::laplacianResidual,
+           py::arg("metric") = true, py::arg("lorentzian") = false,
+           "max_k ||(D^2)_k - laplacian(k, metric, lorentzian)||_F over k=0..n "
+           "(Euclidean) or k=1..n (lorentzian; the k=0 HodgeLaplacian is the "
+           "Hermitian graph Laplacian, not the signed 0-form d'Alembertian). ~0 "
+           "confirms (d+delta)^2 = L.")
+      .def("frameworkDimension", &DiracKahler::frameworkDimension,
+           "The framework spacetime dimension d=4 (fixed; independent of the "
+           "reduced mesh dimension).")
+      .def("gammaDimension", &DiracKahler::gammaDimension,
+           "The Kahler-Atiyah form-fiber dimension 2^d = 16 (side length of each "
+           "gamma matrix).")
+      .def("multiplicity", &DiracKahler::multiplicity,
+           "The 4-fold Dirac-Kahler multiplicity 2^{d/2} = 4: the degenerate Dirac "
+           "copies in Lambda(C^4) = 16 = 4_spinor x 4_taste (candidate flavor "
+           "index). Pinned to 4 in the 4D framework.")
+      .def("signature", &DiracKahler::signature, py::arg("lorentzian") = false,
+           "The metric signature eta as a flat row-major d*d array: Euclidean "
+           "delta_ab, or Lorentzian diag(-1,+1,+1,+1) under lorentzian=True.")
+      .def("gammas", &DiracKahler::gammas, py::arg("lorentzian") = false,
+           "The d=4 gamma generators (Clifford action of unit 1-cochains on "
+           "Lambda(R^4)) as a list of gammaDimension*gammaDimension flat row-major "
+           "complex matrices gamma^a = eps(e^a) + eta^aa iota(e^a). Satisfy "
+           "{gamma^a, gamma^b} = 2 eta^ab I against signature(lorentzian).")
+      .def("cliffordResidual", &DiracKahler::cliffordResidual,
+           py::arg("lorentzian") = false,
+           "max_{a,b} ||{gamma^a, gamma^b} - 2 eta^ab I||_F for gammas(lorentzian) "
+           "against signature(lorentzian). ~0.")
+      .def("lift", &DiracKahler::lift, py::arg("k"), py::arg("component"),
+           "Lift a degree-k cochain (length |C_k|) into a total-space field "
+           "(length totalDimension), zero in every other degree. Raises if the "
+           "component length is wrong.")
+      .def("chargeDensity", &DiracKahler::chargeDensity, py::arg("field"),
+           py::arg("metric") = true,
+           "Per-cell charge density j^0_c = W_c |Phi_c|^2 of a total-space field "
+           "(length totalDimension) in the blockOffsets layout. metric=False uses "
+           "unit weights. Raises if the field length is wrong.")
+      .def("charge", &DiracKahler::charge, py::arg("field"),
+           py::arg("metric") = true,
+           "The carried U(1) charge sum_c j^0_c = <Phi,Phi>_W (j^0 summed over the "
+           "slice). On a closed harmonic this is the carried charge. Raises if the "
+           "field length is wrong.");
 
   // ----- §4b eigenstate synthesis: residual + parameter access (#133) -----
   py::class_<EigenstateSynthesis>(m, "EigenstateSynthesis",

--- a/src/cobordism/DiracKahler.cpp
+++ b/src/cobordism/DiracKahler.cpp
@@ -1,0 +1,312 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/DiracKahler.h"
+
+#include <Eigen/Dense>
+
+#include <bitset>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "cobordism/ChainComplex.h"
+#include "cobordism/HodgeLaplacian.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+using cd = std::complex<double>;
+
+namespace {
+
+// The framework spacetime dimension of the Dirac-Kahler construction: 4D. The
+// gamma/Clifford structure and the taste multiplicity are fixed properties of
+// this 4D framework, independent of the reduced mesh dimension.
+constexpr int kFrameworkDim = 4;
+
+// Diagonal weights W_k (length |C_k|) used by both the operator and the current.
+// Mirrors HodgeLaplacian: W_0 = I; for k >= 1 the per-cell |volume| (metric) or
+// signed volume (lorentzian); metric == false ⇒ unit weights (combinatorial).
+std::vector<double> degreeWeights(const HodgeLaplacian &hl, int k,
+                                  std::size_t count, bool metric,
+                                  bool lorentzian) {
+  if (!metric || k == 0)
+    return std::vector<double>(count, 1.0);
+  std::vector<double> w = hl.weights(k, lorentzian);
+  if (w.size() != count) w.assign(count, 1.0);  // defensive: above top dim
+  return w;
+}
+
+// The boundary matrix d_k (rows |C_{k-1}|, cols |C_k|) as an Eigen matrix.
+Eigen::MatrixXd boundaryMatrix(const ChainComplex &cc, int k, int rows, int cols) {
+  Eigen::MatrixXd d = Eigen::MatrixXd::Zero(rows, cols);
+  if (rows == 0 || cols == 0) return d;
+  const std::vector<long> &flat = cc.boundaryMatrix(k);
+  for (int r = 0; r < rows; ++r)
+    for (int c = 0; c < cols; ++c)
+      d(r, c) = static_cast<double>(flat[static_cast<std::size_t>(r) * cols + c]);
+  return d;
+}
+
+}  // namespace
+
+DiracKahler::DiracKahler(std::shared_ptr<Spacetime> st) : st_(std::move(st)) {}
+
+std::vector<std::size_t> DiracKahler::cellCounts() const {
+  if (!st_) return {};
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const int n = cc.dimension();
+  std::vector<std::size_t> counts;
+  counts.reserve(static_cast<std::size_t>(n + 1));
+  for (int k = 0; k <= n; ++k) counts.push_back(cc.numSimplices(k));
+  return counts;
+}
+
+int DiracKahler::meshDimension() const {
+  if (!st_) return -1;
+  return ChainComplex::fromSpacetime(*st_).dimension();
+}
+
+std::vector<std::size_t> DiracKahler::blockOffsets() const {
+  const std::vector<std::size_t> counts = cellCounts();
+  std::vector<std::size_t> off(counts.size() + 1, 0);
+  for (std::size_t k = 0; k < counts.size(); ++k) off[k + 1] = off[k] + counts[k];
+  return off;
+}
+
+std::size_t DiracKahler::totalDimension() const {
+  const std::vector<std::size_t> off = blockOffsets();
+  return off.empty() ? 0 : off.back();
+}
+
+std::vector<cd> DiracKahler::matrix(bool metric, bool lorentzian) const {
+  const std::vector<std::size_t> counts = cellCounts();
+  const std::vector<std::size_t> off = blockOffsets();
+  const std::size_t total = off.empty() ? 0 : off.back();
+  std::vector<cd> out(total * total, cd(0.0, 0.0));
+  if (total == 0 || !st_) return out;
+
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const HodgeLaplacian hl(st_);
+  const int n = static_cast<int>(counts.size()) - 1;
+
+  for (int k = 1; k <= n; ++k) {
+    const int rows = static_cast<int>(counts[static_cast<std::size_t>(k - 1)]);
+    const int cols = static_cast<int>(counts[static_cast<std::size_t>(k)]);
+    if (rows == 0 || cols == 0) continue;
+    const Eigen::MatrixXd dk = boundaryMatrix(cc, k, rows, cols);
+
+    const std::vector<double> wk =
+        degreeWeights(hl, k, static_cast<std::size_t>(cols), metric, lorentzian);
+    const std::vector<double> wkm1 = degreeWeights(
+        hl, k - 1, static_cast<std::size_t>(rows), metric, lorentzian);
+
+    // Boundary block partial_k: rows in degree k-1, cols in degree k.
+    const std::size_t r0 = off[static_cast<std::size_t>(k - 1)];
+    const std::size_t c0 = off[static_cast<std::size_t>(k)];
+    for (int r = 0; r < rows; ++r)
+      for (int c = 0; c < cols; ++c)
+        out[(r0 + static_cast<std::size_t>(r)) * total + (c0 + static_cast<std::size_t>(c))] +=
+            cd(dk(r, c), 0.0);
+
+    // Codifferential block partial_k* = W_k^-1 d_k^T W_{k-1}: rows in degree k,
+    // cols in degree k-1.
+    for (int i = 0; i < cols; ++i)
+      for (int j = 0; j < rows; ++j) {
+        const double v = (1.0 / wk[static_cast<std::size_t>(i)]) * dk(j, i) *
+                         wkm1[static_cast<std::size_t>(j)];
+        out[(c0 + static_cast<std::size_t>(i)) * total + (r0 + static_cast<std::size_t>(j))] +=
+            cd(v, 0.0);
+      }
+  }
+  return out;
+}
+
+std::vector<cd> DiracKahler::square(bool metric, bool lorentzian) const {
+  const std::size_t total = totalDimension();
+  std::vector<cd> out(total * total, cd(0.0, 0.0));
+  if (total == 0) return out;
+  const std::vector<cd> Dflat = matrix(metric, lorentzian);
+  Eigen::MatrixXcd D(total, total);
+  for (std::size_t i = 0; i < total; ++i)
+    for (std::size_t j = 0; j < total; ++j)
+      D(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+          Dflat[i * total + j];
+  const Eigen::MatrixXcd D2 = D * D;
+  for (std::size_t i = 0; i < total; ++i)
+    for (std::size_t j = 0; j < total; ++j)
+      out[i * total + j] =
+          D2(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+  return out;
+}
+
+double DiracKahler::laplacianResidual(bool metric, bool lorentzian) const {
+  const std::vector<std::size_t> counts = cellCounts();
+  const std::vector<std::size_t> off = blockOffsets();
+  const std::size_t total = off.empty() ? 0 : off.back();
+  if (total == 0 || !st_) return 0.0;
+
+  const std::vector<cd> sq = square(metric, lorentzian);
+  const HodgeLaplacian hl(st_);
+  const int n = static_cast<int>(counts.size()) - 1;
+  // The k=0 HodgeLaplacian is the Hermitian graph Laplacian, which equals the
+  // signed 0-form d'Alembertian only for unit/real weights; skip it on the
+  // lorentzian path (compare the d'Alembertian blocks k>=1).
+  const int kStart = lorentzian ? 1 : 0;
+
+  double worst = 0.0;
+  for (int k = kStart; k <= n; ++k) {
+    const std::size_t m = counts[static_cast<std::size_t>(k)];
+    if (m == 0) continue;
+    const std::vector<cd> lk = hl.laplacian(k, metric, lorentzian);
+    const std::size_t o = off[static_cast<std::size_t>(k)];
+    double sumSq = 0.0;
+    for (std::size_t i = 0; i < m; ++i)
+      for (std::size_t j = 0; j < m; ++j) {
+        const cd diff = sq[(o + i) * total + (o + j)] - lk[i * m + j];
+        sumSq += std::norm(diff);
+      }
+    worst = std::max(worst, std::sqrt(sumSq));
+  }
+  return worst;
+}
+
+int DiracKahler::frameworkDimension() const { return kFrameworkDim; }
+
+std::size_t DiracKahler::gammaDimension() const {
+  return static_cast<std::size_t>(1) << kFrameworkDim;
+}
+
+int DiracKahler::multiplicity() const { return 1 << (kFrameworkDim / 2); }
+
+std::vector<double> DiracKahler::signature(bool lorentzian) const {
+  const int d = kFrameworkDim;
+  std::vector<double> eta(static_cast<std::size_t>(d) * d, 0.0);
+  for (int a = 0; a < d; ++a) {
+    const double s = (lorentzian && a == 0) ? -1.0 : 1.0;
+    eta[static_cast<std::size_t>(a) * d + a] = s;
+  }
+  return eta;
+}
+
+std::vector<std::vector<cd>> DiracKahler::gammas(bool lorentzian) const {
+  const int d = kFrameworkDim;
+  const std::size_t dim = gammaDimension();
+  std::vector<std::vector<cd>> gs;
+  gs.reserve(static_cast<std::size_t>(d));
+  for (int a = 0; a < d; ++a) {
+    std::vector<cd> g(dim * dim, cd(0.0, 0.0));
+    const double etaAA = (lorentzian && a == 0) ? -1.0 : 1.0;
+    const unsigned bit = 1u << a;
+    const unsigned below = bit - 1u;  // bits 0..a-1
+    for (unsigned S = 0; S < dim; ++S) {
+      // sign = (-1)^popcount(S & bits below a) — the Koszul sign of e^a in e^S.
+      const double sign =
+          (std::bitset<32>(S & below).count() % 2 == 0) ? 1.0 : -1.0;
+      if ((S & bit) == 0) {
+        // exterior multiplication: add basis 1-form e^a (raises degree).
+        const unsigned T = S | bit;
+        g[static_cast<std::size_t>(T) * dim + S] += cd(sign, 0.0);
+      } else {
+        // interior multiplication (contraction) by e^a, with the metric eta^aa.
+        const unsigned T = S & ~bit;
+        g[static_cast<std::size_t>(T) * dim + S] += cd(etaAA * sign, 0.0);
+      }
+    }
+    gs.push_back(std::move(g));
+  }
+  return gs;
+}
+
+double DiracKahler::cliffordResidual(bool lorentzian) const {
+  const int d = kFrameworkDim;
+  const std::size_t dim = gammaDimension();
+  const std::vector<std::vector<cd>> gs = gammas(lorentzian);
+  const std::vector<double> eta = signature(lorentzian);
+
+  std::vector<Eigen::MatrixXcd> G;
+  G.reserve(gs.size());
+  for (const auto &gflat : gs) {
+    Eigen::MatrixXcd M(dim, dim);
+    for (std::size_t i = 0; i < dim; ++i)
+      for (std::size_t j = 0; j < dim; ++j)
+        M(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+            gflat[i * dim + j];
+    G.push_back(std::move(M));
+  }
+  const Eigen::MatrixXcd I =
+      Eigen::MatrixXcd::Identity(static_cast<Eigen::Index>(dim),
+                                 static_cast<Eigen::Index>(dim));
+  double worst = 0.0;
+  for (int a = 0; a < d; ++a)
+    for (int b = 0; b < d; ++b) {
+      const Eigen::MatrixXcd anti = G[static_cast<std::size_t>(a)] * G[static_cast<std::size_t>(b)] +
+                                    G[static_cast<std::size_t>(b)] * G[static_cast<std::size_t>(a)];
+      const double etaAB = eta[static_cast<std::size_t>(a) * d + b];
+      worst = std::max(worst, (anti - 2.0 * etaAB * I).norm());
+    }
+  return worst;
+}
+
+std::vector<cd> DiracKahler::lift(int k,
+                                  const std::vector<cd> &component) const {
+  const std::vector<std::size_t> counts = cellCounts();
+  const std::vector<std::size_t> off = blockOffsets();
+  const std::size_t total = off.empty() ? 0 : off.back();
+  if (k < 0 || k >= static_cast<int>(counts.size()))
+    throw std::runtime_error("DiracKahler::lift: degree k=" + std::to_string(k) +
+                             " is out of range [0, " +
+                             std::to_string(static_cast<int>(counts.size()) - 1) +
+                             "]");
+  const std::size_t m = counts[static_cast<std::size_t>(k)];
+  if (component.size() != m)
+    throw std::runtime_error(
+        "DiracKahler::lift: component length " +
+        std::to_string(component.size()) + " != |C_k| " + std::to_string(m));
+  std::vector<cd> field(total, cd(0.0, 0.0));
+  const std::size_t o = off[static_cast<std::size_t>(k)];
+  for (std::size_t c = 0; c < m; ++c) field[o + c] = component[c];
+  return field;
+}
+
+std::vector<double> DiracKahler::chargeDensity(const std::vector<cd> &field,
+                                               bool metric) const {
+  const std::vector<std::size_t> counts = cellCounts();
+  const std::vector<std::size_t> off = blockOffsets();
+  const std::size_t total = off.empty() ? 0 : off.back();
+  if (field.size() != total)
+    throw std::runtime_error(
+        "DiracKahler::chargeDensity: field length " +
+        std::to_string(field.size()) + " != totalDimension " +
+        std::to_string(total));
+  std::vector<double> density(total, 0.0);
+  if (total == 0 || !st_) return density;
+
+  const HodgeLaplacian hl(st_);
+  const int n = static_cast<int>(counts.size()) - 1;
+  for (int k = 0; k <= n; ++k) {
+    const std::size_t m = counts[static_cast<std::size_t>(k)];
+    if (m == 0) continue;
+    // j^0 uses the positive |volume| charge measure (the time component of the
+    // Dirac current is the positive-definite probability/charge density).
+    const std::vector<double> wk =
+        degreeWeights(hl, k, m, metric, /*lorentzian=*/false);
+    const std::size_t o = off[static_cast<std::size_t>(k)];
+    for (std::size_t c = 0; c < m; ++c)
+      density[o + c] = wk[c] * std::norm(field[o + c]);  // std::norm = |.|^2
+  }
+  return density;
+}
+
+double DiracKahler::charge(const std::vector<cd> &field, bool metric) const {
+  const std::vector<double> density = chargeDensity(field, metric);
+  double q = 0.0;
+  for (const double d : density) q += d;
+  return q;
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_dirac_kahler.py
+++ b/tests/cobordism/test_dirac_kahler.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""Dirac-Kahler operator (d+delta) and the conserved current j^0 (#415).
+
+The Dirac-Kahler operator D = d + delta is the label-independent square root of
+the HodgeLaplacian on the inhomogeneous cochain complex (+)_k Omega^k: with the
+boundary part d_k and the metric codifferential d_k* = W_k^-1 d_k^T W_{k-1}, and
+d^2 = (d*)^2 = 0, the square is block-diagonal per degree and reproduces the
+Hodge Laplacian, (d+delta)^2 = L. The gammas are the Clifford action of unit
+1-cochains on the Kahler-Atiyah form fiber, {gamma^a, gamma^b} = 2 eta^ab I, with
+the 4-fold (16 = 4x4) doubling as the candidate flavor/taste index; j^0 is the
+charge density of the conserved U(1) current.
+
+These tests are deterministic by construction (explicit small complexes, the
+uniform l^2 = 1 metric so every weight W_k is fixed; the nominal seed=415 fixes
+no RNG because none is used) and pin the machinery to concrete numbers so later
+flavor/charge subtasks cannot silently drift it.
+"""
+
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders (uniform l^2 = 1 metric; deterministic, no RNG)
+# --------------------------------------------------------------------------- #
+def _from_simplices(num_vertices, simplices):
+    """Build a Spacetime from explicit simplex vertex tuples. createSimplex
+    auto-creates every sub-face/edge."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.HERMITIAN_WEIGHTED, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    verts = [st.createVertex(i) for i in range(num_vertices)]
+    for simplex in simplices:
+        st.createSimplex([verts[i] for i in simplex])
+    return st
+
+
+def _set_lengths(st, l2map=None, default_l2=1.0):
+    for e in st.getEdgeList().toVector():
+        key = frozenset((e.getSource().getId(), e.getTarget().getId()))
+        e.setSquaredLength((l2map or {}).get(key, default_l2))
+        e.setPhase(0.0)
+    return st
+
+
+def _tetra(l2map=None):
+    """A single tetrahedron (dimension 3); cells in every degree 0..3.
+    Uniform unit edges unless `l2map` overrides specific edges."""
+    return _set_lengths(_from_simplices(4, [(0, 1, 2, 3)]), l2map, 1.0)
+
+
+def _triangle_cycle():
+    """S^1 as the 3-cycle 0-1-2-0 (b_1 = 1); all-spacelike unit edges."""
+    return _set_lengths(_from_simplices(3, [(0, 1), (1, 2), (2, 0)]), None, 1.0)
+
+
+def _stacked_laplacian(hl, dk, metric, lorentzian, kmin=0):
+    """Block-diagonal stack of HodgeLaplacian.laplacian(k) over k=kmin..n in the
+    DiracKahler total-space layout."""
+    off = dk.blockOffsets()
+    total = dk.totalDimension()
+    n = dk.meshDimension()
+    L = np.zeros((total, total), dtype=complex)
+    for k in range(kmin, n + 1):
+        m = off[k + 1] - off[k]
+        if m == 0:
+            continue
+        lk = np.array(hl.laplacian(k, metric, lorentzian)).reshape(m, m)
+        L[off[k]:off[k + 1], off[k]:off[k + 1]] = lk
+    return L
+
+
+def _square(dk, metric=True, lorentzian=False):
+    total = dk.totalDimension()
+    return np.array(dk.square(metric, lorentzian)).reshape(total, total)
+
+
+def _matrix(dk, metric=True, lorentzian=False):
+    total = dk.totalDimension()
+    return np.array(dk.matrix(metric, lorentzian)).reshape(total, total)
+
+
+# --------------------------------------------------------------------------- #
+# F1 — (d+delta)^2 == L (the Hodge Laplacian reproduced)
+# --------------------------------------------------------------------------- #
+class TestSquareIsLaplacian(unittest.TestCase):
+    def test_euclidean_square_is_laplacian_all_blocks(self):
+        """F1 (Euclidean): D^2 reproduces laplacian(k, metric=True) block-diagonal
+        over ALL k (k=0 included: with unit real edges the 0-form Hodge Laplacian
+        equals the Hermitian graph Laplacian)."""
+        st = _tetra()
+        dk = cob.DiracKahler(st)
+        hl = cob.HodgeLaplacian(st)
+        D2 = _square(dk, metric=True, lorentzian=False)
+        L = _stacked_laplacian(hl, dk, metric=True, lorentzian=False, kmin=0)
+
+        # Overall.
+        self.assertLess(np.linalg.norm(D2 - L), 1e-10)
+        # Per block.
+        off = dk.blockOffsets()
+        for k in range(dk.meshDimension() + 1):
+            blk = D2[off[k]:off[k + 1], off[k]:off[k + 1]]
+            lk = L[off[k]:off[k + 1], off[k]:off[k + 1]]
+            self.assertLess(np.linalg.norm(blk - lk), 1e-10, f"block k={k}")
+        # The convenience residual agrees.
+        self.assertLess(dk.laplacianResidual(metric=True, lorentzian=False), 1e-10)
+
+    def test_square_is_block_diagonal(self):
+        """The cross-degree blocks of D^2 vanish (d^2 = delta^2 = 0)."""
+        dk = cob.DiracKahler(_tetra())
+        D2 = _square(dk, metric=True, lorentzian=False)
+        off = dk.blockOffsets()
+        offdiag = D2.copy()
+        for k in range(dk.meshDimension() + 1):
+            offdiag[off[k]:off[k + 1], off[k]:off[k + 1]] = 0.0
+        self.assertLess(np.linalg.norm(offdiag), 1e-10)
+
+    def test_lorentzian_square_is_dalembertian_blocks(self):
+        """F1 (Lorentzian): with signed weights the square reproduces the signed
+        d'Alembertian blocks (k>=1) of laplacian(k, lorentzian=True). The k=0
+        HodgeLaplacian is the Hermitian graph Laplacian (a separate operator), so
+        the d'Alembertian reproduction is over k>=1."""
+        # Two timelike edges; deterministic assignment.
+        st = _tetra({frozenset((0, 1)): -1.0, frozenset((2, 3)): -1.0})
+        dk = cob.DiracKahler(st)
+        hl = cob.HodgeLaplacian(st)
+        D2 = _square(dk, metric=True, lorentzian=True)
+        off = dk.blockOffsets()
+        for k in range(1, dk.meshDimension() + 1):
+            m = off[k + 1] - off[k]
+            lk = np.array(hl.laplacian(k, True, True)).reshape(m, m)
+            blk = D2[off[k]:off[k + 1], off[k]:off[k + 1]]
+            self.assertLess(np.linalg.norm(blk - lk), 1e-10, f"d'Alembertian k={k}")
+        self.assertLess(dk.laplacianResidual(metric=True, lorentzian=True), 1e-10)
+
+    def test_matrix_is_real(self):
+        """D = d+delta is a real operator (returned complex with zero imag)."""
+        D = _matrix(cob.DiracKahler(_tetra()))
+        self.assertLess(np.max(np.abs(D.imag)), 1e-14)
+
+    def test_layout_offsets_consistent(self):
+        dk = cob.DiracKahler(_tetra())
+        off = dk.blockOffsets()
+        self.assertEqual(off[0], 0)
+        self.assertEqual(off[-1], dk.totalDimension())
+        # Single tetra: |C_0|=4, |C_1|=6, |C_2|=4, |C_3|=1 -> total 15.
+        self.assertEqual(list(off), [0, 4, 10, 14, 15])
+        self.assertEqual(dk.totalDimension(), 15)
+
+
+# --------------------------------------------------------------------------- #
+# F2 — Clifford relations {gamma_a, gamma_b} = 2 eta_ab
+# --------------------------------------------------------------------------- #
+class TestCliffordRelations(unittest.TestCase):
+    def _check(self, lorentzian):
+        dk = cob.DiracKahler(_tetra())
+        gdim = dk.gammaDimension()
+        gammas = [np.array(g).reshape(gdim, gdim) for g in dk.gammas(lorentzian)]
+        d = dk.frameworkDimension()
+        eta = np.array(dk.signature(lorentzian)).reshape(d, d)
+        I = np.eye(gdim)
+        worst = 0.0
+        for a in range(d):
+            for b in range(d):
+                anti = gammas[a] @ gammas[b] + gammas[b] @ gammas[a]
+                worst = max(worst, np.linalg.norm(anti - 2 * eta[a, b] * I))
+        self.assertLess(worst, 1e-12)
+        # The class-reported residual agrees.
+        self.assertLess(dk.cliffordResidual(lorentzian), 1e-12)
+        return eta
+
+    def test_euclidean_clifford(self):
+        eta = self._check(lorentzian=False)
+        self.assertTrue(np.allclose(eta, np.eye(4)))
+
+    def test_lorentzian_clifford(self):
+        eta = self._check(lorentzian=True)
+        self.assertTrue(np.allclose(np.diag(eta), [-1, 1, 1, 1]))
+
+    def test_gamma_shape(self):
+        dk = cob.DiracKahler(_tetra())
+        self.assertEqual(dk.gammaDimension(), 16)  # 2^4
+        self.assertEqual(len(dk.gammas(False)), 4)  # d=4 generators
+
+
+# --------------------------------------------------------------------------- #
+# F3 — j^0 (charge density) vs the carried charge
+# --------------------------------------------------------------------------- #
+class TestChargeDensity(unittest.TestCase):
+    def test_j0_sums_to_carried_charge(self):
+        """On a closed 1-harmonic Phi (a harmonicMatrix row lifted to the total
+        space), the summed j^0 equals the harmonic's carried charge <Phi,Phi>_W.
+
+        Internal-consistency check (the deferred Gauss-law charge-density ticket,
+        #411, will tighten this to a cross-check against the period-derived
+        charge); here charge() is cross-checked against an independent weighted
+        sum using the public HodgeLaplacian.weights."""
+        st = _triangle_cycle()  # S^1, b_1 = 1
+        dk = cob.DiracKahler(st)
+        hl = cob.HodgeLaplacian(st)
+        m1 = dk.blockOffsets()[2] - dk.blockOffsets()[1]
+        hm = np.array(hl.harmonicMatrix(1)).reshape(-1, m1)
+        self.assertEqual(hm.shape[0], 1)  # b_1 = 1
+        h = hm[0]
+
+        field = dk.lift(1, list(h))
+        q = dk.charge(field)
+        # Independent weighted sum from the public weights API.
+        w1 = np.array(hl.weights(1))
+        expected = float(np.sum(w1 * np.abs(h) ** 2))
+        self.assertAlmostEqual(q, expected, delta=1e-6)
+
+        # charge() == sum(chargeDensity()).
+        dens = np.array(dk.chargeDensity(field))
+        self.assertAlmostEqual(q, float(dens.sum()), delta=1e-12)
+        # Density is nonnegative (a proper charge density) and supported on edges.
+        self.assertTrue(np.all(dens >= -1e-15))
+        off = dk.blockOffsets()
+        self.assertAlmostEqual(float(dens[:off[1]].sum()), 0.0, delta=1e-12)  # no 0-cell charge
+
+    def test_k0_harmonic_charge(self):
+        """The k=0 harmonic (constant function) carries unit charge (W_0 = I)."""
+        st = _triangle_cycle()
+        dk = cob.DiracKahler(st)
+        hl = cob.HodgeLaplacian(st)
+        n0 = dk.blockOffsets()[1]
+        hm = np.array(hl.harmonicMatrix(0)).reshape(-1, n0)
+        h = hm[0]
+        field = dk.lift(0, list(h))
+        self.assertAlmostEqual(dk.charge(field), float(np.sum(np.abs(h) ** 2)),
+                               delta=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# F4 — the 4-fold Dirac-Kahler multiplicity (anti-drift anchor)
+# --------------------------------------------------------------------------- #
+class TestMultiplicity(unittest.TestCase):
+    def test_multiplicity_is_four(self):
+        """The Dirac-Kahler doubling is exactly 4 (16 = 4x4 in 4D), the candidate
+        flavor/taste index. Pinned so a later change cannot silently alter it.
+
+        Reduced-dimension caveat: the current S^2 x I cobordism is 2+1 D, but the
+        multiplicity the operator reports is the fixed 4D framework value."""
+        dk = cob.DiracKahler(_tetra())  # mesh is 3D here; framework is 4D
+        self.assertEqual(dk.multiplicity(), 4)
+        self.assertEqual(dk.frameworkDimension(), 4)
+        self.assertEqual(dk.gammaDimension(), 16)
+        # The mesh dimension is independent of the framework multiplicity.
+        self.assertEqual(dk.meshDimension(), 3)
+
+    def test_multiplicity_independent_of_mesh(self):
+        dk1 = cob.DiracKahler(_triangle_cycle())  # 1D mesh
+        dk3 = cob.DiracKahler(_tetra())            # 3D mesh
+        self.assertEqual(dk1.multiplicity(), 4)
+        self.assertEqual(dk3.multiplicity(), 4)
+
+
+# --------------------------------------------------------------------------- #
+# G7 — determinism (the fixed complex gives reproducible objects)
+# --------------------------------------------------------------------------- #
+class TestDeterminism(unittest.TestCase):
+    def test_bit_for_bit_reproducible(self):
+        def build():
+            st = _tetra({frozenset((0, 1)): -1.0})
+            dk = cob.DiracKahler(st)
+            return (np.array(dk.matrix(True, False)),
+                    np.array(dk.square(True, False)),
+                    np.array(dk.matrix(True, True)),
+                    np.array(dk.gammas(False)[2]),
+                    np.array(dk.gammas(True)[0]))
+
+        a = build()
+        b = build()
+        for x, y in zip(a, b):
+            self.assertTrue(np.array_equal(x, y))  # bit-for-bit
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `DiracKahler`: the discrete **Dirac–Kähler operator** `D = d + δ` on the inhomogeneous cochain complex `⊕_k Ω^k` of a `Spacetime` — the label-independent square root of the `HodgeLaplacian`, and the principled **distinguished frame** the deferred operator read-out (`MergeCobordism::operatorU()`/`choiState()`) lacks. It bridges the electric-charge current `j⁰` to the candidate flavor/taste index (the 4-fold Dirac–Kähler doubling).

Closes #415. Part of #410 (the Flavor and Charge Sectors track).

## What it does

- **The operator.** `D` is assembled block-by-block from the integer boundary maps `∂_k` (`ChainComplex`) and the diagonal inner-product weights `W_k` (`HodgeLaplacian::weights`), reusing the **boundary convention the `HodgeLaplacian` already squares** (`signedLaplacian`): the boundary part `∂_k` (degree-lowering, `Ω^k→Ω^{k-1}`) and the metric codifferential `∂_k* = W_k⁻¹∂_kᵀW_{k-1}` (degree-raising, `Ω^{k-1}→Ω^k`). Because `∂² = (∂*)² = 0`, `square()` is block-diagonal per degree and reproduces the Hodge Laplacian: `(d+δ)² = L_k`.
- **`(d+δ)² = L`.** On uniform per-degree weights (the `l²=1` metric, `W_k = c_k·I`) the square matches the symmetric metric `laplacian(k, metric=True)` block-for-block over all `k`; the `lorentzian` path reproduces the signed d'Alembertian blocks (`k≥1`). `laplacianResidual()` exposes the verification. (The `k=0` `HodgeLaplacian` is the Hermitian U(1)-graph Laplacian — a separate operator — equal to the 0-form Hodge block only for unit/real weights; documented, and the signed reproduction is over `k≥1`.)
- **Clifford / gamma structure.** `gammas()` are the Clifford action of unit 1-cochains on the Kähler–Atiyah form fiber `Λ(ℝ⁴)`, `γ^a = ε(e^a) + η^{aa}ι(e^a)`, satisfying `{γ^a,γ^b} = 2η^{ab}I` **exactly** (Euclidean `δ` and Lorentzian `diag(-1,+1,+1,+1)`; `cliffordResidual ~0`). `multiplicity()` = **4** — `16 = 4_spinor × 4_taste` — the candidate flavor/taste index, pinned in the fixed 4D framework.
- **Conserved current `j⁰`.** `chargeDensity()`/`charge()` are the U(1) current's time component `j⁰ = W_c|Φ_c|²`; summed over a closed slice it integrates to the carried charge `⟨Φ,Φ⟩_W`. On a closed harmonic lifted to the total space this is the harmonic's carried charge (internal consistency; the Gauss-law charge ticket will tighten it to the period cross-check).

## Faithfulness / anti-drift

Pure addition — no change to the `HodgeLaplacian` kernel-only read-out, the register sign convention, or the topology. The class documents the reduced-dimension caveat (the current `S²×I` cobordism is 2+1 D; `D` and the `D²=L` check are generic in `n` D, while the gamma/Clifford framework and `multiplicity` report the fixed 4D values) and the deferred operator read-out frame.

## Tests

`tests/cobordism/test_dirac_kahler.py` (deterministic; uniform `l²=1`, no RNG) — **13 passed**:

- **F1** `(d+δ)² == L`: Euclidean overall + per-block `< 1e-10` (all `k`); Lorentzian d'Alembertian blocks `< 1e-10` (`k≥1`); cross-degree blocks of `D²` vanish; `D` real.
- **F2** Clifford `{γ_a,γ_b} = 2η_ab` `< 1e-12` (Euclidean and Lorentzian); `gammaDimension()==16`, 4 generators.
- **F3** `j⁰` summed over a closed slice == the carried charge `⟨Φ,Φ⟩_W` (cross-checked against an independent `HodgeLaplacian.weights` sum) `< 1e-6`; non-negative density; `#411` hook documented.
- **F4** `multiplicity() == 4` (and independent of the mesh dimension).
- **G7** determinism: build twice, bit-for-bit equal `matrix`/`square`/`gammas`.

Regression: `test_hodge_laplacian_python.py`, `test_hodge_laplacian_lorentzian_python.py`, `test_chaincomplex_python.py`, `test_proton_observables_python.py` (the G1–G5 proton invariants) all green locally (67 passed). The full suite is CI's gate.

## Notes

- C++ on classes, namespaced under `tessera::cobordism`, no free functions; new header `include/cobordism/DiracKahler.h` + impl `src/cobordism/DiracKahler.cpp`, bound in `src/cobordism/Bindings.cpp` (importable as `tessera.cobordism.DiracKahler`), with a `{doxygenfile} DiracKahler.h` entry in `docs/source/cpp_api.md` for the docs-coverage guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
