### PR TITLE
feat(cobordism): orientation-safe surgical coning, dualComplexValid-gated (T2)

### DIFF
--- a/docs/design/orientation_safe_coning_532df97.md
+++ b/docs/design/orientation_safe_coning_532df97.md
@@ -1,0 +1,127 @@
+# Orientation-safe, `dualComplexValid`-gated stellar coning (T2, #459)
+
+Part of the **Emergent Color Topology** epic (#457). T1 (#458) made the stellar
+cone primitives hinge-exact and exactly invertible. T2 makes them
+**orientation-safe** and **`dualComplexValid`-gated**, so a cone can never flip a
+local induced orientation and inject a spurious sign into the **complex**
+(causal / oriented) deficit — i.e. into `Im S`
+(`ReggeSolver::dualReggeAction`), which is real physics.
+
+## The sharp edge
+
+The Lorentzian dual Regge action `S = Σ_h |★h|·ε_h` is **complex**: timelike
+hinges contribute a real angle deficit, spacelike hinges a boost (`acosh`,
+imaginary). A stellar cone builds `d+1` fresh top cells. If a cone quietly
+produced a **non-manifold** or **non-orientable** local configuration, the
+induced orientation could flip on a shared hinge and flip the sign of its
+contribution to `Im S` — a corruption invisible to `|S|` or `Re S` alone. The
+program's rule is to reason about the full complex action; never `Re S` alone.
+
+## What was already safe (T1), and what T2 adds
+
+- **Orientation convention.** The cone's new cells already take the *standard
+  simplicial orientation* from `TemporalOrientation::orientationOf` (the
+  Ambjørn–Loll CDT convention, computed canonically from vertex **times** — not
+  an ad-hoc vertex-label sort) in the `Simplex` constructor. The
+  `sortByVertexId` used by the moves is the deliberate **chain reference
+  orientation** (so `∂²=0` glues), not an orientation heuristic. T1 fix #3 made
+  `lorentzianDihedralAngle` evaluate in the canonical sorted-by-id frame, so the
+  per-hinge deficit — and hence `Im S` — is a true relabelling invariant. For a
+  *valid* refinement the deficit is therefore already order-independent.
+- **What was missing.** Nothing rejected a cone whose *result* was a non-manifold
+  or non-orientable complex. T2 adds that gate and the test net proving the
+  primitives are orientation/`Im`-sign safe.
+
+## Design: the gate lives in the cobordism layer
+
+`AddMove` / `RemoveMove` live in the **`spacetime`** layer; `ChainComplex`
+(`dualComplexValid`, orientation propagation) lives in **`cobordism`**, which
+*depends on* `spacetime`. Putting the `dualComplexValid` gate *inside* the moves
+would invert that dependency. So the gate is a thin **cobordism-layer wrapper**
+that *reuses* the T1 cone primitives rather than reimplementing them — exactly
+the additive path the ticket's "don't touch the action definition or the T1 move
+machinery" guard points to.
+
+### `cobordism::OrientedCone`
+
+A propose/apply/gate/rollback wrapper over the T1 primitives
+(`AddMove`/`RemoveMove` in `PachnerMode::PreGeometric`, the `1↔(d+1)` stellar
+subdivision):
+
+- `coneIn(seed)` / `coneOut(seed)` apply the underlying move, then accept it
+  **only if** the resulting complex passes the gate; on rejection the move is
+  rolled back and the complex is left bit-identical (a rejected cone is a no-op).
+- `rollback()` delegates to the T1 move's exact inverse.
+- `validate()` exposes the gate verdict on the current complex.
+- `orientationCovector()` exposes the induced orientation read-out.
+
+### The gate
+
+A candidate complex is accepted iff **both** hold:
+
+1. **Manifold** — `ChainComplex::dualComplexIsValid` (the #429 check: facet
+   coface counts in `{1,2}`, ridge links single paths/cycles, and for `n ≥ 4`
+   a recursive validation of every vertex link as an `(n-1)`-manifold).
+2. **Orientable** — `ChainComplex::orientationCovector` propagates a consistent
+   global orientation without contradiction.
+
+`dualComplexIsValid` alone is **insufficient**: a non-orientable manifold (e.g.
+an `RP³` region) is a valid manifold yet can reverse induced orientation. The
+orientability check is the second, independent leg of the gate.
+
+### `ChainComplex::orientationCovector(topCells)`
+
+A new static read-out: the per-cell induced-orientation sign `ε_t ∈ {±1}` of a
+whole top-cell complex, by facet-sharing sign propagation (component roots = the
+lexicographically smallest cell, `+1`; across an interior facet the two induced
+signs cancel, `ε_b = −ε_a·s_a·s_b`, with facet `j` of a sorted cell carrying
+boundary sign `(−1)^j` — the same rule `endSignCovector` uses). Aligned to the
+canonical sorted-unique (`C_d`) cell order. **Unlike `fundamentalClass`** it does
+not require the complex to be *closed* (boundary facets impose no constraint), so
+it reads the orientation of an open refinement region (a single cone star, a
+Lorentzian CDT slab). Throws on a non-pseudomanifold or a non-orientable
+contradiction — precisely the verdicts that must make the gate reject a
+sign-flipping cone. It is implemented standalone (it does not refactor
+`endSignCovector`, per the project's preference to leave the load-bearing
+orientation read-out cores alone).
+
+## Scope guard honored
+
+T2 keeps the cone **topology-preserving** (refinement). The topology-changing
+surgical variant (open-star removal without refill) is **T3/#460** and is not
+implemented here. `r_U` / the register / the optimizer (T5) are untouched. The
+action definition and the T1 move internals are unchanged — the work is purely
+additive (one wrapper class, one static read-out, bindings, tests, docs).
+
+## Verification
+
+Build clean (`pip install -e ".[dev]"`, exit 0). Tests run under a 16-thread cap.
+
+**New suite — `tests/cobordism/test_orientation_safe_coning.py` (14 tests, all
+pass):**
+
+- The gate **accepts** a topology-preserving cone-in on `S³` / `S⁴` / `S²×S¹`,
+  and a gated cone-out (`(d+1)→1` weld of a raised apex) on `S³`; each round trip
+  restores the dual Regge action (**Re and Im**) and the top-cell set.
+- The induced orientation (`orientationCovector`; closed-manifold
+  `fundamentalClass`) is well-defined after cone-in, and `move∘move⁻¹` restores
+  **every** sign (per-cell covector bit-identical before/after).
+- `endSignCovector` of a fixed hole pair is stable across a cone applied away
+  from them — stated in its global-sign-invariant form (the *relative*
+  induced orientation of the holes is preserved; the covector itself is defined
+  only up to one overall sign per component, which a cone that removes the
+  lexicographic root cell may flip).
+- `Im S` sign consistency across a **gated** cone on a genuinely Lorentzian CDT
+  toroid (`Im S ≈ −35`): the gate accepted the refinement and the round trip
+  restored `Im S` (asserted on Re **and** Im). (Not skipped — the strict gate
+  accepts a valid CDT refinement.)
+- The orientability gate has teeth: `orientationCovector` **raises** on a
+  non-orientable Möbius complex and returns a clean `±1` covector (lex-root `+1`)
+  on an orientable `S²`.
+
+**No regression:** `tests/cobordism/test_hinge_exact_moves.py` (T1) +
+`tests/cobordism/test_epic410_invariants.py` — 30 passed; the full cobordism
+suite was re-run in parallel (`pytest -n 16`) and stays green. The
+orientation-safety requirement was met entirely within the existing primitives,
+with no change to the action definition or the T1 move machinery — the work is
+purely additive (one wrapper class, one static read-out, bindings, tests, docs).

--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -170,6 +170,8 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} MergeCobordism.h
 ```
+```{doxygenfile} OrientedCone.h
+```
 ```{doxygenfile} TransportCobordism.h
 ```
 ```{doxygenfile} CobordismRelaxer.h

