### PR TITLE
feat(cobordism): S3 window surface + 4D proton event — the 3+1 D foundation

### DIFF
--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -184,6 +184,8 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} SymmetricWindowSurface.h
 ```
+```{doxygenfile} S3WindowSurface.h
+```
 ```{doxygenfile} BipartiteCreationTopology.h
 ```
 ```{doxygenfile} EmergentEventTopology.h

--- a/include/cobordism/EmergentEventTopology.h
+++ b/include/cobordism/EmergentEventTopology.h
@@ -138,6 +138,42 @@ class EmergentEventTopology : public TopologyBuilder {
     /// @param frequency the subdivision frequency \f$ N \ge 2 \f$.
     void setFrequency(int frequency);
 
+    /// Build the genuinely **3+1 D** event over a triangulated \f$ S^3 \f$ spatial
+    /// slice (#453) instead of the 2+1 D \f$ S^2 \f$ slice. When set, `build()`
+    /// uses `S3WindowSurface` (the join-of-cycles \f$ S^3 \f$ with color windows of
+    /// three vertex-disjoint hole **tetrahedra** each), removes the window tetrahedra
+    /// (opening the \f$ b_2 \f$ color register --- the \f$ \ker L_2 \f$ degree
+    /// \f$ k=2 \f$, the \f$ S^3 \f$ analog of \f$ S^2 \f$'s \f$ b_1 \f$/\f$ k=1 \f$),
+    /// and stacks the holed slice over the temporal layers with the **dimension-generic
+    /// symmetric apex reflection** (`Spacetime::symmetricStackCells`, #429) into a
+    /// genuine **4-manifold** (pentatope top cells), gated by the rigorous \f$ n\ge4 \f$
+    /// recursive `dualComplexValid`. The window holes, signs, and bilateral pinning
+    /// flow exactly as in the \f$ S^2 \f$ path but with 4-vertex tetrahedral holes
+    /// read at `registerDegree()` \f$ =2 \f$. Off by default (the \f$ S^2 \f$ slice).
+    /// @param on whether to build the \f$ S^3 \f$ (3+1 D) slice.
+    void setS3Slice(bool on = true);
+
+    /// Whether the \f$ S^3 \f$ (3+1 D) spatial slice is selected (default false).
+    [[nodiscard]] bool s3Slice() const { return s3Slice_; }
+
+    /// Set the number of color windows on the \f$ S^3 \f$ slice (\f$ \ge 1 \f$;
+    /// default 4 = the A,B,C,R structure). The holed slice then carries
+    /// \f$ b_2 = 3\cdot\text{windows} - 1 \f$. Fewer windows make a much smaller
+    /// 4-complex (the like-resolution four-window event is the 10^3-10^4x cost the
+    /// #418 spike budgeted for); one window is the minimal genuinely-4D event. Only
+    /// the first four windows are bilaterally pinned by `readoutHoles` (A,B,C,R).
+    /// @param windows the number of \f$ \mathbb{Z}_3 \f$ color windows.
+    void setS3Windows(int windows);
+
+    /// The number of \f$ S^3 \f$ color windows (default 4).
+    [[nodiscard]] int s3Windows() const { return s3Windows_; }
+
+    /// The Hodge degree \f$ k \f$ at which the color register is read: \f$ k=1 \f$
+    /// (\f$ b_1 \f$, triangle holes) on the \f$ S^2 \f$ slice; \f$ k=2 \f$
+    /// (\f$ b_2 \f$, tetrahedral holes) on the \f$ S^3 \f$ slice. The register is
+    /// always \f$ \ker L_{d-1} \f$ for a \f$ d \f$-dimensional spatial slice.
+    [[nodiscard]] std::size_t registerDegree() const { return s3Slice_ ? 2u : 1u; }
+
     /// The number of temporal layers (\f$ \ge 2 \f$); slices are \f$ 0..nLayers \f$.
     [[nodiscard]] int nLayers() const { return nLayers_; }
 
@@ -171,6 +207,8 @@ class EmergentEventTopology : public TopologyBuilder {
     bool lorentzian_{false};    // timelike cross-layer worldlines
     double lorentzWorldlineLsq_{-1.0};
     bool uTurnTwist_{false};    // anti-baryon (orientation-reversing) sector
+    bool s3Slice_{false};       // genuinely 3+1 D: S^3 slice (#453) vs the S^2 slice
+    int s3Windows_{4};          // number of S^3 color windows (b_2 = 3*windows - 1)
 
     std::uint64_t stride_{0};   // per-layer vertex stride (base vertex count)
 

--- a/include/cobordism/S3WindowSurface.h
+++ b/include/cobordism/S3WindowSurface.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_S3WINDOWSURFACE_H
+#define TESSERA_COBORDISM_S3WINDOWSURFACE_H
+
+#include <cstdint>
+#include <vector>
+
+namespace tessera::cobordism {
+
+/// # S3WindowSurface
+///
+/// The genuinely **3+1 D** color-register base slice (#453): a triangulated
+/// 3-sphere \f$ S^3 \f$ carrying symmetric, color-\f$ \mathbb{Z}_3 \f$-equivariant
+/// windows --- the faithful 4D analog of the \f$ S^2 \f$ `SymmetricWindowSurface`
+/// (the geodesic icosahedron), NOT a 2+1 D shortcut.
+///
+/// ## The dimensional lift (the crux)
+/// On \f$ S^2 \f$ the color register is \f$ \ker L_1 \f$ (\f$ b_1 \f$) and a window
+/// hole is a removed **top 2-cell** (a triangle), whose boundary 1-loop becomes a
+/// 1-cycle (read as a 1-form period at degree \f$ k=1 \f$). The register degree
+/// **tracks the spatial dimension**: it is always \f$ \ker L_{d-1} \f$ with holes
+/// the removed **top \f$ d \f$-cells**. On \f$ S^3 \f$ (\f$ d=3 \f$) the register is
+/// therefore \f$ \ker L_2 \f$ (\f$ b_2 \f$) and a window hole is a removed **top
+/// 3-cell** (a tetrahedron), whose boundary 2-sphere becomes a 2-cycle (read as a
+/// 2-form period at degree \f$ k=2 \f$). \f$ S^3 \f$ is simply connected
+/// (\f$ b_1=0 \f$), so removing tetrahedra cannot make \f$ b_1 \f$ --- the register
+/// genuinely lives one degree up, exactly mirroring the \f$ S^2 \f$ construction one
+/// dimension down. Removing \f$ n \f$ vertex-disjoint tetrahedra from \f$ S^3 \f$
+/// gives \f$ b_2 = n-1 \f$ (the \f$ S^2 \f$ analog: \f$ n \f$ disjoint triangles
+/// give \f$ b_1 = n-1 \f$).
+///
+/// ## The triangulation and the symmetric windows
+/// The slice is the **join of two \f$ K \f$-cycles** \f$ C_K * C_K \f$ --- a clean
+/// triangulated \f$ S^3 \f$ (Betti \f$ [1,0,0,1] \f$) with \f$ 2K \f$ vertices and
+/// \f$ K^2 \f$ top tetrahedra \f$ \{a_i, a_{i+1}, b_j, b_{j+1}\} \f$. Unlike a
+/// product/shuffle triangulation, the join is manifestly cyclically symmetric: the
+/// rotations \f$ \tau:\,a_i\!\to\!a_{i+1},\,b_j\!\to\!b_{j+1} \f$ (and the
+/// rotate-one-factor variants) are simplicial automorphisms. Each **window** is a
+/// \f$ \mathbb{Z}_3 \f$ orbit (under \f$ \sigma = \tau^{K/3} \f$) of three
+/// vertex-disjoint hole tetrahedra; \f$ \sigma \f$ cyclically permutes the three
+/// color holes (the color \f$ \mathbb{Z}_3 \f$), so the transport intertwines color
+/// just as the \f$ A_4 \f$ orbits did on \f$ S^2 \f$. The `windowCount` windows are
+/// themselves one orbit of \f$ \tau^2 \f$ (the seed of window \f$ w \f$ is shifted
+/// by two), so the windows are a genuine symmetry orbit, not a hand-placed set.
+/// With \f$ K = 6\cdot\text{windowCount}\cdot\text{granularity} \f$ the
+/// \f$ 3\cdot\text{windowCount} \f$ holes are all vertex-disjoint, giving
+/// \f$ b_2 = 3\cdot\text{windowCount} - 1 \f$ (windowCount\f$=4 \Rightarrow b_2=11 \f$,
+/// the \f$ S^2 \f$ proton's hole budget lifted to \f$ S^3 \f$).
+///
+/// Pure and deterministic --- a function of (`windowCount`, `granularity`) alone.
+class S3WindowSurface {
+  public:
+    /// A sorted vertex tuple: a top tetrahedron (4 ids) or a hole tetrahedron.
+    using Cell = std::vector<std::uint64_t>;
+
+    /// The slice (its \f$ K^2 \f$ top tetrahedra, sorted) and the `windowCount`
+    /// \f$ \mathbb{Z}_3 \f$-symmetric windows of three hole tetrahedra each. A 4D
+    /// `EmergentEventTopology` (S^3 mode) consumes all the windows (A,B,C,R); the
+    /// hole tetrahedra are the **top 3-cells removed** to open the \f$ b_2 \f$
+    /// register, read at degree \f$ k=2 \f$.
+    struct Surface {
+      std::vector<Cell> faces;                  ///< K^2 top tetrahedra (sorted)
+      std::vector<std::vector<Cell>> windows;   ///< windowCount x 3 hole tetrahedra
+    };
+
+    /// Build the \f$ S^3 \f$ slice + windows.
+    /// @param windowCount the number of color windows (\f$ \ge 1 \f$). Four matches
+    ///   the \f$ W_{ABC} \f$ A,B,C,R structure; one is the minimal color register.
+    /// @param granularity the lattice-refinement factor (\f$ \ge 1 \f$): the cycle
+    ///   length is \f$ K = 6\cdot\text{windowCount}\cdot\text{granularity} \f$, so a
+    ///   larger value refines the triangulation between the (fixed, disjoint) holes
+    ///   (the tunable granularity, the \f$ S^3 \f$ analog of the geodesic frequency).
+    /// @throws std::invalid_argument if `windowCount < 1` or `granularity < 1`.
+    /// @throws std::runtime_error if the generated windows are not a genuine
+    ///   \f$ \mathbb{Z}_3 \f$ orbit, are not base tetrahedra, or are not
+    ///   vertex-disjoint.
+    [[nodiscard]] static Surface build(int windowCount = 4, int granularity = 1);
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_S3WINDOWSURFACE_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -37,6 +37,7 @@
 #include "cobordism/TripartiteRegisterTopology.h"
 #include "cobordism/BipartiteCreationTopology.h"
 #include "cobordism/EmergentEventTopology.h"
+#include "cobordism/S3WindowSurface.h"
 #include "cobordism/FixedBipartiteSequenceTopology.h"
 #include "spacetime/Spacetime.h"  // complete type required by pybind (typeid)
 
@@ -1592,6 +1593,31 @@ prepared states, reproduces the harmonic overlap.)doc")
            "The antiquark window's per-hole induced-orientation signs (sign-reversed "
            "by the U-turn twist relative to the quark window).");
 
+  // === S3WindowSurface (#453): the genuinely 3+1 D color-register slice ===
+  py::class_<S3WindowSurface::Surface>(
+      m, "S3Surface",
+      "The triangulated S^3 spatial slice (.faces: the K^2 top tetrahedra) and its "
+      "Z_3-symmetric color windows (.windows: windowCount x 3 hole tetrahedra).")
+      .def_readonly("faces", &S3WindowSurface::Surface::faces)
+      .def_readonly("windows", &S3WindowSurface::Surface::windows);
+  py::class_<S3WindowSurface>(
+      m, "S3WindowSurface",
+      "The genuinely 3+1 D color-register base slice (#453): a triangulated S^3 "
+      "(the join of two K-cycles) carrying symmetric, color-Z_3-equivariant windows "
+      "-- the faithful 4D analog of the S^2 SymmetricWindowSurface. The register "
+      "degree tracks the spatial dimension (ker L_{d-1}, holes = removed top "
+      "d-cells): on S^3 a window hole is a removed TETRAHEDRON (the b_2/k=2 "
+      "register), and each window is a Z_3 orbit (sigma = tau^{K/3}) of three "
+      "vertex-disjoint hole tetrahedra; removing 3*windowCount disjoint tetrahedra "
+      "gives b_2 = 3*windowCount - 1 (windowCount=4 => b_2=11, the S^2 proton's hole "
+      "budget lifted to S^3). Pure and deterministic.")
+      .def_static("build", &S3WindowSurface::build, py::arg("window_count") = 4,
+                  py::arg("granularity") = 1,
+                  "Build the S^3 slice + windows. window_count >= 1 (four matches "
+                  "the W_ABC A,B,C,R structure; one is the minimal color register); "
+                  "granularity >= 1 refines the lattice between the disjoint holes "
+                  "(K = 6*window_count*granularity).");
+
   // === EmergentEventTopology (#434, Experiment A) ===
   py::class_<EmergentEventTopology, TopologyBuilder,
              std::shared_ptr<EmergentEventTopology>>(
@@ -1633,6 +1659,26 @@ prepared states, reproduces the harmonic overlap.)doc")
            py::arg("frequency"),
            "Set the geodesic subdivision frequency N >= 2 (#404); N=2 (default) is "
            "the 42-vertex base that hosts the 12 disjoint holes.")
+      .def("set_s3_slice", &EmergentEventTopology::setS3Slice,
+           py::arg("on") = true,
+           "Build the genuinely 3+1 D event over a triangulated S^3 slice (#453) "
+           "instead of the 2+1 D S^2 slice: S3WindowSurface (join-of-cycles S^3 + "
+           "Z_3 windows of three hole TETRAHEDRA each, the b_2/k=2 register), holed "
+           "and stacked by the dimension-generic symmetric apex reflection "
+           "(symmetricStackCells, #429) into a genuine 4-manifold (pentatopes), "
+           "gated by the rigorous n=4 recursive dualComplexValid. Off => S^2.")
+      .def("s3_slice", &EmergentEventTopology::s3Slice,
+           "Whether the S^3 (3+1 D) spatial slice is selected (default false).")
+      .def("set_s3_windows", &EmergentEventTopology::setS3Windows,
+           py::arg("windows"),
+           "Set the number of S^3 color windows (>= 1; default 4 = A,B,C,R). The "
+           "holed slice carries b_2 = 3*windows - 1; fewer windows make a much "
+           "smaller 4-complex (one window is the minimal genuinely-4D event).")
+      .def("s3_windows", &EmergentEventTopology::s3Windows,
+           "The number of S^3 color windows (default 4).")
+      .def("register_degree", &EmergentEventTopology::registerDegree,
+           "The Hodge degree k the color register is read at: 1 (b_1, triangle "
+           "holes) on S^2; 2 (b_2, tetrahedral holes) on S^3. Always ker L_{d-1}.")
       .def("n_layers", &EmergentEventTopology::nLayers,
            "The number of temporal layers (>= 2); slices are 0..n_layers.")
       .def("stride", &EmergentEventTopology::stride,
@@ -1651,7 +1697,21 @@ prepared states, reproduces the harmonic overlap.)doc")
            "The per-hole induced-orientation signs of window w (sign-reversed by "
            "the U-turn twist); layer-independent.")
       .def("u_turn_twisted", &EmergentEventTopology::uTurnTwisted,
-           "Whether the U-turn (anti-baryon) twist is applied (default false).");
+           "Whether the U-turn (anti-baryon) twist is applied (default false).")
+      .def(
+          "build_cobordism",
+          [](EmergentEventTopology &self, std::size_t stateDim,
+             std::uint64_t seed) {
+            std::vector<std::vector<std::uint64_t>> boundaryCells;
+            auto st = self.build(stateDim, seed, boundaryCells);
+            return py::make_tuple(st, boundaryCells);
+          },
+          py::arg("state_dim") = 3, py::arg("seed") = 0,
+          "Build the event cobordism W directly (bypassing the k=1 TransportCobordism "
+          "harness): returns (cobordism, boundary_cells). For the S^3 (#453) mode the "
+          "cobordism is a genuine 4-manifold (read its register at register_degree()=2 "
+          "via EigenstateSynthesis(W, 2)); build() already gates it on the rigorous "
+          "n=4 recursive dualComplexValid.");
 
   // === FixedBipartiteSequenceTopology (#438, Experiment B) ===
   py::class_<FixedBipartiteSequenceTopology, EmergentEventTopology,

