### PR TITLE
feat(cobordism): flavor without a register — spatio-temporal split / Dirac–Kähler taste as the u/d label (#414)

### DIFF
--- a/docs/design/proton_flavor_split.md
+++ b/docs/design/proton_flavor_split.md
@@ -1,0 +1,14 @@
+# Flavor as a split of the existing register (not a parallel register)
+
+*Investigation (#414, epic #410).* Can the `u`/`d` flavor label — the isospin index
+that separates the proton (`uud`, `Q = +1`) from the neutron (`udd`, `Q = 0`) — be
+read off the **existing** `W_ABC` geometry as a **split of the register it already
+carries**, rather than a parallel flavor *hole register* (explicitly rejected)? Two
+candidate splits are tested:
+
+- **(i) the spatio-temporal split** — separate each window's transport by the causal
+  type (timelike / cross-layer vs spacelike / within-layer) of the edges it rides on;
+- **(ii) the Dirac–Kähler taste multiplicity** — the `4`-fold taste degeneracy of the
+  discrete Dirac operator `D = d + δ` as the flavor index.
+
+*(stub — measured numbers and the verdict follow once the prototype is run.)*

--- a/docs/design/proton_flavor_split.md
+++ b/docs/design/proton_flavor_split.md
@@ -1,14 +1,169 @@
-# Flavor as a split of the existing register (not a parallel register)
+<!-- Copyright (c) 2026 Twin Vector Labs LLC. All rights reserved. -->
+
+# Flavor as a split of the existing register — the negative result
 
 *Investigation (#414, epic #410).* Can the `u`/`d` flavor label — the isospin index
 that separates the proton (`uud`, `Q = +1`) from the neutron (`udd`, `Q = 0`) — be
 read off the **existing** `W_ABC` geometry as a **split of the register it already
 carries**, rather than a parallel flavor *hole register* (explicitly rejected)? Two
-candidate splits are tested:
+candidate splits are tested, both read **off the relaxed geometry**, per input window
+(A, B, C):
 
 - **(i) the spatio-temporal split** — separate each window's transport by the causal
-  type (timelike / cross-layer vs spacelike / within-layer) of the edges it rides on;
+  type (timelike / cross-layer vs spacelike / within-layer) of the cells it rides on;
 - **(ii) the Dirac–Kähler taste multiplicity** — the `4`-fold taste degeneracy of the
-  discrete Dirac operator `D = d + δ` as the flavor index.
+  discrete Dirac operator `D = d + δ` (#415) as the flavor index.
 
-*(stub — measured numbers and the verdict follow once the prototype is run.)*
+**Verdict: NO.** Both candidates collapse to a **window-independent** value on the
+A₄-symmetric junction, so neither distinguishes `uud` from `udd`. The cause is
+**structural, not dimensional** (the dimensional reach is #429's): flavor is a
+**symmetry-odd** label and the singlet/confinement is a **symmetry-even** fact, and the
+two cannot share the same A₄-symmetric register. This sharpens the prior conclusion
+(`proton_electroweak_finding.md`, `proton_charge_gauss_law.md`): it is not merely that
+the color-only geometry "happens to be flavor-blind", but that **no symmetry-respecting
+split of the register can carry flavor** — a theorem, proved below and pinned in
+`tests/cobordism/test_proton_flavor.py`.
+
+## The construction and what is symmetric about it
+
+The relaxed `W_ABC` junction (`examples/cobordism/proton_observables.py`) carries the
+color singlet on the symmetric apex interior (#413, `Spacetime::symmetricStackCells`).
+Its four windows — the three quark windows A, B, C and the result window R — are **one
+A₄ orbit** at the icosahedron's tetrahedral vertex-orbits (#398). The window-cycling
+`g` (the A₄ 3-cycle fixing R) is **transitive on {A, B, C}**: it permutes
+A → B → C → A, and `P_out` carries the cyclic Z₃ spectrum `{1, ω, ω²}`. The transport
+**intertwines color Z₃** on the symmetric interior:
+
+```
+‖ M P_in − P_out M ‖ / ‖M‖  =  4.5×10⁻¹⁴   on the exact uniform metric (#413),
+                            ≈  9×10⁻⁶       on the lightly-relaxed (RELAX=25) build,
+```
+
+both **orders below** the prism's `4.26×10⁻²` discretization residual. This equivariance
+is **load-bearing**: it is precisely what forces the singlet overlap to `1.000000` and
+the color charge `σ → 0` (confinement). The flavor audit the
+ticket mandates (F4 = the #412 G6 base-vertex-relabeling invariance) is **the same
+equivariance**: a measurable that is invariant under the base-vertex relabelings that
+realize `g` necessarily commutes with `g`.
+
+## The obstruction (the theorem)
+
+> **Claim.** Let `f = (f_A, f_B, f_C)` be any per-window measurable that is invariant
+> under base-vertex relabeling (the F4 / #412 G6 property). Because the window-cycling
+> `g` acts as a **transitive** permutation on `{A, B, C}` and `f` commutes with `g`,
+> `f` is **constant on the orbit**: `f_A = f_B = f_C`. Hence its `u`-vs-`d` discriminator
+> margin `max f − min f` is **identically 0** (exactly so on the uniform metric; bounded
+> by the intertwining residual ~`9×10⁻⁶` on the relaxed build — the measured Dirac–Kähler
+> margin `~3×10⁻⁶` sits right at that bound, confirming the collapse is *forced* by the
+> equivariance, not a numerical accident).
+
+A flavor label `uud` singles out **one** window as different from the other two — it is
+**symmetry-odd** (it breaks the transitive `g`). So **F4 (relabeling-invariance) and F3
+(a real discriminator, margin ≥ 0.1) are mutually exclusive** on the symmetric register.
+The only way to make the per-window measurable differ is to **break the geometric A₄
+symmetry**, which abandons the exact intertwining `M P_in = P_out M` — and with it the
+singlet (the relaxation on a non-symmetric metric does not produce the singlet; #398's
+greedy/jittered build reaches only `~0.74`). The proton and neutron must **both** be
+color singlets (G1/G2), so the symmetry cannot be given up. The obstruction is
+dimension-**independent**: it holds in the full emergent dimension too, because the three
+windows remain a single A₄ orbit however far the apex interior is coned (#429).
+
+## What each candidate measures (and why it collapses)
+
+Measured on the relaxed junction (`build(max_iters=25)`, seed `410414`), per window:
+
+### Candidate (i): the spatio-temporal split
+
+| reading | A | B | C | margin |
+|---|---|---|---|---|
+| causal census (edges) | timelike `0`, spacelike `774`, null `0` (whole complex) | | | — |
+| period timelike fraction | `0` | `0` | `0` | `0` |
+| field `‖E‖` (timelike-leg plaquettes) | `0` | `0` | `0` | `0` |
+| field `‖B‖` (spacelike plaquettes) | `0.19049` | `0.19046` | `0.19047` | `3×10⁻⁵` |
+| electric plaquette count `#E` | `0` | `0` | `0` | — |
+| `Q_electric = ∮_S E` per window | `0` | `0` | `0` | `0` |
+
+The relaxed junction is **Riemannian — `0` timelike edges**, so the **electric
+(timelike-leg) sector is empty**: `fieldStrengthSplit` finds no electric plaquettes and
+every window's field strength `F = dψ` is entirely **magnetic**. The signed-edge period
+rides only the three spacelike hole-boundary edges of its window, so its timelike
+fraction is identically `0`. There is **nothing to split** — and the magnetic content
+is **equal** across the three windows (A₄-symmetric), confirming the theorem. (Populating
+`E` needs genuine Lorentzian worldlines, a *metric* choice — but even a populated `E`
+sector would be A₄-equal per window, so it would still not label `u` vs `d`.)
+
+### Candidate (ii): the Dirac–Kähler taste multiplicity
+
+| reading | A | B | C | margin |
+|---|---|---|---|---|
+| per-window charge `q_k = ⟨Φ_k, Φ_k⟩_W` | `6.61798` | `6.61799` | `6.61799` | `3×10⁻⁶` |
+| charge-density minimum `min_c j⁰_c` | `0` | `0` | `0` | (≥ 0) |
+| `multiplicity()` | `4` | `4` | `4` | (fixed) |
+
+The Dirac–Kähler charge collapses **two ways**:
+
+1. **It is A₄-equal across windows** (`margin ~3×10⁻⁶`, machine precision) — the theorem
+   again: `q_k` is a relabeling-invariant per-window measurable, so it is constant on the
+   orbit. It cannot separate one window from the other two.
+2. **It is positive-definite.** `j⁰_c = W_c |Φ_c|²` is a **norm / constituent density**
+   (`dens_min = 0`), and `charge()` returns `⟨Φ, Φ⟩_W > 0`. It can never carry the
+   **opposite signs** the flavor-electric charges need (`u: +⅔` vs `d: −⅓`); it counts
+   constituents, it does not sign them.
+
+Separately, the taste multiplicity is a **fixed framework constant** `multiplicity() = 4`
+(four lattice **tastes**, the staggered/Dirac–Kähler doubling), **independent of the
+window** and **not a 2-valued isospin doublet** (`4 ≠ 2`). There is moreover **no
+per-window taste projector** — the `DiracKahler` API exposes the conserved current and
+the `16 = 4 × 4` Clifford action, but the taste-block projector is explicitly deferred
+(`include/cobordism/DiracKahler.h`, the `diracMatrices`/`tasteProjector` note). Even if it
+existed, the A₄ symmetry would force all three windows into identical taste content.
+
+### The discriminator
+
+The would-be per-window `u`/`d` label vector `sign(q_k − mean q)·[|q_k − mean q| > 0.1]`
+is the **constant zero vector** `[0, 0, 0]`: it is **neither `uud` nor `udd`**, and the
+two assignments are indistinguishable. A `uud` labeling and a `udd` labeling produce the
+**same** (neutral) geometry and the **same** charge — the existing `Q = ∮_S E = 0`,
+`net Dirac–Kähler = 0` neutral total. The ticket's success target `Q(uud) = +1` vs
+`Q(udd) = 0` is therefore **unreached** on the symmetric register.
+
+## Why a parallel register is *also* not the answer (and what is)
+
+The rejected route — a flavor *hole register* parallel to color — would add holes,
+inflating `b₁` past `11` and double-counting holonomy (the G4 guard fails). It is rejected
+not only as "arbitrary" but because it is the **wrong shape of fix**: flavor is not extra
+**capacity**, it is a **symmetry-breaking** between otherwise-equivalent windows. The
+faithful resolution is an explicit **isospin structure** that distinguishes the windows —
+a (necessarily new) construction in which the three windows are **not** a single
+symmetric orbit, e.g. an SU(2) isospin doublet attached to the windows so that one is
+`I₃ = −½` (`d`) and two are `I₃ = +½` (`u`), giving `Q = I₃ + Y/2` with the triality
+`Y/2` the construction already carries (`proton_charge_gauss_law.md`). That is
+symmetry-**odd** new structure, by the theorem above; it cannot be recovered as a split
+of the symmetric color register. The **dimensional** reach needed to host the full `E⃗`
+and `4×4` Dirac structure is a separate question, owned by #429 (iterated apex-reflection
+cobordism); it is **not** the obstruction here.
+
+## Faithfulness
+
+The conclusion is pinned in `tests/cobordism/test_proton_flavor.py` (N1–N7): the electric
+sector is empty (N1), both candidate splits collapse to margin `0` (N2, N3), the
+Dirac–Kähler charge is A₄-equal and positive-definite (N4), the discriminator is the
+constant zero vector (N5), the structural cause — transitive 3-cycle + exact intertwining
+⟹ constant on the orbit (N6) — and an `xfail` pinning the unreached `Q(uud)=+1` /
+`Q(udd)=0` target with its precise obstruction (N7). The shared epic invariants
+(`tests/cobordism/test_epic410_invariants.py`, G1–G5) are unchanged: this investigation
+adds **no geometry** (`b₁ == 11`), only a read-out, and reads the same neutral singlet.
+
+## References
+
+- `docs/design/proton_electroweak_finding.md` — the #405 deferral; "charge needs flavor".
+- `docs/design/proton_charge_gauss_law.md` — `Q = ∮_S E`; the A₄-equal per-window
+  Noether charges; the `I₃` (isospin) factor named as the missing piece.
+- `docs/design/proton_symmetric_windows.tex` — the exact intertwining / Stokes constraint
+  and the g-invariant metric (the symmetry this note shows is incompatible with flavor).
+- `examples/cobordism/proton_flavor_split.py` — the worked example reading the two
+  candidate measurables and the discriminator collapse off the relaxed geometry.
+- `include/cobordism/DiracKahler.h` — `charge` / `chargeDensity` (the positive-definite
+  `j⁰`), `multiplicity` (the fixed `4`-taste constant), and the deferred taste projector.
+- `include/cobordism/EigenstateSynthesis.h` — `curvatureFromConnection`,
+  `fieldStrengthSplit`, `gaussLawCharge` (the E/B split and the temporal Gauss law).

--- a/examples/cobordism/proton_flavor_split.py
+++ b/examples/cobordism/proton_flavor_split.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+
+"""Flavor as a split of the existing register --- the negative result (#414).
+
+This reads the two candidate ``u``/``d`` flavor measurables OFF the relaxed ``W_ABC``
+junction (`examples/cobordism/proton_observables.py`), per input window (A, B, C),
+emergent-first --- and shows both collapse to a window-INDEPENDENT value, so neither
+distinguishes the proton (``uud``, ``Q = +1``) from the neutron (``udd``, ``Q = 0``):
+
+  * candidate (i)  spatio-temporal split --- split each window's signed-edge period,
+    and its field strength ``F = dpsi``, by the causal type (timelike/spacelike) of
+    the cells it rides on. On the relaxed geometry there are ZERO timelike edges, so
+    the electric (timelike-leg) sector is empty: every window's split is 100% spacelike
+    and the per-window timelike fraction is identically 0 (margin 0 across A, B, C).
+
+  * candidate (ii) Dirac-Kahler taste --- the per-window conserved charge
+    ``q_k = <Phi_k, Phi_k>_W`` (#415). It is EQUAL across the three windows to machine
+    precision (the A4-symmetric apex interior, #413) AND positive-definite (a norm /
+    constituent count), so it can neither separate the windows nor sign the opposite
+    charges ``u: +2/3`` vs ``d: -1/3``. ``multiplicity() == 4`` is a fixed framework
+    constant (4 lattice tastes, not a 2-valued isospin), with no per-window taste
+    projector.
+
+The root cause is structural, not dimensional (the dimensional reach is #429's): the
+three quark windows are ONE A4 orbit (the window-cycling ``g`` is a 3-cycle, transitive
+on {A, B, C}), and the transport intertwines color Z3 (``M P_in = P_out M``, residual
+~1e-14). Any per-window measurable that is invariant under base-vertex relabeling --- the
+#412 G6 property the flavor audit (F4) REQUIRES --- is therefore constant on the orbit,
+so its u-vs-d discriminator margin is identically 0. Relabeling-invariance (F4) and a
+real discriminator (F3, margin >= 0.1) are mutually exclusive on the symmetric register:
+flavor is a symmetry-ODD label, the singlet/confinement is a symmetry-EVEN fact, and they
+cannot share the same A4-symmetric geometry. The resolution is a symmetry-BREAKING isospin
+structure (new construction), not a split of the existing register.
+
+Run:  python examples/cobordism/proton_flavor_split.py
+"""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(__file__))
+import proton_observables as P  # noqa: E402
+
+import tessera  # noqa: E402
+
+cob = tessera.cobordism
+
+# the per-flavor electric charges we would need to assign (the target, never reached)
+_Q_UP, _Q_DOWN = 2.0 / 3.0, -1.0 / 3.0
+
+
+def build(max_iters=25):
+    """The relaxed symmetric W_ABC junction with the natural omega-rep proton input."""
+    seed = cob.TransportCobordism([[1, -1, 0], [1, 0, -1], [0, 1, -1]],
+                                  max_iters=0, seed=0,
+                                  topology=cob.TripartiteRegisterTopology())
+    states = P._omega_rep_input(P._windows(seed))
+    return cob.TransportCobordism(states, max_iters=max_iters, seed=0,
+                                  topology=cob.TripartiteRegisterTopology())
+
+
+def causal_census(m):
+    """(timelike, spacelike, null) edge counts on the relaxed metric."""
+    tl = sp = nu = 0
+    for e in m.cobordism.getEdgeList().toVector():
+        if e.isNull():
+            nu += 1
+        elif e.isTimelike():
+            tl += 1
+        else:
+            sp += 1
+    return tl, sp, nu
+
+
+def _per_window_carry(m):
+    """Carry a unit input on each input window k -> carried representative psi_k."""
+    es1 = cob.EigenstateSynthesis(m.cobordism, 1)
+    windows = P._windows(m)
+    psis = [np.array(es1.carriedRepresentative([list(h) for h in windows[k]],
+                                               [1.0, 1.0, 1.0])) for k in range(3)]
+    return es1, windows, psis
+
+
+def candidate_i_period_split(m):
+    """(i) per-window signed-edge period, split by the causal type of each edge.
+
+    Returns the per-window timelike fraction tl/(tl+sp); identically 0 (every window
+    boundary edge is spacelike)."""
+    es1, windows, psis = _per_window_carry(m)
+    eidx = {(min(c), max(c)): i
+            for i, c in enumerate(es1.cellSimplices()) if len(c) == 2}
+    timelike = {}
+    for e in m.cobordism.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        timelike[(min(a, b), max(a, b))] = e.isTimelike()
+    fracs = []
+    for k in range(3):
+        tl = sp = 0.0
+        for (a, b, c) in windows[k]:
+            for (x, y) in [(a, b), (b, c), (a, c)]:
+                key = (min(x, y), max(x, y))
+                mag = abs(psis[k][eidx[key]])
+                if timelike.get(key, False):
+                    tl += mag
+                else:
+                    sp += mag
+        fracs.append(tl / (tl + sp + 1e-30))
+    return fracs
+
+
+def candidate_i_field_split(m):
+    """(i') per-window field strength F = dpsi, split into E (timelike-leg) and B.
+
+    Returns (electric_fraction, Q_electric, n_electric_cells) per window."""
+    es1, windows, psis = _per_window_carry(m)
+    es2 = cob.EigenstateSynthesis(m.cobordism, 2)
+    out = []
+    for k in range(3):
+        F = list(es2.curvatureFromConnection(list(psis[k])))
+        split = es2.fieldStrengthSplit(F)
+        ne = float(np.linalg.norm(np.array(split.electric)))
+        nb = float(np.linalg.norm(np.array(split.magnetic)))
+        enclosed = sorted(set(v for h in windows[k] for v in h))
+        qe = abs(es2.gaussLawCharge(F, enclosed, True))
+        out.append((ne / (ne + nb + 1e-30), qe, len(split.electricCells)))
+    return out
+
+
+def candidate_ii_dk_charge(m):
+    """(ii) per-window Dirac-Kahler charge q_k and its (non-negative) density bounds."""
+    es1, windows, psis = _per_window_carry(m)
+    dk = cob.DiracKahler(m.cobordism)
+    out = []
+    for k in range(3):
+        field = dk.lift(1, list(psis[k]))
+        q = dk.charge(field)
+        dens = np.array(dk.chargeDensity(field))
+        out.append((q, float(dens.min())))
+    return out, dk.multiplicity()
+
+
+def label_vector(m):
+    """The would-be per-window u/d label = sign of (q_k - mean q).  On the symmetric
+    interior the three q_k are equal, so this is the zero vector --- it cannot encode
+    either uud or udd, and the two are indistinguishable (margin 0)."""
+    dkr, _mult = candidate_ii_dk_charge(m)
+    qs = np.array([q for q, _ in dkr])
+    margin = float(qs.max() - qs.min())
+    labels = np.sign(qs - qs.mean()) * (np.abs(qs - qs.mean()) > 0.1)
+    return labels.tolist(), margin
+
+
+def main():
+    m = build(25)
+    tl, sp, nu = causal_census(m)
+    print("FLAVOR AS A SPLIT OF THE EXISTING REGISTER --- the negative result (#414)\n")
+    print(f"causal census (relaxed metric): timelike={tl}  spacelike={sp}  null={nu}")
+    print("  -> the electric (timelike-leg) sector is unpopulated; there is no causal")
+    print("     split to read off candidate (i) on the relaxed geometry.\n")
+
+    fracs = candidate_i_period_split(m)
+    print("candidate (i)  period causal-split   [per-window timelike fraction]:")
+    print("  A,B,C = " + ", ".join(f"{x:.3e}" for x in fracs)
+          + f"   margin = {max(fracs) - min(fracs):.3e}")
+
+    fi = candidate_i_field_split(m)
+    print("candidate (i') field E/B split       [E-fraction, Q_electric, #E-cells]:")
+    for k, (ef, qe, ne) in enumerate(fi):
+        print(f"  {'ABC'[k]}: Efrac={ef:.3e}  Q_E={qe:.3e}  nE={ne}")
+    print(f"  margin(Efrac) = {max(e for e, _, _ in fi) - min(e for e, _, _ in fi):.3e}")
+
+    dkr, mult = candidate_ii_dk_charge(m)
+    print("candidate (ii) Dirac-Kahler charge   [q_k, density min]:")
+    for k, (q, dmin) in enumerate(dkr):
+        print(f"  {'ABC'[k]}: q={q:.6f}  dens_min={dmin:.3e}  (>= 0: a norm, never -1/3)")
+    qs = [q for q, _ in dkr]
+    print(f"  margin(q) = {max(qs) - min(qs):.3e}   multiplicity = {mult} (fixed; not 2)")
+
+    labels, margin = label_vector(m)
+    print(f"\nwould-be per-window u/d label vector = {labels}   (margin {margin:.3e})")
+    print("  -> the label vector is constant: it is neither uud nor udd, and the two")
+    print("     assignments are indistinguishable.  No symmetry-respecting split of the")
+    print("     register carries flavor (F4 relabeling-invariance forces margin 0,")
+    print("     mutually exclusive with F3's required discriminator margin >= 0.1).")
+    print(f"\ntarget electric charges (unreachable here): u={_Q_UP:+.3f}  d={_Q_DOWN:+.3f}")
+    print("  Q(uud) = +1, Q(udd) = 0 require a symmetry-BREAKING isospin structure")
+    print("  (new construction), NOT a split of the A4-symmetric color register.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cobordism/test_proton_flavor.py
+++ b/tests/cobordism/test_proton_flavor.py
@@ -1,0 +1,153 @@
+"""Flavor without a register: the documented NEGATIVE result (#414, epic #410).
+
+The proton (`uud`, `Q = +1`) and the neutron (`udd`, `Q = 0`) differ only in flavor.
+This ticket asks whether the `u`/`d` label can be read off the EXISTING `W_ABC`
+geometry as a split of the register it already carries --- spatio-temporally (timelike
+vs spacelike) or via the Dirac-Kahler taste multiplicity --- WITHOUT a parallel hole
+register. The answer is NO, and these tests PIN the obstruction so the suite can never
+silently regress to a false-positive "flavor found".
+
+The precise cause is structural (NOT dimensional --- the dimensional reach is #429's):
+the three quark windows are one A4 orbit (the window-cycling `g` is a transitive 3-cycle
+on {A, B, C}) and the transport intertwines color Z3 exactly (`M P_in = P_out M`). Any
+per-window measurable invariant under base-vertex relabeling --- the #412 G6 property the
+flavor audit (F4) REQUIRES --- is therefore CONSTANT on the orbit, so its u-vs-d margin is
+identically 0. Relabeling-invariance (F4) and a real discriminator (F3, margin >= 0.1) are
+mutually exclusive on the symmetric register. Both candidate measurables collapse:
+  (i)  the spatio-temporal split: the relaxed geometry has 0 timelike edges, so the
+       electric (timelike-leg) sector is empty --- there is nothing to split;
+  (ii) the Dirac-Kahler charge: equal across windows AND positive-definite (a norm),
+       so it can neither separate the windows nor sign u(+2/3) vs d(-1/3).
+
+Fixed seed `numpy.random.default_rng(410414)` (G7); the build is the relaxed `W_ABC`
+color singlet read OFF the relaxed geometry (G8). See `docs/design/proton_flavor_split.md`.
+"""
+
+import cmath
+import os
+import sys
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+_W = cmath.exp(2j * cmath.pi / 3)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..",
+                                "examples", "cobordism"))
+import proton_observables as P  # noqa: E402
+import proton_flavor_split as FS  # noqa: E402
+
+_RELAX = 25
+_SEED = 410414
+
+# The F3 discriminator threshold from the ticket: a real u/d split must differ by
+# >= 0.1. The negative result is that every candidate margin sits orders below this.
+_F3_MARGIN = 0.1
+
+
+class ProtonFlavorNegativeResultTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        np.random.seed(_SEED)
+        cls.m = FS.build(_RELAX)
+        cls.tl, cls.sp, cls.nu = FS.causal_census(cls.m)
+        cls.period_fracs = FS.candidate_i_period_split(cls.m)
+        cls.field = FS.candidate_i_field_split(cls.m)
+        cls.dk, cls.mult = FS.candidate_ii_dk_charge(cls.m)
+        cls.labels, cls.dk_margin = FS.label_vector(cls.m)
+
+    # --- N1: candidate (i) --- the electric (timelike) sector is structurally empty ---
+    def test_N1_electric_sector_is_empty(self):
+        # The relaxed symmetric junction is Riemannian: no timelike edges, hence no
+        # electric (timelike-leg) plaquettes -- candidate (i) has nothing to split.
+        self.assertEqual(self.tl, 0)
+        for _efrac, q_e, n_e in self.field:
+            self.assertEqual(n_e, 0)              # no electric plaquettes
+            self.assertLessEqual(q_e, 1e-9)       # Q_electric = oint_S E = 0 per window
+
+    # --- N2: candidate (i) period split COLLAPSES (window-independent) ---
+    def test_N2_period_causal_split_collapses(self):
+        margin = max(self.period_fracs) - min(self.period_fracs)
+        for f in self.period_fracs:
+            self.assertLessEqual(f, 1e-9)         # every window period is 100% spacelike
+        self.assertLessEqual(margin, 1e-9)
+        self.assertLess(margin, _F3_MARGIN)       # cannot meet the F3 discriminator
+
+    # --- N3: candidate (i') field E/B split COLLAPSES ---
+    def test_N3_field_strength_split_collapses(self):
+        efracs = [ef for ef, _, _ in self.field]
+        margin = max(efracs) - min(efracs)
+        for ef in efracs:
+            self.assertLessEqual(ef, 1e-9)        # entirely magnetic, no electric part
+        self.assertLessEqual(margin, 1e-9)
+        self.assertLess(margin, _F3_MARGIN)
+
+    # --- N4: candidate (ii) DK charge is A4-EQUAL and POSITIVE-DEFINITE ---
+    def test_N4_dirac_kahler_charge_equal_and_positive(self):
+        qs = [q for q, _ in self.dk]
+        margin = max(qs) - min(qs)
+        self.assertLessEqual(margin, 1e-4)        # equal across windows (A4-symmetric)
+        for q, dens_min in self.dk:
+            self.assertGreater(q, 0.0)            # a norm <Phi,Phi>_W, strictly positive
+            self.assertGreaterEqual(dens_min, -1e-12)  # density j^0 = W|Phi|^2 >= 0
+        # the taste multiplicity is a FIXED framework constant of 4 lattice tastes,
+        # never a 2-valued isospin doublet, and independent of the window.
+        self.assertEqual(self.mult, 4)
+
+    # --- N5: THE DISCRIMINATOR COLLAPSES --- uud and udd are indistinguishable ---
+    def test_N5_discriminator_collapses(self):
+        # The would-be per-window u/d label vector is the constant (zero) vector: it is
+        # neither uud nor udd, so the two assignments cannot be separated. This directly
+        # negates the ticket's F3 ("the discriminator is real, margin >= 0.1").
+        self.assertEqual([abs(x) for x in self.labels], [0.0, 0.0, 0.0])
+        self.assertLess(self.dk_margin, _F3_MARGIN)
+
+    # --- N6: STRUCTURAL CAUSE --- equivariance forces the collapse (F4 vs F3) ---
+    def test_N6_relabeling_invariance_forces_collapse(self):
+        # The window-cycling g is a TRANSITIVE 3-cycle on {A, B, C}: P_out has the cyclic
+        # Z3 spectrum {1, w, w^2}, so g permutes the three windows in a single orbit.
+        p_in, p_out = P._window_cycle_rep(P._windows(self.m))
+        angles = sorted(float(np.angle(e)) for e in np.linalg.eigvals(p_out))
+        for got, exp in zip(angles, sorted([0.0, 2 * np.pi / 3, -2 * np.pi / 3])):
+            self.assertAlmostEqual(got, exp, delta=1e-6)   # transitive 3-cycle (exact)
+        # The transport intertwines color Z3 on the symmetric apex interior (#413):
+        # M P_in = P_out M -- machine-zero (4.5e-14) on the exact uniform metric, and
+        # ~1e-5 on this lightly-relaxed (RELAX=25) build, still orders below the prism's
+        # 4.26e-2. Any relabeling-invariant per-window measurable (F4/G6) commutes with g,
+        # so it is CONSTANT on the {A,B,C} orbit up to the intertwining residual.
+        M = P._transport(self.m)
+        residual = np.linalg.norm(M @ p_in - p_out @ M) / (np.linalg.norm(M) + 1e-30)
+        self.assertLessEqual(residual, 1e-4)               # symmetric-apex scale, not prism
+        # the smoking gun: the per-window discriminator margin is BOUNDED BY (the same
+        # order as) the intertwining residual -- the collapse is forced by the equivariance,
+        # not a coincidence. F4 therefore implies margin ~0, mutually exclusive with F3
+        # (margin >= 0.1): no symmetry-respecting split of the register carries flavor.
+        self.assertLessEqual(self.dk_margin, 10.0 * residual + 1e-9)
+
+    # --- N7: the success TARGET is unreachable on the symmetric register (xfail) ---
+    @unittest.expectedFailure
+    def test_N7_flavor_charge_target_unreached(self):
+        """DOCUMENTED OBSTRUCTION (expected to fail): the ticket's success target is
+        Q(uud) = +1 and Q(udd) = 0 from DISTINCT per-window u/d labels. On the
+        A4-symmetric register the per-window label vector is constant (margin
+        ~1e-6 << 0.1), so a uud labeling and a udd labeling are indistinguishable --
+        they yield the SAME (neutral) charge. The assertion below demands a real
+        discriminator and a +1 proton charge; it cannot be met without a
+        symmetry-BREAKING isospin structure (new construction), so it xfails by design.
+        """
+        qs = np.array([q for q, _ in self.dk])
+        # a real discriminator would separate one window from the other two by >= 0.1...
+        self.assertGreaterEqual(float(qs.max() - qs.min()), _F3_MARGIN)
+        # ...and the proton (uud) would carry total charge +1.
+        q_uud = 2 * FS._Q_UP + FS._Q_DOWN  # = +1 IF the labels were assignable; they are not
+        self.assertAlmostEqual(q_uud, 1.0, delta=1e-9)
+        # the conjunction (real margin AND a faithful +1 read OFF the geometry) is what
+        # fails: the margin is ~1e-6, so the first assertion above already xfails.
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Investigation (#414, epic #410): can the `u`/`d` flavor label be read off the existing
`W_ABC` geometry as a **split of the register it already carries** — spatio-temporally
(timelike vs spacelike) or via the Dirac–Kähler taste multiplicity — **without** a
parallel hole register?

**Documented NEGATIVE result.** Both candidate per-window measurables collapse to a
**window-independent** value on the A₄-symmetric junction, so neither distinguishes the
proton (`uud`, `Q=+1`) from the neutron (`udd`, `Q=0`).

### The obstruction (structural, not dimensional)

The three quark windows are **one transitive A₄ orbit** (the window-cycling `g` is a
3-cycle; `P_out` spectrum `{1, ω, ω²}`) and the transport **intertwines color Z₃**
(`M P_in = P_out M`: `4.5e-14` on the exact uniform metric, `~9e-6` lightly relaxed).
Any per-window measurable invariant under base-vertex relabeling — the **F4 / #412 G6**
audit the ticket mandates — therefore **commutes with `g` and is constant on the orbit**,
so its u-vs-d margin is forced to `0`. That is **mutually exclusive** with a real
discriminator (**F3**, margin ≥ 0.1). Flavor is a **symmetry-odd** label; the
singlet/confinement is a **symmetry-even** fact (G1/G2 must hold for *both* proton and
neutron); they cannot share the A₄-symmetric register. The cause is dimension-**independent**
(the dimensional reach is #429's), so it is **not** the inadmissible "dimensional
insufficiency" plea.

### Measured (relaxed junction, seed 410414)

| candidate | per-window reading A / B / C | margin |
|---|---|---|
| (i) period timelike-fraction | `0 / 0 / 0` (0 timelike edges; electric sector empty) | `0` |
| (i') field `‖E‖` / `Q_electric` | `0 / 0 / 0` (entirely magnetic, `nE=0`) | `0` |
| (ii) Dirac–Kähler charge `q_k` | `6.61798 / 6.61799 / 6.61799` (equal **and** positive-definite, never −1/3) | `~3e-6` |

`multiplicity() = 4` is a fixed framework constant (4 lattice tastes, not a 2-valued
isospin), with no per-window taste projector. The DK margin (`~3e-6`) is **bounded by the
intertwining residual** (`~9e-6`) — the collapse is *forced* by the equivariance.

### What's in this PR (observable-only, no geometry added)

- `docs/design/proton_flavor_split.md` — the negative result + the theorem + the fix shape
  (a symmetry-**breaking** isospin structure, a new construction; not a register split).
- `examples/cobordism/proton_flavor_split.py` — reads both candidate measurables and the
  discriminator collapse off the relaxed geometry, emergent-first.
- `tests/cobordism/test_proton_flavor.py` — **N1–N6** pin the collapse and its structural
  cause; **N7** `xfail`s the unreached `Q(uud)=+1`/`Q(udd)=0` target with its precise reason.

## Test results

- `tests/cobordism/test_proton_flavor.py`: **6 passed, 1 xfailed** (N7 by design), 60s.
- `tests/cobordism/test_epic410_invariants.py` (G1–G5): **5 passed**, 135s — unchanged
  (`b1 == 11`, singlet 1.0, σ→0, Z₃ intact: no register smuggled in).
- Build green in a throwaway venv (`pip install -e ".[dev]"`).

Closes #414.