--- a/include/cobordism/ChainComplex.h
+++ b/include/cobordism/ChainComplex.h
@@ -142,6 +142,32 @@ class ChainComplex {
         const std::vector<std::vector<std::uint64_t>> &surfaceCells,
         const std::vector<std::vector<std::uint64_t>> &holes);
 
+    /// The **induced-orientation covector** of a whole top-cell complex: the
+    /// per-cell sign \f$ \varepsilon_t \in \{\pm 1\} \f$ assigned by orienting
+    /// the complex through facet-sharing propagation. Each `topCells` entry is
+    /// a sorted vertex-id tuple, all of one dimension; the returned vector is
+    /// aligned to the **sorted-unique** (lexicographic) order of those cells —
+    /// the canonical \f$ C_d \f$ column order, i.e. the order of
+    /// orientedTopSimplices() / kSimplexVertices(dimension()). Roots of each
+    /// connected component (its lexicographically smallest cell) carry
+    /// \f$ +1 \f$ and the sign propagates across every shared facet by the same
+    /// rule endSignCovector() uses (facet \f$ j \f$ of a sorted cell carries
+    /// boundary sign \f$ (-1)^j \f$, and across an interior facet the two
+    /// induced signs cancel: \f$ \varepsilon_b = -\varepsilon_a s_a s_b \f$).
+    /// Unlike fundamentalClass() this does **not** require the complex to be
+    /// closed — boundary facets (one coface) simply impose no constraint — so it
+    /// is the orientation read-out for an open refinement region (e.g. a single
+    /// stellar cone star, or a Lorentzian CDT slab with boundary). Determined
+    /// purely combinatorially, independent of geometry, vertex labels (any
+    /// order-preserving relabel leaves it unchanged), and the order `topCells`
+    /// is supplied in. Empty for the empty complex.
+    /// @throws std::runtime_error if the cells are not all of one dimension, a
+    ///   facet has more than two cofaces (not a pseudomanifold), or the
+    ///   orientation propagation contradicts itself (non-orientable) — exactly
+    ///   the conditions a surgical cone must never silently introduce.
+    [[nodiscard]] static std::vector<int> orientationCovector(
+        const std::vector<std::vector<std::uint64_t>> &topCells);
+
     /// The symmetric intersection form \f$ Q_{ij} = \langle \alpha_i \cup
     /// \alpha_j, [K] \rangle \f$ on a basis \f$ \{\alpha_i\} \f$ of the free
     /// part of \f$ H^2 \f$, as a flat row-major \f$ b_2 \times b_2 \f$ matrix.

