### PR TITLE
fix(ci): green main after the #412 rename + #429 symmetric-default

### DIFF
--- a/docs/design/flavor_charge_sectors.tex
+++ b/docs/design/flavor_charge_sectors.tex
@@ -177,7 +177,7 @@ is therefore not $g$-equivariant, and the symmetry leaks into the read-out.
 Every simplex orientation/sign --- in the boundary operator, the period read-out
 covector, and any triangulation diagonal --- is sourced from the standard simplicial
 orientation formula tied to the manifold's induced orientation
-(\texttt{SimplexOrientation::}\allowbreak\texttt{orientationOf}). Sorting survives only as a sign-neutral
+(\texttt{TemporalOrientation::}\allowbreak\texttt{orientationOf}). Sorting survives only as a sign-neutral
 canonical storage key, never as a sign.
 \end{principle}
 

--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -39,7 +39,7 @@ exclusions to see the entire interface.
 
 ```{doxygenfile} Simplex.h
 ```
-```{doxygenfile} SimplexOrientation.h
+```{doxygenfile} TemporalOrientation.h
 ```
 ```{doxygenfile} Vertex.h
 ```

--- a/examples/cobordism/wabc_relaxation_animation.py
+++ b/examples/cobordism/wabc_relaxation_animation.py
@@ -39,6 +39,12 @@ _WORLDLINE_LSQ = -0.3      # cross-layer worldlines start timelike (so null can 
 def _build(k):
     """The Lorentzian W_ABC junction relaxed to exactly k iterations (deterministic)."""
     t = cob.TripartiteRegisterTopology()
+    # The emergent photon is a worldline relaxing through l^2 ~ 0. On the symmetric apex
+    # interior (#413, now the default) the worldlines stay timelike and no null edge
+    # emerges; the prism (x I) triangulation is the one whose worldlines relax through
+    # null, so this animation -- whose subject IS the emergent photon -- exercises the
+    # prism path explicitly.
+    t.set_symmetric_interior(False)
     t.set_lorentzian_worldlines(_WORLDLINE_LSQ)
     return cob.TransportCobordism(_NEUTRAL, max_iters=k, seed=0, topology=t)
 

--- a/tests/cobordism/test_finer_lattice_python.py
+++ b/tests/cobordism/test_finer_lattice_python.py
@@ -10,7 +10,8 @@ production C++ path and the convergence example:
   * N=2 (the default) is backward-compatible with #398 (the four A4-orbit windows are
     exactly the #398 oracle), and every N gives a valid b1=11 manifold;
   * the lattice actually refines (more vertices) with N;
-  * refining shrinks the intertwining residual and drives the singlet overlap -> 1;
+  * the symmetric apex interior (#413, the default) holds the intertwining residual at the
+    machine-zero floor and the singlet overlap at 1.0 across frequencies;
   * frequency < 2 is rejected.
 """
 
@@ -55,9 +56,15 @@ class FinerLatticeTest(unittest.TestCase):
     def test_finer_lattice_has_more_vertices(self):
         self.assertGreater(self.o3["verts"], self.o2["verts"])
 
-    def test_refining_shrinks_the_intertwining_residual(self):
-        # The residual is a fixed-resolution artifact; it decreases with N.
-        self.assertLess(self.o3["intertwine"], self.o2["intertwine"])
+    def test_refining_keeps_the_residual_at_the_machine_zero_floor(self):
+        # With the symmetric apex interior (#413, now the default) the transport is
+        # exactly equivariant at every frequency, so the intertwining residual
+        # ||M Pin - Pout M||/||M|| sits at the machine-zero floor (~1e-13) -- not the
+        # prism's ~4e-2 fixed-resolution artifact. Refining the lattice keeps it there
+        # (the singlet overlap stays 1.0); there is no finite residual left to shrink.
+        floor = 1e-9
+        self.assertLess(self.o2["intertwine"], floor)
+        self.assertLess(self.o3["intertwine"], floor)
 
     def test_singlet_overlap_is_near_one_and_improves(self):
         self.assertGreater(self.o2["overlap_min"], 0.999)

--- a/tests/cobordism/test_orientation_relabeling_invariance.py
+++ b/tests/cobordism/test_orientation_relabeling_invariance.py
@@ -38,9 +38,10 @@ _COLORED = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 _SEED = 412
 
 
-def _build(inputs):
-    return cob.TransportCobordism(inputs, max_iters=0, seed=0,
-                                  topology=cob.TripartiteRegisterTopology())
+def _build(inputs, symmetric=True):
+    topology = cob.TripartiteRegisterTopology()
+    topology.set_symmetric_interior(symmetric)
+    return cob.TransportCobordism(inputs, max_iters=0, seed=0, topology=topology)
 
 
 def _geometry(m):
@@ -149,7 +150,13 @@ class RelabelingInvarianceTest(unittest.TestCase):
     while the unsigned charge is scrambled."""
 
     def test_signed_charge_is_relabeling_invariant_raw_is_not(self):
-        m = _build(_COLORED)
+        # The relabeling rebuild reconstructs the cobordism from its prism stride
+        # (N = nverts // 3, three layers base x I) and rebuilds it under a per-layer
+        # permutation, so pin the prism interior: the symmetric apex interior (#413,
+        # the default) adds apex vertices and is not a clean three-layer stride. The
+        # signed-charge invariant is a property of the orientation read-out, independent
+        # of which interior fills the bulk.
+        m = _build(_COLORED, symmetric=False)
         faces, holes, tets, N = _geometry(m)
 
         def sigma(cobordism, perm, signed):


### PR DESCRIPTION
## Summary
`main` went red after the epic #410 merges (#432/#433): CI `build` (pytest) reported `5 failed, 1737 passed, 13 skipped, 1 xfailed`. This greens it end-to-end. Each cobordism failure was triaged stale-test-vs-real-regression **before** any edit; the up-front regression clearance is that `tests/cobordism/test_epic410_invariants.py` G1–G5 stay green on the symmetric default.

Two root causes:
- **#412** renamed `SimplexOrientation.h` -> `TemporalOrientation.h` (the CDT temporal-orientation class), but the docs index `docs/source/cpp_api.md` still pointed at the old basename.
- **#429/#413** made `Spacetime::symmetricStackCells` the **default** cobordism interior (symmetric apex, label-independent, no vertex-sort diagonal). Three tests were written against the legacy **prism** extrusion and asserted prism-only behavior.

## Verdict per failure (all STALE tests, no regression)

**Regression clearance (symmetric default, epic410 G1–G5 all PASS):** singlet overlap >= 0.999, color charge sigma -> 0, charge flux <= 1e-6, b1 == 11 + dualComplexValid, P_out spectrum {1, w, w^2}. #429 broke no correctness.

1. **docs `test_every_header_is_documented`** — #412 rename; trivial docs-index fix.
2. **docs `test_no_stale_documented_headers`** — #412 rename; trivial docs-index fix.
3. **`test_finer_lattice::test_refining_shrinks_the_intertwining_residual`** — STALE. The symmetric apex is exactly equivariant at every frequency, so the residual `||M Pin - Pout M||/||M||` is at the machine-zero floor (N=2: 4.78e-14, N=3: 1.14e-13), with singlet overlap **1.000000** and b1=11/dual_valid at both N. There is no finite residual left to shrink (the strict-shrink assertion was a prism artifact, residual ~4e-2). Relaxed to an absolute floor (1e-9) after confirming overlap == 1.0; renamed to reflect the behavior.
4. **`test_orientation_relabeling::test_signed_charge_is_relabeling_invariant_raw_is_not`** — STALE reconstruction. It rebuilds the cobordism from the prism three-layer stride (`N = nverts // 3`) under a per-layer permutation; the symmetric apex adds vertices (nverts=152, 3N=150 -> tets reference vid 151 -> the IndexError). Pinned the prism interior for this rebuild. The invariant still holds exactly: signed charge = 3.000000 across all 5 relabelings, raw = [0.8463, 0.8463, 1.1318, 3.0, 0.8463] scrambled.
5. **`test_relaxation_animation::test_photon_null_edge_emerges_under_relax`** — STALE prism-only behavior. The emergent photon is a worldline relaxing through l^2~0; on the symmetric apex the worldlines stay timelike (null counts {0:0, 2:0, 5:0, 10:0}, matching #413's documented no-spurious-photon), on the prism the photon emerges ({0:0, 2:2, 5:3, 10:5}). The animation's whole subject is the photon, so its `_build` now exercises the prism path explicitly. Assertion preserved.

Also completed the #412 rename in `docs/design/flavor_charge_sectors.tex` (cited `SimplexOrientation::orientationOf`; not a CI gate, design .tex).

## Test plan
- [x] Build in a throwaway venv (`pip install -e ".[dev]"`).
- [x] Run the 5 failing test files + `tests/cobordism/test_epic410_invariants.py` (G1–G5) + `tests/test_cpp_api_docs_coverage.py` — **25 passed, 0 failed**.
- [x] Confirm each #3/#4/#5 verdict with positive evidence (overlap 1.0, sigma->0, b1=11, dualComplexValid, residual at floor, signed-charge invariant, prism photon emerges).

Closes #436.
