### PR TITLE
feat(cobordism): electric charge as the temporal-sector Gauss-law holonomy (#411)

### DIFF
--- a/docs/design/proton_charge_gauss_law.md
+++ b/docs/design/proton_charge_gauss_law.md
@@ -1,0 +1,176 @@
+# Electric charge as the temporal-sector Gauss-law holonomy
+
+This note reads the proton's **electric charge** off the relaxed `W_ABC` color
+singlet as a discrete **Gauss-law holonomy** `Q = ∮_S E`, and gives a verdict on
+whether fractional (multiples-of-⅓) quark charge is structurally tied to
+**triality** (the color `Z₃` the construction already carries) via the
+Gell-Mann–Nishijima relation `Q = I₃ + Y/2`.
+
+## The Gauss-law charge `Q = ∮_S E`
+
+The register read-out is **kernel-only**: the carried representative
+`ψ = carriedRepresentative(result_windows, [1, ω, ω²])` is a closed (harmonic)
+1-cochain — the discrete U(1) connection that carries the singlet target on the
+three result windows (`EigenstateSynthesis(st, 1)`). Its **field strength** is the
+exact 2-cochain
+
+```
+F = dψ = curvatureFromConnection(ψ)        (EigenstateSynthesis(st, 2))
+```
+
+`F` splits by the causal type of each plaquette (`fieldStrengthSplit`, #417): the
+**electric** part `E` lives on plaquettes carrying a timelike leg (one temporal
+index, the discrete `F_{0i}`); the **magnetic** part `B` on purely-spacelike
+plaquettes (`F_{ij}`).
+
+The **electric charge** is then **Gauss's law on the temporal sector**:
+
+```
+Q(S) = ∮_S E = Σ_{p ∈ S} (induced-orientation sign) · E(p)
+```
+
+over a **closed surface** `S = ∂V` bounding the worldtube region `V` enclosing the
+three quark windows. `EigenstateSynthesis::gaussLawCharge(F, enclosedVertices,
+electricOnly)` builds `V` as the **closed star** of the window vertices (every
+tetrahedron touching one), accumulates `∂V` as the signed boundary 2-chain
+(interior faces shared by two `V`-cells cancel under the `(-1)^j` induced
+orientation), and sums `E` (or the full `F`) over the surviving surface plaquettes.
+
+### Why `Q` is a genuine gauged-U(1) holonomy
+
+Because `F = dψ` is **exact**, the full closed-surface flux is
+
+```
+∮_S F = ⟨dψ, ∂V⟩ = ⟨ψ, ∂²V⟩ = 0
+```
+
+to round-off — the discrete coboundary `d` is **metric-free**, so the closed-surface
+flux is **topologically protected** for any metric. This is the discrete Gauss law:
+the net charge enclosed by a closed surface vanishes because the field strength is
+sourceless (the singlet is neutral). It is the *same* protection as the exact Stokes
+identity `σ_R = -(σ_A + σ_B + σ_C)` the color read-out already relies on.
+
+## Measured values (relaxed `W_ABC` singlet, uniform `l² = 1`)
+
+| quantity | value | reading |
+|---|---|---|
+| `‖F = dψ‖` | `0.189` | a genuine, nonzero field strength (sourced at the holes) |
+| timelike edges | `0` | the relaxed seed is Riemannian (2+1 D reduced) |
+| electric plaquettes | `0` | no timelike leg ⇒ the electric sector is **unpopulated** |
+| `Q = ∮_S E` | `0` (exact) | the **electric Gauss-law charge** |
+| `∮_S F` (full flux) | `4.4×10⁻¹⁷` | machine-precision **0** by genuine cancellation of nonzero `F` |
+| covector `(⅔,⅔,−⅓)·periods` | `0.48` | the **non-holonomy** baseline (a hand-weighted number) |
+| Dirac–Kähler per-window `j⁰` | `[2.225, 2.225, 2.225]` | the three quark charges are **equal** (A₄-symmetric apex, #413) |
+| Dirac–Kähler net `Σ phaseₖ·qₖ` | `2.4×10⁻⁶` | the **net** Noether charge ⇒ 0 (neutral) |
+| Dirac–Kähler total `Σ qₖ` | `6.70` | the constituent norm `⟨Φ,Φ⟩_W` (three colored quarks) |
+
+So `Q = ∮_S E = 0`: the color singlet is electrically neutral, and the reduced
+color-only geometry has **no populated temporal sector** to carry an electric field
+in the first place.
+
+### Jitter-robustness: holonomy vs covector
+
+Under `N` independent spacelike-`l²` jitter perturbations (relative magnitude
+`δ`, `numpy.random.default_rng(411)`), the protected Gauss-law `Q` stays put while
+the non-equivariant covector drifts:
+
+| `δ` | `std(∮_S F)` | `std(covector)` | `max|Δcovector|` | `std(covector)/std(∮_S F)` |
+|---|---|---|---|---|
+| `0.01` | `4.0×10⁻¹⁷` | `2.4×10⁻⁴` | `1.2×10⁻³` | `~6×10¹²` |
+| `0.10` | `2.8×10⁻¹⁷` | `9.4×10⁻³` | `2.0×10⁻²` | `~3×10¹⁴` |
+| `0.20` | `3.6×10⁻¹⁷` | `2.0×10⁻²` | `4.0×10⁻²` | `~6×10¹⁴` |
+
+`Q = ∮_S E` is **exactly 0** for every jitter (the electric sector stays empty under
+spacelike perturbations), and `∮_S F` stays at machine precision (the closed-surface
+flux of an exact form is protected). The covector — a fixed `(⅔,⅔,−⅓)` weighting of
+the per-window field-strength periods — is **not** A₄/color-`Z₃` equivariant, hence
+**not** a closed-surface flux, so it drifts by `≥ 2` orders of magnitude more. The
+period-based covector is itself a quasi-protected harmonic holonomy, so its drift
+only reaches the `~0.07` "jittered-seed" scale under a sizable perturbation
+(`δ ≈ 0.2`); the protection of `Q`, by contrast, is exact at every magnitude.
+
+### Cross-check against the Dirac–Kähler conserved current `j⁰` (#415)
+
+The Dirac–Kähler operator ships the conserved current's time component as the charge
+density `j⁰_c = W_c |Φ_c|²` (`DiracKahler::chargeDensity`), summing to the Noether
+charge `carriedCharge = ⟨Φ,Φ⟩_W` (`DiracKahler::charge`). On the carried
+representative this **equals the period read-out's weighted norm** to `9×10⁻¹⁶` —
+`j⁰` is the bona-fide conserved density of the harmonic the periods ride on.
+
+The Gauss-law flux and the Noether charge **agree on neutrality**:
+
+- The three per-window Noether charges are **equal** (`2.225` each — the A₄-symmetric
+  apex interior, #413), so the **net** charge `Σₖ phaseₖ·qₖ` weighted by the singlet
+  phases `[1, ω, ω²]` (which sum to `0`) is `2.4×10⁻⁶ ≈ 0` — the **net** Noether
+  charge of the neutral singlet, matching `Q = ∮_S E = 0`.
+- The positive **total** `carriedCharge = 6.70 = 3 × 2.225` is the constituent norm
+  (the probability/particle measure for three colored quarks), **not** the net U(1)
+  charge — it counts constituents, the neutral net is carried by the signed periods.
+
+The Gauss-law net (`0`) and the Noether net (`0`) agree; the positive total counts
+the three quarks. This is the discrete charge-conservation statement made concrete.
+
+## Verdict: triality and the fractional-(⅓)-charge link
+
+**The color-only `S²×I` geometry, as it stands, produces only the neutral total
+(`Q = 0`); it cannot produce a flavor-dependent electric charge.** Three independent
+facts pin this:
+
+1. **The electric sector is unpopulated.** The relaxed singlet is Riemannian (zero
+   timelike edges), so `fieldStrengthSplit` finds **no** electric plaquettes: the
+   field strength `F = dψ` is entirely **magnetic** (the color holonomy lives in the
+   spacelike plaquettes). The electric Gauss-law charge is therefore identically `0`
+   — there is no temporal sector for an electric field to live in. Populating `E`
+   requires genuine **Lorentzian worldlines** (timelike legs), i.e. relaxing the
+   junction on a Lorentzian metric over the symmetric apex interior (#413), and —
+   for the full `E⃗`-vector — a **3+1 D** cobordism over a triangulated `S³` (#418);
+   the present `S²×I` is a 2+1 D reduced sector (out of scope here, per #410).
+
+2. **The geometry is flavor-blind.** The construction carries **color** (the
+   `Z₃ ⊂ S₃` window-cycling `g`, `P_out` eigenvalues `{1, ω, ω²}`) and nothing else.
+   The three quark windows are **equivalent under A₄** — their Noether charges are
+   equal to `12` digits. There is no isospin / `u`-vs-`d` index to break that
+   symmetry, so the geometry assigns the windows their **color** values, never
+   distinct **flavor-electric** values (`+⅔` for `u`, `−⅓` for `d`). The
+   `(⅔,⅔,−⅓)` covector imposes exactly such a splitting **by hand**; it is not
+   A₄-equivariant, not a closed-surface flux, and drifts under jitter — the
+   numerical signature that it is **bookkeeping, not a holonomy**.
+
+3. **The triality bridge is present but not yet sourced.** Gell-Mann–Nishijima
+   `Q = I₃ + Y/2` with `Y/2 ~ baryon-number/triality` is structurally compatible
+   with this geometry: the color `Z₃` center **is** the triality the construction
+   carries, and the singlet is the definite-triality state `[1, ω, ω²]`. The
+   ⅓-quanta of quark charge are exactly the values tied to a `Z₃`/`N`-ality center.
+   But the geometry supplies **only** the `Y/2`-like (triality/baryon) factor; it has
+   **no `I₃` (weak-isospin) factor**, because there is no flavor register. With both
+   per-window charges equal and the triality phases summing to zero, the net is the
+   neutral total — the proton's `+1` (and the neutron's `0`) require the **isospin
+   splitting** `I₃ = +½` (`u`) vs `−½` (`d`) that a flavor index would provide.
+
+**What the fractional/per-flavor split requires (named precisely).** A
+flavor-dependent electric charge — `Q(uud) = +1` vs `Q(udd) = 0` — needs, in
+addition to the triality/`Z₃` already carried, **either** (a) a **flavor (isospin)
+register** parallel to color that breaks the A₄ window-equivalence and assigns
+`I₃ = ±½` per window (the `u`/`d` label, #414), **or** (b) the **Dirac–Kähler
+multiplicity** as the flavor/taste index (#414/#415) supplying the same `I₃`; and,
+to carry a *nonzero* electric field at all, **(c) Lorentzian worldlines** populating
+the electric sector, with the **full `E⃗`-vector** living on a **3+1 D `S³`** slice
+(#418). Until then `∮_S E` correctly reports the only electric quantity the geometry
+defines: the **neutral total, `Q = 0`** — robustly, as a genuine gauged-U(1)
+holonomy, in contrast to the drifting hand-weighted covector.
+
+## References
+
+- `examples/cobordism/proton_observables.py` — `gauss_law_charge`, `covector_charge`,
+  `dirac_kahler_net_charge`, and the `"charge_Q"` keys in `measure()`.
+- `include/cobordism/EigenstateSynthesis.h`, `src/cobordism/EigenstateSynthesis.cpp`
+  — `gaussLawCharge` (the `Q = ∮_S E` holonomy), `fieldStrengthSplit`,
+  `curvatureFromConnection` (#417).
+- `include/cobordism/DiracKahler.h` — `chargeDensity` / `charge` (the conserved
+  current `j⁰`, #415).
+- `docs/design/proton_electroweak_finding.md` — net-orientation = color flux; charge
+  needs flavor (the prior conclusion this note refines).
+- `docs/design/proton_bipartite_obstruction.tex` — triality, `ψ = (1, ω, ω²)`,
+  `Z₃ ⊂ S₃`.
+- `tests/cobordism/test_proton_charge_gauss_law.py` — the robustness, quantization,
+  determinism, cross-check, and regression-guard tests.

--- a/docs/design/proton_charge_gauss_law.md
+++ b/docs/design/proton_charge_gauss_law.md
@@ -55,7 +55,7 @@ identity `σ_R = -(σ_A + σ_B + σ_C)` the color read-out already relies on.
 | quantity | value | reading |
 |---|---|---|
 | `‖F = dψ‖` | `0.189` | a genuine, nonzero field strength (sourced at the holes) |
-| timelike edges | `0` | the relaxed seed is Riemannian (2+1 D reduced) |
+| timelike edges | `0` | the relaxed seed is Riemannian (all spacelike) — set Lorentzian worldlines to populate `E` |
 | electric plaquettes | `0` | no timelike leg ⇒ the electric sector is **unpopulated** |
 | `Q = ∮_S E` | `0` (exact) | the **electric Gauss-law charge** |
 | `∮_S F` (full flux) | `4.4×10⁻¹⁷` | machine-precision **0** by genuine cancellation of nonzero `F` |
@@ -122,9 +122,11 @@ facts pin this:
    spacelike plaquettes). The electric Gauss-law charge is therefore identically `0`
    — there is no temporal sector for an electric field to live in. Populating `E`
    requires genuine **Lorentzian worldlines** (timelike legs), i.e. relaxing the
-   junction on a Lorentzian metric over the symmetric apex interior (#413), and —
-   for the full `E⃗`-vector — a **3+1 D** cobordism over a triangulated `S³` (#418);
-   the present `S²×I` is a 2+1 D reduced sector (out of scope here, per #410).
+   junction on a Lorentzian metric over the symmetric apex interior (#413) — a metric
+   choice, not a dimensional one. The full `E⃗`-vector lives in the **full emergent
+   dimension**, reached by generalizing the apex interior via coface-mirroring (#429,
+   the dimension-generic / `S³` build), **not** by a reduced 2+1 D sector: the program
+   is emergent and reducing dimension changes the physics.
 
 2. **The geometry is flavor-blind.** The construction carries **color** (the
    `Z₃ ⊂ S₃` window-cycling `g`, `P_out` eigenvalues `{1, ω, ω²}`) and nothing else.
@@ -142,7 +144,9 @@ facts pin this:
    carries, and the singlet is the definite-triality state `[1, ω, ω²]`. The
    ⅓-quanta of quark charge are exactly the values tied to a `Z₃`/`N`-ality center.
    But the geometry supplies **only** the `Y/2`-like (triality/baryon) factor; it has
-   **no `I₃` (weak-isospin) factor**, because there is no flavor register. With both
+   **no `I₃` (weak-isospin) factor** yet — the geometry carries only color/triality.
+   That `I₃` index is the flavor work of #414 (the spatio-temporal split or the
+   Dirac–Kähler taste multiplicity), **not** a parallel flavor register. With both
    per-window charges equal and the triality phases summing to zero, the net is the
    neutral total — the proton's `+1` (and the neutron's `0`) require the **isospin
    splitting** `I₃ = +½` (`u`) vs `−½` (`d`) that a flavor index would provide.

--- a/examples/cobordism/proton_observables.py
+++ b/examples/cobordism/proton_observables.py
@@ -171,6 +171,78 @@ def shell_deficit(st, seed_vertices):
     return float(sum(shells.values())), shells
 
 
+# --- electric charge: the temporal-sector Gauss-law holonomy (#411) ---
+# Q = oint_S E reads electric charge as a discrete Gauss law on the electric part of
+# the field strength F = d psi (E = plaquettes with a timelike leg, #417), summed over
+# a closed surface S enclosing the quark windows. A closed-surface flux of an exact F
+# is topologically protected (oint d psi = <psi, d^2 V> = 0), so Q is a genuine gauged-
+# U(1) holonomy -- metric-robust like the color charge sigma -- unlike the hand-weighted
+# (2/3, 2/3, -1/3) flavor covector, which is not A4/color-Z3 equivariant and drifts.
+_FLAVOR_COVECTOR = (2.0 / 3.0, 2.0 / 3.0, -1.0 / 3.0)  # (u, u, d): the NON-equivariant baseline
+
+
+def _carried_singlet(m):
+    """The carried representative psi -- the kernel (closed) 1-cochain U(1) connection
+    of the color singlet [1, w, w^2] pinned on the result windows. The field strength
+    F = d psi (its E/B split, and the Gauss-law Q) is read off this."""
+    es1 = cob.EigenstateSynthesis(m.cobordism, 1)
+    result = [list(h) for h in _windows(m)[3]]
+    return es1, np.array(es1.carriedRepresentative(result, [1.0, _W, _W * _W]))
+
+
+def gauss_law_charge(m):
+    """Electric charge Q = oint_S E, the temporal-sector Gauss-law holonomy (#411): the
+    orientation-signed sum of the ELECTRIC part of F = d psi over the closed surface S
+    bounding the worldtube of the three quark windows. Returns (Q_electric, Q_full):
+    Q_full = oint_S F is the full closed-surface flux (0 to round-off, the topological
+    protection); Q_electric restricts to the timelike-leg plaquettes (exactly 0 on the
+    all-spacelike reduced geometry -- the neutral total of the color-only sector)."""
+    es1, psi = _carried_singlet(m)
+    es2 = cob.EigenstateSynthesis(m.cobordism, 2)
+    F = list(es2.curvatureFromConnection(list(psi)))
+    enclosed = sorted(set(v for w in _windows(m)[:3] for h in w for v in h))
+    return es2.gaussLawCharge(F, enclosed, True), es2.gaussLawCharge(F, enclosed, False)
+
+
+def covector_charge(m):
+    """The NON-HOLONOMY baseline (CONTRAST ONLY): a fixed (2/3, 2/3, -1/3) flavor
+    covector dotted into the three quark windows' field-strength periods. Not
+    A4/color-Z3 equivariant, hence not a closed-surface flux -- it drifts under metric
+    jitter where the Gauss-law Q stays protected. It is NOT a charge the geometry
+    carries; it exists to make the robustness contrast measurable."""
+    es1, psi = _carried_singlet(m)
+    edge = {(min(c), max(c)): i
+            for i, c in enumerate(es1.cellSimplices()) if len(c) == 2}
+
+    def period(h):
+        a, b, c = h
+        return psi[edge[(a, b)]] + psi[edge[(b, c)]] - psi[edge[(a, c)]]
+
+    windows = _windows(m)[:3]  # the three quark windows (each three holes)
+    return sum(_FLAVOR_COVECTOR[i] * sum(period(h) for h in win)
+               for i, win in enumerate(windows))
+
+
+def dirac_kahler_net_charge(m):
+    """The conserved Dirac-Kahler (Noether) charge cross-check (#415): the per-window
+    j^0 charges weighted by the singlet phases [1, w, w^2]. The three quark charges are
+    equal (the A4-symmetric apex interior, #413), so the net Sum_k phase_k * q_k -> 0 --
+    agreeing with the Gauss-law flux Q. The (positive) total carriedCharge Sum_k q_k is
+    the constituent norm (three colored quarks), NOT the net. Returns (net, total)."""
+    es1 = cob.EigenstateSynthesis(m.cobordism, 1)
+    dk = cob.DiracKahler(m.cobordism)
+    result = [list(h) for h in _windows(m)[3]]
+    phases = [1.0, _W, _W * _W]
+    qk = []
+    for k in range(3):
+        target = [0.0, 0.0, 0.0]
+        target[k] = 1.0
+        psik = es1.carriedRepresentative(result, target)
+        qk.append(dk.charge(dk.lift(1, list(psik))))
+    net = sum(phases[k] * qk[k] for k in range(3))
+    return net, float(sum(qk))
+
+
 def measure(max_iters=80):
     """Build the symmetric junction, pin the omega-rep proton input, relax, and read
     the emergent observables off the relaxed geometry. Returns a dict."""
@@ -195,9 +267,18 @@ def measure(max_iters=80):
     mass_a = abs(m.stats.dual_action)
     quark_holes = set(v for w in _windows(m)[:3] for h in w for v in h)
     mass_b, shells = shell_deficit(m.cobordism, quark_holes)
+
+    # electric charge: the temporal-sector Gauss-law holonomy (#411).
+    q_e, q_f = gauss_law_charge(m)
+    dk_net, dk_total = dirac_kahler_net_charge(m)
     return {
         "sigma": _proj(v_charge, result),          # color charge (singlet => 0)
         "singlet": _proj(v_singlet, result),       # the proton (=> 1)
+        "charge_Q": abs(q_e),                      # electric Gauss-law charge oint_S E
+        "charge_flux": abs(q_f),                   # full closed-surface flux (the protection)
+        "charge_covector": abs(covector_charge(m)),  # NON-holonomy baseline (drifts)
+        "charge_dk_net": abs(dk_net),              # net Dirac-Kahler charge (=> 0, neutral)
+        "charge_dk_total": dk_total,               # constituent norm (three quarks)
         "radius": r, "n_spacelike": n_sp, "n_timelike": n_tl,
         "mass_a": mass_a, "mass_b": mass_b, "shells": shells,
         "rm_a": r * mass_a, "rm_b": r * mass_b,    # anchor on B
@@ -212,6 +293,12 @@ def main():
     print("color (the result emerges from the symmetric quark input, never pinned):")
     print(f"  color charge sigma = {o['sigma']:.3e}   (confinement: singlet => 0)")
     print(f"  singlet component  = {o['singlet']:.4f}   (the proton)")
+    print(f"\nelectric charge (the temporal-sector Gauss-law holonomy, #411):")
+    print(f"  Q = oint_S E       = {o['charge_Q']:.3e}   (electric Gauss-law charge; neutral total)")
+    print(f"  oint_S F (full)    = {o['charge_flux']:.3e}   (closed-surface flux: the protection => 0)")
+    print(f"  covector baseline  = {o['charge_covector']:.4f}   (NON-holonomy (2/3,2/3,-1/3); drifts)")
+    print(f"  Dirac-Kahler j^0   net={o['charge_dk_net']:.3e}  total={o['charge_dk_total']:.4f}"
+          f"   (Noether: net=>0 neutral, total=constituents)")
     print(f"\nradius:")
     print(f"  r = sqrt(mean(l^2>0)) = {o['radius']:.4f}   "
           f"({o['n_spacelike']} spacelike, {o['n_timelike']} timelike/null edges)")

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -624,6 +624,30 @@ class EigenstateSynthesis {
     [[nodiscard]] std::vector<std::complex<double>> curvatureFromConnection(
         const std::vector<std::complex<double>> &A) const;
 
+    /// The discrete Gauss-law charge \f$ Q = \oint_S E \f$: the temporal-sector
+    /// flux of the field-strength 2-cochain `F` through the closed surface
+    /// \f$ S = \partial V \f$ bounding the worldtube region `V` of the
+    /// `enclosedVertices` (the quark windows). `V` is the closed star — every
+    /// degree-3 cell (tetrahedron) touching an enclosed vertex — and `S` its
+    /// boundary 2-chain (interior faces shared by two `V`-cells cancel under the
+    /// induced \f$ (-1)^j \f$ orientation, leaving the enclosing surface). `Q` is
+    /// the orientation-signed sum of `F` over `S`, restricted to the ELECTRIC
+    /// plaquettes (a timelike leg, the discrete \f$ F_{0i} \f$; `fieldStrengthSplit`'s
+    /// `electricCells`) when `electricOnly`, else the full flux. Because
+    /// \f$ F = d\psi \f$ is exact, the full flux is \f$ \langle d\psi, \partial V\rangle
+    /// = \langle \psi, \partial^2 V\rangle = 0 \f$ to round-off — the topological
+    /// protection (metric-free \f$ d \f$): a genuine gauged-U(1) holonomy that does
+    /// not drift under metric jitter, unlike a hand-weighted flavor covector. On an
+    /// all-spacelike (Riemannian) complex no plaquette is electric, so the electric
+    /// `Q` is exactly `0` (the neutral total of the reduced color-only sector). A
+    /// degree-2 read-out: it classifies cells by `Edge::isTimelike()` and sums a
+    /// supplied `F`, never mutating geometry.
+    /// @throws std::runtime_error if `degree() != 2` or `F.size() != order()`.
+    [[nodiscard]] std::complex<double> gaussLawCharge(
+        const std::vector<std::complex<double>> &F,
+        const std::vector<std::uint64_t> &enclosedVertices,
+        bool electricOnly = true) const;
+
   private:
     std::shared_ptr<Spacetime> st_;
     int k_{0};  // the Hodge degree of L_k that apply()/residual() score against

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -739,7 +739,21 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "index lists into cellSimplices(). A plaquette is electric iff any of "
            "its three edges is Edge.isTimelike() on the live complex. Raises if "
            "degree() != 2, if len(F) != order(), or if a plaquette edge is "
-           "missing.");
+           "missing.")
+      .def("gaussLawCharge", &EigenstateSynthesis::gaussLawCharge, py::arg("F"),
+           py::arg("enclosedVertices"), py::arg("electricOnly") = true,
+           "The discrete Gauss-law charge Q = oint_S E (#411): the temporal-sector "
+           "flux of a field-strength 2-cochain F through the closed surface S = dV "
+           "bounding the worldtube V (the closed star of enclosedVertices, the quark "
+           "windows). Sums F over S's plaquettes with their induced (-1)^j "
+           "orientation (interior faces of V cancel), restricted to the ELECTRIC "
+           "(timelike-leg, F_{0i}) plaquettes when electricOnly, else the full flux. "
+           "For an exact F = d psi the full flux is <psi, d^2 V> = 0 to round-off -- "
+           "the topological protection that makes Q a metric-robust gauged-U(1) "
+           "holonomy (unlike a hand-weighted flavor covector). On an all-spacelike "
+           "(Riemannian) complex no plaquette is electric, so the electric Q is "
+           "exactly 0 (the neutral total of the reduced color-only sector). Raises "
+           "if degree() != 2 or len(F) != order().");
 
   // The result of fieldStrengthSplit (#417): the E/B partition of F in Omega^2.
   py::class_<EigenstateSynthesis::FieldStrengthSplit>(

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1088,6 +1088,73 @@ EigenstateSynthesis::FieldStrengthSplit EigenstateSynthesis::fieldStrengthSplit(
   return split;
 }
 
+cd EigenstateSynthesis::gaussLawCharge(
+    const std::vector<cd> &F, const std::vector<std::uint64_t> &enclosedVertices,
+    bool electricOnly) const {
+  if (k_ != 2)
+    throw std::runtime_error(
+        "EigenstateSynthesis::gaussLawCharge: requires a degree-2 instance (the "
+        "field strength F is a 2-cochain); this instance is degree " +
+        std::to_string(k_));
+  if (F.size() != order_)
+    throw std::runtime_error(
+        "EigenstateSynthesis::gaussLawCharge: F has " +
+        std::to_string(F.size()) + " components; the degree-2 operator has " +
+        std::to_string(order_) + " cells");
+
+  // The electric (timelike-leg) plaquettes — the same E/B causal split #417
+  // delivers, so Q lives on the same temporal sector. magnetic-only Q (the full
+  // flux on an all-spacelike complex) is recovered with electricOnly = false.
+  const FieldStrengthSplit split = fieldStrengthSplit(F);
+  const std::set<std::size_t> electric(split.electricCells.begin(),
+                                       split.electricCells.end());
+
+  // Sorted 2-cell tuple -> its component index, so a boundary face of an
+  // enclosed tetrahedron maps back to its F entry.
+  std::map<std::vector<std::uint64_t>, std::size_t> faceIdx;
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i)
+    faceIdx[cellOrdering_[i]] = i;
+
+  const std::set<std::uint64_t> enclosed(enclosedVertices.begin(),
+                                         enclosedVertices.end());
+
+  // V = the closed star of the enclosed vertices (every tetrahedron touching
+  // one). S = boundary 2-chain dV: accumulate each enclosed tetrahedron's four
+  // (-1)^j-signed faces; faces interior to V (shared by two V-cells with
+  // opposite induced orientation) cancel, leaving the enclosing surface.
+  const auto tets = ChainComplex::fromSpacetime(*st_).kSimplexVertices(3);
+  std::map<std::vector<std::uint64_t>, double> boundary;
+  for (const auto &tet : tets) {
+    if (tet.size() != 4) continue;
+    bool touches = false;
+    for (const std::uint64_t v : tet)
+      if (enclosed.count(v)) {
+        touches = true;
+        break;
+      }
+    if (!touches) continue;
+    for (int j = 0; j < 4; ++j) {  // drop vertex j carries (-1)^j; tet sorted
+      std::vector<std::uint64_t> face;
+      face.reserve(3);
+      for (int q = 0; q < 4; ++q)
+        if (q != j) face.push_back(tet[static_cast<std::size_t>(q)]);
+      boundary[face] += (j % 2 == 0) ? 1.0 : -1.0;
+    }
+  }
+
+  // Q = sum over the surviving surface plaquettes of the orientation-signed F,
+  // restricted to the electric (temporal-sector) plaquettes when asked.
+  cd Q(0.0, 0.0);
+  for (const auto &[face, coeff] : boundary) {
+    if (std::abs(coeff) < 1e-12) continue;  // interior face, cancelled
+    const auto it = faceIdx.find(face);
+    if (it == faceIdx.end()) continue;
+    if (electricOnly && electric.find(it->second) == electric.end()) continue;
+    Q += coeff * F[it->second];
+  }
+  return Q;
+}
+
 std::vector<cd> EigenstateSynthesis::carriedFromReadout(
     const RegisterReadout &ro, const std::vector<cd> &targetPeriods) const {
   const std::size_t n = order_;

--- a/tests/cobordism/test_epic410_invariants.py
+++ b/tests/cobordism/test_epic410_invariants.py
@@ -1,0 +1,80 @@
+"""Shared regression guard for the charge/flavor-sector epic (#410).
+
+Every PR in the epic must keep this module green -- it pins the proton invariants
+G1-G5 so a later subtask cannot silently drift an earlier result. The build is the
+emergent relaxed `W_ABC` color singlet (`examples/cobordism/proton_observables.py`
+`measure()`), read off the relaxed geometry (never hand-placed).
+
+- G1  singlet overlap >= 0.999  (the proton emerges)
+- G2  color charge sigma -> 0   (confinement)
+- G3  charge conservation: the closed-surface field-strength flux (the discrete
+      Stokes holonomy) vanishes to round-off
+- G4  topology: b1 == 11 and dualComplexValid  (no smuggled holes/registers)
+- G5  color Z3 intact: P_out eigenvalues are {1, w, w^2}
+"""
+
+import cmath
+import os
+import sys
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+_W = cmath.exp(2j * cmath.pi / 3)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..",
+                                "examples", "cobordism"))
+import proton_observables as P  # noqa: E402
+
+_RELAX = 25
+
+
+def _build(max_iters=_RELAX):
+    seed = cob.TransportCobordism([[1, -1, 0], [1, 0, -1], [0, 1, -1]],
+                                  max_iters=0, seed=0,
+                                  topology=cob.TripartiteRegisterTopology())
+    states = P._omega_rep_input(P._windows(seed))
+    return cob.TransportCobordism(states, max_iters=max_iters, seed=0,
+                                  topology=cob.TripartiteRegisterTopology())
+
+
+class Epic410InvariantsTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.o = P.measure(max_iters=_RELAX)
+        cls.m = _build()
+
+    def test_G1_singlet_emerges(self):
+        self.assertGreaterEqual(self.o["singlet"], 0.999)
+
+    def test_G2_color_charge_confined(self):
+        self.assertLessEqual(self.o["sigma"], 0.06)
+
+    def test_G3_charge_conservation_stokes_holonomy(self):
+        # The full closed-surface field-strength flux oint_S F = <psi, d^2 V> = 0:
+        # the discrete Stokes / charge-conservation holonomy, exact to round-off.
+        self.assertLessEqual(self.o["charge_flux"], 1e-6)
+        # the net Dirac-Kahler (Noether) charge is likewise 0 (neutral singlet).
+        self.assertLessEqual(self.o["charge_dk_net"], 1e-4)
+
+    def test_G4_topology_unchanged(self):
+        cc = cob.ChainComplex.fromSpacetime(self.m.cobordism)
+        self.assertEqual(list(cc.bettiNumbers())[1], 11)  # b1 == 11, no new holes
+        valid, _msg = cob.EigenstateSynthesis(self.m.cobordism, 1).dualComplexValid()
+        self.assertTrue(valid)
+
+    def test_G5_color_z3_spectrum_intact(self):
+        _p_in, p_out = P._window_cycle_rep(P._windows(self.m))
+        eigs = np.linalg.eigvals(p_out)
+        angles = sorted(float(np.angle(e)) for e in eigs)
+        expected = sorted([0.0, 2 * np.pi / 3, -2 * np.pi / 3])
+        for got, exp in zip(angles, expected):
+            self.assertAlmostEqual(got, exp, delta=1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_proton_charge_gauss_law.py
+++ b/tests/cobordism/test_proton_charge_gauss_law.py
@@ -1,0 +1,179 @@
+"""Electric charge as the temporal-sector Gauss-law holonomy (#411).
+
+`Q = oint_S E` reads electric charge as a discrete Gauss law on the electric part
+of the field strength `F = d psi` (`EigenstateSynthesis.gaussLawCharge`), summed
+over a closed surface `S` enclosing the quark windows. The claim under test: `Q` is
+a genuine gauged-U(1) holonomy -- quantized and metric-robust, like the color charge
+sigma -- whereas the hand-weighted `(2/3, 2/3, -1/3)` flavor covector is not
+A4/color-Z3 equivariant and drifts under metric jitter.
+
+All randomness uses a FIXED seed (`numpy.random.default_rng(411)`); the build is the
+existing relaxed `W_ABC` color singlet, read OFF the relaxed geometry (never
+hand-placed). See `docs/design/proton_charge_gauss_law.md`.
+"""
+
+import cmath
+import os
+import sys
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+_W = cmath.exp(2j * cmath.pi / 3)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..",
+                                "examples", "cobordism"))
+import proton_observables as P  # noqa: E402
+
+_RELAX = 25     # short relax keeps the test quick; the reading is under test
+_N_JIT = 16     # independent jitter seeds (F1/F2)
+_MAG = 0.20     # relative spacelike-l^2 jitter magnitude
+
+
+def _build(max_iters=_RELAX):
+    seed = cob.TransportCobordism([[1, -1, 0], [1, 0, -1], [0, 1, -1]],
+                                  max_iters=0, seed=0,
+                                  topology=cob.TripartiteRegisterTopology())
+    states = P._omega_rep_input(P._windows(seed))
+    return cob.TransportCobordism(states, max_iters=max_iters, seed=0,
+                                  topology=cob.TripartiteRegisterTopology())
+
+
+def _read(m):
+    """One carried representative -> (Q_electric, Q_full, covector), off the LIVE
+    metric (exercises the shipped `gaussLawCharge` C++ method)."""
+    es1 = cob.EigenstateSynthesis(m.cobordism, 1)
+    es2 = cob.EigenstateSynthesis(m.cobordism, 2)
+    result = [list(h) for h in P._windows(m)[3]]
+    psi = np.array(es1.carriedRepresentative(result, [1.0, _W, _W * _W]))
+    F = list(es2.curvatureFromConnection(list(psi)))
+    enclosed = sorted(set(v for w in P._windows(m)[:3] for h in w for v in h))
+    q_e = es2.gaussLawCharge(F, enclosed, True)
+    q_f = es2.gaussLawCharge(F, enclosed, False)
+    edge = {(min(c), max(c)): i
+            for i, c in enumerate(es1.cellSimplices()) if len(c) == 2}
+
+    def period(h):
+        a, b, c = h
+        return psi[edge[(a, b)]] + psi[edge[(b, c)]] - psi[edge[(a, c)]]
+
+    cov = sum(P._FLAVOR_COVECTOR[i] * sum(period(h) for h in win)
+              for i, win in enumerate(P._windows(m)[:3]))
+    return q_e, q_f, cov
+
+
+def _jitter_sweep(m, n=_N_JIT, mag=_MAG):
+    """N independent jitter perturbations of the spacelike l^2 metric, restoring to
+    the pristine metric between each. Returns (Q_E, Q_F, covector) arrays."""
+    evec = m.cobordism.getEdgeList().toVector()
+    l0 = [e.getSquaredLength() for e in evec]
+    rng = np.random.default_rng(411)
+    qe, qf, cov = [], [], []
+    for _ in range(n):
+        for e in evec:
+            v = e.getSquaredLength()
+            if v.real > 0:
+                nv = v.real * (1.0 + rng.normal(0.0, mag))
+                if nv > 0:
+                    e.setSquaredLength(nv)
+        a, b, c = _read(m)
+        qe.append(a)
+        qf.append(b)
+        cov.append(c)
+        for e, v in zip(evec, l0):  # restore the pristine metric
+            e.setSquaredLength(v)
+    return np.array(qe), np.array(qf), np.array(cov)
+
+
+class ProtonChargeGaussLawTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.m = _build()
+        # uniform-metric readings, through the SHIPPED helpers.
+        cls.Q_uniform, cls.QF_uniform = P.gauss_law_charge(cls.m)
+        cls.C_uniform = P.covector_charge(cls.m)
+        cls.dk_net, cls.dk_total = P.dirac_kahler_net_charge(cls.m)
+        # the F1/F2 jitter sweep (restores the metric afterwards).
+        cls.Qe_jit, cls.Qf_jit, cls.C_jit = _jitter_sweep(cls.m)
+
+    # --- F1: Q is metric-ROBUST (the headline claim) ---
+    def test_F1_gauss_charge_is_metric_robust(self):
+        # The electric Gauss charge is exactly 0 for every jitter (no temporal
+        # sector to populate E under spacelike perturbations).
+        self.assertLessEqual(float(np.std(np.abs(self.Qe_jit))), 1e-9)
+        self.assertLessEqual(
+            float(np.max(np.abs(self.Qe_jit - self.Q_uniform))), 1e-9)
+        # The full closed-surface flux is the topological protection: <psi,d^2 V>=0
+        # to round-off, robust under metric jitter (the genuine cancellation of a
+        # NONzero field strength).
+        self.assertLessEqual(float(np.std(np.abs(self.Qf_jit))), 1e-3)
+        self.assertLessEqual(
+            float(np.max(np.abs(self.Qf_jit - self.QF_uniform))), 1e-3)
+
+    # --- F2: the covector baseline DRIFTS (the contrast that makes F1 meaningful) ---
+    def test_F2_covector_baseline_drifts(self):
+        std_c = float(np.std(np.abs(self.C_jit)))
+        max_dev = float(np.max(np.abs(self.C_jit - self.C_uniform)))
+        self.assertGreaterEqual(std_c, 1e-2)        # the covector genuinely drifts
+        self.assertGreaterEqual(max_dev, 2e-2)      # reaching the ~0.07 jittered scale
+        # the separation: the holonomy is protected, the covector is not.
+        std_q = max(float(np.std(np.abs(self.Qf_jit))), 1e-12)
+        self.assertGreaterEqual(std_c / std_q, 100.0)
+
+    # --- F3: Q equals the neutral total on the singlet ---
+    def test_F3_gauss_charge_is_the_neutral_total(self):
+        Q_EXPECTED = 0.0  # flavor-blind S^2 x I sees only the neutral total
+        self.assertLessEqual(abs(abs(self.Q_uniform) - Q_EXPECTED), 1e-6)
+
+    # --- F4: Q is quantized (integer / third-integer lattice) ---
+    def test_F4_gauss_charge_is_quantized(self):
+        q = abs(self.Q_uniform)
+        self.assertLessEqual(abs(q - round(3.0 * q) / 3.0), 1e-6)
+
+    # --- F5: determinism (G7) ---
+    def test_F5_determinism(self):
+        q1, qf1, c1 = _jitter_sweep(self.m)
+        q2, qf2, c2 = _jitter_sweep(self.m)
+        self.assertTrue(np.array_equal(q1, q2))
+        self.assertTrue(np.array_equal(qf1, qf2))
+        self.assertTrue(np.array_equal(c1, c2))
+        # the uniform reading is reproducible too.
+        q_e, q_f = P.gauss_law_charge(self.m)
+        self.assertEqual(q_e, self.Q_uniform)
+        self.assertEqual(q_f, self.QF_uniform)
+
+    # --- required cross-check: Q == Dirac-Kahler j^0 / carriedCharge (#415) ---
+    def test_gauss_flux_agrees_with_dirac_kahler_current(self):
+        # The NET Dirac-Kahler (Noether) charge of the neutral singlet is 0 -- the
+        # three per-window j^0 charges are equal (A4-symmetric apex) and the singlet
+        # phases [1, w, w^2] sum to 0 -- agreeing with the Gauss-law flux Q = 0.
+        self.assertLessEqual(abs(self.dk_net), 1e-4)
+        self.assertLessEqual(abs(abs(self.Q_uniform) - abs(self.dk_net)), 1e-4)
+        # The positive TOTAL carriedCharge is the constituent norm (three quarks),
+        # NOT the net -- it counts |Phi|^2, the neutral net is carried by the signed
+        # periods.
+        self.assertGreater(self.dk_total, 1.0)
+        # j^0 is the bona-fide conserved density: charge(lift(psi)) == the period
+        # read-out's weighted norm Sum_e W_e |psi_e|^2 (HodgeLaplacian.weights).
+        es1 = cob.EigenstateSynthesis(self.m.cobordism, 1)
+        hl = cob.HodgeLaplacian(self.m.cobordism)
+        dk = cob.DiracKahler(self.m.cobordism)
+        psi = np.array(es1.carriedRepresentative(
+            [list(h) for h in P._windows(self.m)[3]], [1.0, _W, _W * _W]))
+        q_noether = dk.charge(dk.lift(1, list(psi)))
+        w_norm = float(np.sum(np.array(hl.weights(1)) * np.abs(psi) ** 2))
+        self.assertAlmostEqual(q_noether, w_norm, delta=1e-9)
+
+    # --- charge conservation (no net source on the closed surface) ---
+    def test_charge_conservation_closed_surface_flux_vanishes(self):
+        # oint_S F = <d psi, d V> = <psi, d^2 V> = 0: the net charge enclosed by the
+        # closed worldtube boundary vanishes (the neutral singlet is sourceless).
+        self.assertLessEqual(abs(self.QF_uniform), 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #411.

## Electric charge as the temporal-sector Gauss-law holonomy

Reads the proton's electric charge emergent-first as a discrete Gauss-law holonomy
`Q = ∮_S E`: `EigenstateSynthesis::gaussLawCharge(F, enclosedVertices, electricOnly)`
sums the **electric** (timelike-leg, #417 `fieldStrengthSplit`) part of the field
strength `F = dψ` over the closed surface `S = ∂V` bounding the worldtube of the three
quark windows (the closed star of the window vertices; interior faces cancel under the
induced `(-1)^j` orientation).

Because `F = dψ` is exact, the full closed-surface flux is `⟨dψ, ∂V⟩ = ⟨ψ, ∂²V⟩ = 0`
to round-off — a genuine, topologically-protected gauged-U(1) holonomy (metric-free
`d`), in contrast to a hand-weighted flavor covector.

### Measured (relaxed `W_ABC` singlet, uniform `l²=1`)

| quantity | value | reading |
|---|---|---|
| `‖F = dψ‖` | `0.189` | a genuine, nonzero field strength |
| timelike edges / electric plaquettes | `0` / `0` | the reduced sector is all-spacelike |
| `Q = ∮_S E` | `0` (exact) | the electric Gauss-law charge (neutral total) |
| `∮_S F` (full flux) | `~5e-17` | machine-zero by genuine cancellation |
| covector `(⅔,⅔,−⅓)·periods` | `0.48` | the non-holonomy baseline |
| Dirac–Kähler per-window `j⁰` | `[2.225, 2.225, 2.225]` | equal (A₄-symmetric apex, #413) |
| Dirac–Kähler net `Σ phaseₖ·qₖ` | `~2e-6` | net Noether charge ⇒ 0 (neutral) |
| Dirac–Kähler total | `6.70` | constituent norm (three quarks) |

**Jitter robustness** (`numpy.random.default_rng(411)`, 16 seeds, `δ=0.2`):
`std(∮_S F) ~ 4e-17` (protected) vs `std(covector) ~ 0.02`, `max|Δcovector| ~ 0.04`
— a separation of `~10¹⁴` (≫ the ≥100 acceptance criterion).

### Required cross-check (#415)

`Q = ∮_S E` agrees with the Dirac–Kähler conserved current `j⁰`: the three per-window
Noether charges are equal, so the **net** `Σ phaseₖ·qₖ ⇒ 0`, matching `Q = 0`; the
positive **total** `carriedCharge = ⟨Φ,Φ⟩_W` is the constituent norm (not the net).
`charge(lift(ψ))` equals the period read-out's weighted norm to `9e-16` — `j⁰` is the
bona-fide conserved density.

### Verdict (design note)

The color-only `S²×I` (2+1 D reduced, flavor-blind) geometry produces **only the
neutral total** (`Q = 0`). A flavor-dependent electric charge needs, beyond the
triality/`Z₃` already carried, a **flavor (isospin) register** (or the Dirac–Kähler
multiplicity) supplying `I₃`, plus **Lorentzian worldlines** to populate the electric
sector (full `E⃗` on a 3+1 D `S³`, #418). The `(⅔,⅔,−⅓)` covector imposes that splitting
by hand and is not a holonomy — it drifts. See `docs/design/proton_charge_gauss_law.md`.

### Deliverables
- `EigenstateSynthesis::gaussLawCharge` (C++, on the existing observable class) + binding.
- `gauss_law_charge` / `covector_charge` / `dirac_kahler_net_charge` helpers and the
  `charge_Q` keys in `proton_observables.measure()`.
- `docs/design/proton_charge_gauss_law.md` (definition, robustness table, triality verdict).
- `tests/cobordism/test_proton_charge_gauss_law.py` (F1–F5 + DK cross-check + conservation).
- `tests/cobordism/test_epic410_invariants.py` (shared G1–G5 regression guard).

### Tests (throwaway-venv build, green)
`19 passed` — 7 charge (F1–F5, DK cross-check, conservation) + 5 epic-410 invariants
(G1–G5) + 7 proton observables; `24 passed` siblings (`test_field_strength_split`,
`test_dirac_kahler`) — no regression.
