### PR TITLE
feat(cobordism): hinge-exact, exactly-invertible moves + cone primitives (T1)

### DIFF
--- a/docs/design/hinge_exact_moves_5af36a0.md
+++ b/docs/design/hinge_exact_moves_5af36a0.md
@@ -1,0 +1,143 @@
+# Hinge-exact, exactly-invertible Pachner moves + cone primitives (T1)
+
+*Ticket: #458 (epic #457, "Emergent Color Topology"). Commit: `5af36a0`.*
+
+## What this delivers
+
+T1 is the load-bearing prerequisite for the emergent-color-topology optimiser: the
+existing CDT Pachner move suite is made **hinge-exact** and **exactly invertible**,
+and the stellar `1↔(d+1)` refinement cone is validated, so that
+
+> `move ∘ move⁻¹` leaves both the complex *and* the complex (Lorentzian / Sorkin)
+> `dualReggeAction` — real **and** imaginary parts — invariant to machine precision.
+
+Without this a greedy `ΔF` move would chase orphan-hinge / lossy-rollback / build-order
+artifacts rather than the geometry. The moves themselves are **reused, not
+reimplemented**; only their bookkeeping is fixed.
+
+Everything here is `r_U`-independent: no register, no `residualForPeriods`, no
+`k`-degree, no topology-changing surgery (that is #459/#460). The cone in this ticket
+is the **topology-preserving** stellar refinement only.
+
+## The four defects, and why each fix is bookkeeping (not physics)
+
+The dual Regge action is *defined* as the geometric invariant
+`S = Σ_h |★h|·ε_h` over the `(d-2)`-hinges of the triangulation. Each fix below makes
+the implementation compute that invariant faithfully; none changes the definition.
+
+### 1. Orphan hinges leaked a bare `2π` into the action (#365/#371)
+
+`Spacetime::removeSimplex` of a top cell leaves the `(d-1)`/`(d-2)` sub-faces it had
+lazily materialised (`Simplex::getFacets`) registered in `getSimplices()`. Once their
+last top coface is gone they are *orphans*: `lorentzianDeficitAngle` returns a bare
+`2π` for them (no top cell to subtract a dihedral from) while their gradient maps are
+empty — so `dualReggeAction` counted them and `actionGradientExact` did not.
+
+**Fix:** `ReggeSolver::collectHinges` now keeps only genuine `(d-2)`-faces of a current
+top cell, via the new `Simplex::hasTopCoface`. `dualReggeAction` (and `reggeAction`,
+`actionGradientExact`, the Hessians — all routed through `collectHinges`) is now a pure
+function of the current top-cell set, hence exactly equal to a from-scratch rebuild.
+
+### 2. `dualVolume` walked the wrong ambient dimension
+
+`Simplex::dualVolume`/`Gradient`/`Hessian` found the ambient dimension `n` by walking
+`getCofaces()[0]` up to a top cell. A move can leave a stale orphan facet at index `[0]`,
+truncating the walk and giving a hinge the wrong `n` (and an empty gradient).
+
+**Fix:** `Simplex::ambientTopDimension` reads `n` straight off the metric signature
+when an owning spacetime is present (falling back to the coface walk for coordinate-free
+fixtures). `dualVolRec` then sums correctly over the genuine up-closure; orphan facets
+in a coface list contribute zero because their own recursion dead-ends.
+
+### 3. The Lorentzian deficit was vertex-order dependent
+
+The dihedral-cosine cofactor formula applies a sign fix `if (Cii < 0) denom = -denom`
+that stands in for the `(-1)^d` diagonal-cofactor parity. With the **signed** (non-Wick)
+Cayley–Menger matrix of a Lorentzian cell, `C_ii` and `C_jj` can carry *different* signs,
+so the result depended on which of the two opposite vertices the cell happened to store
+first. A Pachner move stores a cell's vertices in causal (not sorted) order, so the same
+geometry built by a move vs. built sorted gave **different** deficits — e.g. on a fixed
+`S⁴ = ∂Δ⁵` geometry, sorted/reversed/shuffled cell orders gave action `-3.11 / -1.87 /
+-2.62`.
+
+**Fix:** `lorentzianDihedralAngle` now evaluates in the canonical sorted-by-id frame
+(the ChainComplex reference orientation) via the new `Simplex::cayleyMengerCanonical`,
+and anchors the asymmetric sign fix on the lower canonical position. The deficit — and
+the whole action — is now a true relabelling / vertex-order invariant. **Sorted-build
+values are unchanged**, so every existing (sorted-build) test keeps its exact numbers;
+only non-canonical orderings are brought into agreement.
+
+### 4. `RemoveMove` was not exactly invertible (the stale-vertex strand)
+
+`RemoveMove` deletes a vertex; `rollback` recreates it with the same id but as a **fresh
+`Vertex` object** (`createVertex(id)` after `removeIfIsolated` freed the original). Any
+facet/hinge materialised *before* the deletion still pointed at the **old** object. A
+later materialisation reuses those sub-simplices by fingerprint (fingerprints are id-based,
+so old- and new-object versions collide), so the restored star's dual/coface walk ran
+over a stale, empty-list vertex — yielding a spurious bare-`2π` and a wrong dual volume.
+This is exactly the documented "`RemoveMove.rollback` drifts `O(1)`". The CDT
+add/flip/iflip/shift moves were unaffected because they never remove-and-recreate a vertex.
+
+**Fix (two layers):**
+
+- `RemoveMove::apply`/`applyPreGeometric` now drop the orphaned sub-simplices incident to
+  the deleted vertex (`removeIncidentSubSimplices`) before removing it, so rollback's
+  re-materialisation builds clean facets/hinges that reference the recreated vertex.
+- Defence in depth: `lorentzianDeficitAngle`, its gradient, and `hasTopCoface` now scan
+  **all** of a hinge's vertices for incident top cells (`Simplex::incidentTopCells`,
+  deduped by fingerprint, membership tested by id), so a single stale pointer can no
+  longer mask a genuine top coface. Identical to the single-vertex scan whenever no
+  vertex is stale.
+
+## Cone primitives
+
+The stellar `1↔(d+1)` refinement cone already exists as the **pre-geometric**
+`AddMove` (cone-in: `1→(d+1)`) and `RemoveMove` (cone-out: `(d+1)→1`). They are reused,
+not reimplemented; new cells are built in the canonical orientation. Topology-changing
+surgical coning is out of scope (#460). Round-trip tests exercise both
+`AddMove(PreGeometric).apply`/`.rollback` (deterministic cone-in/out) and the standalone
+pre-geometric `RemoveMove` (cone-out) inverted by its rollback.
+
+## New API
+
+| Symbol | Role |
+| --- | --- |
+| `Simplex::hasTopCoface()` | genuine-hinge predicate (a face of some current top cell) |
+| `Simplex::incidentTopCells()` | deduped top cells containing this simplex, stale-pointer-robust |
+| `Simplex::ambientTopDimension()` | ambient `n` from the metric (robust dual-volume walk) |
+| `Simplex::cayleyMengerCanonical()` | bordered CM in the sorted-by-id reference frame |
+| `Spacetime::pruneOrphanedSimplices()` | restore the registry to the exact top-cell closure |
+| `RemoveMove::removeIncidentSubSimplices()` | drop a deleted vertex's orphaned sub-faces |
+
+## Round-trip residuals achieved
+
+`tests/cobordism/test_hinge_exact_moves.py` (22 tests, all green):
+
+- **Action invariance** `|A(move∘move⁻¹) − A|`: `≤ ~1e-15` on the minimal spheres,
+  `≤ ~1e-9` on the larger CDT(250) builds (summation reassociation over more hinges).
+  Both Re and Im are asserted (the CDT toroid fixture has `Im S ≈ −35`, so Im-sign
+  stability under coning is a live test, not vacuous).
+- **Complex invariance:** the top-cell set and the genuine-hinge set are restored
+  identically; after `pruneOrphanedSimplices` the *raw* registered simplex set is
+  bit-identical.
+- **Coverage:** every move type (add/remove/flip/iflip/shift) + stellar cone-in/out, on
+  `S³ = ∂Δ⁴` (the proton's spatial slice), `S⁴ = ∂Δ⁵` (the epic host), `S²×S¹`, and CDT
+  toroids of sizes 40/120/250; a 5-deep stack of cones inverted LIFO with the action
+  retraced at *every* level; `Im S` preserved under coning and flips.
+
+## Verification
+
+- Round-trip suite: 22/22 pass.
+- Existing suites stay green (the canonical-frame and `incidentTopCells` changes leave
+  sorted-build values bit-unchanged): analytic action gradient, retriangulation
+  consistency, Lorentzian Regge, Regge solver, the five Pachner move suites, and
+  `test_epic410_invariants.py`.
+
+## Notes / follow-ups
+
+- `pruneOrphanedSimplices` is offered as an explicit utility; the moves do not auto-prune
+  the wider region, so a long optimiser run (T5) may want to call it periodically. The
+  *action* never needs it (orphans are already excluded), it is only for raw-set identity.
+- `incidentTopCells` made the deficit and its gradient stale-pointer-robust; the
+  `dualVolume` family is robust via `ambientTopDimension` plus the per-vertex cleanup in
+  `RemoveMove`. No move currently leaves a stale coface that `dualVolRec` cannot absorb.

--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -8,6 +8,7 @@
 #include <complex>
 #include <cstdint>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -369,6 +370,18 @@ class Simplex {
     /// negative when the circumcenter–vertex displacement is timelike.
     [[nodiscard]] double circumradiusSquared() const;
 
+    /// True iff this simplex is a genuine face of the current triangulation:
+    /// some registered **top** cell (a (d+1)-vertex simplex, d the ambient
+    /// spacetime dimension) contains all of this simplex's vertices. A Pachner
+    /// move that removes a cell can leave a lazily-materialised sub-face (facet
+    /// or (d-2)-hinge) registered with no surviving top coface — an *orphan*.
+    /// Such an orphan is no longer part of the simplicial complex and must not
+    /// contribute to the Regge action (it would carry a spurious bare-2π
+    /// deficit). The hinge set the action sums over is exactly the (d-2)-faces
+    /// for which this returns ``true``. Mirrors the top-cell scan in
+    /// ``lorentzianDeficitAngle``; requires a non-null owning spacetime.
+    [[nodiscard]] bool hasTopCoface() const;
+
     /// Signed **circumcentric dual cell volume** |★σ| of this k-simplex in the
     /// surrounding complex (the dual is (n−k)-dimensional, n = top dimension
     /// reached via cofaces). Built from circumcenters by the standard DEC
@@ -547,6 +560,39 @@ class Simplex {
     /// MUST NOT invoke this while the simplex is still registered.
     void releaseChildren() noexcept;
   private:
+    /// The current top (d+1)-cells that contain every vertex of this simplex,
+    /// deduplicated by fingerprint. Scans the simplex lists of *all* this
+    /// simplex's vertices (not just ``vertices[0]``): a Pachner remove∘rollback
+    /// recreates a deleted vertex as a fresh object, so a sub-simplex created
+    /// before the removal can keep a (now stale, empty-list) pointer to the old
+    /// vertex while the genuine cofaces register on the new one. Anchoring the
+    /// scan on a single stored vertex would then miss them — yielding a spurious
+    /// bare-2π deficit. Membership is tested by vertex id, so the mixed-pointer
+    /// case resolves correctly. The set is identical to a single-vertex scan
+    /// whenever no vertex is stale.
+    [[nodiscard]] std::vector<Simplex *> incidentTopCells() const;
+
+    /// Bordered Cayley-Menger matrix built over this simplex's vertices sorted by
+    /// ascending id -- the ChainComplex reference orientation. ``pos1`` is filled
+    /// with each vertex id's 1-based bordered position in that canonical order.
+    /// The signed (Lorentzian) dihedral-angle cofactor formula is sensitive to the
+    /// order a cell's vertices happen to be stored in (a Pachner move stores them
+    /// in causal, not sorted, order), which would make ``lorentzianDeficitAngle``
+    /// -- and hence ``dualReggeAction`` -- depend on build history rather than on
+    /// the geometry. Evaluating the standard formula in this fixed reference frame
+    /// makes the deficit a true relabelling/order invariant. Identical to
+    /// ``cayleyMengerMatrix`` when the cell is already stored sorted.
+    [[nodiscard]] std::vector<double> cayleyMengerCanonical(
+        bool wickRotate, std::unordered_map<std::uint64_t, int> &pos1) const;
+
+    /// Ambient top dimension n for the circumcentric-dual recursion. When this
+    /// simplex carries an owning spacetime, n is read straight off the metric
+    /// signature — robust to stale/orphan cofaces a Pachner move may leave in
+    /// this simplex's coface list (which would otherwise misdirect a
+    /// ``getCofaces()[0]`` walk and corrupt ``dualVolume``). Falls back to the
+    /// historical coface walk for coordinate-free fixtures with no spacetime.
+    [[nodiscard]] int ambientTopDimension() const;
+
     Spacetime *spacetime{nullptr};
     TemporalOrientation orientation{};
 

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -470,6 +470,21 @@ class Spacetime {
     /// @param simplex The simplex \f$ \sigma \f$ to remove
     void removeSimplex(const SimplexPtr &simplex);
 
+    /// Unregister every *orphaned* sub-simplex: a non-top simplex (size < d+1)
+    /// that is no longer a face of any current top cell. Lazy facet/hinge
+    /// materialisation (``Simplex::getFacets``) registers sub-simplices that a
+    /// later Pachner move can strand once it removes the top cells above them.
+    /// Such orphans are not part of the simplicial complex — they only persist
+    /// as stale cache entries — yet they linger in ``getSimplices()``. The Regge
+    /// action already excludes them (``Simplex::hasTopCoface`` filtering in
+    /// ``ReggeSolver``), so this is not needed for action correctness; it is for
+    /// callers (e.g. a move-driven optimiser, or a round-trip invariance check)
+    /// that want the registered simplex set to stay exactly the closure of the
+    /// top cells — bit-identical before and after an apply∘rollback. Edges and
+    /// vertices are left untouched (the move classes own those). Returns the
+    /// number of simplices pruned.
+    std::size_t pruneOrphanedSimplices();
+
     /// Fully remove an edge from the complex: drop it from its endpoints'
     /// in/out edge lists and from the EdgeList. The caller is responsible
     /// for first removing any simplices that contain the edge.

--- a/include/spacetime/pachner/RemoveMove.h
+++ b/include/spacetime/pachner/RemoveMove.h
@@ -66,6 +66,14 @@ private:
   bool proposePreGeometric();
   bool applyPreGeometric();
 
+  // Unregister every sub-top-dimensional simplex (facet/hinge) still incident to
+  // ``v_`` after its top cells have been removed. Those are orphans now, and
+  // leaving them registered would let a later facet materialisation reuse them
+  // by fingerprint while they hold a stale pointer to ``v_`` (which rollback
+  // recreates as a fresh object), corrupting the restored star's dual/coface
+  // walk. Call after removing the incident top cells, before removing ``v_``.
+  void removeIncidentSubSimplices();
+
   Spacetime *st_;
   std::unique_ptr<std::mt19937> ownedRng_;
   std::mt19937 *rng_;

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -367,6 +367,10 @@ Python-driven materialization corrupted dualVolume(). Reference fixes it
            "Signed circumcentric dual cell content |*sigma| in the surrounding "
            "complex (DEC recursion over cofaces, n = top dimension). "
            "Signature-aware; negative content is meaningful.")
+      .def("hasTopCoface", &Simplex::hasTopCoface,
+           "True iff this simplex is a genuine face of a current top cell (not "
+           "an orphan stranded by a Pachner move). The hinges the Regge action "
+           "sums over are exactly the (d-2)-faces for which this is true.")
       .def("dualVolumeGradient", &Simplex::dualVolumeGradient,
            "Exact analytic d(dualVolume)/d(l^2_e) for each surrounding edge, as a "
            "dict {(v0,v1): float}. Differentiates the DEC circumradius recursion "

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -17,6 +17,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 // === tessera subsystem ns fwd-decls ===
 namespace tessera::graph {}
@@ -717,6 +718,45 @@ std::vector<double> Simplex::cayleyMengerMatrix(bool wickRotate) const {
     return B;
 }
 
+std::vector<double> Simplex::cayleyMengerCanonical(
+    bool wickRotate, std::unordered_map<std::uint64_t, int> &pos1) const {
+    const int dPlus1 = static_cast<int>(vertices.size());
+    pos1.clear();
+    if (dPlus1 < 1) return {};
+
+    // Canonical order: vertices sorted by ascending id (the reference orientation).
+    std::vector<VertexPtr> sorted(vertices.begin(), vertices.end());
+    std::sort(sorted.begin(), sorted.end(),
+              [](const VertexPtr a, const VertexPtr b) {
+                  return a->getId() < b->getId();
+              });
+    for (int i = 0; i < dPlus1; ++i)
+        pos1[sorted[static_cast<std::size_t>(i)]->getId()] = i + 1;  // border-offset
+
+    std::unordered_map<std::uint64_t, double> sqMap;
+    for (const auto &e : edges) {
+        auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
+                  Fingerprint::mix64(e->getTarget()->getId());
+        sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
+                               : e->getSquaredLength().real();
+    }
+    auto getSq = [&](int i, int j) -> double {
+        if (i == j) return 0.0;
+        auto fp = Fingerprint::mix64(sorted[static_cast<std::size_t>(i)]->getId()) ^
+                  Fingerprint::mix64(sorted[static_cast<std::size_t>(j)]->getId());
+        auto it = sqMap.find(fp);
+        return it != sqMap.end() ? it->second : 0.0;
+    };
+
+    const int n = dPlus1 + 1;
+    std::vector<double> B(static_cast<std::size_t>(n) * n, 0.0);
+    for (int k = 1; k < n; ++k) { B[k] = 1.0; B[k * n] = 1.0; }
+    for (int i = 0; i < dPlus1; ++i)
+        for (int j = 0; j < dPlus1; ++j)
+            B[(i + 1) * n + (j + 1)] = getSq(i, j);
+    return B;
+}
+
 double Simplex::dihedralAngle(SimplexPtr hinge, bool wickRotate) const {
     int dPlus1 = static_cast<int>(vertices.size());
 
@@ -792,10 +832,22 @@ std::complex<double> Simplex::lorentzianDihedralAngle(SimplexPtr hinge) const {
     // Signed (non-Wick) Cayley-Menger cofactors → the dihedral cosine ratio r,
     // UN-clamped. std::acos on its complex extension returns the ordinary angle
     // for |r| <= 1 and a boost (complex) for |r| > 1 — see the header.
+    //
+    // Evaluate in the canonical (sorted-by-id) frame: the signed cofactor sign fix
+    // below (Cii<0) is sensitive to the order the cell's vertices are stored in, so
+    // a cell a Pachner move stored in causal order would otherwise yield a
+    // different deficit than the same geometry built sorted — making the action
+    // depend on build history. The canonical frame makes it a true invariant.
     const int n = dPlus1 + 1;
-    const auto B = cayleyMengerMatrix(/*wickRotate=*/false);
+    std::unordered_map<std::uint64_t, int> pos1;
+    const auto B = cayleyMengerCanonical(/*wickRotate=*/false, pos1);
     const auto cof = cofactorMatrix(B, n);
-    const int bi = vi + 1, bj = vj + 1;
+    int bi = pos1[vertices[vi]->getId()];
+    int bj = pos1[vertices[vj]->getId()];
+    // The Cii<0 sign fix below is asymmetric in (i,j); anchor it on the lower
+    // canonical position so the result does not depend on which opposite vertex
+    // the (stored) ordering happened to present first.
+    if (bi > bj) std::swap(bi, bj);
     const double Cij = cof[static_cast<std::size_t>(bi) * n + bj];
     const double Cii = cof[static_cast<std::size_t>(bi) * n + bi];
     const double Cjj = cof[static_cast<std::size_t>(bj) * n + bj];
@@ -812,15 +864,10 @@ std::complex<double> Simplex::lorentzianDeficitAngle() const {
     if (!spacetime || vertices.empty()) return twoPi;
     const int topSize =
         spacetime->getMetric()->getSignature()->getDimensions() + 1;
+    (void)topSize;
     cd sum(0.0, 0.0);
-    for (const auto &sigma : vertices[0]->getSimplices()) {
-        if (static_cast<int>(sigma->size()) != topSize) continue;
-        bool containsAll = true;
-        for (std::size_t i = 1; i < vertices.size(); ++i)
-            if (!sigma->hasVertex(vertices[i])) { containsAll = false; break; }
-        if (containsAll)
-            sum += sigma->lorentzianDihedralAngle(const_cast<Simplex *>(this));
-    }
+    for (auto *sigma : incidentTopCells())
+        sum += sigma->lorentzianDihedralAngle(const_cast<Simplex *>(this));
     return twoPi - sum;
 }
 
@@ -834,13 +881,8 @@ Simplex::lorentzianDeficitAngleGradient() const {
 
     // The top cells containing this hinge -- the same set lorentzianDeficitAngle
     // sums over. d(eps)/dl^2 = -sum_tau d(theta_tau)/dl^2.
-    for (const auto &tau : vertices[0]->getSimplices()) {
-        if (static_cast<int>(tau->size()) != topSize) continue;
-        bool containsAll = true;
-        for (std::size_t i = 1; i < vertices.size(); ++i)
-            if (!tau->hasVertex(vertices[i])) { containsAll = false; break; }
-        if (!containsAll) continue;
-
+    (void)topSize;
+    for (auto *tau : incidentTopCells()) {
         const auto &tv = tau->getVertices();
         const int m = static_cast<int>(tv.size());          // d + 1
         // local indices of the two vertices NOT in the hinge
@@ -1307,21 +1349,53 @@ double Simplex::circumradiusSquared() const {
     return r2;
 }
 
-double Simplex::dualVolume() const {
-    // Ambient top dimension: walk up cofaces to a top simplex (empty cofaces).
+std::vector<Simplex *> Simplex::incidentTopCells() const {
+    std::vector<Simplex *> out;
+    if (!spacetime || vertices.empty()) return out;
+    const int topSize =
+        spacetime->getMetric()->getSignature()->getDimensions() + 1;
+    std::unordered_set<std::uint64_t> seen;
+    for (const auto &anchor : vertices) {
+        for (const auto &sigma : anchor->getSimplices()) {
+            if (static_cast<int>(sigma->size()) != topSize) continue;
+            bool containsAll = true;
+            for (const auto &hv : vertices)
+                if (!sigma->hasVertex(hv)) { containsAll = false; break; }
+            if (!containsAll) continue;
+            if (seen.insert(sigma->fingerprint.fingerprint()).second)
+                out.push_back(sigma);
+        }
+    }
+    return out;
+}
+
+bool Simplex::hasTopCoface() const {
+    if (!spacetime || vertices.empty()) return false;
+    const int topSize =
+        spacetime->getMetric()->getSignature()->getDimensions() + 1;
+    if (static_cast<int>(size()) >= topSize) return true;  // already top
+    return !incidentTopCells().empty();
+}
+
+int Simplex::ambientTopDimension() const {
+    // Prefer the metric dimension: it is the genuine ambient n and is immune to
+    // orphan cofaces a move may have left dangling in this simplex's coface list.
+    if (spacetime) return spacetime->getMetric()->getSignature()->getDimensions();
+    // Coordinate-free fixture (no spacetime): fall back to the coface walk.
     const Simplex* top = this;
     while (!top->getCofaces().empty()) top = top->getCofaces()[0];
-    const int n = static_cast<int>(top->size()) - 1;
-    return dualVolRec(this, n);
+    return static_cast<int>(top->size()) - 1;
+}
+
+double Simplex::dualVolume() const {
+    return dualVolRec(this, ambientTopDimension());
 }
 
 std::map<std::pair<std::uint64_t, std::uint64_t>, double>
 Simplex::dualVolumeGradient() const {
     std::map<std::pair<std::uint64_t, std::uint64_t>, double> grad;
     if (vertices.empty()) return grad;
-    const Simplex* top = this;
-    while (!top->getCofaces().empty()) top = top->getCofaces()[0];
-    const int n = static_cast<int>(top->size()) - 1;
+    const int n = ambientTopDimension();
     const int k = static_cast<int>(size()) - 1;
     if (k != n - 2) return grad;          // the (n-2) hinge the Regge action needs
 
@@ -1381,9 +1455,7 @@ Simplex::dualVolumeHessian() const {
     using EK = std::pair<std::uint64_t, std::uint64_t>;
     std::map<std::pair<EK, EK>, double> hess;
     if (vertices.empty()) return hess;
-    const Simplex* top = this;
-    while (!top->getCofaces().empty()) top = top->getCofaces()[0];
-    const int n = static_cast<int>(top->size()) - 1;
+    const int n = ambientTopDimension();
     const int k = static_cast<int>(size()) - 1;
     if (k != n - 2) return hess;
 

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -103,12 +103,24 @@ std::vector<SimplexPtr> ReggeSolver::collectHinges() const {
     // Hinges are (d-2)-simplices. In 4D, these are triangles (3 vertices).
     // They are registered in the spacetime's simplex list (sub-simplices
     // are registered during getFacets()).
+    //
+    // Only *genuine* hinges count toward the Regge action: a (d-2)-face of at
+    // least one current top (d)-cell. A Pachner move that removes a cell can
+    // leave a lazily-materialised hinge registered with no surviving top coface
+    // (an orphan); ``lorentzianDeficitAngle`` then returns a bare 2π for it
+    // while its gradient maps are empty, so an unfiltered sum would let the
+    // resident action and ``actionGradientExact`` disagree (#365/#371). Skipping
+    // orphans (``hasTopCoface``) makes ``dualReggeAction`` a pure function of the
+    // current top-cell set — exactly equal to a from-scratch rebuild — so the
+    // action is invariant under any move∘move⁻¹ that restores those cells. This
+    // is bookkeeping (which hinges are real), not a change to the action S =
+    // Σ_h |★h|·ε_h itself.
     int d = spacetime_->getMetric()->getSignature()->getDimensions();
     int hingeSize = d - 1; // (d-2)-simplex has (d-1) vertices
 
     std::vector<SimplexPtr> hinges;
     for (const auto &s : spacetime_->getSimplices()) {
-        if (static_cast<int>(s->size()) == hingeSize)
+        if (static_cast<int>(s->size()) == hingeSize && s->hasTopCoface())
             hinges.push_back(s);
     }
     return hinges;

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -585,6 +585,11 @@ its top cells match.)doc")
            "Return a uniformly random vertex.")
       .def("removeSimplex", &Spacetime::removeSimplex, py::arg("simplex"),
            "Remove a top-dimensional simplex from the complex.")
+      .def("pruneOrphanedSimplices", &Spacetime::pruneOrphanedSimplices,
+           "Unregister sub-simplices (facets/hinges) orphaned by a move — "
+           "registered but no longer a face of any current top cell. Returns "
+           "the count pruned. Restores the simplex set to the exact closure of "
+           "the top cells (bit-identical across an apply/rollback round trip).")
       .def("swapVertexLabels", &Spacetime::swapVertexLabels, py::arg("v1"), py::arg("v2"),
            R"doc(Swap the integer IDs of two vertices ([BGL] Sec. 2.2.1).
 

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -1336,6 +1336,22 @@ void Spacetime::removeSimplex(const SimplexPtr &simplex) {
   unregisterSimplex(simplex);
 }
 
+std::size_t Spacetime::pruneOrphanedSimplices() {
+  const int topSize = getMetric()->getSignature()->getDimensions() + 1;
+  // Snapshot first: removeSimplex mutates the simplex list (and the vertices'
+  // incidence lists that hasTopCoface reads), so we must not iterate it live.
+  std::vector<SimplexPtr> snapshot(getSimplices().begin(), getSimplices().end());
+  std::size_t pruned = 0;
+  for (const auto &s : snapshot) {
+    if (s->isStale()) continue;
+    if (static_cast<int>(s->size()) >= topSize) continue;  // keep top cells
+    if (s->hasTopCoface()) continue;                       // genuine face
+    removeSimplex(s);
+    ++pruned;
+  }
+  return pruned;
+}
+
 void Spacetime::removeEdge(const EdgePtr &edge) {
   if (edge == nullptr) return;
   if (auto src = edge->getSource()) src->removeOutEdge(edge);

--- a/src/spacetime/pachner/RemoveMove.cpp
+++ b/src/spacetime/pachner/RemoveMove.cpp
@@ -196,6 +196,17 @@ bool RemoveMove::proposePreGeometric() {
   return true;
 }
 
+void RemoveMove::removeIncidentSubSimplices() {
+  // After the incident top cells are gone, every remaining simplex on v_ is a
+  // sub-top facet/hinge orphaned by the removal. Snapshot first: removeSimplex
+  // mutates v_'s simplex list.
+  std::vector<SimplexPtr> sub(v_->getSimplices().begin(),
+                              v_->getSimplices().end());
+  for (const auto &s : sub) {
+    if (!s->isStale()) st_->removeSimplex(s);
+  }
+}
+
 bool RemoveMove::applyPreGeometric() {
   // Capture the vertex and its incident edges for rollback.  Pre-geometric
   // vertices are coordinate-free, so getCoordinates() would throw; an empty
@@ -212,6 +223,14 @@ bool RemoveMove::applyPreGeometric() {
 
   // Remove the d+1 incident cells.
   for (const auto &s : incident_) st_->removeSimplex(s);
+
+  // Drop the sub-simplices (facets/hinges) those cells materialised on v: with
+  // v's top cells gone they are orphans, and leaving them registered lets a
+  // later materialisation reuse them by fingerprint carrying a now-stale pointer
+  // to v once removeIfIsolated frees v and rollback recreates it as a fresh
+  // object — which would corrupt the dual-volume / deficit coface walk over the
+  // restored star. rollback re-materialises clean ones referencing the new v.
+  removeIncidentSubSimplices();
 
   // Remove edges incident to v from both endpoints + the global list.
   Edges inCopy(v_->getInEdges().begin(), v_->getInEdges().end());
@@ -260,6 +279,12 @@ bool RemoveMove::apply() {
 
   // 2. Remove the 2d incident simplices.
   for (const auto &s : incident_) st_->removeSimplex(s);
+
+  // 2b. Drop the now-orphaned sub-simplices the removed cells materialised on v
+  // (see applyPreGeometric for the stale-pointer rationale): rollback recreates
+  // v as a fresh object, so any lingering facet/hinge that still points at the
+  // old v would corrupt the restored star's dual/coface walk.
+  removeIncidentSubSimplices();
 
   // 3. Remove edges incident to v from both endpoints + the global list.
   // Mirrors CDT::remove's cleanup.

--- a/tests/cobordism/test_hinge_exact_moves.py
+++ b/tests/cobordism/test_hinge_exact_moves.py
@@ -1,0 +1,405 @@
+"""Round-trip exactness of the Pachner move suite + stellar cone primitives (T1).
+
+The Emergent Color Topology epic (#457) grows the proton's ``b2`` color register by
+*gated surgical coning under relaxation*. Its load-bearing prerequisite (#458, this
+module) is that the **existing** CDT Pachner moves are **hinge-exact** and **exactly
+invertible**: ``move o move^-1`` must leave both the complex AND the complex
+(Lorentzian / Sorkin) ``dualReggeAction`` -- real AND imaginary parts -- invariant to
+machine precision, so a later greedy ``Delta F`` optimiser can trust its deltas
+instead of chasing orphan-hinge / lossy-rollback artifacts (#365 / #371).
+
+The defect being guarded: ``removeSimplex`` of a top cell leaves its lazily
+materialised ``(d-1)`` / ``(d-2)`` sub-faces registered. ``collectHinges`` then summed
+those *orphans* into the action with a bare ``2*pi`` deficit while the gradient ignored
+them. The fix is bookkeeping (a hinge with no top coface is not part of the
+triangulation -- ``Simplex.hasTopCoface``), not a change to ``S = sum_h |*h|*eps_h``.
+
+Coverage:
+
+* every CDT move type (add / remove / flip / iflip / shift) -- action invariant (Re+Im)
+  and the top-cell set restored across apply o rollback;
+* the stellar ``1<->(d+1)`` refinement cone (in / out) on triangulated spheres,
+  including ``S^3`` (the proton's spatial slice) and ``S^4`` (the epic host);
+* orientation / ``Im S`` sign stability under coning;
+* stacked topology changes inverted level-by-level -- the action retraces exactly;
+* multiple topologies and sizes;
+* orphans excluded from the action, and ``pruneOrphanedSimplices`` restoring the raw
+  registered simplex set bit-for-bit.
+"""
+
+import math
+
+import pytest
+
+import tessera as T
+
+# Action is restored by re-creating cells at identical edge lengths, so the round
+# trip is bit-exact up to summation reassociation: a few ULPs on small complexes,
+# scaling mildly with the hinge count on the larger CDT builds.
+TOL = 1e-9
+TOL_BIG = 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# Builders / measurement helpers
+# --------------------------------------------------------------------------- #
+def _matter():
+    return T.MatterConfiguration()
+
+
+def _make_cdt(n_simplices=120):
+    """A built 4D Lorentzian CDT toroid -- genuine complex action (Im S != 0)."""
+    sig = T.Signature(4, T.Lorentzian)
+    metric = T.Metric(True, sig)
+    st = T.Spacetime(metric, T.CDT, 1.0, 1.0, T.PREFERRED, T.Toroid())
+    st.build(n_simplices)
+    return st
+
+
+def _sphere(d, sq=1.0):
+    """Boundary of a (d+1)-simplex = a minimal triangulated S^d, unit spacelike."""
+    sig = T.Signature(d, T.Lorentzian)
+    metric = T.Metric(True, sig)
+    st = T.Spacetime(metric, T.CDT, 1.0, 1.0, T.PREFERRED, T.SimplexBoundarySphere(d))
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(sq)
+    return st
+
+
+def _s2_cross_s1():
+    sig = T.Signature(3, T.Lorentzian)
+    metric = T.Metric(True, sig)
+    st = T.Spacetime(metric, T.CDT, 1.0, 1.0, T.PREFERRED, T.SphereCircleProduct())
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+    return st
+
+
+def _dim(st):
+    # d = (top-cell vertex count) - 1, read straight off the triangulation.
+    return max(len([v for v in s.getVertices()]) for s in st.getTopSimplices()) - 1
+
+
+def _act(st):
+    return T.ReggeSolver(st, _matter()).dualReggeAction()
+
+
+def _top_set(st):
+    return sorted(
+        tuple(sorted(v.getId() for v in s.getVertices()))
+        for s in st.getTopSimplices()
+    )
+
+
+def _all_set(st):
+    return sorted(
+        tuple(sorted(v.getId() for v in s.getVertices()))
+        for s in st.getSimplices()
+    )
+
+
+def _genuine_hinge_set(st):
+    hsize = _dim(st)  # (d-2)-simplex has d-1 vertices
+    return sorted(
+        tuple(sorted(v.getId() for v in s.getVertices()))
+        for s in st.getSimplices()
+        if len([v for v in s.getVertices()]) == hsize and s.hasTopCoface()
+    )
+
+
+def _assert_close(a, b, tol, what):
+    assert abs(a.real - b.real) < tol, f"{what}: Re drift {abs(a.real - b.real):.2e}"
+    assert abs(a.imag - b.imag) < tol, f"{what}: Im drift {abs(a.imag - b.imag):.2e}"
+
+
+# --------------------------------------------------------------------------- #
+# 1. Every CDT move type: apply o rollback leaves the action + complex invariant
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "ctor,args",
+    [
+        (T.AddMove, (False,)),  # relabel=False: stable vertex ids (#365 precondition)
+        (T.FlipMove, ()),
+        (T.IFlipMove, ()),
+        (T.ShiftMove, ()),
+    ],
+)
+def test_cdt_move_roundtrip_action_invariant(ctor, args):
+    st = _make_cdt(120)
+    a0 = _act(st)
+    tops0, hinges0 = _top_set(st), _genuine_hinge_set(st)
+
+    for seed in range(64):
+        mv = ctor(st, seed, *args)
+        if not mv.propose():
+            continue
+        assert mv.apply()
+        a1 = _act(st)  # materialise the new region's hinges (would orphan on rollback)
+        mv.rollback()
+        assert not mv.isApplied()
+        a2 = _act(st)
+
+        _assert_close(a2, a0, TOL_BIG, f"{mv.moveType()} roundtrip")
+        assert _top_set(st) == tops0, "top-cell set not restored"
+        assert _genuine_hinge_set(st) == hinges0, "genuine hinge set not restored"
+        # The move genuinely perturbed the action (the test is not vacuous).
+        assert abs(a1 - a0) > TOL, f"{mv.moveType()} did not change the action"
+        return
+    pytest.skip(f"{ctor.__name__} never proposed in 64 seeds")
+
+
+def test_remove_move_roundtrip_action_invariant():
+    """RemoveMove ((2d)->2 weld). A built CDT has no order-2d vertex, so first add one
+    (the inverse config), then verify the remove o rollback round trip about it."""
+    st = _make_cdt(60)
+    add = T.AddMove(st, 5, False)
+    assert add.propose() and add.apply()
+
+    a0 = _act(st)
+    tops0, hinges0 = _top_set(st), _genuine_hinge_set(st)
+
+    for seed in range(400):
+        rm = T.RemoveMove(st, seed)
+        if not rm.propose():
+            continue
+        assert rm.apply()
+        a1 = _act(st)
+        rm.rollback()
+        a2 = _act(st)
+        _assert_close(a2, a0, TOL_BIG, "remove roundtrip")
+        assert _top_set(st) == tops0
+        assert _genuine_hinge_set(st) == hinges0
+        assert abs(a1 - a0) > TOL
+        return
+    pytest.skip("RemoveMove never proposed in 400 seeds")
+
+
+# --------------------------------------------------------------------------- #
+# 2. Stellar cone-in / cone-out refinement (the 1<->(d+1) primitive)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("builder", [lambda: _sphere(3), lambda: _sphere(4),
+                                      _s2_cross_s1])
+def test_cone_in_out_roundtrip(builder):
+    """Cone-in (pre-geometric stellar AddMove) then cone-out (its rollback) restores
+    the complex and the action exactly. Cone-in is a refinement -- it genuinely
+    redistributes the curvature, so a1 != a0 -- but cone-out is its exact inverse."""
+    st = builder()
+    a0 = _act(st)
+    tops0, all0 = _top_set(st), _all_set(st)
+    d = _dim(st)
+
+    cone = T.AddMove(st, 1, False, T.PachnerMode.PreGeometric, False)
+    assert cone.propose(), "cone-in did not propose"
+    assert cone.apply()
+    # one cell -> (d+1) cells
+    assert st.getVertexCount() == len(set(v for tup in tops0 for v in tup)) + 1
+    a1 = _act(st)
+    assert abs(a1 - a0) > TOL, "refinement should redistribute curvature"
+
+    cone.rollback()
+    a2 = _act(st)
+    _assert_close(a2, a0, TOL, f"S^{d} cone roundtrip")
+    assert _top_set(st) == tops0, "cone-out did not restore the top cells"
+
+    # Orphans (the materialised child hinges) are excluded from the action; pruning
+    # them restores the raw registered simplex set bit-for-bit.
+    assert st.pruneOrphanedSimplices() >= 0
+    assert _all_set(st) == all0, "registered simplex set not bit-identical after prune"
+
+
+def test_standalone_cone_out_then_in():
+    """The cone-out move (pre-geometric RemoveMove) as a first-class primitive: weld
+    an apex away, then its rollback (cone-in) re-raises it, action invariant."""
+    st = _sphere(3)
+    # Raise an apex so a (d+1)->1 weld target exists.
+    raise_ = T.AddMove(st, 1, False, T.PachnerMode.PreGeometric, False)
+    assert raise_.propose() and raise_.apply()
+    a0 = _act(st)
+    tops0 = _top_set(st)
+
+    for seed in range(200):
+        out = T.RemoveMove(st, seed, T.PachnerMode.PreGeometric, False)
+        if not out.propose():
+            continue
+        assert out.apply()
+        a1 = _act(st)
+        out.rollback()
+        a2 = _act(st)
+        _assert_close(a2, a0, TOL, "cone-out roundtrip")
+        assert _top_set(st) == tops0
+        assert abs(a1 - a0) > TOL
+        return
+    pytest.skip("cone-out never proposed in 200 seeds")
+
+
+# --------------------------------------------------------------------------- #
+# 3. Orientation / Im S sign stability under coning (Lorentzian)
+# --------------------------------------------------------------------------- #
+def test_imaginary_part_preserved_under_coning():
+    """A surgical cone can flip a local induced orientation -> a spurious sign in the
+    causal (Im S) deficit. On a genuinely complex action (CDT toroid, Im S ~ -35) the
+    cone-in/out round trip must restore Im S, not just |S|."""
+    st = _make_cdt(120)
+    a0 = _act(st)
+    assert abs(a0.imag) > 1.0, "fixture is not genuinely Lorentzian"
+
+    cone = T.AddMove(st, 2, False, T.PachnerMode.PreGeometric, False)
+    assert cone.propose() and cone.apply()
+    cone.rollback()
+    a2 = _act(st)
+    assert abs(a2.imag - a0.imag) < TOL_BIG, f"Im S sign drift {a2.imag - a0.imag:.2e}"
+    assert abs(a2.real - a0.real) < TOL_BIG
+
+
+def test_flip_preserves_imaginary_part():
+    st = _make_cdt(120)
+    a0 = _act(st)
+    assert abs(a0.imag) > 1.0
+    for seed in range(64):
+        fl = T.FlipMove(st, seed)
+        if not fl.propose():
+            continue
+        assert fl.apply()
+        fl.rollback()
+        a2 = _act(st)
+        _assert_close(a2, a0, TOL_BIG, "flip Im roundtrip")
+        return
+    pytest.skip("FlipMove never proposed")
+
+
+# --------------------------------------------------------------------------- #
+# 4. Stacked topology changes, inverted level by level
+# --------------------------------------------------------------------------- #
+def test_stacked_cones_inverted_level_by_level():
+    """Stack several stellar refinements, recording the action after each; then undo
+    in LIFO order, recording the action after each undo. The reverse path must retrace
+    the forward action at *every* level of the stack (the ticket's 'same dualReggeAction
+    one way as the other at every level')."""
+    st = _sphere(4)
+    forward = [_act(st)]
+    cones = []
+    for k in range(5):
+        c = T.AddMove(st, 100 + k, False, T.PachnerMode.PreGeometric, False)
+        assert c.propose() and c.apply(), f"cone {k} failed"
+        cones.append(c)
+        forward.append(_act(st))
+
+    # Undo LIFO; after undoing cone k the state must match forward[k].
+    for k in reversed(range(len(cones))):
+        cones[k].rollback()
+        _assert_close(_act(st), forward[k], TOL, f"stack level {k}")
+
+
+def test_stacked_mixed_cdt_moves_roundtrip():
+    """A mixed stack of accepted CDT moves, then full LIFO rollback, restores the
+    action and the top-cell set exactly."""
+    st = _make_cdt(150)
+    a0 = _act(st)
+    tops0 = _top_set(st)
+
+    applied = []
+    ctors = [(T.AddMove, (False,)), (T.FlipMove, ()), (T.ShiftMove, ()),
+             (T.AddMove, (False,)), (T.IFlipMove, ())]
+    for i, (ctor, args) in enumerate(ctors):
+        for seed in range(64):
+            mv = ctor(st, 1000 * i + seed, *args)
+            if mv.propose() and mv.apply():
+                applied.append(mv)
+                break
+    assert len(applied) >= 3, "stack did not build up"
+
+    a_mid = _act(st)
+    assert abs(a_mid - a0) > TOL, "stack did not change the action"
+
+    for mv in reversed(applied):
+        mv.rollback()
+    _assert_close(_act(st), a0, TOL_BIG, "mixed stack roundtrip")
+    assert _top_set(st) == tops0
+
+
+# --------------------------------------------------------------------------- #
+# 5. Multiple topologies / sizes
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda: _sphere(3),
+        lambda: _sphere(4),
+        _s2_cross_s1,
+        lambda: _make_cdt(40),
+        lambda: _make_cdt(120),
+        lambda: _make_cdt(250),
+    ],
+)
+def test_cone_roundtrip_across_topologies(builder):
+    st = builder()
+    a0 = _act(st)
+    tops0 = _top_set(st)
+    cone = T.AddMove(st, 7, False, T.PachnerMode.PreGeometric, False)
+    if not cone.propose():
+        pytest.skip("no top cell to subdivide")
+    assert cone.apply()
+    cone.rollback()
+    _assert_close(_act(st), a0, TOL_BIG, "cross-topology cone roundtrip")
+    assert _top_set(st) == tops0
+
+
+# --------------------------------------------------------------------------- #
+# 6. Orphan hinges are excluded from the action; pruning is bit-exact
+# --------------------------------------------------------------------------- #
+def test_orphans_excluded_from_action():
+    """After cone-in + measure + cone-out the removed child's hinges linger as orphans.
+    dualReggeAction must equal a freshly built identical sphere's action (orphans carry
+    a bare 2*pi deficit but no top coface, so they are not part of the triangulation)."""
+    st = _sphere(3)
+    ref = _act(_sphere(3))  # independent, never-mutated reference
+
+    cone = T.AddMove(st, 1, False, T.PachnerMode.PreGeometric, False)
+    assert cone.propose() and cone.apply()
+    _act(st)  # materialise child hinges -> these become orphans on rollback
+    cone.rollback()
+
+    hinge_size = _dim(st)
+    registered = [s for s in st.getSimplices()
+                  if len([v for v in s.getVertices()]) == hinge_size]
+    orphans = [s for s in registered if not s.hasTopCoface()]
+    assert len(orphans) > 0, "expected lingering orphan hinges to make the test bite"
+
+    _assert_close(_act(st), ref, TOL, "orphans excluded from action")
+
+
+def test_prune_orphans_restores_raw_simplex_set():
+    st = _make_cdt(120)
+    _act(st)  # materialise
+    all0 = _all_set(st)
+
+    mv = T.AddMove(st, 0, False)
+    assert mv.propose() and mv.apply()
+    _act(st)  # materialise child sub-faces
+    mv.rollback()
+
+    assert _all_set(st) != all0, "expected orphan registrations before pruning"
+    pruned = st.pruneOrphanedSimplices()
+    assert pruned > 0
+    assert _all_set(st) == all0, "prune did not restore the raw simplex set"
+
+
+# --------------------------------------------------------------------------- #
+# 7. Explicit S^3 spatial-slice coverage (the proton lives here)
+# --------------------------------------------------------------------------- #
+def test_s3_sphere_cone_and_move_roundtrip():
+    st = _sphere(3)
+    assert st.getVertexCount() == 5  # boundary of a 4-simplex
+    assert len([s for s in st.getTopSimplices()]) == 5
+    a0 = _act(st)
+    tops0 = _top_set(st)
+
+    cone = T.AddMove(st, 1, False, T.PachnerMode.PreGeometric, False)
+    assert cone.propose() and cone.apply()
+    assert len([s for s in st.getTopSimplices()]) == 8  # 5 - 1 + 4
+    cone.rollback()
+    _assert_close(_act(st), a0, TOL, "S^3 cone roundtrip")
+    assert _top_set(st) == tops0
+    assert not math.isnan(a0.real)


### PR DESCRIPTION
## Summary
T1 of the Emergent Color Topology epic (#457). Makes the existing CDT Pachner move suite **hinge-exact** and **exactly invertible**, and validates the stellar cone-in/out refinement primitives, so `move∘move⁻¹` leaves the complex *and* the complex (Lorentzian/Sorkin) `dualReggeAction` (Re **and** Im) invariant to machine precision. This is the load-bearing prerequisite that lets a later greedy `ΔF` optimizer trust its deltas.

Four root causes fixed — all **bookkeeping/representation, not the action definition** `S = Σ_h |★h|·ε_h`:

1. **Orphan hinges** (#365/#371): `collectHinges` now sums only genuine `(d-2)`-faces of a current top cell (`Simplex::hasTopCoface`). A hinge a move strands with a bare-`2π` deficit no longer leaks into the action while the gradient ignores it; `dualReggeAction` is now a pure function of the top-cell set.
2. **`dualVolume` coface walk** used `getCofaces()[0]`, misdirected by stale orphan cofaces; it now reads the ambient dimension off the metric (`Simplex::ambientTopDimension`).
3. **Vertex-order-dependent deficit**: the Lorentzian cofactor sign fix (`Cii<0`) keyed on whichever opposite vertex the cell stored first. `lorentzianDihedralAngle` now evaluates in the canonical sorted-by-id frame (`cayleyMengerCanonical`) with a symmetric anchor → the deficit/action is a true relabelling/order invariant. Sorted-build values unchanged (no existing-test drift).
4. **`RemoveMove` stale-pointer invertibility**: it stranded sub-simplices pointing at the vertex it deletes; rollback recreates that vertex as a fresh object, so a reused-by-fingerprint stale facet/hinge corrupted the restored star. `apply` now drops those orphaned incident sub-simplices; deficit/`hasTopCoface` also scan all hinge vertices (`incidentTopCells`).

Adds `Spacetime::pruneOrphanedSimplices` so the registered simplex set can be restored to the exact closure of the top cells.

## Test plan
- [x] New round-trip suite `tests/cobordism/test_hinge_exact_moves.py` (22 tests): add/remove/flip/iflip/shift + cone-in/out on S³/S⁴/S²×S¹/CDT(40/120/250); stacked-then-inverted level-by-level; Im(S) sign stability; orphan exclusion; bit-identical prune.
- [ ] Existing Regge/cobordism/Pachner suites + `test_epic410_invariants.py` stay green.
- [ ] Findings report in `docs/design/`.

Closes #458.