--- a/include/cobordism/OrientedCone.h
+++ b/include/cobordism/OrientedCone.h
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_ORIENTEDCONE_H
+#define TESSERA_COBORDISM_ORIENTEDCONE_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tessera::spacetime {
+class Spacetime;
+class PachnerMove;
+}  // namespace tessera::spacetime
+
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # OrientedCone
+///
+/// An **orientation-safe, `dualComplexValid`-gated** stellar cone move — the
+/// safety net the Emergent Color Topology epic's surgical `b₂`-growth (#457)
+/// relies on. It is a thin wrapper that *reuses* the hinge-exact T1 cone
+/// primitives (`spacetime::AddMove` / `spacetime::RemoveMove` in
+/// `PachnerMode::PreGeometric`, the \f$ 1 \leftrightarrow (d+1) \f$ stellar
+/// subdivision) rather than reimplementing them, and accepts a move **only if**
+/// the resulting complex survives the full manifold check.
+///
+/// ## Why this is needed
+/// A stellar cone builds \f$ d+1 \f$ fresh top cells. Their reference
+/// orientation comes from `TemporalOrientation::orientationOf` (the
+/// Ambjørn–Loll CDT convention, computed canonically from vertex times — never
+/// an ad-hoc vertex-label sort), and the Lorentzian dihedral deficit is
+/// evaluated in the canonical sorted-by-id frame (T1 fix #3), so for a *valid*
+/// refinement the complex (causal/oriented) deficit — and hence
+/// \f$ \operatorname{Im} S \f$ in `ReggeSolver::dualReggeAction` — is a true
+/// relabelling invariant. The danger is a cone that quietly produces a
+/// **non-manifold** or **non-orientable** local configuration: there the
+/// induced orientation can flip, injecting a spurious sign into
+/// \f$ \operatorname{Im} S \f$ (real physics). This class makes that
+/// impossible by construction.
+///
+/// ## The gate
+/// After applying the underlying move, the candidate complex is accepted only
+/// when **both** hold:
+///   1. `ChainComplex::dualComplexIsValid` — a genuine manifold: facet coface
+///      counts in \f$ \{1,2\} \f$, ridge links single paths/cycles, and (the
+///      #429 check) for \f$ n \geq 4 \f$ a recursive validation of every vertex
+///      link as an \f$ (n-1) \f$-manifold;
+///   2. `ChainComplex::orientationCovector` returns without contradiction — a
+///      consistent global induced orientation exists (orientable).
+/// On rejection the move is rolled back and the complex is left bit-identical
+/// to its pre-cone state, so a caller can treat a rejected cone as a no-op. For
+/// a *topology-preserving* refinement (this ticket, T2) the gate always passes;
+/// it is the live guard the *topology-changing* surgical variant (T3) leans on.
+///
+/// ## Lifecycle
+/// At most one cone is held applied at a time. `coneIn` / `coneOut` apply and
+/// gate; `rollback` undoes the last accepted cone (delegating to the T1 move's
+/// exact inverse). The move is owned so the round trip \f$ m \circ m^{-1} \f$
+/// restores the complex — and every orientation sign — exactly.
+class OrientedCone {
+ public:
+  /// Bind the cone to a spacetime. Does not mutate it.
+  explicit OrientedCone(Spacetime *spacetime);
+  ~OrientedCone();
+
+  OrientedCone(const OrientedCone &) = delete;
+  OrientedCone &operator=(const OrientedCone &) = delete;
+
+  /// Gated stellar \f$ 1 \to (d+1) \f$ refinement (**cone-in**): pick a top
+  /// cell (seeded), subdivide it with the T1 `AddMove(PreGeometric)`, then
+  /// accept only if the result is a valid, orientable manifold. Returns
+  /// `(true, "ok")` on acceptance; otherwise the move is rolled back and the
+  /// reason is returned. A no-op `(false, …)` if a cone is already applied.
+  std::pair<bool, std::string> coneIn(std::uint64_t seed);
+
+  /// Gated stellar \f$ (d+1) \to 1 \f$ weld (**cone-out**): the inverse
+  /// refinement, via the T1 `RemoveMove(PreGeometric)`, under the same gate.
+  std::pair<bool, std::string> coneOut(std::uint64_t seed);
+
+  /// Undo the last accepted cone (delegating to the T1 move's exact inverse),
+  /// restoring the complex bit-for-bit. Returns `false` if nothing is applied.
+  bool rollback();
+
+  /// True iff a cone has been accepted and not yet rolled back.
+  [[nodiscard]] bool isApplied() const { return applied_; }
+
+  /// The induced-orientation covector of the **current** top complex
+  /// (`ChainComplex::orientationCovector` over its top cells), aligned to the
+  /// canonical sorted-unique top-cell order. The read-out tests assert is
+  /// restored exactly across a cone round trip.
+  /// @throws std::runtime_error if the current complex is non-orientable.
+  [[nodiscard]] std::vector<int> orientationCovector() const;
+
+  /// The manifold/orientability verdict on the **current** complex, the same
+  /// gate `coneIn` / `coneOut` apply. `(true, "ok")` when it is a valid,
+  /// orientable manifold; otherwise the first violation is named.
+  [[nodiscard]] std::pair<bool, std::string> validate() const;
+
+ private:
+  /// Top cells of the bound spacetime as sorted vertex-id tuples (canonical
+  /// C_d order), the input to both the manifold and the orientation checks.
+  [[nodiscard]] std::vector<std::vector<std::uint64_t>> topCells() const;
+
+  Spacetime *st_;
+  std::unique_ptr<PachnerMove> lastMove_;
+  bool applied_ = false;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_ORIENTEDCONE_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -25,6 +25,7 @@
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
 #include "cobordism/MergeCobordism.h"
+#include "cobordism/OrientedCone.h"
 #include "cobordism/PreparedBoundaryState.h"
 #include "cobordism/RealizabilityOracle.h"
 #include "cobordism/Register.h"
@@ -135,6 +136,20 @@ numbers (over ℚ and GF(2)), torsion coefficients, Euler characteristic, and th
           "under order-preserving relabelings (e.g. a layer shift). Raises "
           "on mixed-dimension cells, a facet with > 2 cofaces, or a "
           "non-orientable surface.")
+      .def_static(
+          "orientationCovector", &ChainComplex::orientationCovector,
+          py::arg("top_cells"),
+          "The induced-orientation covector eps in {+/-1}^len(top_cells): the "
+          "per-cell sign from orienting a whole top-cell complex by facet-"
+          "sharing propagation (component roots = lex-smallest cells, +1; "
+          "across an interior facet the two induced signs cancel). The result "
+          "aligns to the sorted-unique (canonical C_d) order of the cells. "
+          "Unlike fundamentalClass() it does NOT require closedness (boundary "
+          "facets impose nothing), so it reads the orientation of an open "
+          "refinement region (a stellar cone star, a CDT slab). Determined "
+          "combinatorially, independent of geometry, vertex labels, and input "
+          "order. Raises on mixed-dimension cells, a facet with > 2 cofaces, "
+          "or a non-orientable propagation contradiction.")
       .def("intersectionForm", &ChainComplex::intersectionForm,
            "Symmetric intersection form on free H^2 (flat b2 x b2), for a closed "
            "oriented 4-manifold; empty if n != 4 or b2 == 0.")
