### PR TITLE
feat(cobordism): gated surgical cone-out/cone-in topology change (T3)

### DIFF
--- a/docs/design/surgical_cone_topology_7ad8be9.md
+++ b/docs/design/surgical_cone_topology_7ad8be9.md
@@ -1,0 +1,115 @@
+# Gated surgical cone-out / cone-in: the topology-changer (T3, #460)
+
+Part of the **Emergent Color Topology** epic (#457). T1 (#458) made the cone
+primitives hinge-exact and exactly invertible; T2 (#459) made the
+topology-**preserving** refinement cone orientation-safe and gated. T3 adds the
+genuine **topology-changer** — the move that actually grows `b_k` — and gates it
+on the full manifold check.
+
+## The sharp edge (#457's "sharp edge #1")
+
+Pachner moves and the stellar refinement cone are topology-**preserving**: none
+of the emergent color holes come from them. The genuine hole-creator is a
+**surgical cone-out** — remove a top cell *without* refilling — and its inverse a
+**surgical cone-in**. Surgery is powerful and dangerous: an ungated cut can
+pinch the complex into a non-manifold (exactly what broke the #353 weld). The
+rule is therefore: **surgery is allowed *because* it is gated**, on the full
+`dualComplexValid` manifold check; never bypass it.
+
+## What the moves do
+
+### `cobordism::SurgicalCone` (sibling of T2's `OrientedCone`)
+
+- **`coneOut(cell)`** — remove the top cell whose sorted vertex ids equal `cell`:
+  drop the `d`-simplex, then every edge of it that no surviving top cell still
+  covers (the ticket's "if the edge multiplicity > 1 decrement it, else remove
+  it" — an edge's multiplicity *is* its surviving-coface count), then any vertex
+  left with no incident edge. Refuses to remove the last top cell (that would
+  drop the complex dimension).
+- **`coneIn(targetVerts)`** — the literal "add a vertex, draw edges to `d`
+  others": create a fresh apex vertex and the single top cell on
+  `targetVerts ∪ {apex}`.
+- **`rollback()` / `rollbackAll()`** — undo accepted moves LIFO. A cone-out's
+  inverse re-creates the exact removed cell *and restores every removed edge's
+  length and phase bit-exactly* — this is the surgical **cone-in of that cell**,
+  and it is what makes the round trip action-exact.
+- **`bettiNumbers()` / `validate()`** — read-outs the tests assert on.
+
+The class lives in the **cobordism** layer (which depends on `spacetime`) so it
+can call `ChainComplex` directly, mirroring `OrientedCone`. It reuses the
+existing `Spacetime` mutators (`removeSimplex`, `removeEdge`, `removeIfIsolated`,
+`createVertex`, `createSimplexTracked`) — no move machinery is reimplemented.
+
+### The gate
+
+Every accepted move must leave the complex a valid combinatorial
+**manifold-with-boundary**: `ChainComplex::dualComplexIsValid` over the current
+top cells (facet coface counts in `{1,2}` — a removed cell's facets become
+boundary at count 1; ridge links single paths/cycles; the #429 recursive
+`n ≥ 4` vertex-link validation). A move whose result fails the gate (e.g. a
+cone-in onto an interior facet, which would give that facet 3 cofaces) is rolled
+back and the complex left bit-identical; the caller sees `(False, reason)`.
+
+## Why a single cone-out raises `b_{d-1}`, and where
+
+Removing one open `d`-ball from a closed connected `d`-manifold kills the top
+class `b_d` but leaves the result contractible-rel-boundary — `b_{d-1}` is
+**unchanged**. A `b_{d-1}` hole appears only when a *second* ball, **disjoint**
+from the first, is removed (the complement gains an `S^{d-1}` factor). So on
+`S^3` (where `b_2` is the color register's degree) the surgical degree is `b_2`,
+and the empirical sequence is:
+
+| step | complex | Betti `[b0,b1,b2,b3]` |
+| --- | --- | --- |
+| start | refined `S^3` | `[1,0,0,1]` |
+| cone-out cell A | punctured | `[1,0,0,0]` |
+| cone-out cell B (disjoint from A) | two punctures | `[1,0,1,0]` ← `b_2` **+1** |
+| inverse (cone B back in) | one puncture | `[1,0,0,0]` ← `b_2` **−1** |
+| inverse (cone A back in) | refined `S^3` | `[1,0,0,1]` (restored) |
+
+**The minimal `S^3 = ∂Δ⁴` (5 tetrahedra) has *no* disjoint cell pair** — every
+facet pair shares a ridge — so no single removal can open a `b_2` hole there.
+The test refines `S^3` with a dozen topology-preserving stellar subdivisions
+(T1 `AddMove(PreGeometric)`) to 41 tetrahedra (still Betti `[1,0,0,1]`), where
+127 disjoint pairs exist, then cones one out.
+
+`coneIn` with a fresh apex is **homotopy-neutral** when it caps a boundary disk
+(it cones a disk, adding no cycle), so it does not by itself lower `b_2`; the
+clean `b_2`-lowering inverse is the exact cone-out inverse (`rollback`). On a
+*closed* manifold `coneIn` always rejects (every facet already has two cofaces),
+so it is only ever accepted after a cone-out has opened a boundary — the two
+moves are genuinely complementary.
+
+## Verification
+
+Build clean (`pip install -e ".[dev]"`, exit 0). Tests run under a 16-thread cap,
+parallelized with `pytest -n 16`.
+
+**New suite — `tests/cobordism/test_surgical_cone_topology.py` (7 tests, all
+pass):**
+
+- A surgical **cone-out raises `b_2` by exactly 1** on a refined `S^3` (removing
+  a cell disjoint from a first puncture), and the **inverse lowers it by 1**;
+  unwinding fully restores the top-cell set and Betti vector.
+- The **round trip restores the dual Regge action — Re *and* Im** — on a
+  genuinely Lorentzian CDT toroid (`Im S ≈ −35`): cone-out then inverse leaves
+  the complex action invariant to `< 1e-6` (observed Re drift `~1e-15`, Im drift
+  `0`).
+- The **gate rejects a non-manifold attempt** (a cone-in onto an interior facet
+  → 3 cofaces) and leaves the complex unchanged.
+- **cone-in needs a boundary** (always rejects on a closed manifold) and is
+  exactly reversible where accepted.
+- The **`n ≥ 4` recursive gate** accepts and round-trips a cone-out on `S^4`.
+- Degenerate inputs (unknown cell, wrong arity) are rejected cleanly with no
+  mutation.
+
+**No regression:** `tests/cobordism/test_epic410_invariants.py` and the full
+cobordism suite re-run with `pytest -n 16` stay green.
+
+## Scope guard honored
+
+T3 implements *only* the move + its gate + reversibility. **When** to fire a
+surgery (the optimizer loop, T5/#462) and **whether a hole should emerge from the
+physics** (T6/#463) are out of scope — here we only prove the move correctly and
+reversibly changes `b_k`. Nothing hand-identifies "the hole": the move + gate are
+the sole sanctioned mechanism, never an answer inserted by fiat.

--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -170,6 +170,8 @@ exclusions to see the entire interface.
 ```
 ```{doxygenfile} MergeCobordism.h
 ```
+```{doxygenfile} SurgicalCone.h
+```
 ```{doxygenfile} TransportCobordism.h
 ```
 ```{doxygenfile} CobordismRelaxer.h

--- a/include/cobordism/SurgicalCone.h
+++ b/include/cobordism/SurgicalCone.h
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_SURGICALCONE_H
+#define TESSERA_COBORDISM_SURGICALCONE_H
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace tessera::spacetime {
+class Spacetime;
+}  // namespace tessera::spacetime
+
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # SurgicalCone
+///
+/// The **topology-changing** surgical cone of the Emergent Color Topology epic
+/// (#457, T3) — the genuine `b_k`-hole creator. Pachner moves and the stellar
+/// refinement cone (T1/T2, `OrientedCone`) are topology-**preserving**: none of
+/// the emergent color holes come from them. A *surgical* cone does change the
+/// topology, and is dangerous, so **every** move is gated on the full manifold
+/// check — surgery is allowed *because* it is gated. Bypassing the gate is
+/// exactly what broke the #353 weld; this class never bypasses it.
+///
+/// ## The two moves
+/// * **cone-out** (`coneOut`) — the hole-creator. Remove a single top cell:
+///   drop the \f$ d \f$-simplex, then every edge it had that no surviving top
+///   cell still covers (the "decrement multiplicity, remove at zero" of the
+///   ticket), then any vertex left with no incident edge. Removing one top cell
+///   from a closed \f$ d \f$-manifold opens it to a manifold-with-boundary;
+///   removing a cell disjoint from an existing hole raises \f$ b_{d-1} \f$ by 1
+///   (on \f$ S^3 \f$, \f$ b_2 \f$ — the color register degree).
+/// * **cone-in** (`coneIn`) — add a single top cell built on a **fresh** vertex
+///   joined to \f$ d \f$ chosen existing vertices. Capping a hole's boundary
+///   this way lowers \f$ b_{d-1} \f$ by 1.
+///
+/// ## The gate
+/// After applying a move the candidate complex is accepted **only if**
+/// `ChainComplex::dualComplexIsValid` holds over its top cells — a genuine
+/// combinatorial **manifold-with-boundary** (facet coface counts in
+/// \f$ \{1,2\} \f$, ridge links single paths/cycles, and the #429 recursive
+/// \f$ n \geq 4 \f$ vertex-link validation). A move that would pinch the complex
+/// or give a facet \f$ > 2 \f$ cofaces is rejected and rolled back, leaving the
+/// complex bit-identical to its pre-move state.
+///
+/// ## Lifecycle and exact reversibility
+/// Accepted moves are pushed on a stack; `rollback()` undoes the last one,
+/// restoring the complex — every edge length and phase — bit-for-bit, so a
+/// round trip leaves the dual Regge action (Re **and** Im) invariant. The moves
+/// are first-class and composable (cone-out two disjoint cells, then roll both
+/// back LIFO).
+class SurgicalCone {
+ public:
+  /// Bind the cone to a spacetime. Does not mutate it.
+  explicit SurgicalCone(Spacetime *spacetime);
+  ~SurgicalCone();
+
+  SurgicalCone(const SurgicalCone &) = delete;
+  SurgicalCone &operator=(const SurgicalCone &) = delete;
+
+  /// Gated surgical **cone-out**: remove the top cell whose sorted vertex ids
+  /// equal \p cell (plus its orphaned edges and any vertex thereby isolated),
+  /// then accept only if the result is a valid manifold-with-boundary. Returns
+  /// `(true, "ok")` on acceptance; otherwise the complex is restored and the
+  /// reason returned. Rejects removing the last top cell (it would drop the
+  /// complex dimension).
+  std::pair<bool, std::string> coneOut(const std::vector<std::uint64_t> &cell);
+
+  /// Gated surgical **cone-in**: create a fresh vertex, join it to the \f$ d \f$
+  /// vertices \p targetVerts to form a new top cell, then accept only if the
+  /// result is a valid manifold-with-boundary. Returns `(true, "ok")` on
+  /// acceptance; otherwise the additions are undone and the reason returned.
+  std::pair<bool, std::string> coneIn(
+      const std::vector<std::uint64_t> &targetVerts);
+
+  /// Undo the last accepted move (LIFO), restoring the complex bit-for-bit —
+  /// every edge length and phase. Returns `false` if nothing is applied.
+  bool rollback();
+
+  /// Roll every accepted move back, restoring the original complex. Returns the
+  /// number of moves undone.
+  std::size_t rollbackAll();
+
+  /// Number of accepted, not-yet-rolled-back moves on the stack.
+  [[nodiscard]] std::size_t depth() const;
+
+  /// True iff at least one move is accepted and not yet rolled back.
+  [[nodiscard]] bool isApplied() const;
+
+  /// The Betti numbers \f$ b_0, \ldots, b_n \f$ (over \f$ \mathbb{Q} \f$) of the
+  /// **current** complex (`ChainComplex::fromSpacetime(...).bettiNumbers()`).
+  /// The read-out the `b_k`-delta tests assert a surgical move shifts by one.
+  [[nodiscard]] std::vector<int> bettiNumbers() const;
+
+  /// The manifold verdict on the **current** complex — the same gate `coneOut` /
+  /// `coneIn` apply. `(true, "ok")` when it is a valid manifold-with-boundary;
+  /// otherwise the first violation is named.
+  [[nodiscard]] std::pair<bool, std::string> validate() const;
+
+ private:
+  /// One accepted surgical move, with everything needed to invert it exactly.
+  struct Move {
+    enum class Kind { ConeOut, ConeIn };
+    Kind kind;
+    /// The d+1 vertex ids of the removed (cone-out) / added (cone-in) top cell.
+    std::vector<std::uint64_t> cell;
+    /// Edges touched: removed orphans (cone-out, to re-create) / freshly
+    /// inserted edges (cone-in, to drop), each (u, v, l2_real, phase).
+    std::vector<std::tuple<std::uint64_t, std::uint64_t, double, double>> edges;
+    /// Vertices touched: isolated vertices removed (cone-out, to re-create) /
+    /// the single fresh vertex (cone-in, to drop), each (id, coords). An empty
+    /// coords vector marks a coordinate-free vertex.
+    std::vector<std::pair<std::uint64_t, std::vector<double>>> verts;
+  };
+
+  /// Top cells of the bound spacetime as sorted vertex-id tuples (canonical
+  /// C_d order), the input to the manifold check.
+  [[nodiscard]] std::vector<std::vector<std::uint64_t>> topCells() const;
+
+  /// Vertices-per-top-cell (d+1), or 0 if no dimension is set.
+  [[nodiscard]] std::size_t topVerts() const;
+
+  /// Re-create the exact cell of a cone-out Move (its isolated vertices, the top
+  /// cell, and the removed edges' lengths/phases).
+  void undoConeOut(const Move &m);
+  /// Drop the exact cell of a cone-in Move (the top cell, its fresh edges, the
+  /// fresh vertex).
+  void undoConeIn(const Move &m);
+
+  Spacetime *st_;
+  std::vector<Move> moves_;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_SURGICALCONE_H

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -25,6 +25,7 @@
 #include "cobordism/HodgeLaplacian.h"
 #include "cobordism/IntegerLinalg.h"
 #include "cobordism/MergeCobordism.h"
+#include "cobordism/SurgicalCone.h"
 #include "cobordism/PreparedBoundaryState.h"
 #include "cobordism/RealizabilityOracle.h"
 #include "cobordism/Register.h"
@@ -1856,4 +1857,49 @@ prepared states, reproduces the harmonic overlap.)doc")
                              "the read-out is symmetric with the signed inputs "
                              "(relabeling-invariant sigma_R). Empty if unsigned.")
       .def_property_readonly("stats", &TransportCobordism::stats);
+
+  // ----- Gated surgical cone-out/cone-in (topology change, #460) -----
+  py::class_<SurgicalCone>(m, "SurgicalCone",
+      R"doc(Gated surgical cone-out/cone-in: the topology-CHANGING move (#460, T3).
+
+The genuine b_k-hole creator of the Emergent Color Topology epic (#457). Pachner
+moves and the stellar refinement cone (OrientedCone, T1/T2) are topology-
+PRESERVING; this is not. coneOut removes one top cell (its orphaned edges, then
+any isolated vertex) -- on a closed manifold this opens a manifold-with-boundary
+and, for a cell disjoint from an existing hole, raises b_{d-1} by 1 (on S^3, the
+color register's b_2). coneIn adds one top cell on a fresh vertex joined to d
+existing vertices, lowering b_{d-1} by 1 when it caps a hole. EVERY move is gated
+on ChainComplex.dualComplexIsValid (a valid manifold-with-boundary; the #429
+n>=4 recursive check) -- surgery is allowed BECAUSE it is gated; bypassing the
+gate is what broke the #353 weld. Rejected moves roll back bit-identically.
+Accepted moves stack; rollback() undoes the last LIFO, restoring every edge
+length and phase so a round trip leaves the dual Regge action (Re AND Im)
+invariant.)doc")
+      .def(py::init<Spacetime *>(), py::arg("spacetime"), py::keep_alive<1, 2>(),
+           "Bind the cone to a spacetime (does not mutate it).")
+      .def("coneOut", &SurgicalCone::coneOut, py::arg("cell"),
+           "(ok, reason): gated surgical cone-out -- remove the top cell whose "
+           "sorted vertex ids equal `cell` (plus orphaned edges and any vertex "
+           "thereby isolated). Accepts only a valid manifold-with-boundary; "
+           "otherwise restores the cell and names the reason. Rejects removing "
+           "the last top cell.")
+      .def("coneIn", &SurgicalCone::coneIn, py::arg("target_verts"),
+           "(ok, reason): gated surgical cone-in -- create a fresh vertex, join "
+           "it to the d `target_verts` to form a new top cell. Accepts only a "
+           "valid manifold-with-boundary; otherwise undoes the additions.")
+      .def("rollback", &SurgicalCone::rollback,
+           "Undo the last accepted move (LIFO), restoring the complex bit-for-"
+           "bit (edge lengths and phases). False if nothing is applied.")
+      .def("rollbackAll", &SurgicalCone::rollbackAll,
+           "Roll every accepted move back; returns the number undone.")
+      .def_property_readonly("depth", &SurgicalCone::depth,
+           "Number of accepted, not-yet-rolled-back moves on the stack.")
+      .def_property_readonly("isApplied", &SurgicalCone::isApplied,
+           "True iff at least one move is accepted and not yet rolled back.")
+      .def("bettiNumbers", &SurgicalCone::bettiNumbers,
+           "Betti numbers b_0..b_n (over Q) of the CURRENT complex -- the read-"
+           "out the b_k-delta tests assert a surgical move shifts by one.")
+      .def("validate", &SurgicalCone::validate,
+           "(ok, reason): the manifold-with-boundary verdict on the CURRENT "
+           "complex -- the same gate coneOut / coneIn apply.");
 }

--- a/src/cobordism/SurgicalCone.cpp
+++ b/src/cobordism/SurgicalCone.cpp
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/SurgicalCone.h"
+
+#include <algorithm>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "cobordism/ChainComplex.h"
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Simplex.h"
+#include "mesh/Vertex.h"
+#include "mesh/VertexList.h"
+#include "spacetime/Metric.h"
+#include "spacetime/Signature.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+SurgicalCone::SurgicalCone(Spacetime *spacetime) : st_(spacetime) {}
+
+SurgicalCone::~SurgicalCone() = default;
+
+std::size_t SurgicalCone::topVerts() const {
+  if (st_ == nullptr) return 0;
+  const int d = st_->getMetric()->getSignature()->getDimensions();
+  return (d >= 0) ? static_cast<std::size_t>(d) + 1 : 0;
+}
+
+std::vector<std::vector<std::uint64_t>> SurgicalCone::topCells() const {
+  std::vector<std::vector<std::uint64_t>> cells;
+  const std::size_t tv = topVerts();
+  if (tv == 0) return cells;
+  for (const auto &s : st_->getSimplices()) {
+    if (s == nullptr || s->size() != tv) continue;
+    std::vector<std::uint64_t> ids;
+    ids.reserve(tv);
+    for (const auto &v : s->getVertices())
+      if (v != nullptr) ids.push_back(v->getId());
+    if (ids.size() != tv) continue;
+    std::sort(ids.begin(), ids.end());
+    cells.push_back(std::move(ids));
+  }
+  std::sort(cells.begin(), cells.end());
+  cells.erase(std::unique(cells.begin(), cells.end()), cells.end());
+  return cells;
+}
+
+std::pair<bool, std::string> SurgicalCone::validate() const {
+  const auto tops = topCells();
+  if (tops.empty()) return {false, "no top cells"};
+  const int dim = static_cast<int>(tops.front().size()) - 1;
+  return ChainComplex::dualComplexIsValid(tops, dim);
+}
+
+std::vector<int> SurgicalCone::bettiNumbers() const {
+  if (st_ == nullptr) return {};
+  return ChainComplex::fromSpacetime(*st_).bettiNumbers();
+}
+
+std::size_t SurgicalCone::depth() const { return moves_.size(); }
+
+bool SurgicalCone::isApplied() const { return !moves_.empty(); }
+
+namespace {
+
+/// Build {id -> Vertex*} over the live vertex list.
+std::unordered_map<std::uint64_t, ::tessera::mesh::Vertex *> vertexIndex(
+    Spacetime *st) {
+  std::unordered_map<std::uint64_t, ::tessera::mesh::Vertex *> idx;
+  for (const auto v : st->getVertexList()->toVector())
+    if (v != nullptr) idx.emplace(v->getId(), v);
+  return idx;
+}
+
+/// Build {min(u,v),max(u,v) -> Edge*} over the live edge list.
+std::map<std::pair<std::uint64_t, std::uint64_t>, ::tessera::mesh::Edge *>
+edgeIndex(Spacetime *st) {
+  std::map<std::pair<std::uint64_t, std::uint64_t>, ::tessera::mesh::Edge *> idx;
+  for (const auto e : st->getEdgeList()->toVector()) {
+    if (e == nullptr || e->getSource() == nullptr || e->getTarget() == nullptr)
+      continue;
+    const std::uint64_t a = e->getSource()->getId();
+    const std::uint64_t b = e->getTarget()->getId();
+    idx[{std::min(a, b), std::max(a, b)}] = e;
+  }
+  return idx;
+}
+
+/// Coordinates of a vertex, or an empty vector for a coordinate-free one.
+std::vector<double> coordsOf(::tessera::mesh::Vertex *v) {
+  try {
+    return v->getCoordinates();
+  } catch (const std::exception &) {
+    return {};
+  }
+}
+
+}  // namespace
+
+std::pair<bool, std::string> SurgicalCone::coneOut(
+    const std::vector<std::uint64_t> &cell) {
+  if (st_ == nullptr) return {false, "no spacetime"};
+  const std::size_t tv = topVerts();
+  if (tv < 2) return {false, "degenerate dimension"};
+  if (cell.size() != tv)
+    return {false, "cell is not a top cell (" + std::to_string(cell.size()) +
+                       " vertices, expected " + std::to_string(tv) + ")"};
+  std::vector<std::uint64_t> want(cell.begin(), cell.end());
+  std::sort(want.begin(), want.end());
+
+  // Locate the target top cell; collect the OTHER top cells (to know which of
+  // want's edges survive). Refuse to remove the last top cell of the dimension.
+  ::tessera::mesh::Simplex *target = nullptr;
+  std::vector<std::vector<std::uint64_t>> otherTop;
+  for (const auto s : st_->getSimplices()) {
+    if (s == nullptr || s->size() != tv) continue;
+    std::vector<std::uint64_t> ids;
+    ids.reserve(tv);
+    for (const auto v : s->getVertices())
+      if (v != nullptr) ids.push_back(v->getId());
+    std::sort(ids.begin(), ids.end());
+    if (target == nullptr && ids == want)
+      target = s;
+    else
+      otherTop.push_back(std::move(ids));
+  }
+  if (target == nullptr) return {false, "no such top cell"};
+  if (otherTop.empty()) return {false, "refusing to remove the last top cell"};
+
+  // An edge {u,v} of the cell is orphaned iff no surviving top cell covers both
+  // endpoints. Capture (u, v, l2, phase) for each orphan so rollback restores it.
+  const auto covered = [&](std::uint64_t u, std::uint64_t v) {
+    for (const auto &c : otherTop) {
+      const bool hu = std::find(c.begin(), c.end(), u) != c.end();
+      const bool hv = std::find(c.begin(), c.end(), v) != c.end();
+      if (hu && hv) return true;
+    }
+    return false;
+  };
+  auto eidx = edgeIndex(st_);
+  Move m;
+  m.kind = Move::Kind::ConeOut;
+  m.cell = want;
+  std::vector<::tessera::mesh::Edge *> toRemove;
+  for (std::size_t i = 0; i + 1 < want.size(); ++i)
+    for (std::size_t j = i + 1; j < want.size(); ++j) {
+      const std::uint64_t u = want[i], v = want[j];
+      if (covered(u, v)) continue;
+      const auto it = eidx.find({std::min(u, v), std::max(u, v)});
+      if (it == eidx.end()) continue;  // already absent
+      m.edges.emplace_back(u, v, it->second->getSquaredLength().real(),
+                           it->second->getPhase());
+      toRemove.push_back(it->second);
+    }
+
+  // Snapshot the cell vertices' coords (for any that go isolated).
+  auto vidx = vertexIndex(st_);
+  std::unordered_map<std::uint64_t, std::vector<double>> coordSnap;
+  for (const std::uint64_t id : want) {
+    const auto it = vidx.find(id);
+    if (it != vidx.end()) coordSnap[id] = coordsOf(it->second);
+  }
+
+  // Mutate: drop the top cell, then its orphaned edges.
+  st_->removeSimplex(target);
+  for (auto *e : toRemove)
+    if (e != nullptr) st_->removeEdge(e);
+
+  // Any cell vertex now carrying no edge is deleted (and recorded for rollback).
+  vidx = vertexIndex(st_);
+  for (const std::uint64_t id : want) {
+    const auto it = vidx.find(id);
+    if (it == vidx.end()) continue;
+    if (it->second->degree() == 0) {
+      m.verts.emplace_back(id, coordSnap[id]);
+      st_->removeIfIsolated(it->second);
+    }
+  }
+
+  // Gate: the result must be a valid manifold-with-boundary. On rejection,
+  // restore the cell exactly (the inverse of this same move) and report.
+  const auto verdict = validate();
+  if (!verdict.first) {
+    undoConeOut(m);
+    return verdict;
+  }
+  moves_.push_back(std::move(m));
+  return {true, "ok"};
+}
+
+std::pair<bool, std::string> SurgicalCone::coneIn(
+    const std::vector<std::uint64_t> &targetVerts) {
+  if (st_ == nullptr) return {false, "no spacetime"};
+  const std::size_t tv = topVerts();
+  if (tv < 2) return {false, "degenerate dimension"};
+  if (targetVerts.size() != tv - 1)
+    return {false, "cone-in needs " + std::to_string(tv - 1) +
+                       " target vertices (got " +
+                       std::to_string(targetVerts.size()) + ")"};
+  // The targets must be distinct existing vertices.
+  auto vidx = vertexIndex(st_);
+  std::unordered_set<std::uint64_t> seen;
+  ::tessera::mesh::VertexPtrs targets;
+  targets.reserve(tv);
+  for (const std::uint64_t id : targetVerts) {
+    if (!seen.insert(id).second) return {false, "duplicate target vertex"};
+    const auto it = vidx.find(id);
+    if (it == vidx.end()) return {false, "no such target vertex"};
+    targets.push_back(it->second);
+  }
+
+  // The fresh apex + the d targets form the new top cell.
+  ::tessera::mesh::Vertex *apex = st_->createVertex();
+  Move m;
+  m.kind = Move::Kind::ConeIn;
+  m.verts.emplace_back(apex->getId(), coordsOf(apex));
+  ::tessera::mesh::VertexPtrs verts = targets;
+  verts.push_back(apex);
+  std::vector<std::uint64_t> cellIds;
+  cellIds.reserve(tv);
+  for (const auto v : verts) cellIds.push_back(v->getId());
+  std::sort(cellIds.begin(), cellIds.end());
+  m.cell = cellIds;
+
+  auto r = st_->createSimplexTracked(verts);
+  for (const auto &e : r.newEdges)
+    if (e != nullptr && e->getSource() != nullptr && e->getTarget() != nullptr)
+      m.edges.emplace_back(e->getSource()->getId(), e->getTarget()->getId(),
+                           e->getSquaredLength().real(), e->getPhase());
+
+  const auto verdict = validate();
+  if (!verdict.first) {
+    undoConeIn(m);
+    return verdict;
+  }
+  moves_.push_back(std::move(m));
+  return {true, "ok"};
+}
+
+void SurgicalCone::undoConeOut(const Move &m) {
+  // Re-create any isolated vertices first, then the top cell, then restore the
+  // removed edges' lengths/phases bit-exactly.
+  for (const auto &[id, coords] : m.verts) {
+    if (coords.empty())
+      (void)st_->createVertex(id);
+    else
+      (void)st_->createVertex(id, coords);
+  }
+  auto vidx = vertexIndex(st_);
+  ::tessera::mesh::VertexPtrs verts;
+  verts.reserve(m.cell.size());
+  for (const std::uint64_t id : m.cell) {
+    const auto it = vidx.find(id);
+    if (it == vidx.end()) return;  // a cell vertex vanished — cannot restore
+    verts.push_back(it->second);
+  }
+  st_->createSimplexTracked(verts);
+
+  auto eidx = edgeIndex(st_);
+  for (const auto &[u, v, w, theta] : m.edges) {
+    const auto it = eidx.find({std::min(u, v), std::max(u, v)});
+    if (it != eidx.end()) {
+      it->second->setSquaredLength(std::complex<double>{w, 0.0});
+      it->second->setPhase(theta);
+    }
+  }
+}
+
+void SurgicalCone::undoConeIn(const Move &m) {
+  // Drop the added top cell, its fresh edges, then the fresh apex vertex.
+  auto vidx = vertexIndex(st_);
+  ::tessera::mesh::VertexPtrs verts;
+  verts.reserve(m.cell.size());
+  for (const std::uint64_t id : m.cell) {
+    const auto it = vidx.find(id);
+    if (it != vidx.end()) verts.push_back(it->second);
+  }
+  if (verts.size() == m.cell.size()) {
+    if (auto s = st_->findSimplexByVerts(verts)) st_->removeSimplex(s);
+  }
+  auto eidx = edgeIndex(st_);
+  for (const auto &[u, v, w, theta] : m.edges) {
+    (void)w;
+    (void)theta;
+    const auto it = eidx.find({std::min(u, v), std::max(u, v)});
+    if (it != eidx.end()) st_->removeEdge(it->second);
+  }
+  for (const auto &[id, coords] : m.verts) {
+    (void)coords;
+    const auto it = vidx.find(id);
+    if (it != vidx.end()) st_->removeIfIsolated(it->second);
+  }
+}
+
+bool SurgicalCone::rollback() {
+  if (moves_.empty()) return false;
+  const Move m = std::move(moves_.back());
+  moves_.pop_back();
+  if (m.kind == Move::Kind::ConeOut)
+    undoConeOut(m);
+  else
+    undoConeIn(m);
+  return true;
+}
+
+std::size_t SurgicalCone::rollbackAll() {
+  std::size_t n = 0;
+  while (rollback()) ++n;
+  return n;
+}
+
+}  // namespace tessera::cobordism

--- a/tests/cobordism/test_surgical_cone_topology.py
+++ b/tests/cobordism/test_surgical_cone_topology.py
@@ -1,0 +1,240 @@
+"""Gated surgical cone-out / cone-in: the topology-changer (T3, #460).
+
+The Emergent Color Topology epic (#457) grows the proton's ``b2`` color register
+by *gated surgical coning*. T1 (#458) made the cone primitives hinge-exact and
+exactly invertible; T2 (#459) made the topology-PRESERVING refinement cone
+orientation-safe. T3 (this module) adds the genuine topology-CHANGER:
+
+* **cone-out** removes one top cell (its orphaned edges, then any isolated
+  vertex). On a closed manifold this opens a manifold-with-boundary; removing a
+  cell disjoint from an existing hole raises ``b_{d-1}`` by exactly 1 -- on
+  ``S^3`` that is ``b_2``, the color register's degree.
+* **cone-in** adds one top cell on a fresh vertex joined to ``d`` existing
+  vertices (the literal "add a vertex, draw edges" of the ticket).
+
+Every surgical move is gated on ``ChainComplex.dualComplexIsValid`` as a
+*manifold-with-boundary* (the #429 ``n>=4`` recursive check). Surgery is allowed
+BECAUSE it is gated; bypassing the gate is what broke the #353 weld. A rejected
+move is rolled back bit-identically. The exact inverse of a cone-out (re-adding
+the removed cell -- ``rollback``) restores topology AND the complex (Lorentzian /
+Sorkin) action, Re AND Im, to machine precision.
+
+Coverage:
+
+* a surgical cone-out raises ``b_2`` by exactly 1 on a small ``S^3``, and the
+  inverse lowers it by 1 (topology restored);
+* the cone-out round trip restores the dual Regge action (Re AND Im) on a
+  genuinely Lorentzian CDT toroid (``Im S`` ~ -35);
+* the gate rejects a non-manifold attempt (a cone-in onto an interior facet ->
+  3 cofaces) and leaves the complex unchanged;
+* cone-in needs a boundary (it always rejects on a closed manifold) and is
+  reversible where it is accepted;
+* the ``n>=4`` recursive gate accepts + round-trips a cone-out on ``S^4``.
+"""
+
+import pytest
+
+import tessera as T
+
+cob = T.cobordism
+
+TOL = 1e-9
+TOL_BIG = 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# Builders / helpers
+# --------------------------------------------------------------------------- #
+def _matter():
+    return T.MatterConfiguration()
+
+
+def _sphere(d, sq=1.0):
+    """Boundary of a (d+1)-simplex = a minimal triangulated S^d, unit spacelike."""
+    sig = T.Signature(d, T.Lorentzian)
+    st = T.Spacetime(T.Metric(True, sig), T.CDT, 1.0, 1.0, T.PREFERRED,
+                     T.SimplexBoundarySphere(d))
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(sq)
+    return st
+
+
+def _refined_s3(n_refine=12):
+    """A refined S^3 (still Betti [1,0,0,1]) with enough tetrahedra that disjoint
+    top cells exist -- the minimal S^3 = dDelta4 has none (every facet pair shares
+    a ridge), so no single removal can open a b_2 hole."""
+    st = _sphere(3)
+    for seed in range(n_refine):
+        mv = T.AddMove(st, seed, False, T.PachnerMode.PreGeometric, False)
+        if mv.propose():
+            mv.apply()
+    return st
+
+
+def _make_cdt(n_simplices=120):
+    sig = T.Signature(4, T.Lorentzian)
+    st = T.Spacetime(T.Metric(True, sig), T.CDT, 1.0, 1.0, T.PREFERRED, T.Toroid())
+    st.build(n_simplices)
+    return st
+
+
+def _act(st):
+    return T.ReggeSolver(st, _matter()).dualReggeAction()
+
+
+def _tops(st):
+    return sorted(
+        tuple(sorted(v.getId() for v in s.getVertices()))
+        for s in st.getTopSimplices()
+    )
+
+
+def _betti(st):
+    return cob.ChainComplex.fromSpacetime(st).bettiNumbers()
+
+
+def _first_disjoint_pair(cells):
+    for i, a in enumerate(cells):
+        sa = set(a)
+        for b in cells[i + 1:]:
+            if sa.isdisjoint(b):
+                return a, b
+    return None
+
+
+def _assert_close(a, b, tol, what):
+    assert abs(a.real - b.real) < tol, f"{what}: Re drift {abs(a.real - b.real):.2e}"
+    assert abs(a.imag - b.imag) < tol, f"{what}: Im drift {abs(a.imag - b.imag):.2e}"
+
+
+# --------------------------------------------------------------------------- #
+# 1. cone-out raises b_2 by exactly 1; the inverse lowers it by 1
+# --------------------------------------------------------------------------- #
+def test_surgical_cone_out_raises_b2_and_inverse_lowers_it():
+    st = _refined_s3()
+    cells = _tops(st)
+    assert _betti(st)[3] == 1 and _betti(st)[2] == 0, "fixture is not an S^3"
+    pair = _first_disjoint_pair(cells)
+    assert pair is not None, "refined S^3 must contain a disjoint cell pair"
+    a, b = pair
+
+    sc = cob.SurgicalCone(st)
+    # First removal opens the manifold (b_3 -> 0) but does NOT yet make a b_2 hole.
+    ok, reason = sc.coneOut(list(a))
+    assert ok, reason
+    b2_after_first = _betti(st)[2]
+    assert sc.validate()[0]
+
+    # Removing a cell DISJOINT from the first raises b_2 by exactly 1.
+    ok, reason = sc.coneOut(list(b))
+    assert ok, reason
+    assert sc.validate()[0]
+    assert _betti(st)[2] == b2_after_first + 1, "cone-out did not raise b_2 by 1"
+
+    # The inverse (cone the cell back in) lowers b_2 by exactly 1 ...
+    assert sc.rollback()
+    assert _betti(st)[2] == b2_after_first, "inverse did not lower b_2 by 1"
+    # ... and unwinding fully restores the original topology + cell set.
+    assert sc.rollback()
+    assert sc.depth == 0
+    assert _tops(st) == cells, "round trip did not restore the top cells"
+    assert _betti(st) == cob.ChainComplex.fromSpacetime(st).bettiNumbers()
+    assert _betti(st)[3] == 1
+
+
+# --------------------------------------------------------------------------- #
+# 2. round-trip restores the complex action (Re AND Im) on a Lorentzian CDT
+# --------------------------------------------------------------------------- #
+def test_round_trip_restores_action_re_and_im():
+    st = _make_cdt(120)
+    a0 = _act(st)
+    assert abs(a0.imag) > 1.0, "fixture is not genuinely Lorentzian"
+    tops0 = _tops(st)
+
+    sc = cob.SurgicalCone(st)
+    for cell in _tops(st):
+        ok, _ = sc.coneOut(list(cell))
+        if not ok:
+            continue
+        # The surgery genuinely changes the action ...
+        assert abs(_act(st) - a0) > TOL, "cone-out did not change the action"
+        # ... and the exact inverse restores it, Re AND Im, to machine precision.
+        assert sc.rollback()
+        _assert_close(_act(st), a0, TOL_BIG, "surgical cone round trip")
+        assert _tops(st) == tops0, "round trip did not restore the top cells"
+        return
+    pytest.skip("no gated cone-out accepted on the CDT")
+
+
+# --------------------------------------------------------------------------- #
+# 3. the gate rejects a non-manifold attempt and leaves the complex unchanged
+# --------------------------------------------------------------------------- #
+def test_gate_rejects_non_manifold_cone_in():
+    st = _sphere(3)
+    cells = _tops(st)
+    sc = cob.SurgicalCone(st)
+    # {0,1,2} is an interior facet (shared by (0,1,2,3) and (0,1,2,4)); a fresh
+    # cell on it would give that facet 3 cofaces -- a non-manifold pinch.
+    ok, reason = sc.coneIn([0, 1, 2])
+    assert not ok
+    assert "cofaces" in reason, reason
+    assert sc.depth == 0
+    assert _tops(st) == cells, "a rejected move must leave the complex unchanged"
+
+
+# --------------------------------------------------------------------------- #
+# 4. cone-in needs a boundary (rejects on a closed manifold) + is reversible
+# --------------------------------------------------------------------------- #
+def test_cone_in_needs_a_boundary_and_is_reversible():
+    st = _sphere(3)
+    cells = _tops(st)
+    sc = cob.SurgicalCone(st)
+    # Closed manifold: every facet has 2 cofaces, so any cone-in pinches -> reject.
+    assert not sc.coneIn([0, 1, 2])[0]
+
+    # Open a boundary, then a cone-in onto a boundary triangle is accepted and
+    # exactly reversible.
+    assert sc.coneOut([0, 1, 2, 3])[0]
+    ok, reason = sc.coneIn([0, 1, 2])
+    assert ok, reason
+    assert sc.validate()[0]
+    assert sc.rollbackAll() == 2
+    assert _tops(st) == cells, "cone-in round trip did not restore the complex"
+
+
+# --------------------------------------------------------------------------- #
+# 5. the n>=4 recursive gate accepts + round-trips a cone-out on S^4
+# --------------------------------------------------------------------------- #
+def test_n_ge_4_recursive_gate_on_s4():
+    st = _sphere(4)
+    cells = _tops(st)
+    assert _betti(st)[4] == 1, "fixture is not an S^4"
+    sc = cob.SurgicalCone(st)
+    ok, reason = sc.coneOut(list(cells[0]))
+    assert ok, reason
+    assert sc.validate()[0], "the n>=4 recursive manifold gate must accept this"
+    assert sc.rollback()
+    assert _tops(st) == cells
+
+
+# --------------------------------------------------------------------------- #
+# 6. degenerate inputs are rejected cleanly (no mutation)
+# --------------------------------------------------------------------------- #
+def test_unknown_cell_and_last_cell_rejected():
+    st = _sphere(3)
+    cells = _tops(st)
+    sc = cob.SurgicalCone(st)
+    # A cell that is not present.
+    assert not sc.coneOut([90, 91, 92, 93])[0]
+    # Wrong arity.
+    assert not sc.coneOut([0, 1, 2])[0]
+    assert not sc.coneIn([0, 1, 2, 3])[0]
+    assert sc.depth == 0
+    assert _tops(st) == cells
+
+
+def test_validate_matches_the_applied_gate():
+    st = _sphere(3)
+    ok, reason = cob.SurgicalCone(st).validate()
+    assert ok, reason


### PR DESCRIPTION
## Summary

T3 of the **Emergent Color Topology** epic (#457) — the genuine topology-changer. Pachner moves and refinement-coning (T1/T2) are topology-preserving; none of the emergent color holes come from them. This adds the **surgical cone-out** (the hole-creator: remove one top cell → a `b_k` hole) and its inverse **surgical cone-in** (add a top cell via a fresh vertex), each **gated on `ChainComplex::dualComplexIsValid` as a manifold-with-boundary** (the #429 `n≥4` recursive check). Surgery is allowed *because* it is gated — bypassing the gate is what broke the #353 weld.

New `cobordism::SurgicalCone` (sibling of T2's `OrientedCone`): propose → apply → gate → rollback, with exact-inverse bookkeeping so a round trip restores the complex action (Re **and** Im) bit-exactly.

## Test plan
- [ ] `b_k`-delta: a surgical cone-out raises `b₂` by exactly 1 on a small `S³`; the inverse lowers it by 1.
- [ ] The gate rejects a non-manifold attempt (pinch / >2 cofaces) and leaves the complex unchanged.
- [ ] Round-trip `cone-out ∘ inverse` restores topology **and** the dual Regge action (Re + Im).
- [ ] No regression: `tests/cobordism/test_epic410_invariants.py` + full cobordism suite (`pytest -n 16`).
- [ ] Findings report in `docs/design/`.

Closes #460.