### PR TITLE
test(cobordism): promote the Experiment-A invariants to the shared epic guard

### DIFF
--- a/tests/cobordism/test_epic410_invariants.py
+++ b/tests/cobordism/test_epic410_invariants.py
@@ -11,6 +11,24 @@ emergent relaxed `W_ABC` color singlet (`examples/cobordism/proton_observables.p
       Stokes holonomy) vanishes to round-off
 - G4  topology: b1 == 11 and dualComplexValid  (no smuggled holes/registers)
 - G5  color Z3 intact: P_out eigenvalues are {1, w, w^2}
+
+The Experiment-A (#434) bilateral q/qbar -> proton relaxation
+(`examples/cobordism/emergent_intermediates.py` `EmergentEventTopology`) pins three
+further invariants. They reuse the exact PRE-REGISTERED thresholds + measurement
+helpers from `tests/cobordism/test_emergent_intermediates.py` (copied, never
+re-derived; the thresholds are NEVER loosened to manufacture green):
+
+- G9   bilateral pinning regulates the conformal runaway: ||grad S||^2 < 100 at the
+       minimal/fair depth nL=2 (asserted at nL=2 ONLY -- ||grad S||^2 is extensive in
+       the temporal volume: 71 / 159 / 268 at nL=2 / 3 / 4)
+- G10  non-degenerate, CPT-conserved emergent Gauss-law charge: |Q_e| > 0.05
+       (Lorentzian) AND <= 1e-9 (all-spacelike control) AND |Q_proton + Q_antiproton|
+       <= 1e-3 (CPT)
+- G11  proton color singlet >= 0.95 from frame-symmetric COLORED inputs (color is
+       never painted; the singlet emerges off the relaxed geometry)
+
+(G6/G7/G8 are the cross-cutting relabeling / determinism / emergent-first concepts
+exercised across the suite, not concrete invariants in this module.)
 """
 
 import cmath
@@ -30,8 +48,21 @@ _W = cmath.exp(2j * cmath.pi / 3)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..",
                                 "examples", "cobordism"))
 import proton_observables as P  # noqa: E402
+import emergent_intermediates as E  # noqa: E402
 
 _RELAX = 25
+
+# --- Experiment-A (#434) harness, copied verbatim from
+# `tests/cobordism/test_emergent_intermediates.py` (PRE-REGISTERED; never loosened). ---
+_A_RELAX = 60             # enough to plateau; the reading is under test
+_A_LAYERS = 2             # minimal temporal depth (slices 0,1,2; middle = 1, emergent).
+                          # ||grad S||^2 is extensive in temporal volume -- it MEETS the
+                          # pre-registered floor only at minimal depth (71 at nL=2, vs 159
+                          # at nL=3, 268 at nL=4).
+_A_GRADS2_FLOOR = 100.0   # carriable ||grad S||^2 (tens) vs strained (thousands)
+_A_SINGLET_FLOOR = 0.95   # final proton/anti-proton color-singlet overlap
+_A_CHARGE_CANCEL = 1e-3   # |Q_proton + Q_antiproton| (CPT total charge 0)
+_A_CHARGE_TAU = 0.05      # min Lorentzian emergent |Q_e| (a degenerate Q == 0 FAILS)
 
 
 def _build(max_iters=_RELAX):
@@ -77,6 +108,53 @@ class Epic410InvariantsTest(unittest.TestCase):
         expected = sorted([0.0, 2 * np.pi / 3, -2 * np.pi / 3])
         for got, exp in zip(angles, expected):
             self.assertAlmostEqual(got, exp, delta=1e-6)
+
+
+@pytest.mark.slow
+class Epic410ExperimentAInvariantsTest(unittest.TestCase):
+    """G9-G11: the Experiment-A (#434) bilateral q/qbar -> proton relaxation, read OFF
+    the relaxed `EmergentEventTopology` geometry. The proton sector is Lorentzian
+    (timelike worldlines -> a non-empty electric sector), the anti-proton is the
+    U-turn twist (opposite charge), and the all-spacelike (Riemannian) build is the
+    degenerate control the Lorentzian node must beat."""
+
+    @classmethod
+    def setUpClass(cls):
+        # proton sector (untwisted, Lorentzian) at the minimal depth nL=2.
+        cls.mp, cls.tp = E.build_event(n_layers=_A_LAYERS, lorentzian=True,
+                                       u_turn=False, max_iters=_A_RELAX)
+        cls.op = E.measure(cls.mp, cls.tp)
+        # anti-proton sector (U-turn twist) -- opposite-sign emergent charge.
+        cls.ma, cls.ta = E.build_event(n_layers=_A_LAYERS, lorentzian=True,
+                                       u_turn=True, max_iters=_A_RELAX)
+        cls.oa = E.measure(cls.ma, cls.ta)
+        # all-spacelike control: the degenerate E == 0 case (no electric sector).
+        cls.m0, cls.t0 = E.build_event(n_layers=_A_LAYERS, lorentzian=False,
+                                       u_turn=False, max_iters=_A_RELAX)
+        cls.o0 = E.measure(cls.m0, cls.t0)
+
+    def test_G9_bilateral_pinning_regulates_runaway(self):
+        # bilateral pinning supplies the restoring force the singly-pinned #435 node
+        # lacked: at minimal temporal depth the relaxed ||grad S||^2 is BELOW the
+        # carriable floor (71 < 100 at nL=2). Asserted at nL=2 ONLY -- the residual is
+        # extensive in the temporal volume (159 at nL=3, 268 at nL=4).
+        self.assertLess(self.op["gradS2"], _A_GRADS2_FLOOR)
+
+    def test_G10_emergent_charge_nondegenerate_cpt(self):
+        # the Lorentzian proton carries a NON-DEGENERATE emergent Gauss-law charge
+        # (|Q_e| > tau), while the all-spacelike control stays degenerate (|Q_e| ~ 0);
+        # the charge is emergent (read off the relaxed connection), never a register.
+        self.assertGreater(abs(self.op["Q_e"]), _A_CHARGE_TAU)
+        self.assertLessEqual(abs(self.o0["Q_e"]), 1e-9)
+        # proton + anti-proton total electric charge cancels (CPT).
+        self.assertLessEqual(abs(self.op["Q_e"] + self.oa["Q_e"]), _A_CHARGE_CANCEL)
+
+    def test_G11_proton_singlet_from_colored_inputs(self):
+        # the pinned top slice crystallizes to the color singlet (>= 0.95) from the
+        # frame-symmetric, color-INDEFINITE quark inputs -- color is never painted, the
+        # singlet emerges. Both the proton and anti-proton sectors are singlets.
+        self.assertGreaterEqual(self.op["top_singlet"], _A_SINGLET_FLOOR)
+        self.assertGreaterEqual(self.oa["top_singlet"], _A_SINGLET_FLOOR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Promote the Experiment-A (#434) `EmergentEventTopology` physics into the shared epic guard (`tests/cobordism/test_epic410_invariants.py`) as three permanent regression invariants, continuing the G-numbering after the existing G1-G5 (G6-G8 are cross-cutting relabeling/determinism/emergent-first concepts already in use). The new invariants reuse the exact pre-registered thresholds + measurement helpers from `tests/cobordism/test_emergent_intermediates.py` (copied verbatim, no re-derivation):

- **G9** bilateral pinning regulates the conformal runaway: `||grad S||^2 < 100` at nL=2 (asserted at the minimal/fair depth only; the residual is extensive in temporal volume: 71 / 159 / 268 at nL=2/3/4).
- **G10** non-degenerate, CPT-conserved emergent charge: `|Q_e| > 0.05` (Lorentzian) AND `<= 1e-9` (all-spacelike control) AND `|Q_proton + Q_antiproton| <= 1e-3`.
- **G11** proton color singlet `>= 0.95` from frame-symmetric COLORED inputs (color not painted).

All three (and the heavy `setUpClass` relaxation) are tagged `@pytest.mark.slow` so they land in the full/nightly lane, not the 16-min fast PR lane. Existing G1-G5 classification is unchanged (already slow). Test-only; no C++ touched.

## Test plan
- [ ] `pytest tests/cobordism/test_epic410_invariants.py` -- existing G1-G5 + the new G9-G11 all green
- [ ] confirm G9-G11 PASS at the documented thresholds (no loosening)
- [ ] CI green

Closes #447.