--- a/src/cobordism/EmergentEventTopology.cpp
+++ b/src/cobordism/EmergentEventTopology.cpp
@@ -10,6 +10,7 @@
 
 #include "cobordism/ChainComplex.h"
 #include "cobordism/EigenstateSynthesis.h"
+#include "cobordism/S3WindowSurface.h"
 #include "cobordism/SymmetricWindowSurface.h"
 #include "mesh/Edge.h"
 #include "mesh/EdgeList.h"
@@ -33,6 +34,16 @@ void EmergentEventTopology::setLorentzianWorldlines(double worldlineLsq) {
 }
 
 void EmergentEventTopology::setUTurnTwist(bool on) { uTurnTwist_ = on; }
+
+void EmergentEventTopology::setS3Slice(bool on) { s3Slice_ = on; }
+
+void EmergentEventTopology::setS3Windows(int windows) {
+  if (windows < 1)
+    throw std::invalid_argument(
+        "EmergentEventTopology: S^3 windows must be >= 1 (four is the A,B,C,R "
+        "structure; one is the minimal genuinely-4D color event)");
+  s3Windows_ = windows;
+}
 
 void EmergentEventTopology::setFrequency(int frequency) {
   if (frequency < 2)
@@ -61,19 +72,33 @@ std::shared_ptr<Spacetime> EmergentEventTopology::build(
   // three color holes are readable at EVERY temporal slice (the base holes shifted
   // by layer*stride). The bottom (ell=0) and top (ell=nLayers_) slices are pinned;
   // the middle slices relax (the emergent intermediates).
-  const auto surface = SymmetricWindowSurface::build(frequency_);
-  const auto &faces = surface.faces;
+  // The spatial slice + its color windows. S^2 (2+1 D, default): the geodesic
+  // icosahedron with four A4 windows of three vertex-disjoint hole TRIANGLES each
+  // (the b_1 / k=1 register). S^3 (3+1 D, #453): the join-of-cycles 3-sphere with
+  // four Z_3 windows of three vertex-disjoint hole TETRAHEDRA each (the b_2 / k=2
+  // register — the faithful dimensional lift, ker L_{d-1} with holes the removed
+  // top d-cells). Both expose .faces (top d-cells) and .windows (windowCount x 3).
+  std::vector<Face> faces;
+  std::vector<std::vector<Face>> windows;
+  if (s3Slice_) {
+    auto surface = S3WindowSurface::build(s3Windows_, /*granularity=*/1);
+    faces = std::move(surface.faces);
+    windows = std::move(surface.windows);
+  } else {
+    auto surface = SymmetricWindowSurface::build(frequency_);
+    faces = std::move(surface.faces);
+    windows = std::move(surface.windows);
+  }
 
-  // Flatten all four windows' (A,B,C,R) twelve holes in window order, for the
-  // base-layer endSignCovector and for the per-layer accessors.
+  // Flatten all four windows' (A,B,C,R) holes in window order, for the base-layer
+  // endSignCovector and for the per-layer accessors.
   std::vector<Face> holes;
-  holes.reserve(12);
-  for (std::size_t w = 0; w < surface.windows.size(); ++w)
-    for (const auto &h : surface.windows[w]) holes.push_back(h);
+  for (std::size_t w = 0; w < windows.size(); ++w)
+    for (const auto &h : windows[w]) holes.push_back(h);
 
-  blockHoles_.assign(surface.windows.size(), {});
-  for (std::size_t w = 0; w < surface.windows.size(); ++w)
-    for (const auto &h : surface.windows[w]) blockHoles_[w].push_back(h);
+  blockHoles_.assign(windows.size(), {});
+  for (std::size_t w = 0; w < windows.size(); ++w)
+    for (const auto &h : windows[w]) blockHoles_[w].push_back(h);
 
   // Holed surface -> 3-complex: the staircase prism over [0, nLayers_]. An
   // interval (NOT looped), so the two end caps + the hole-tube walls are the
@@ -87,14 +112,23 @@ std::shared_ptr<Spacetime> EmergentEventTopology::build(
   for (const auto &f : holed)
     for (const auto v : f) stride_ = std::max(stride_, v + 1);
 
-  const auto prism = Spacetime::prismCells(holed, /*layers=*/nLayers_);
+  // Holed slice -> cobordism. S^2: the dimension-generic staircase prism over the
+  // nLayers_ temporal layers, giving a 3-complex (tetrahedra). S^3 (#453): the
+  // dimension-generic SYMMETRIC apex reflection (symmetricStackCells, #429) over
+  // nLayers_ apex slices, giving a genuine 4-complex (pentatope top cells) — a real
+  // 3+1 D worldvolume, never a 2+1 D shortcut. The primal vertices layer the same
+  // way in both (v + ell*stride), so windowHolesAtLayer is unchanged.
+  const int dim = s3Slice_ ? 4 : 3;
+  const auto stacked = s3Slice_
+                           ? Spacetime::symmetricStackCells(holed, nLayers_)
+                           : Spacetime::prismCells(holed, /*layers=*/nLayers_);
   std::vector<std::vector<std::uint64_t>> cells;
-  cells.reserve(prism.size());
-  for (auto c : prism) {
+  cells.reserve(stacked.size());
+  for (auto c : stacked) {
     std::sort(c.begin(), c.end());
     cells.push_back(std::move(c));
   }
-  auto cobordism = Spacetime::fromCells(3, cells, 1.0, 0.0);
+  auto cobordism = Spacetime::fromCells(dim, cells, 1.0, 0.0);
 
   // The symmetric UNIFORM seed (l^2 = 1): the symmetric windows need a
   // symmetry-respecting metric for the transport to intertwine the color Z3, and
@@ -121,16 +155,24 @@ std::shared_ptr<Spacetime> EmergentEventTopology::build(
   // grouped per window A,B,C,R). The carried condition is sign . psi = 0, so
   // targets are pre-multiplied by it; the emergent windows are read in the SAME
   // global orientation, making sigma the relabeling-invariant Stokes charge (#412).
-  const std::vector<int> covec = ChainComplex::endSignCovector(faces, holes);
-  if (covec.size() != holes.size())
-    throw std::runtime_error(
-        "EmergentEventTopology: endSignCovector returned " +
-        std::to_string(covec.size()) + " signs, expected " +
-        std::to_string(holes.size()));
   signTable_.assign(blockHoles_.size(), std::vector<int>(3, 1));
-  for (std::size_t w = 0; w < blockHoles_.size(); ++w)
-    for (std::size_t k = 0; k < 3; ++k)
-      signTable_[w][k] = covec[w * 3 + k];
+  if (!s3Slice_) {
+    // S^2: induced-orientation covector over the 12 triangle holes, so sigma is the
+    // relabeling-invariant Stokes charge (#412).
+    const std::vector<int> covec = ChainComplex::endSignCovector(faces, holes);
+    if (covec.size() != holes.size())
+      throw std::runtime_error(
+          "EmergentEventTopology: endSignCovector returned " +
+          std::to_string(covec.size()) + " signs, expected " +
+          std::to_string(holes.size()));
+    for (std::size_t w = 0; w < blockHoles_.size(); ++w)
+      for (std::size_t k = 0; k < 3; ++k)
+        signTable_[w][k] = covec[w * 3 + k];
+  }
+  // S^3 (#453): the b_2 register carries the omega color states with the raw
+  // tetrahedral-hole periods (residualForPeriods machine-zero on a carried target),
+  // so the foundation pins with +1 signs; the induced-orientation signing of a
+  // 2-cycle for a relabeling-invariant sigma_R is the stage-2 physics build-out.
 
   // The orientation-reversing U-TURN TWIST (#416): reverse every window's
   // induced-orientation covector, so each carried period (and emergent charge) is
@@ -161,8 +203,11 @@ std::shared_ptr<Spacetime> EmergentEventTopology::build(
     if (kv.second == 1) boundaryCells.push_back(kv.first);
   }
 
-  // === manifold gate: dualComplexValid (rigorous for n <= 3) ===
-  const auto valid = EigenstateSynthesis(cobordism, 1).dualComplexValid();
+  // === manifold gate: dualComplexValid (rigorous recursive link check; for the
+  // S^3 path this is the n=4 4-manifold gate, vertex links validated as 3-manifolds)
+  const auto valid =
+      EigenstateSynthesis(cobordism, static_cast<int>(registerDegree()))
+          .dualComplexValid();
   if (!valid.first)
     throw std::runtime_error(
         "EmergentEventTopology: seed failed the dual-complex manifold gate: " +

--- a/src/cobordism/S3WindowSurface.cpp
+++ b/src/cobordism/S3WindowSurface.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/S3WindowSurface.h"
+
+#include <algorithm>
+#include <set>
+#include <stdexcept>
+#include <utility>
+
+namespace tessera::cobordism {
+
+namespace {
+
+using Cell = S3WindowSurface::Cell;
+
+// The join of two K-cycles C_K * C_K: a clean triangulated S^3 with 2K vertices
+// (a_i = i, b_j = K + j) and K^2 top tetrahedra {a_i, a_{i+1 mod K}, b_j,
+// b_{j+1 mod K}}. The two core circles are Hopf-linked; the rotations of either
+// factor are simplicial automorphisms (the join is cyclically symmetric, unlike a
+// shuffle product). Betti [1,0,0,1]. Deterministic.
+std::vector<Cell> joinOfCycles(std::uint64_t K) {
+  std::vector<Cell> faces;
+  faces.reserve(static_cast<std::size_t>(K) * K);
+  for (std::uint64_t i = 0; i < K; ++i)
+    for (std::uint64_t j = 0; j < K; ++j) {
+      Cell t = {i, (i + 1) % K, K + j, K + (j + 1) % K};
+      std::sort(t.begin(), t.end());
+      faces.push_back(std::move(t));
+    }
+  return faces;
+}
+
+// The hole tetrahedron seated at the diagonal grid position p (its a- and b-pair
+// both start at p): {a_p, a_{p+1}, b_p, b_{p+1}} — a genuine join top cell.
+Cell holeAt(std::uint64_t p, std::uint64_t K) {
+  Cell t = {p % K, (p + 1) % K, K + p % K, K + (p + 1) % K};
+  std::sort(t.begin(), t.end());
+  return t;
+}
+
+}  // namespace
+
+S3WindowSurface::Surface S3WindowSurface::build(int windowCount, int granularity) {
+  if (windowCount < 1)
+    throw std::invalid_argument(
+        "S3WindowSurface: windowCount must be >= 1 (four matches the W_ABC "
+        "A,B,C,R structure; one is the minimal color register)");
+  if (granularity < 1)
+    throw std::invalid_argument(
+        "S3WindowSurface: granularity must be >= 1 (the lattice-refinement "
+        "factor; larger refines the triangulation between the disjoint holes)");
+
+  // K is a multiple of 6: divisible by 3 for the color Z_3 = tau^{K/3}, and the
+  // even spacing keeps the windowCount windows' 3*windowCount holes vertex-disjoint.
+  const std::uint64_t K = static_cast<std::uint64_t>(6) *
+                          static_cast<std::uint64_t>(windowCount) *
+                          static_cast<std::uint64_t>(granularity);
+  const std::uint64_t colorStep = K / 3;  // the color-Z_3 generator sigma = tau^{K/3}
+
+  auto faces = joinOfCycles(K);
+  const std::set<Cell> faceSet(faces.begin(), faces.end());
+
+  // Window w: the sigma-orbit (sigma = tau^{K/3}, order 3) of a seed hole at the
+  // diagonal position 2w. sigma cyclically permutes the three color holes (the
+  // color Z_3); tau^2 maps window w -> window w+1, so the windows are themselves
+  // one symmetry orbit (not a hand-placed set). Asserts: each window a genuine Z_3
+  // orbit of base tetrahedra, all holes vertex-disjoint.
+  std::vector<std::vector<Cell>> windows(static_cast<std::size_t>(windowCount));
+  std::set<std::uint64_t> used;
+  for (int w = 0; w < windowCount; ++w) {
+    const std::uint64_t seed = static_cast<std::uint64_t>(2 * w);
+    Cell h0 = holeAt(seed, K);
+    Cell h1 = holeAt(seed + colorStep, K);
+    Cell h2 = holeAt(seed + 2 * colorStep, K);
+    if (holeAt(seed + 3 * colorStep, K) != h0)
+      throw std::runtime_error(
+          "S3WindowSurface: color window is not a Z_3 orbit");
+    for (const Cell &h : {h0, h1, h2}) {
+      if (!faceSet.count(h))
+        throw std::runtime_error(
+            "S3WindowSurface: color hole is not a base tetrahedron");
+      for (const auto v : h)
+        if (!used.insert(v).second)
+          throw std::runtime_error(
+              "S3WindowSurface: color windows are not vertex-disjoint");
+      windows[static_cast<std::size_t>(w)].push_back(h);
+    }
+  }
+
+  return Surface{std::move(faces), std::move(windows)};
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_s3_window_surface.py
+++ b/tests/cobordism/test_s3_window_surface.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The genuinely 3+1 D color-register foundation (#453).
+
+Stage 1 of the 4D conversion of the proton experiments: a triangulated ``S^3``
+spatial slice carrying symmetric, color-``Z_3``-equivariant windows (the faithful
+4D analog of the ``S^2`` ``SymmetricWindowSurface`` / geodesic icosahedron),
+stacked over time into a genuine **4-manifold** event. NEVER 2+1 D, no ``S^2``
+fallback.
+
+The crux: the color register degree **tracks the spatial dimension** -- it is
+``ker L_{d-1}`` with the holes the removed **top d-cells**. On ``S^2`` (``d=2``) a
+window hole is a removed TRIANGLE (the ``b_1`` / ``k=1`` register); on ``S^3``
+(``d=3``) it is a removed TETRAHEDRON (the ``b_2`` / ``k=2`` register). ``S^3`` is
+simply connected (``b_1 = 0``), so the register genuinely lives one degree up,
+mirroring the ``S^2`` construction one dimension down. Removing ``n`` disjoint
+tetrahedra from ``S^3`` gives ``b_2 = n - 1`` (the ``S^2`` analog: ``n`` disjoint
+triangles give ``b_1 = n - 1``).
+
+The slice is the join of two ``K``-cycles (a clean ``Z_3``-symmetric triangulated
+3-sphere); each window is a ``Z_3`` orbit of three vertex-disjoint hole
+tetrahedra; the holed slice is stacked over time by the dimension-generic
+symmetric apex reflection (``Spacetime.symmetricStackCells``, #429) into a
+pentatope 4-complex, gated by the rigorous ``n=4`` recursive ``dualComplexValid``.
+"""
+
+import cmath
+import math
+import unittest
+
+import pytest
+
+import tessera
+
+cob = tessera.cobordism
+S = tessera.Spacetime
+
+# The color triple's omega phase and the three reps on the color triple.
+_W = cmath.exp(2j * math.pi / 3)
+_SINGLET = [1.0, 1.0, 1.0]          # the trivial rep -- NOT carried (confinement)
+_OMEGA = [1.0, _W, _W * _W]         # the standard-rep color state -- carried
+_OMEGABAR = [1.0, _W * _W, _W]      # its conjugate -- carried
+
+
+def _holed(window_count, granularity=1):
+    """The S^3 slice minus its window tetrahedra, and the flat hole list."""
+    surf = cob.S3WindowSurface.build(window_count, granularity)
+    faces = [list(t) for t in surf.faces]
+    windows = [[list(h) for h in w] for w in surf.windows]
+    holes = [h for w in windows for h in w]
+    holeset = {tuple(h) for h in holes}
+    holed = [t for t in faces if tuple(t) not in holeset]
+    return faces, windows, holes, holed
+
+
+def _betti(top_cells, dim):
+    st = S.fromCells(dim, [list(c) for c in top_cells], 1.0, 0.0)
+    return list(cob.ChainComplex.fromSpacetime(st).bettiNumbers()), st
+
+
+class S3WindowSurfaceTest(unittest.TestCase):
+    """The S^3 slice + Z_3 windows + the b_2 / k=2 color register."""
+
+    def test_slice_is_a_clean_triangulated_three_sphere(self):
+        surf = cob.S3WindowSurface.build(1, 1)
+        betti, st = _betti(surf.faces, 3)
+        self.assertEqual(betti, [1, 0, 0, 1])               # S^3
+        self.assertEqual(len(st.getBoundary()), 0)          # closed
+        ok, _msg = cob.EigenstateSynthesis(st, 2).dualComplexValid()
+        self.assertTrue(ok)
+        # the join of two K-cycles: K = 6, 2K = 12 vertices, K^2 = 36 tetrahedra
+        self.assertEqual(len(surf.faces), 36)
+
+    def test_windows_are_z3_orbits_of_disjoint_hole_tetrahedra(self):
+        wc = 4
+        surf = cob.S3WindowSurface.build(wc, 1)
+        windows = [[tuple(h) for h in w] for w in surf.windows]
+        self.assertEqual(len(windows), wc)
+        # every hole is a TETRAHEDRON (4 vertices) -- the d=3 register's removed
+        # top cell, not a triangle.
+        for w in windows:
+            self.assertEqual(len(w), 3)
+            for h in w:
+                self.assertEqual(len(h), 4)
+        # all 3*wc holes are vertex-disjoint (mirrors the S^2 12-disjoint-holes).
+        verts = [v for w in windows for h in w for v in h]
+        self.assertEqual(len(verts), len(set(verts)))
+        # the color Z_3 sigma = tau^{K/3} cyclically permutes each window's holes.
+        K = 6 * wc
+        step = K // 3
+
+        def sigma(v):
+            return (v + step) % K if v < K else K + ((v - K + step) % K)
+
+        for w in windows:
+            rotated = {tuple(sorted(sigma(v) for v in h)) for h in w}
+            self.assertEqual(rotated, set(w))               # sigma preserves the window
+            # and it is a genuine 3-cycle, not the identity
+            self.assertNotEqual(tuple(sorted(sigma(v) for v in w[0])), w[0])
+
+    def test_removing_windows_opens_the_b2_register(self):
+        # b_2 = 3*windowCount - 1, the S^3 lift of the S^2 proton's b_1 = 11.
+        for wc, expect_b2 in [(1, 2), (2, 5), (4, 11)]:
+            _f, _w, _h, holed = _holed(wc)
+            betti, st = _betti(holed, 3)
+            self.assertEqual(betti[2], expect_b2, f"windowCount={wc}")
+            self.assertEqual(betti[1], 0)                   # no spurious b_1
+            ok, _msg = cob.EigenstateSynthesis(st, 2).dualComplexValid()
+            self.assertTrue(ok, f"windowCount={wc} not a valid manifold")
+
+    def test_color_register_carries_omega_not_singlet(self):
+        # The crux: pin a color state on one window's three tetrahedral holes and
+        # read its period at k=2. The omega (standard-rep) states are carried
+        # (residual -> machine zero); the singlet is NOT (confinement / Sum=0).
+        _f, windows, _h, holed = _holed(1)
+        st = S.fromCells(3, [list(t) for t in holed], 1.0, 0.0)
+        es = cob.EigenstateSynthesis(st, 2)
+        holes = [list(h) for h in windows[0]]
+        r_omega = es.residualForPeriods(holes, [complex(x) for x in _OMEGA])
+        r_obar = es.residualForPeriods(holes, [complex(x) for x in _OMEGABAR])
+        r_singlet = es.residualForPeriods(holes, [complex(x) for x in _SINGLET])
+        self.assertLess(r_omega, 1e-12)
+        self.assertLess(r_obar, 1e-12)
+        self.assertGreater(r_singlet, 1.0)                  # confinement
+
+    def test_deterministic(self):
+        a = cob.S3WindowSurface.build(2, 1)
+        b = cob.S3WindowSurface.build(2, 1)
+        self.assertEqual([list(t) for t in a.faces], [list(t) for t in b.faces])
+        self.assertEqual([[list(h) for h in w] for w in a.windows],
+                         [[list(h) for h in w] for w in b.windows])
+
+
+_EVENT_CACHE = {}
+
+# The minimal genuinely-4D event: one Z_3 color window (b_2 = 2), stacked over two
+# temporal apex slices. The like-resolution four-window event (b_2 = 11) is the
+# 10^3-10^4x cost the #418 spike budgeted for; the b_2 = 11 headline is verified on
+# the (cheap) holed S^3 3-complex in S3WindowSurfaceTest instead.
+_EVENT_WINDOWS = 1
+_EVENT_B2 = 3 * _EVENT_WINDOWS - 1
+
+
+def _s3_event(n_layers=2):
+    """Build (once) the S^3 EmergentEventTopology event cobordism, gated on the
+    rigorous n=4 recursive dualComplexValid inside build()."""
+    if n_layers not in _EVENT_CACHE:
+        topo = cob.EmergentEventTopology()
+        topo.set_s3_slice(True)
+        topo.set_s3_windows(_EVENT_WINDOWS)
+        topo.set_layers(n_layers)
+        W, boundary = topo.build_cobordism(state_dim=3, seed=0)
+        _EVENT_CACHE[n_layers] = (topo, W, boundary)
+    return _EVENT_CACHE[n_layers]
+
+
+class S3FourManifoldEventTest(unittest.TestCase):
+    """The EmergentEventTopology S^3 path: a genuine 4-manifold carrying the register."""
+
+    def test_register_degree_is_two(self):
+        topo = cob.EmergentEventTopology()
+        topo.set_s3_slice(True)
+        self.assertTrue(topo.s3_slice())
+        self.assertEqual(topo.register_degree(), 2)
+
+    def test_s2_path_unchanged(self):
+        # the default (S^2) path is untouched: register degree 1, a 3-complex.
+        s2 = cob.EmergentEventTopology()
+        self.assertFalse(s2.s3_slice())
+        self.assertEqual(s2.register_degree(), 1)
+
+    @pytest.mark.slow
+    def test_event_is_a_genuine_four_manifold(self):
+        _topo, W, _bd = _s3_event()
+        # dimension 4 (pentatope top cells), not a 2+1 D thing in disguise.
+        self.assertEqual(cob.CombinatorialDimension().compute(W), 4.0)
+        cc = cob.ChainComplex.fromSpacetime(W)
+        fvec = list(cc.fVector())
+        self.assertEqual(len(fvec), 5)                      # V,E,tri,tet,pentatope
+        # the b_2 color register survives the temporal stack.
+        self.assertEqual(list(cc.bettiNumbers())[2], _EVENT_B2)
+        # the rigorous n=4 recursive manifold gate (vertex links are 3-manifolds).
+        ok, _msg = cob.EigenstateSynthesis(W, 2).dualComplexValid()
+        self.assertTrue(ok)
+
+    @pytest.mark.slow
+    def test_carries_register_through_bilateral_pinning(self):
+        # Read the windows at the BOTTOM (ell=0) and TOP (ell=nLayers) temporal
+        # slices -- the bilaterally pinned endpoints -- at k=2: the omega color
+        # state is carried at both ends, the singlet is not.
+        topo, W, _bd = _s3_event()
+        es = cob.EigenstateSynthesis(W, 2)
+        n = topo.n_layers()
+        for layer in (0, n):
+            holes = [list(h) for h in topo.window_holes_at_layer(0, layer)]
+            self.assertEqual(len(holes), 3)
+            self.assertTrue(all(len(h) == 4 for h in holes))   # tetrahedral holes
+            r_omega = es.residualForPeriods(holes, [complex(x) for x in _OMEGA])
+            r_singlet = es.residualForPeriods(holes, [complex(x) for x in _SINGLET])
+            self.assertLess(r_omega, 1e-9, f"omega not carried at layer {layer}")
+            self.assertGreater(r_singlet, 1.0, f"no confinement at layer {layer}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Stage 1 (foundation) of the 4-stage 4D conversion of the proton experiments. A genuinely **3+1 D** base — never 2+1 D, no S² fallback: a triangulated **S³ spatial slice carrying symmetric, color-Z₃-equivariant windows** (the faithful 4D analog of the S² `SymmetricWindowSurface` / geodesic icosahedron), stacked over time via the dimension-generic `Spacetime::symmetricStackCells` (#429) into a genuine **4-manifold** event.

### The crux, solved
The color register degree **tracks the spatial dimension**: it is `ker L_{d-1}` with the holes the removed **top d-cells**. On S² (d=2) a window hole is a removed **triangle** (the b₁ / k=1 register); on S³ (d=3) it is a removed **tetrahedron** (the b₂ / k=2 register). S³ is simply connected (b₁=0), so the register genuinely lives one degree up — mirroring the S² construction one dimension down. Removing n disjoint tetrahedra from S³ gives **b₂ = n−1** (the S² analog: n disjoint triangles give b₁ = n−1). No drilling, no subdivision — clean manifolds throughout, exactly mirroring S².

- **S³ triangulation**: the **join of two K-cycles** `C_K * C_K` — a clean triangulated 3-sphere (Betti [1,0,0,1]), manifestly Z₃-symmetric (cycle rotations are simplicial automorphisms, unlike a product/shuffle triangulation).
- **Windows as a symmetry orbit**: each window = a Z₃ orbit (under σ = τ^{K/3}) of three vertex-disjoint hole **tetrahedra**; σ cyclically permutes the three color holes (the color Z₃); the windows themselves are one τ² orbit. `windowCount=4` → **b₂ = 11** (the S² proton's hole budget lifted to S³).

## Verified
- [x] `S3WindowSurface` builds a clean Z₃-symmetric triangulated S³ with Z₃-orbit color windows (disjoint hole tetrahedra)
- [x] Removing the windows opens the **b₂ = 3·windowCount − 1** register (=11 for 4 windows); valid manifold, deterministic
- [x] Windows carry the color register at **k=2**: ω=[1,ω,ω²] and ω̄ carried (residual ~1e-27), singlet [1,1,1] rejected (~confinement)
- [x] 4D event via `symmetricStackCells` → genuine **4-manifold**: CombinatorialDimension=4, **n≥4 recursive `dualComplexValid`**, b₂ preserved, deterministic
- [x] `EmergentEventTopology` S³ mode (`set_s3_slice`) builds + validates the 4-manifold and carries the register through bilateral (bottom/top temporal slice) pinning; `register_degree()`=2
- [x] `tests/cobordism/test_epic410_invariants.py` green (8 passed); full non-slow cobordism suite green (870 passed); S² path untouched

## Out of scope (stage 2+)
- Deleting `SymmetricWindowSurface` / re-pointing Bipartite/Fixed/Tripartite to S³
- Threading the register degree through the `TransportCobordism`/`MergeCobordism` relaxation harness (hardcoded k=1 today), so full merge/relaxation at k=2
- Induced-orientation signing of the 2-cycle for a relabeling-invariant σ_R; full E,B / 4×4 Dirac field content
- The like-resolution four-window event (b₂=11) relaxation — the 10³–10⁴× cost the #418 spike budgeted for (the foundation tests run the minimal one-window event)

Closes #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
