### PR TITLE
feat(cobordism): thread register degree through the relaxation harness + run the 4D S3 proton

### DIFF
--- a/include/cobordism/CobordismRelaxer.h
+++ b/include/cobordism/CobordismRelaxer.h
@@ -51,6 +51,21 @@ class CobordismRelaxer {
     /// numerical noise that, through the ill-conditioned action Hessian, explodes
     /// the step). Returns the final residual; leaves the interior edges at the
     /// best point found.
+    ///
+    /// `registerDegree` is the Hodge degree \f$ k \f$ the state residual is read
+    /// at (`TopologyBuilder::registerDegree()`): \f$ 1 \f$ (\f$ b_1 \f$, triangle
+    /// holes) on an \f$ S^2 \f$ (2+1 D) slice, \f$ 2 \f$ (\f$ b_2 \f$, tetrahedral
+    /// holes) on an \f$ S^3 \f$ (3+1 D) slice. The `residualForPeriods` cost is
+    /// degree-general (a hole is a \f$ (k+2) \f$-vertex tuple whose facets are
+    /// \f$ k \f$-cells), so the line search tracks the carried register at any
+    /// degree. The analytic state-residual GRADIENT, however, is the degree-1
+    /// \f$ L_1 \f$ port (`periodGradientOverLoops`), so it is folded in ONLY at
+    /// \f$ k=1 \f$; at \f$ k \ge 2 \f$ the descent is the action gradient alone
+    /// (\f$ \beta\lVert\nabla_I S\rVert^2 \f$) with the degree-\f$ k \f$ state cost
+    /// still gating the line search -- on the symmetric uniform seed the carried
+    /// register already sits at its `residualForPeriods` floor, so its gradient is
+    /// the dropped numerical-noise term either way (#396). The default \f$ 1 \f$
+    /// keeps every \f$ S^2 \f$ caller byte-identical.
     [[nodiscard]] static double relaxInterior(
         const std::shared_ptr<Spacetime> &st, double beta,
         const std::vector<EigenstateSynthesis::EdgeLoop> &stateLoops,
@@ -58,7 +73,7 @@ class CobordismRelaxer {
         const std::vector<std::vector<std::uint64_t>> &stateHoles,
         const std::vector<std::complex<double>> &holeTargets, int maxIters,
         int &iterCounter, bool periodPin, double stateEpsilon,
-        bool verbose = false);
+        bool verbose = false, int registerDegree = 1);
 };
 
 }  // namespace tessera::cobordism

--- a/include/cobordism/EmergentEventTopology.h
+++ b/include/cobordism/EmergentEventTopology.h
@@ -172,7 +172,9 @@ class EmergentEventTopology : public TopologyBuilder {
     /// (\f$ b_1 \f$, triangle holes) on the \f$ S^2 \f$ slice; \f$ k=2 \f$
     /// (\f$ b_2 \f$, tetrahedral holes) on the \f$ S^3 \f$ slice. The register is
     /// always \f$ \ker L_{d-1} \f$ for a \f$ d \f$-dimensional spatial slice.
-    [[nodiscard]] std::size_t registerDegree() const { return s3Slice_ ? 2u : 1u; }
+    [[nodiscard]] std::size_t registerDegree() const override {
+      return s3Slice_ ? 2u : 1u;
+    }
 
     /// The number of temporal layers (\f$ \ge 2 \f$); slices are \f$ 0..nLayers \f$.
     [[nodiscard]] int nLayers() const { return nLayers_; }

--- a/include/cobordism/TopologyBuilder.h
+++ b/include/cobordism/TopologyBuilder.h
@@ -144,6 +144,19 @@ class TopologyBuilder {
             "MergeCobordism: state dimension must be a power of two >= 2");
     }
 