@@ -1856,4 +1871,40 @@ prepared states, reproduces the harmonic overlap.)doc")
                              "the read-out is symmetric with the signed inputs "
                              "(relabeling-invariant sigma_R). Empty if unsigned.")
       .def_property_readonly("stats", &TransportCobordism::stats);
+
+  // ----- Orientation-safe, dualComplexValid-gated stellar cone (#459) -----
+  py::class_<OrientedCone>(m, "OrientedCone",
+      R"doc(Orientation-safe, dualComplexValid-gated stellar cone move (#459).
+
+A thin wrapper that REUSES the T1 cone primitives (AddMove / RemoveMove in
+PachnerMode.PreGeometric, the 1<->(d+1) stellar subdivision) and accepts a cone
+only if the resulting complex is a valid, ORIENTABLE manifold -- so a cone can
+never flip a local induced orientation and inject a spurious sign into the
+complex (Lorentzian/Sorkin) deficit, i.e. into Im(dualReggeAction). On rejection
+the move is rolled back and the complex is left bit-identical. For a topology-
+PRESERVING refinement the gate always passes; it is the safety net the topology-
+CHANGING surgical variant (T3) relies on.)doc")
+      .def(py::init<Spacetime *>(), py::arg("spacetime"), py::keep_alive<1, 2>(),
+           "Bind the cone to a spacetime (does not mutate it).")
+      .def("coneIn", &OrientedCone::coneIn, py::arg("seed"),
+           "(ok, reason): gated stellar 1->(d+1) refinement (cone-in) via the "
+           "T1 AddMove(PreGeometric). Accepts only a valid orientable manifold; "
+           "otherwise rolls back and names the reason. No-op if a cone is "
+           "already applied.")
+      .def("coneOut", &OrientedCone::coneOut, py::arg("seed"),
+           "(ok, reason): gated stellar (d+1)->1 weld (cone-out) via the T1 "
+           "RemoveMove(PreGeometric), under the same gate.")
+      .def("rollback", &OrientedCone::rollback,
+           "Undo the last accepted cone (the T1 move's exact inverse), "
+           "restoring the complex bit-for-bit. False if nothing is applied.")
+      .def_property_readonly("isApplied", &OrientedCone::isApplied,
+           "True iff a cone is accepted and not yet rolled back.")
+      .def("orientationCovector", &OrientedCone::orientationCovector,
+           "The induced-orientation covector of the CURRENT top complex "
+           "(ChainComplex.orientationCovector over its top cells), aligned to "
+           "the canonical sorted-unique top-cell order. Restored exactly across "
+           "a cone round trip. Raises if the current complex is non-orientable.")
+      .def("validate", &OrientedCone::validate,
+           "(ok, reason): the manifold + orientability verdict on the CURRENT "
+           "complex -- the same gate coneIn / coneOut apply.");
 }

--- a/src/cobordism/ChainComplex.cpp
+++ b/src/cobordism/ChainComplex.cpp
@@ -1042,4 +1042,87 @@ std::vector<int> ChainComplex::endSignCovector(
   return sigma;
 }
 
+std::vector<int> ChainComplex::orientationCovector(
+    const std::vector<std::vector<std::uint64_t>> &topCells) {
+  using Cell = std::vector<std::uint64_t>;
+  const auto joinIds = [](const Cell &c) {
+    std::string out = "(";
+    for (std::size_t i = 0; i < c.size(); ++i) {
+      if (i) out += ",";
+      out += std::to_string(c[i]);
+    }
+    return out + ")";
+  };
+  if (topCells.empty()) return {};
+
+  // Sorted-unique cells: the canonical C_d column order, so the returned
+  // covector aligns with orientedTopSimplices() / kSimplexVertices(dim) and is
+  // independent of the order topCells is supplied in.
+  std::set<Cell> uniq;
+  const std::size_t nv = topCells.front().size();
+  for (const auto &raw : topCells) {
+    if (raw.size() != nv)
+      throw std::runtime_error(
+          "ChainComplex::orientationCovector: cell " + joinIds(raw) + " has " +
+          std::to_string(raw.size()) + " vertices, expected " +
+          std::to_string(nv) + " (one dimension throughout)");
+    Cell c = raw;
+    std::sort(c.begin(), c.end());
+    uniq.insert(std::move(c));
+  }
+  const std::vector<Cell> cells(uniq.begin(), uniq.end());
+
+  // facet -> its cofaces as (cell index, boundary sign): facet j of a sorted
+  // cell drops vertex j and carries (-1)^j.
+  std::map<Cell, std::vector<std::pair<std::size_t, int>>> cofaces;
+  for (std::size_t ci = 0; ci < cells.size(); ++ci)
+    for (std::size_t j = 0; j < nv; ++j) {
+      Cell f;
+      f.reserve(nv - 1);
+      for (std::size_t i = 0; i < nv; ++i)
+        if (i != j) f.push_back(cells[ci][i]);
+      cofaces[f].emplace_back(ci, (j % 2 == 0) ? 1 : -1);
+    }
+  for (const auto &[f, at] : cofaces)
+    if (at.size() > 2)
+      throw std::runtime_error(
+          "ChainComplex::orientationCovector: facet " + joinIds(f) + " has " +
+          std::to_string(at.size()) + " cofaces (not a pseudomanifold)");
+
+  // Orient by propagation: across an interior facet the two induced signs must
+  // cancel (eps_b = -eps_a * s_a * s_b); boundary facets (one coface) impose
+  // nothing. Component roots are the lex-smallest unvisited cells, eps = +1.
+  std::vector<int> eps(cells.size(), 0);
+  for (std::size_t root = 0; root < cells.size(); ++root) {
+    if (eps[root] != 0) continue;
+    eps[root] = 1;
+    std::vector<std::size_t> stack{root};
+    while (!stack.empty()) {
+      const std::size_t a = stack.back();
+      stack.pop_back();
+      for (std::size_t j = 0; j < nv; ++j) {
+        Cell f;
+        f.reserve(nv - 1);
+        for (std::size_t i = 0; i < nv; ++i)
+          if (i != j) f.push_back(cells[a][i]);
+        const int sa = (j % 2 == 0) ? 1 : -1;
+        for (const auto &[b, sb] : cofaces.at(f)) {
+          if (b == a) continue;
+          const int want = -eps[a] * sa * sb;
+          if (eps[b] == 0) {
+            eps[b] = want;
+            stack.push_back(b);
+          } else if (eps[b] != want) {
+            throw std::runtime_error(
+                "ChainComplex::orientationCovector: orientation propagation "
+                "contradicts itself at facet " + joinIds(f) +
+                " (the complex is non-orientable)");
+          }
+        }
+      }
+    }
+  }
+  return eps;
+}
+
 }  // namespace tessera::cobordism

