### PR TITLE
perf(ci): parallelize the pytest suite with xdist + a slow/fast split

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # Nightly full-suite run (07:00 UTC) so the slow tests deselected on PR
+    # pushes still gate the tree at least once a day, independent of merges.
+    - cron: "0 7 * * *"
   workflow_dispatch:
 
 permissions:
@@ -68,7 +72,40 @@ jobs:
           print("quantum subsystem present")
           PY
 
-      # Self-hosted gives us the headroom to run the entire suite (it times out
-      # on GitHub-hosted). Runs from the repo root so pytest discovers tests/.
-      - name: Run full test suite
-        run: python -m pytest tests/ -q
+      # The editable install above keeps conftest.py's xdist-unsafe build
+      # fallback dormant (its fast path returns as soon as ``tessera._tessera``
+      # imports), so the suite below can shard across workers safely.
+      #
+      # Thread budget: this suite is BLAS / OpenMP bound — its long-pole tests
+      # (cobordism relaxations, the example subprocess) thread-scale, so the
+      # naive OMP=1 + -n auto actually REGRESSES (a single-threaded long pole
+      # floors the wall clock, and each worker re-pays the heavy module imports).
+      # Profiling across thread budgets (workers x OMP held ~= cores) put the
+      # optimum at OMP=4 per worker: the heavy tests keep 4 threads while 4x as
+      # many run at once. So pin every math library to 4 and run cores/4 workers.
+      #
+      # PR pushes run only the fast lane (the >30s ``slow`` tests deselected);
+      # merge-to-main, the nightly schedule, and manual dispatch run the FULL
+      # suite. Coverage is split, never cut — every ``slow`` test still runs on
+      # main/nightly. Both lanes run from the repo root so pytest finds tests/.
+      - name: Run fast test suite (PR pushes)
+        if: github.event_name == 'pull_request'
+        env:
+          OMP_NUM_THREADS: "4"
+          OPENBLAS_NUM_THREADS: "4"
+          MKL_NUM_THREADS: "4"
+          BLIS_NUM_THREADS: "4"
+        run: |
+          workers=$(( $(nproc) / 4 )); [ "$workers" -lt 1 ] && workers=1
+          python -m pytest tests/ -q -m "not slow" -n "$workers" --dist worksteal
+
+      - name: Run full test suite (main / nightly / manual)
+        if: github.event_name != 'pull_request'
+        env:
+          OMP_NUM_THREADS: "4"
+          OPENBLAS_NUM_THREADS: "4"
+          MKL_NUM_THREADS: "4"
+          BLIS_NUM_THREADS: "4"
+        run: |
+          workers=$(( $(nproc) / 4 )); [ "$workers" -lt 1 ] && workers=1
+          python -m pytest tests/ -q -n "$workers" --dist worksteal

--- a/tests/cobordism/test_emergent_bulk_python.py
+++ b/tests/cobordism/test_emergent_bulk_python.py
@@ -31,6 +31,8 @@ import subprocess
 import sys
 import unittest
 
+import pytest
+
 import numpy as np
 
 import tessera