+    /// The Hodge degree \f$ k \f$ at which this topology's color register is read:
+    /// the holes' facets are \f$ k \f$-cells and \f$ \ker L_k \f$ carries the
+    /// state (the register is \f$ \ker L_{d-1} \f$ for a \f$ d \f$-dimensional
+    /// spatial slice). The relaxation harness (`CobordismRelaxer`,
+    /// `TransportCobordism`, `MergeCobordism`) reads the register at this degree
+    /// instead of a hardcoded \f$ 1 \f$, so the read-out cycles and the
+    /// `residualForPeriods` cost track the spatial dimension. The default is
+    /// \f$ 1 \f$ (the \f$ b_1 \f$ / triangle-hole register of every \f$ S^2 \f$
+    /// (2+1 D) topology), so threading it leaves the \f$ S^2 \f$ path
+    /// byte-identical; `EmergentEventTopology`'s \f$ S^3 \f$ (3+1 D) slice
+    /// overrides it to \f$ 2 \f$ (the \f$ b_2 \f$ / tetrahedral-hole register).
+    [[nodiscard]] virtual std::size_t registerDegree() const { return 1; }
+
     /// Human-readable topology name, for `MergeCobordism::Stats::topology`.
     [[nodiscard]] virtual std::string name() const = 0;
 };