--- a/src/cobordism/OrientedCone.cpp
+++ b/src/cobordism/OrientedCone.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/OrientedCone.h"
+
+#include <algorithm>
+
+#include "cobordism/ChainComplex.h"
+#include "mesh/Simplex.h"
+#include "mesh/Vertex.h"
+#include "spacetime/Metric.h"
+#include "spacetime/Signature.h"
+#include "spacetime/Spacetime.h"
+#include "spacetime/pachner/AddMove.h"
+#include "spacetime/pachner/RemoveMove.h"
+
+namespace tessera::cobordism {
+
+OrientedCone::OrientedCone(Spacetime *spacetime) : st_(spacetime) {}
+
+OrientedCone::~OrientedCone() = default;
+
+std::vector<std::vector<std::uint64_t>> OrientedCone::topCells() const {
+  std::vector<std::vector<std::uint64_t>> cells;
+  if (st_ == nullptr) return cells;
+  const int d = st_->getMetric()->getSignature()->getDimensions();
+  const std::size_t topVerts = (d >= 0) ? static_cast<std::size_t>(d) + 1 : 0;
+  if (topVerts == 0) return cells;
+  for (const auto &s : st_->getSimplices()) {
+    if (s == nullptr) continue;
+    if (s->size() != topVerts) continue;
+    std::vector<std::uint64_t> ids;
+    ids.reserve(topVerts);
+    for (const auto &v : s->getVertices())
+      if (v != nullptr) ids.push_back(v->getId());
+    if (ids.size() != topVerts) continue;
+    std::sort(ids.begin(), ids.end());
+    cells.push_back(std::move(ids));
+  }
+  std::sort(cells.begin(), cells.end());
+  cells.erase(std::unique(cells.begin(), cells.end()), cells.end());
+  return cells;
+}
+
+std::pair<bool, std::string> OrientedCone::validate() const {
+  const auto tops = topCells();
+  if (tops.empty()) return {false, "no top cells"};
+  const int dim = static_cast<int>(tops.front().size()) - 1;
+  // 1. Manifold (the #429 check: pseudomanifold + ridge links + n>=4 recursive
+  //    vertex-link validation).
+  const auto manifold = ChainComplex::dualComplexIsValid(tops, dim);
+  if (!manifold.first) return {false, "not a manifold: " + manifold.second};
+  // 2. Orientability: a consistent global induced orientation must exist, or a
+  //    cone could flip a local sign into Im S. orientationCovector throws on a
+  //    non-pseudomanifold or non-orientable propagation contradiction.
+  try {
+    (void)ChainComplex::orientationCovector(tops);
+  } catch (const std::exception &e) {
+    return {false, std::string("orientation: ") + e.what()};
+  }
+  return {true, "ok"};
+}
+
+std::vector<int> OrientedCone::orientationCovector() const {
+  return ChainComplex::orientationCovector(topCells());
+}
+
+std::pair<bool, std::string> OrientedCone::coneIn(std::uint64_t seed) {
+  if (st_ == nullptr) return {false, "no spacetime"};
+  if (applied_) return {false, "a cone is already applied; rollback first"};
+  // Reuse the T1 cone primitive: a pre-geometric 1 -> (d+1) stellar subdivision,
+  // no vertex relabelling (the new cells carry the standard orientation from
+  // their vertex times — TemporalOrientation::orientationOf — by construction).
+  auto move = std::make_unique<AddMove>(
+      st_, seed, /*relabelEnabled=*/false, PachnerMode::PreGeometric,
+      /*boundaryFixed=*/false);
+  if (!move->propose()) return {false, "cone-in did not propose"};
+  if (!move->apply()) return {false, "cone-in did not apply"};
+  const auto verdict = validate();
+  if (!verdict.first) {
+    move->rollback();
+    return verdict;
+  }
+  lastMove_ = std::move(move);
+  applied_ = true;
+  return {true, "ok"};
+}
+
+std::pair<bool, std::string> OrientedCone::coneOut(std::uint64_t seed) {
+  if (st_ == nullptr) return {false, "no spacetime"};
+  if (applied_) return {false, "a cone is already applied; rollback first"};
+  auto move = std::make_unique<RemoveMove>(
+      st_, seed, PachnerMode::PreGeometric, /*boundaryFixed=*/false);
+  if (!move->propose()) return {false, "cone-out did not propose"};
+  if (!move->apply()) return {false, "cone-out did not apply"};
+  const auto verdict = validate();
+  if (!verdict.first) {
+    move->rollback();
+    return verdict;
+  }
+  lastMove_ = std::move(move);
+  applied_ = true;
+  return {true, "ok"};
+}
+
+bool OrientedCone::rollback() {
+  if (!applied_ || lastMove_ == nullptr) return false;
+  lastMove_->rollback();
+  lastMove_.reset();
+  applied_ = false;
+  return true;
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_orientation_safe_coning.py
+++ b/tests/cobordism/test_orientation_safe_coning.py
@@ -1,0 +1,317 @@
+"""Orientation-safe, ``dualComplexValid``-gated stellar coning (T2, #459).
+
+The Emergent Color Topology epic (#457) grows the proton's ``b2`` color register
+by *gated surgical coning*. T1 (#458) made the cone primitives hinge-exact and
+exactly invertible; this module (T2) makes them **orientation-safe** and gates
+them on the **full manifold check**, so a cone can never flip a local induced
+orientation and inject a spurious sign into the **complex** (causal / oriented)
+deficit -- i.e. into ``Im S`` (``ReggeSolver.dualReggeAction``), which is real
+physics. The Lorentzian action is complex: every round-trip assertion here pins
+**both** Re and Im.
+
+The gate (``cobordism::OrientedCone``) reuses the T1 cone primitives
+(``AddMove`` / ``RemoveMove`` in ``PachnerMode.PreGeometric``, the
+``1<->(d+1)`` stellar subdivision) and accepts a cone only when the result is a
+valid (``ChainComplex.dualComplexIsValid``, the #429 n>=4 recursive manifold
+check) **and orientable** (``ChainComplex.orientationCovector`` propagates
+without contradiction) complex. For a topology-PRESERVING refinement (this
+ticket) the gate always passes; it is the live guard the topology-CHANGING
+surgical variant (T3, #460) relies on.
+
+Coverage:
+
+* the gate accepts a topology-preserving cone on S^3 / S^4 / S^2xS^1, and the
+  round trip restores the action (Re+Im) and the top-cell set exactly;
+* the induced orientation (``orientationCovector`` / closed-manifold
+  ``fundamentalClass``) is well-defined after cone-in and **identical** after the
+  cone round trip -- ``move o move^-1`` restores every sign;
+* ``endSignCovector`` of a fixed set of holes is stable across a cone applied
+  away from them;
+* ``Im S`` sign consistency across a gated cone on a genuinely Lorentzian CDT;
+* the orientability gate has teeth: ``orientationCovector`` raises on a
+  non-orientable (Moebius) complex and returns a clean covector on an orientable
+  one -- the exact condition that makes the gate reject a sign-flipping cone.
+"""
+
+import math
+
+import pytest
+
+import tessera as T
+
+cob = T.cobordism  # ChainComplex / OrientedCone live in the cobordism submodule
+
+TOL = 1e-9
+TOL_BIG = 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# Builders / measurement helpers (mirroring test_hinge_exact_moves.py)
+# --------------------------------------------------------------------------- #
+def _matter():
+    return T.MatterConfiguration()
+
+
+def _sphere(d, sq=1.0):
+    """Boundary of a (d+1)-simplex = a minimal triangulated S^d, unit spacelike."""
+    sig = T.Signature(d, T.Lorentzian)
+    metric = T.Metric(True, sig)
+    st = T.Spacetime(metric, T.CDT, 1.0, 1.0, T.PREFERRED, T.SimplexBoundarySphere(d))
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(sq)
+    return st
+
+
+def _s2_cross_s1():
+    sig = T.Signature(3, T.Lorentzian)
+    metric = T.Metric(True, sig)
+    st = T.Spacetime(metric, T.CDT, 1.0, 1.0, T.PREFERRED, T.SphereCircleProduct())
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+    return st
+
+
+def _make_cdt(n_simplices=120):
+    """A built 4D Lorentzian CDT toroid -- genuine complex action (Im S != 0)."""
+    sig = T.Signature(4, T.Lorentzian)
+    metric = T.Metric(True, sig)
+    st = T.Spacetime(metric, T.CDT, 1.0, 1.0, T.PREFERRED, T.Toroid())
+    st.build(n_simplices)
+    return st
+
+
+def _act(st):
+    return T.ReggeSolver(st, _matter()).dualReggeAction()
+
+
+def _top_set(st):
+    return sorted(
+        tuple(sorted(v.getId() for v in s.getVertices()))
+        for s in st.getTopSimplices()
+    )
+
+
+def _assert_close(a, b, tol, what):
+    assert abs(a.real - b.real) < tol, f"{what}: Re drift {abs(a.real - b.real):.2e}"
+    assert abs(a.imag - b.imag) < tol, f"{what}: Im drift {abs(a.imag - b.imag):.2e}"
+
+
+def _orientation_map(st):
+    """The induced orientation as a {top-cell-tuple: +/-1} dict, comparable across
+    a move that preserves the cell set (covector is aligned to canonical order)."""
+    cc = cob.ChainComplex.fromSpacetime(st)
+    d = cc.dimension()
+    cells = [tuple(c) for c in cc.kSimplexVertices(d)]
+    eps = cob.ChainComplex.orientationCovector([list(c) for c in cells])
+    # orientationCovector is aligned to the sorted-unique cell order, which is the
+    # same canonical C_d order kSimplexVertices(d) returns.
+    return dict(zip(cells, eps))
+
+
+# --------------------------------------------------------------------------- #
+# 1. The gate accepts a topology-preserving cone; round trip is exact (Re+Im)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "builder", [lambda: _sphere(3), lambda: _sphere(4), _s2_cross_s1]
+)
+def test_gated_cone_in_accepts_and_roundtrips(builder):
+    st = builder()
+    a0 = _act(st)
+    tops0 = _top_set(st)
+
+    cone = cob.OrientedCone(st)
+    for seed in range(64):
+        ok, reason = cone.coneIn(seed)
+        if not ok:
+            # A topology-preserving stellar refinement of a manifold is always a
+            # valid, orientable manifold -- the gate must never reject it.
+            assert "did not propose" in reason, f"gate wrongly rejected: {reason}"
+            continue
+        assert cone.isApplied
+        # The refinement genuinely redistributes curvature.
+        assert abs(_act(st) - a0) > TOL, "cone-in did not change the action"
+        # The current complex passes its own gate.
+        ok2, reason2 = cone.validate()
+        assert ok2, f"post-cone validate failed: {reason2}"
+
+        assert cone.rollback()
+        assert not cone.isApplied
+        _assert_close(_act(st), a0, TOL_BIG, "gated cone round trip")
+        assert _top_set(st) == tops0, "cone-out did not restore the top cells"
+        return
+    pytest.skip("cone-in never proposed in 64 seeds")
+
+
+def test_gated_cone_out_accepts_and_roundtrips():
+    """The gated cone-out (d+1)->1 weld as a first-class primitive: raise an apex,
+    then a gated OrientedCone.coneOut welds it away and accepts (valid orientable
+    manifold); its rollback re-raises it, restoring the action (Re+Im) exactly."""
+    st = _sphere(3)
+    # Raise an apex so a (d+1)->1 weld target exists (the T1 raw add primitive).
+    raise_ = T.AddMove(st, 1, False, T.PachnerMode.PreGeometric, False)
+    assert raise_.propose() and raise_.apply()
+    a0 = _act(st)
+    tops0 = _top_set(st)
+
+    cone = cob.OrientedCone(st)
+    for seed in range(200):
+        ok, reason = cone.coneOut(seed)
+        if not ok:
+            assert "did not propose" in reason, f"gate wrongly rejected: {reason}"
+            continue
+        assert cone.isApplied
+        assert abs(_act(st) - a0) > TOL, "cone-out did not change the action"
+        ok2, reason2 = cone.validate()
+        assert ok2, f"post-weld validate failed: {reason2}"
+        assert cone.rollback()
+        _assert_close(_act(st), a0, TOL, "gated cone-out round trip")
+        assert _top_set(st) == tops0, "cone-in did not restore the top cells"
+        return
+    pytest.skip("cone-out never proposed in 200 seeds")
+
+
+# --------------------------------------------------------------------------- #
+# 2. Induced orientation is well-defined after coning and restored by the inverse
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("builder", [lambda: _sphere(3), lambda: _sphere(4)])
+def test_induced_orientation_after_cone_in(builder):
+    """After a cone-in the refined complex is still a closed oriented manifold: the
+    orientation covector exists (no propagation contradiction) and the closed-manifold
+    fundamental class is still a single +/-1 generator."""
+    st = builder()
+    cone = cob.OrientedCone(st)
+    for seed in range(64):
+        ok, _ = cone.coneIn(seed)
+        if not ok:
+            continue
+        eps = cone.orientationCovector()
+        assert len(eps) == len(_top_set(st))
+        assert all(s in (-1, 1) for s in eps)
+        # Closed oriented manifold: fundamentalClass is the unique +/-1 generator.
+        fc = cob.ChainComplex.fromSpacetime(st).fundamentalClass()
+        assert len(fc) == len(eps) and all(s in (-1, 1) for s in fc)
+        return
+    pytest.skip("cone-in never proposed in 64 seeds")
+
+
+@pytest.mark.parametrize(
+    "builder", [lambda: _sphere(3), lambda: _sphere(4), _s2_cross_s1]
+)
+def test_roundtrip_restores_every_orientation_sign(builder):
+    """move o move^-1 must restore *all* signs: the per-cell induced orientation
+    covector is bit-identical before and after a cone round trip."""
+    st = builder()
+    before = _orientation_map(st)
+    cone = cob.OrientedCone(st)
+    for seed in range(64):
+        ok, _ = cone.coneIn(seed)
+        if not ok:
+            continue
+        assert cone.rollback()
+        after = _orientation_map(st)
+        assert after == before, "cone round trip did not restore the orientation signs"
+        return
+    pytest.skip("cone-in never proposed in 64 seeds")
+
+
+# --------------------------------------------------------------------------- #
+# 3. endSignCovector of fixed holes is stable across a cone applied away from them
+# --------------------------------------------------------------------------- #
+def test_end_sign_covector_stable_across_cone():
+    st = _sphere(4)
+    tops_before = _top_set(st)
+
+    cone = cob.OrientedCone(st)
+    for seed in range(64):
+        ok, _ = cone.coneIn(seed)
+        if not ok:
+            continue
+        tops_after = _top_set(st)
+        # The subdivided cell is the one present before but gone after; the holes
+        # must be survivors so the same hole set is valid in both surfaces.
+        survivors = [c for c in tops_after if c in tops_before]
+        assert len(survivors) >= 2
+        holes = [list(survivors[0]), list(survivors[1])]
+
+        sig_before = cob.ChainComplex.endSignCovector(
+            [list(c) for c in tops_before], holes
+        )
+        sig_after = cob.ChainComplex.endSignCovector(
+            [list(c) for c in tops_after], holes
+        )
+        assert all(s in (-1, 1) for s in sig_before)
+        assert all(s in (-1, 1) for s in sig_after)
+        # The covector is defined up to one overall sign per connected component
+        # (the constraint sum_k sigma_k p_k = 0 holds for either sign); a cone
+        # that removes the lexicographic root cell can flip that global sign. The
+        # global-sign-invariant statement of "end-sign stability" is that the
+        # *relative* induced orientation between holes is preserved.
+        assert (
+            sig_before[0] * sig_before[1] == sig_after[0] * sig_after[1]
+        ), "relative end-sign of the holes drifted across the cone"
+        cone.rollback()
+        return
+    pytest.skip("cone-in never proposed in 64 seeds")
+
+
+# --------------------------------------------------------------------------- #
+# 4. Im S sign consistency across a gated cone on a genuinely Lorentzian CDT
+# --------------------------------------------------------------------------- #
+def test_gated_cone_preserves_imaginary_part():
+    """On a genuinely complex action (CDT toroid, Im S ~ -35) the gated cone-in/out
+    round trip must restore Im S, not just |S|. A flipped induced orientation would
+    show up here as an Im drift -- the precise corruption the gate exists to stop."""
+    st = _make_cdt(120)
+    a0 = _act(st)
+    assert abs(a0.imag) > 1.0, "fixture is not genuinely Lorentzian"
+
+    cone = cob.OrientedCone(st)
+    last_reason = "cone-in never proposed on the CDT in 64 seeds"
+    for seed in range(64):
+        ok, reason = cone.coneIn(seed)
+        if not ok:
+            last_reason = reason
+            continue
+        a1 = _act(st)
+        assert abs(a1 - a0) > TOL, "cone-in did not change the action"
+        assert cone.rollback()
+        a2 = _act(st)
+        _assert_close(a2, a0, TOL_BIG, "gated cone Im round trip")
+        return
+    # A valid CDT refinement should be gate-accepted; if every candidate was
+    # rejected on a manifold ground that is a finding about the gate's strictness
+    # vs the CDT build, not an Im-sign failure -- surface it rather than fail.
+    pytest.skip(f"no gated cone accepted on the CDT: {last_reason}")
+
+
+# --------------------------------------------------------------------------- #
+# 5. The orientability gate has teeth (pure combinatorics)
+# --------------------------------------------------------------------------- #
+def test_orientation_covector_orientable_sphere():
+    """S^2 = boundary of a tetrahedron: orientable, so orientationCovector returns a
+    clean +/-1 covector with the lexicographically smallest cell carrying +1."""
+    s2 = [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]
+    eps = cob.ChainComplex.orientationCovector(s2)
+    assert len(eps) == 4 and all(s in (-1, 1) for s in eps)
+    # Sorted-unique order puts [0,1,2] first -> the component root carries +1.
+    assert eps[0] == 1
+
+
+def test_orientation_covector_raises_on_non_orientable():
+    """A minimal Moebius band (5 triangles in a flipped cycle) is non-orientable: the
+    sign propagation contradicts itself, so orientationCovector must raise -- exactly
+    the verdict that makes OrientedCone reject a sign-flipping (orientation-reversing)
+    cone."""
+    moebius = [[0, 1, 2], [1, 2, 3], [2, 3, 4], [0, 3, 4], [0, 1, 4]]
+    with pytest.raises(RuntimeError, match="orientationCovector"):
+        cob.ChainComplex.orientationCovector(moebius)
+
+
+def test_validate_is_the_applied_gate():
+    """OrientedCone.validate() reports the same (manifold + orientable) verdict the
+    cone moves gate on; on a pristine sphere it is (True, 'ok')."""
+    st = _sphere(3)
+    ok, reason = cob.OrientedCone(st).validate()
+    assert ok, reason


### PR DESCRIPTION
## Summary

T2 of the **Emergent Color Topology** epic (#457). T1 (#458/PR #465) made the stellar cone primitives hinge-exact and exactly invertible. T2 makes them **orientation-safe** and gates them on the **full manifold check**, so a cone can never flip a local induced orientation and inject a spurious sign into the **complex** (causal/oriented) deficit — i.e. into `Im S` (`ReggeSolver::dualReggeAction`), which is real physics.

The work is purely additive — no change to the action definition or the T1 move machinery:

- **`cobordism::OrientedCone`** — a thin wrapper that *reuses* the T1 cone primitives (`AddMove`/`RemoveMove` in `PachnerMode::PreGeometric`, the `1↔(d+1)` stellar subdivision) and accepts a cone **only if** the result is a valid, **orientable** manifold. New cells take the standard simplicial orientation (`TemporalOrientation::orientationOf`, Ambjørn–Loll CDT convention) — never an ad-hoc vertex-label sort. On rejection the move is rolled back and the complex is left bit-identical.
- **The gate** = `ChainComplex::dualComplexIsValid` (the #429 `n≥4` recursive manifold check) **and** `ChainComplex::orientationCovector` propagating a consistent global orientation. `dualComplexIsValid` alone is insufficient — a non-orientable manifold (e.g. an `RP³` region) is a valid manifold yet can reverse induced orientation.
- **`ChainComplex::orientationCovector(topCells)`** — a new static read-out: the per-cell induced-orientation sign `ε_t ∈ {±1}` by facet-sharing propagation. Unlike `fundamentalClass` it does not require the complex to be closed, so it reads an open refinement region; throws on a non-pseudomanifold or a non-orientable contradiction.

Topology change (open-star removal without refill) is **out of scope** here (T3/#460); T2 keeps coning topology-preserving and establishes the orientation/`Im`-sign safety net the surgical move relies on.

## Test plan
- [x] `tests/cobordism/test_orientation_safe_coning.py` (14 tests): gate accepts a topology-preserving cone-in on `S³`/`S⁴`/`S²×S¹` and a gated cone-out weld on `S³`; round trip restores the action (**Re and Im**) and the top-cell set; induced orientation restored bit-identically by `move∘move⁻¹`; `endSignCovector` stable across a cone; `Im S` consistency on a genuinely Lorentzian CDT toroid (`Im S ≈ −35`); orientability gate raises on a Möbius complex.
- [x] No regression: `test_hinge_exact_moves.py` (T1) + `test_epic410_invariants.py` (30 passed); full cobordism suite re-run with `pytest -n 16`.
- [x] Findings report: `docs/design/orientation_safe_coning_532df97.md`.

Closes #459.