@@ -176,6 +178,7 @@ class MeridianTwoBoundaryTest(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------- #
+@pytest.mark.slow
 class SurgeryMovesB1Test(unittest.TestCase):
     """3: the SURGERY search moves b_1 0 -> 1 on its own; the matched meridian then
     realizes, the flipped one still floors on the opened handle."""
@@ -255,6 +258,7 @@ class HarmonicCriterionTest(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------- #
+@pytest.mark.slow
 class ExampleSelfVerifiesTest(unittest.TestCase):
     """The committed example runs end-to-end and exits 0 (its own assertions)."""
 

--- a/tests/cobordism/test_epic410_invariants.py
+++ b/tests/cobordism/test_epic410_invariants.py
@@ -18,6 +18,8 @@ import os
 import sys
 import unittest
 
+import pytest
+
 import numpy as np
 
 import tessera
@@ -41,6 +43,7 @@ def _build(max_iters=_RELAX):
                                   topology=cob.TripartiteRegisterTopology())
 
 
+@pytest.mark.slow
 class Epic410InvariantsTest(unittest.TestCase):
 
     @classmethod

--- a/tests/cobordism/test_finer_lattice_python.py
+++ b/tests/cobordism/test_finer_lattice_python.py
@@ -19,6 +19,8 @@ import importlib.util
 import pathlib
 import unittest
 
+import pytest
+
 import tessera
 
 cob = tessera.cobordism
@@ -36,6 +38,7 @@ _ORACLE = [[(2, 13, 14), (8, 31, 32), (10, 22, 36)],
 _ORACLE = [[tuple(sorted(h)) for h in w] for w in _ORACLE]
 
 
+@pytest.mark.slow
 class FinerLatticeTest(unittest.TestCase):
 
     @classmethod

--- a/tests/cobordism/test_mediated_synthesis_python.py
+++ b/tests/cobordism/test_mediated_synthesis_python.py
@@ -134,6 +134,7 @@ def _decide_disk(beta=0.0, max_cones=3, max_vertices=16, explicit_beta=True,
 
 
 # --------------------------------------------------------------------------- #
+@pytest.mark.slow
 class Beta0ReproducesBaseLayer(unittest.TestCase):
     def test_explicit_beta0_equals_default(self):
         # The β=0 mediated path is the base-layer search bit-for-bit: residual,
@@ -156,6 +157,7 @@ class Beta0ReproducesBaseLayer(unittest.TestCase):
         self.assertEqual(v0.regge_action, v5.regge_action)
 
 
+@pytest.mark.slow
 class ReggeActionReported(unittest.TestCase):
     def test_regge_action_finite_nonnegative(self):
         _, v = _decide_disk(beta=0.0)

--- a/tests/cobordism/test_merge_cobordism_operator_python.py
+++ b/tests/cobordism/test_merge_cobordism_operator_python.py
@@ -29,6 +29,8 @@ pair-of-pants example ``examples/cobordism/merge_cobordism.py`` (ker L1 = 2).
 import math
 import unittest
 
+import pytest
+
 import numpy as np
 
 import tessera
@@ -273,6 +275,7 @@ class OperatorDeferredTest(unittest.TestCase):
         self.assertEqual(len(_M.choi_state), 0)
 
 
+@pytest.mark.slow
 class DeterminismTest(unittest.TestCase):
     """A fixed seed gives a bit-identical relaxation (reproducible)."""
 
@@ -294,6 +297,7 @@ class DeterminismTest(unittest.TestCase):
         self.assertEqual(list(self.m2.output_state), list(_M.output_state))
 
 
+@pytest.mark.slow
 class StateResidualModeTest(unittest.TestCase):
     """The selectable r_state term (#377): r_U realizability (default) vs r_psi
     hard period-pin. The topology/structure is the term-independent substrate;

--- a/tests/cobordism/test_proton_charge_gauss_law.py
+++ b/tests/cobordism/test_proton_charge_gauss_law.py
@@ -17,6 +17,8 @@ import os
 import sys
 import unittest
 
+import pytest
+
 import numpy as np
 
 import tessera
@@ -88,6 +90,7 @@ def _jitter_sweep(m, n=_N_JIT, mag=_MAG):
     return np.array(qe), np.array(qf), np.array(cov)
 
 
+@pytest.mark.slow
 class ProtonChargeGaussLawTest(unittest.TestCase):
 
     @classmethod

--- a/tests/cobordism/test_proton_flavor.py
+++ b/tests/cobordism/test_proton_flavor.py
@@ -28,6 +28,8 @@ import os
 import sys
 import unittest
 
+import pytest
+
 import numpy as np
 
 import tessera
@@ -48,6 +50,7 @@ _SEED = 410414
 _F3_MARGIN = 0.1
 
 
+@pytest.mark.slow
 class ProtonFlavorNegativeResultTest(unittest.TestCase):
 
     @classmethod

--- a/tests/cobordism/test_proton_observables_python.py
+++ b/tests/cobordism/test_proton_observables_python.py
@@ -18,6 +18,8 @@ import importlib.util
 import pathlib
 import unittest
 
+import pytest
+
 _EXAMPLE = (pathlib.Path(__file__).resolve().parents[2]
             / "examples" / "cobordism" / "proton_observables.py")
 _spec = importlib.util.spec_from_file_location("proton_observables", _EXAMPLE)
@@ -25,6 +27,7 @@ _obs = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_obs)
 
 
+@pytest.mark.slow
 class ProtonObservablesTest(unittest.TestCase):
     """All observables are read off ONE relaxed geometry; a short relax keeps the
     test quick (the reading interface is what is under test, not the relax depth)."""

--- a/tests/cobordism/test_symmetric_interior.py
+++ b/tests/cobordism/test_symmetric_interior.py
@@ -25,6 +25,8 @@ import cmath
 import math
 import unittest
 
+import pytest
+
 import numpy as np
 
 import tessera
@@ -209,6 +211,7 @@ class SymmetricLorentzianTest(unittest.TestCase):
         m = cob.TransportCobordism(_NEUTRAL, max_iters=0, seed=0, topology=trt)
         self.assertGreater(sum(1 for x in self._l2(m) if x < -1e-9), 0)
 
+    @pytest.mark.slow
     def test_worldlines_stay_timelike_no_spurious_photon(self):
         # The symmetric counterpart of the prism's photon test, and a finding: on the
         # symmetric interior the relax keeps ALL worldlines uniformly timelike (-0.3) --

--- a/tests/cobordism/test_tripartite_junction_python.py
+++ b/tests/cobordism/test_tripartite_junction_python.py
@@ -42,6 +42,8 @@ import cmath
 import math
 import unittest
 
+import pytest
+
 import numpy as np
 
 import tessera
@@ -249,6 +251,7 @@ class CarryAndConservationTest(unittest.TestCase):
         self.assertGreater(sigma, 2.0 * neutral)
 
 
+@pytest.mark.slow
 class RelaxationFixTest(unittest.TestCase):
     """#396: the junction relaxation stalled at iteration 0 (a converged state
     residual's spurious gradient exploded the ill-conditioned step); the
@@ -264,6 +267,7 @@ class RelaxationFixTest(unittest.TestCase):
         self.assertLess(relaxed, seed)
 
 
+@pytest.mark.slow
 class SingletReachabilityTest(unittest.TestCase):
     """A 74% overlap for a NAIVE input is a suboptimal input, not a geometry limit.
     The carried-input read is linear, so the input->result transport is a matrix M;
@@ -370,6 +374,7 @@ class LorentzianPhotonTest(unittest.TestCase):
         timelike = sum(1 for x in _edge_l2(m) if x < -1e-9)
         self.assertGreater(timelike, 0)
 
+    @pytest.mark.slow
     def test_a_photon_null_edge_emerges_under_relax(self):
         # With near-null worldlines, the relax drives a worldline edge through null
         # (l^2 -> 0, lightlike) -- the predicted photon.


### PR DESCRIPTION
## Summary
CI's `build.yml` ran `python -m pytest tests/ -q` fully serial — the test phase alone is ~41 min. `pytest-xdist` is already a `[dev]` dependency and a `slow` marker is defined in `pyproject.toml`, but nothing used either.

This PR turns the parallelism on, **data-driven from a `--durations` profile**:
- `build.yml`: shard with `pytest-xdist --dist worksteal`, and **split** CI — fast `-m "not slow"` lane on PR pushes, FULL suite on merge-to-main + a nightly `schedule`. No coverage loss: every `slow` test still runs on main/nightly.
- Tag the 60 genuinely heavy (>30s) cobordism/quantum tests `@pytest.mark.slow`.
- **Thread budget is the real finding.** This suite is OpenMP/BLAS bound — its long-pole tests (cobordism relaxations, the `test_example_exits_zero` subprocess) thread-scale, so the naive `OMP=1 + -n auto` *regresses*: a single-threaded long pole floors the wall clock and every xdist worker re-pays the heavy module imports / `setUpClass` fixtures. Profiling across budgets (workers × OMP held ≈ cores) put the optimum at **OMP=4 per worker, cores/4 workers**.

## Results (16-core budget, box under contention — idle-runner gains larger)
| Config | Wall clock | Outcome |
|---|---|---|
| Serial `OMP=16` (BEFORE) | **2475s (41:15)** | 1761 passed |
| `-n16 × OMP=1` full | 3103s (51:43) | regresses |
| **`-n4 × OMP=4` full (main/nightly)** | **1988s (33:08)** | 1761 passed — identical to serial, 0 failures |
| `-n16 × OMP=1` fast lane | 2055s (34:15) | OMP=1 hurts |
| **`-n4 × OMP=4` fast lane (PR)** | **985s (16:25)** | 1702 passed, 60 slow deselected |

PR pushes: **41m → 16m (~60%)**. Main/nightly full suite: **41m → 33m (~20%)**. Both well under the 90-min CI budget.

No xdist test-isolation bugs: the `-n16/OMP1` run showed 2 extra skips, but those are OpenMP-threshold-gated benchmark skips (e.g. the thread-scaling test), not failures — `-n4/OMP4` recovers the exact serial pass count (1761).

## Test plan
- [x] Profile serial suite (`--durations=40`) → BEFORE wall-clock + slowest tests
- [x] Re-run full suite under xdist → 0 failures, real wall-clock reduction (BEFORE vs AFTER)
- [x] Diagnose any test that passes serially but fails under xdist (none — the skip delta is OMP-gated, not isolation)
- [x] Confirm CI stays well under the 90-min budget (33m full / 16m fast)

Closes #442.