--- a/src/cobordism/CobordismRelaxer.cpp
+++ b/src/cobordism/CobordismRelaxer.cpp
@@ -43,8 +43,14 @@ double CobordismRelaxer::relaxInterior(
     const std::vector<std::complex<double>> &stateTargets,
     const std::vector<std::vector<std::uint64_t>> &stateHoles,
     const std::vector<std::complex<double>> &holeTargets, int maxIters,
-    int &iterCounter, bool periodPin, double stateEpsilon, bool verbose) {
-  EigenstateSynthesis es(st, 1);
+    int &iterCounter, bool periodPin, double stateEpsilon, bool verbose,
+    int registerDegree) {
+  EigenstateSynthesis es(st, registerDegree);
+  // The analytic state-residual gradient (periodGradientOverLoops) is the
+  // degree-1 L_1 port; at k >= 2 it is unavailable (tetrahedral holes are not
+  // 3-vertex edge-loops), so only the degree-k residualForPeriods COST gates the
+  // line search there (the action gradient drives the descent). See the header.
+  const bool foldStateGradient = (registerDegree == 1);
   std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> interiorRank;
   for (const auto &uv : es.interiorEdges()) interiorRank.emplace(uv, 0);
   const auto edges = st->getEdgeList()->toVector();
@@ -85,17 +91,23 @@ double CobordismRelaxer::relaxInterior(
   if (nI == 0) return beta * actionNorm2() + stateCost();
 
   // cellSimplices order (the state-residual gradient) -> interior param index, so
-  // the analytic state-residual gradient folds into the action gradient.
-  std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> paramOf;
-  for (std::size_t c = 0; c < nI; ++c) paramOf[edgeKey(interiorEdgePtr[c])] = c;
-  const auto &cells = es.cellSimplices();
-  std::vector<int> cellToParam(cells.size(), -1);
-  for (std::size_t j = 0; j < cells.size(); ++j) {
-    if (cells[j].size() < 2) continue;
-    const std::pair<std::uint64_t, std::uint64_t> key{
-        std::min(cells[j][0], cells[j][1]), std::max(cells[j][0], cells[j][1])};
-    const auto it = paramOf.find(key);
-    if (it != paramOf.end()) cellToParam[j] = static_cast<int>(it->second);
+  // the analytic state-residual gradient folds into the action gradient. Only the
+  // degree-1 gradient is folded (see foldStateGradient), and only there are the
+  // cells edges whose first two ids ARE the edge key, so build this map there
+  // alone (at k >= 2 cellSimplices are k-cells, not edges).
+  std::vector<int> cellToParam;
+  if (foldStateGradient) {
+    std::map<std::pair<std::uint64_t, std::uint64_t>, std::size_t> paramOf;
+    for (std::size_t c = 0; c < nI; ++c) paramOf[edgeKey(interiorEdgePtr[c])] = c;
+    const auto &cells = es.cellSimplices();
+    cellToParam.assign(cells.size(), -1);
+    for (std::size_t j = 0; j < cells.size(); ++j) {
+      if (cells[j].size() < 2) continue;
+      const std::pair<std::uint64_t, std::uint64_t> key{
+          std::min(cells[j][0], cells[j][1]), std::max(cells[j][0], cells[j][1])};
+      const auto it = paramOf.find(key);
+      if (it != paramOf.end()) cellToParam[j] = static_cast<int>(it->second);
+    }
   }
 
   auto cost = [&]() { return beta * actionNorm2() + stateCost(); };
@@ -128,7 +140,8 @@ double CobordismRelaxer::relaxInterior(
     // converged we minimize the action alone. [#396]
     const double rStateNow = stateCost();
     Eigen::VectorXd grad = (2.0 * beta * (HII.adjoint() * gI)).real();
-    if (rStateNow > stateEpsilon && (useHoles || !stateLoops.empty())) {
+    if (foldStateGradient && rStateNow > stateEpsilon &&
+        (useHoles || !stateLoops.empty())) {
       const auto rg =
           useHoles
               ? (periodPin

--- a/src/cobordism/MergeCobordism.cpp
+++ b/src/cobordism/MergeCobordism.cpp
@@ -117,7 +117,8 @@ void MergeCobordism::optimize() {
   CobordismRelaxer::relaxInterior(cobordism_, beta_, stateLoops_, stateTargets_,
                                   /*stateHoles=*/{}, /*holeTargets=*/{}, maxIters_,
                                   stats_.relaxIterations, periodPin, epsilon_,
-                                  verbose_);
+                                  verbose_,
+                                  static_cast<int>(topology_->registerDegree()));
   extractOperator();
   stats_.converged = stats_.residual < epsilon_;
 }

--- a/src/cobordism/TransportCobordism.cpp
+++ b/src/cobordism/TransportCobordism.cpp
@@ -72,13 +72,17 @@ void TransportCobordism::optimize() {
   CobordismRelaxer::relaxInterior(cobordism_, beta_, /*stateLoops=*/{},
                                   /*stateTargets=*/{}, stateHoles_, holeTargets_,
                                   maxIters_, stats_.relaxIterations, periodPin,
-                                  epsilon_, verbose_);
+                                  epsilon_, verbose_,
+                                  static_cast<int>(topology_->registerDegree()));
   readResult();
   stats_.converged = stats_.residual < epsilon_;
 }
 
 void TransportCobordism::readResult() {
-  EigenstateSynthesis es(cobordism_, 1);
+  // The register read-out degree travels with the topology: k=1 (b_1, triangle
+  // holes) on S^2, k=2 (b_2, tetrahedral holes) on S^3. cyclePeriods /
+  // residualForPeriods are degree-general (a hole is a (k+2)-vertex tuple).
+  EigenstateSynthesis es(cobordism_, static_cast<int>(topology_->registerDegree()));
   bulkCells_ = es.bulkMinusBoundaryCells();
 
   // === topology stats ===


### PR DESCRIPTION
## Summary
Stage 2 of the 4D (S³) proton rebuild. Threads the **register degree** `k`
(`TopologyBuilder::registerDegree()`: 1 on S², 2 on S³) through the relaxation
harness (`CobordismRelaxer`, `TransportCobordism`, `MergeCobordism`,
`EigenstateSynthesis`) so the bilateral-pinned proton can run end-to-end on the
genuine 4D `EmergentEventTopology` (`set_s3_slice`) built in #453/#454, then
re-measures the proton physics in genuine 4D.

The threading is **degree-generic** (driven by `register_degree()`), never
S³-special-cased. The S²/k=1 path is byte-identical (the default degree is 1).

Built on `feat/s3-window-surface` (#454).

## Test plan
- [ ] S² path byte-identical: `test_epic410_invariants.py` G1–G11 stay green
- [ ] 4D S³ proton runs end-to-end through the full relaxation (minimal event)
- [ ] 4D numbers reported: conformal regulation, color singlet at pinned top, b₂
- [ ] `@pytest.mark.slow` for the heavy relaxation; CI runs the minimal event only

Closes #455.