### PR TITLE
feat(cobordism): incremental local ΔF = Γ·Δr_U + Δ‖∇S_Regge‖² (T4)

### DIFF
--- a/docs/design/incremental_delta_f.md
+++ b/docs/design/incremental_delta_f.md
@@ -90,13 +90,14 @@ the localized **gradient norm** over the affected edges.
    → the localized dual action over a FIXED hinge set (genuine-only), so
    `ΔS_Regge = after − before` is exact. The action value is a diagnostic; the
    objective (below) uses the gradient norm built from the same per-hinge terms.
-2. **Δ‖∇S_Regge‖² (hinge-local, the geometry objective).** `‖∇S_Regge‖² = Σ_e|∂S/∂ℓ²_e|²`.
-   A move changes the gradient component only for edges sharing a hinge with the
-   touched region, so the affected-edge set = edges appearing in the affected hinges'
-   gradient maps. For each affected edge compute the full per-edge gradient
-   `∂S/∂ℓ²_e = Σ_{h∋e}[∂|*h|·ε_h + |*h|·∂ε_h]` (local — `e`'s incident hinges) before
-   and after; `Δ‖∇S‖² = Σ_e(|g_e^after|² − |g_e^before|²)`. Re **and** Im (complex
-   modulus). Covers combinatorial moves and edge-length perturbations.
+2. **Δ‖∇S_Regge‖² (hinge-local, the geometry objective — DONE).**
+   `ReggeSolver::affectedEdgesOfCells` (the edges a move on the touched cells can
+   change) + `gradientNorm2OverEdges` (`Σ_e|∂S/∂ℓ²_e|²` with each `∂S/∂ℓ²_e` the full
+   per-edge gradient over `e`'s star, complex modulus). Over a fixed affected-edge
+   set across a move, `Δ‖∇S‖² = after − before` is exact. Verified to machine
+   precision for an edge perturbation and a Pachner move; `gradientNorm2OverEdges`
+   over all edges equals `Σ_e|actionGradientExact()_e|²`. Genuinely local: one edge
+   perturbation touches ~23% of a 260-edge toroid (shrinking as the mesh grows).
 3. **Δr_U.** The change in the state residual at `k = 2` induced by the move,
    including across a topology change where `b_k` (and thus the register dimension)
    shifts. Validate the incremental update against `residualForPeriods` recompute.

--- a/docs/design/incremental_delta_f.md
+++ b/docs/design/incremental_delta_f.md
@@ -115,13 +115,27 @@ the localized **gradient norm** over the affected edges.
    Richardson-extrapolated FD to 4e-9). The period-gap family is the separate #377
    hard period-pin `r_ψ`, kept as-is.
 
-   *Arbitrary-k analytic gradient (Stage-2 affordability):* the existing
-   `residualForPeriodsGradient` is k=1-only (hardcoded `laplacian(1)` / edge-loop
-   covector). Generalizing it needs (a) **`Simplex::volumeGradient`** — the per-degree
-   Hodge-weight gradient `∂W_j/∂ℓ²` (DONE: Jacobi on the Gram determinant, reusing the
-   #354 machinery; exact to ~1e-11 across triangle/tet/pentatope), (b) a general-k
-   `∂L_k/∂ℓ²` assembled from it, (c) a faithful general-k port of the eigenvector-
-   perturbation gradient over the `assembleRegisterReadout` period map. (b)/(c) remain.
+   *Arbitrary-k analytic gradient (Stage-2 affordability) — DONE.* The existing
+   `residualForPeriodsGradient` was k=1-only (hardcoded `laplacian(1)` / edge-loop
+   covector). It now generalizes through three exact, hand-verified pieces:
+   - (a) **`Simplex::volumeGradient`** — the per-degree Hodge-weight gradient `∂W_j/∂ℓ²`
+     (Jacobi on the Gram determinant, reusing the #354 machinery). Verified by
+     closed forms (equilateral triangle `1/(4√3)`, regular tet `1/(24√2)`) and the
+     Euler identity `Σ_e ℓ²_e ∂V/∂ℓ²_e = (j/2)V`.
+   - (b) **`HodgeLaplacian::laplacianGradient`** — general-k `∂L_k/∂ℓ²` (`L_k =
+     BₖᵀBₖ + Bₖ₊₁Bₖ₊₁ᵀ`, `dBₖ = diag(a_{k-1})Bₖ + Bₖdiag(b_k)`). Verified by the Euler
+     identity `Σ_e ℓ²_e ∂L_k/∂ℓ²_e = −½L_k` (3.4e-15 at k=1, k=2).
+   - (c) **`EigenstateSynthesis::periodGradientGeneral`** — the general-k `∂r_U/∂ℓ²`:
+     `M = L_k`, the per-edge `∂L_k/∂ℓ²` through the same eigenvector-perturbation
+     derivation, period covector from each removed-(k+1)-cell hole's facets. Matches
+     the k=1 `residualForPeriodsGradient` to 1.7e-15, and satisfies the exact Euler
+     identity `Σ_e ℓ²_e ∂r_U/∂ℓ²_e = −r_U` (4e-16 at k=1, 3.4e-14 at k=2).
+
+   Finite difference is roundoff-limited and does **not** converge; the optimizer
+   uses these analytic gradients, and the tests certify them against hand-derived
+   identities, not FD. (Consolidation — routing `residualForPeriodsGradient` through
+   the general path and retiring the k=1-only `periodGradientOverLoops` — is a clean
+   follow-up once the general path has soaked.)
 4. **ΔF = Δ‖∇S_Regge‖² + Γ·Δr_U**, and correctness tests: `ΔF` matches a full `F`
    recompute to ~machine precision across **every** move class — Pachner, surgical
    cone-out/in, and edge-length perturbation — including across a topology change.

--- a/docs/design/incremental_delta_f.md
+++ b/docs/design/incremental_delta_f.md
@@ -125,17 +125,29 @@ the localized **gradient norm** over the affected edges.
    - (b) **`HodgeLaplacian::laplacianGradient`** — general-k `∂L_k/∂ℓ²` (`L_k =
      BₖᵀBₖ + Bₖ₊₁Bₖ₊₁ᵀ`, `dBₖ = diag(a_{k-1})Bₖ + Bₖdiag(b_k)`). Verified by the Euler
      identity `Σ_e ℓ²_e ∂L_k/∂ℓ²_e = −½L_k` (3.4e-15 at k=1, k=2).
-   - (c) **`EigenstateSynthesis::periodGradientGeneral`** — the general-k `∂r_U/∂ℓ²`:
-     `M = L_k`, the per-edge `∂L_k/∂ℓ²` through the same eigenvector-perturbation
-     derivation, period covector from each removed-(k+1)-cell hole's facets. Matches
-     the k=1 `residualForPeriodsGradient` to 1.7e-15, and satisfies the exact Euler
-     identity `Σ_e ℓ²_e ∂r_U/∂ℓ²_e = −r_U` (4e-16 at k=1, 3.4e-14 at k=2).
+   - (c) **`EigenstateSynthesis::residualForPeriodsGradient`** (consolidated) — the
+     general-k `∂r_U/∂ℓ²`: `M = L_k`, the per-edge `∂L_k/∂ℓ²` through the same
+     eigenvector-perturbation derivation, period covector from each removed-(k+1)-cell
+     hole's facets. The arbitrary-k implementation now **is** `residualForPeriodsGradient`
+     (it no longer routes through the k=1-only `holeLoops`/`periodGradientOverLoops`
+     path); reproduces the prior k=1 result to 1.7e-15 (the GPU oracle test still
+     passes) and satisfies the exact Euler identity `Σ_e ℓ²_e ∂r_U/∂ℓ²_e = −r_U`
+     (4e-16 at k=1, 3.4e-14 at k=2). `periodGradientOverLoops` is retained only for
+     the genuinely loop-input path (`residualForLoopsGradient`, used by Merge/Relaxer).
 
    Finite difference is roundoff-limited and does **not** converge; the optimizer
    uses these analytic gradients, and the tests certify them against hand-derived
-   identities, not FD. (Consolidation — routing `residualForPeriodsGradient` through
-   the general path and retiring the k=1-only `periodGradientOverLoops` — is a clean
-   follow-up once the general path has soaked.)
+   identities, not FD.
+
+5. **End-to-end `ΔF` + surgical-move tests — DONE** (`test_delta_f_end_to_end_python.py`).
+   - Stage-2 edge perturbation on the k=2 register: `ΔF = Δ‖∇S‖²(local) + Γ·Δr_U(recompute)`
+     == full `F` recompute.
+   - Stage-1 surgical cone-out on a CDT with edge multiplicities: cone-out **decrements**
+     shared-edge multiplicity (covered base edges survive); local `Δ‖∇S‖²` == full Δ.
+   - A disjoint-pair cone-out **shifts the b₂ register**; `r_U` recomputes post-surgery
+     and its analytic gradient stays exact (the Euler identity).
+   - Cone-out is the **exact inverse** of cone-in (removes only the k apex edges);
+     cone-in∘cone-out restores the structure bit-for-bit.
 4. **ΔF = Δ‖∇S_Regge‖² + Γ·Δr_U**, and correctness tests: `ΔF` matches a full `F`
    recompute to ~machine precision across **every** move class — Pachner, surgical
    cone-out/in, and edge-length perturbation — including across a topology change.

--- a/docs/design/incremental_delta_f.md
+++ b/docs/design/incremental_delta_f.md
@@ -1,0 +1,70 @@
+# Incremental local ΔF = Δr_U + β·ΔS_Regge (T4)
+
+Part of the Emergent Color Topology epic (#457). Working design note for #461; this
+file is finalized as the ticket's findings report (`incremental_delta_f_<hash>.md`).
+
+## Problem
+
+The emergent optimizer evaluates `ΔF` for every candidate move, every step, where
+
+```
+F = r_U + β · S_Regge          (the #10/#11 mediation F_β, full-complex Lorentzian/Sorkin action — keep Im)
+```
+
+A full recompute of `F` per candidate is the #418 cost spike (10³–10⁴×). The same `F`
+and the **same single** `r_U` govern both optimization stages — only the move class
+differs:
+
+- **Stage 1** — combinatorial/topological moves at fixed edge length: Pachner
+  (`AddMove`/`RemoveMove`/`FlipMove`) + gated surgical cone-out/in (`SurgicalCone`,
+  `OrientedCone`, #468/#469).
+- **Stage 2** — continuous edge-length perturbations.
+
+So `ΔF` must cover **both** move classes and stay exact.
+
+## Gauge state is the single existing `r_U` (no flavor register)
+
+Per the epic owner's decision (recorded on #457/#461/#462/#463/#464): **flavor is
+emergent** from the fully general optimization driven by the action we already have.
+There is **no** second isospin/`ℂ³⊗ℂ²` register, no parallel holonomy, no per-sector
+read-out. `r_U` is `EigenstateSynthesis.residualForPeriods` read at the spatial
+register degree `k = 2` (the `b₂` color holes on `S⁴`), and that single residual is
+the whole gauge state. `Δr_U` is built against it directly; nothing here waits on a
+flavor-representation design.
+
+## Existing infrastructure (what we build on)
+
+- `ReggeSolver::dualReggeAction()` — full-complex action, already **hinge-local**:
+  `S = Σ_h |*h| · ε_h` with `|*h| = Simplex::dualVolume()` and
+  `ε_h = Simplex::lorentzianDeficitAngle()` (complex). Per-hinge analytic
+  gradients/Hessians exist on `Simplex`.
+- `ReggeSolver::actionGradientExact()` (#365/#371) — per-hinge product-rule
+  accounting with the `relabel=false` / stable-id machinery; the template for
+  hinge-local recomputation.
+- Move classes track what they change: `AddMove` (`touchedVertexIds`,
+  `createdSimplexVerts`, `createdEdges`), `RemoveMove` (`deletedEdges`,
+  `createdSimplexVerts`), `FlipMove` (`oldSimplexVerts`/`newSimplexVerts`);
+  `SurgicalCone`/`OrientedCone` wrap them.
+- `EigenstateSynthesis::residualForPeriods(holes, target)` at degree `k`, plus
+  `cyclePeriods`, `residualForPeriodsGradient`, `dualComplexValid` — currently
+  **full recompute** (eigendecomp of `L_k`, `|λ|<1e-9` threshold).
+
+## Plan (no shortcuts)
+
+1. **ΔS_Regge (hinge-local).** Given a move's touched-cell set, enumerate the hinges
+   whose `(|*h|, ε_h)` change (the closed star of the touched simplices), decrement
+   their old contributions and increment the new ones — Re **and** Im — reusing the
+   stable-id machinery so orphaned hinges are accounted for (cf. #365/#371). Covers
+   both the combinatorial moves (cells added/removed) and the edge-length
+   perturbation (the hinges incident to the perturbed edge).
+2. **Δr_U.** The change in the state residual at `k = 2` induced by the move,
+   including across a topology change where `b_k` (and thus the register dimension)
+   shifts. Validate the incremental update against `residualForPeriods` recompute.
+3. **Correctness tests.** `ΔF` matches a full `F` recompute to ~machine precision
+   across **every** move class — Pachner, surgical cone-out/in, and edge-length
+   perturbation — including across a topology change. Keep
+   `tests/cobordism/test_epic410_invariants.py` green.
+
+## Status
+
+Scaffolding. Implementation tracked on `feat/incremental-delta-f` (PR for #461).

--- a/docs/design/incremental_delta_f.md
+++ b/docs/design/incremental_delta_f.md
@@ -100,7 +100,28 @@ the localized **gradient norm** over the affected edges.
    perturbation touches ~23% of a 260-edge toroid (shrinking as the mesh grows).
 3. **Δr_U.** The change in the state residual at `k = 2` induced by the move,
    including across a topology change where `b_k` (and thus the register dimension)
-   shifts. Validate the incremental update against `residualForPeriods` recompute.
+   shifts. `r_U` is a **global** spectral quantity — `residualForPeriods` =
+   `‖L_k ψ − λ ψ‖²` with `ψ` built from the harmonic subspace `harmonicMatrix(k)`
+   (the eigendecomposition is the cost), so it has no exact hinge-local delta like
+   the action. The **exact** `Δr_U` is therefore a before/after `residualForPeriods`
+   recompute — confirmed end-to-end: `ΔF = Δ‖∇S_Regge‖²(local) + Γ·Δr_U(recompute)`
+   matches a full `F` recompute to 2.4e-15 on the holed-S³ **k=2** register (ω carried
+   ~3e-3, singlet ~47).
+
+   *Residual choice (investigated):* `residualForPeriods` (eigenvector residual) is
+   the `r_U` — it is the only residual that supports general `k` (`periodGapForPeriods`
+   is k=1-only, throwing on tetrahedral holes), and its analytic gradient
+   `residualForPeriodsGradient` is exact to the 1e-9 spectral floor (matches a
+   Richardson-extrapolated FD to 4e-9). The period-gap family is the separate #377
+   hard period-pin `r_ψ`, kept as-is.
+
+   *Arbitrary-k analytic gradient (Stage-2 affordability):* the existing
+   `residualForPeriodsGradient` is k=1-only (hardcoded `laplacian(1)` / edge-loop
+   covector). Generalizing it needs (a) **`Simplex::volumeGradient`** — the per-degree
+   Hodge-weight gradient `∂W_j/∂ℓ²` (DONE: Jacobi on the Gram determinant, reusing the
+   #354 machinery; exact to ~1e-11 across triangle/tet/pentatope), (b) a general-k
+   `∂L_k/∂ℓ²` assembled from it, (c) a faithful general-k port of the eigenvector-
+   perturbation gradient over the `assembleRegisterReadout` period map. (b)/(c) remain.
 4. **ΔF = Δ‖∇S_Regge‖² + Γ·Δr_U**, and correctness tests: `ΔF` matches a full `F`
    recompute to ~machine precision across **every** move class — Pachner, surgical
    cone-out/in, and edge-length perturbation — including across a topology change.

--- a/docs/design/incremental_delta_f.md
+++ b/docs/design/incremental_delta_f.md
@@ -5,11 +5,21 @@ file is finalized as the ticket's findings report (`incremental_delta_f_<hash>.m
 
 ## Problem
 
-The emergent optimizer evaluates `ΔF` for every candidate move, every step, where
+The emergent optimizer evaluates `ΔF` for every candidate move, every step. The
+objective **extremizes** the action (drives `δS = 0`) — it does **not** minimize the
+action magnitude (a bare action minimum collapses the curvature, `∫R → 0` /
+conformal runaway). So the geometry term is the **squared gradient norm**:
 
 ```
-F = r_U + β · S_Regge          (the #10/#11 mediation F_β, full-complex Lorentzian/Sorkin action — keep Im)
+F = ‖∇S_Regge‖²  +  Γ · r_U          (full-complex Lorentzian/Sorkin gradient — keep Im)
+    ‖∇S_Regge‖² = Σ_e |∂S/∂ℓ²_e|²    (complex modulus, NOT ‖∇Re S‖²)
 ```
+
+This corrects the earlier `F = r_U + β·S_Regge` / "not a ‖∇S‖² proxy" wording in the
+epic and #461 (owner decision; note posted on #457/#461/#462/#463/#464). The
+stationary point (`∂S/∂ℓ² = 0`, the Regge equations) is where `‖∇S_Regge‖² = 0`, with
+`Γ·r_U` the only matter/state term. Matches `CobordismRelaxer` (`β·‖∇S‖² + r_state`),
+the existing stationary-action relaxation.
 
 A full recompute of `F` per candidate is the #418 cost spike (10³–10⁴×). The same `F`
 and the **same single** `r_U` govern both optimization stages — only the move class
@@ -32,6 +42,30 @@ register degree `k = 2` (the `b₂` color holes on `S⁴`), and that single resi
 the whole gauge state. `Δr_U` is built against it directly; nothing here waits on a
 flavor-representation design.
 
+## Dual vs primal (pinned)
+
+`F` uses the **dual** Regge action `dualReggeAction()` (`ReggeSolver.cpp:141`):
+`S = Σ_h |*h| · ε_h`, where the weight `|*h| = Simplex::dualVolume()`
+(`Simplex.cpp:1390` → `dualVolRec`, `:1218`) is the **circumcentric dual cell
+volume** — built from circumradii/circumcenters, *not* the primal hinge area. The
+legacy primal `reggeAction()` (`:133`, `Σ hingeArea·deficit`) is **not** in `F`.
+
+The deficit `ε_h = lorentzianDeficitAngle()` (`Simplex.cpp:861`) is
+`2π − Σ_{σ∋h} σ.lorentzianDihedralAngle(h)` over the incident top cells, with the
+dihedral the **Lorentzian boost** angle (un-clamped Cayley–Menger; `acos` → ordinary
+angle for `|r|≤1`, complex boost for `|r|>1` — the source of `Im`). `ε_h` is the
+hinge **curvature** and is the *same* in the primal `A_h·ε_h` and dual `|*h|·ε_h`
+actions; the *dual* character of the action is the `|*h|` weight, not the deficit.
+There is no separate "dual deficit angle".
+
+The objective term is `‖∇S_Regge‖²`, whose per-edge component
+`∂S/∂ℓ²_e = Σ_{h∋e}[∂|*h|·ε_h + |*h|·∂ε_h]` is built from the **same** per-hinge
+dual-measure terms (`Simplex::dualVolumeGradient` / `lorentzianDeficitAngleGradient`),
+so the gradient — and hence `‖∇S_Regge‖²` and its increment — inherits the dual
+measure identically. The localized action `dualReggeActionOverHinges` is the
+hinge-accounting building block (and a value-level diagnostic); the objective uses
+the localized **gradient norm** over the affected edges.
+
 ## Existing infrastructure (what we build on)
 
 - `ReggeSolver::dualReggeAction()` — full-complex action, already **hinge-local**:
@@ -51,19 +85,25 @@ flavor-representation design.
 
 ## Plan (no shortcuts)
 
-1. **ΔS_Regge (hinge-local).** Given a move's touched-cell set, enumerate the hinges
-   whose `(|*h|, ε_h)` change (the closed star of the touched simplices), decrement
-   their old contributions and increment the new ones — Re **and** Im — reusing the
-   stable-id machinery so orphaned hinges are accounted for (cf. #365/#371). Covers
-   both the combinatorial moves (cells added/removed) and the edge-length
-   perturbation (the hinges incident to the perturbed edge).
-2. **Δr_U.** The change in the state residual at `k = 2` induced by the move,
+1. **Affected-hinge accounting (building block, done).** `hingeFacesOfCells` →
+   the `(d-2)` hinges that are faces of a move's touched cells; `dualReggeActionOverHinges`
+   → the localized dual action over a FIXED hinge set (genuine-only), so
+   `ΔS_Regge = after − before` is exact. The action value is a diagnostic; the
+   objective (below) uses the gradient norm built from the same per-hinge terms.
+2. **Δ‖∇S_Regge‖² (hinge-local, the geometry objective).** `‖∇S_Regge‖² = Σ_e|∂S/∂ℓ²_e|²`.
+   A move changes the gradient component only for edges sharing a hinge with the
+   touched region, so the affected-edge set = edges appearing in the affected hinges'
+   gradient maps. For each affected edge compute the full per-edge gradient
+   `∂S/∂ℓ²_e = Σ_{h∋e}[∂|*h|·ε_h + |*h|·∂ε_h]` (local — `e`'s incident hinges) before
+   and after; `Δ‖∇S‖² = Σ_e(|g_e^after|² − |g_e^before|²)`. Re **and** Im (complex
+   modulus). Covers combinatorial moves and edge-length perturbations.
+3. **Δr_U.** The change in the state residual at `k = 2` induced by the move,
    including across a topology change where `b_k` (and thus the register dimension)
    shifts. Validate the incremental update against `residualForPeriods` recompute.
-3. **Correctness tests.** `ΔF` matches a full `F` recompute to ~machine precision
-   across **every** move class — Pachner, surgical cone-out/in, and edge-length
-   perturbation — including across a topology change. Keep
-   `tests/cobordism/test_epic410_invariants.py` green.
+4. **ΔF = Δ‖∇S_Regge‖² + Γ·Δr_U**, and correctness tests: `ΔF` matches a full `F`
+   recompute to ~machine precision across **every** move class — Pachner, surgical
+   cone-out/in, and edge-length perturbation — including across a topology change.
+   Keep `tests/cobordism/test_epic410_invariants.py` green.
 
 ## Status
 

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -336,6 +336,20 @@ class EigenstateSynthesis {
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
+    /// **Arbitrary-degree** analytic gradient \f$ \partial r_U / \partial l^2_e \f$
+    /// of `residualForPeriods` — the degree-generic generalization of
+    /// `residualForPeriodsGradient` (which is \f$ k = 1 \f$ only). Eigendecomposes
+    /// \f$ M = L_k \f$ (`HodgeLaplacian`), uses the per-edge analytic
+    /// \f$ \partial L_k/\partial l^2 \f$ (`HodgeLaplacian::laplacianGradient`, built on
+    /// `Simplex::volumeGradient`) through the same first-order eigenvector-perturbation
+    /// derivation, with the period covector + leak read from each removed-\f$(k\!+\!1)\f$-cell
+    /// hole's facet boundary. Returned in `ChainComplex` 1-cell (edge) order. Equals
+    /// the \f$ k = 1 \f$ loop core on triangle holes; validated by the exact Euler
+    /// identity \f$ \sum_e l^2_e\,\partial r_U/\partial l^2_e = -r_U \f$ at every degree.
+    [[nodiscard]] std::vector<double> periodGradientGeneral(
+        const std::vector<std::vector<std::uint64_t>> &holes,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
     /// FP32 cuBLAS (SGEMM) GPU port of `residualForPeriodsGradient` (#348): the
     /// identical analytic gradient, but the dominant per-edge GEMMs
     /// (\f$ U_{nn}^\top f_a \f$, the core product, \f$ dU_n = U_{nn}(\dots) \f$,

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -325,16 +325,13 @@ class EigenstateSynthesis {
 
     /// **Arbitrary-degree** exact analytic gradient \f$ \partial r_U / \partial l^2_e \f$
     /// of `residualForPeriods` w.r.t. each edge's squared length, in `ChainComplex`
-    /// 1-cell (edge) order. Eigendecomposes the metric Laplacian \f$ M = L_k \f$
-    /// (`HodgeLaplacian`), builds the same carried representative \f$ \psi \f$ (period
-    /// covector + leak from each removed-\f$(k\!+\!1)\f$-cell hole's facet boundary),
-    /// then propagates the per-edge analytic \f$ \partial L_k/\partial l^2 \f$
-    /// (`HodgeLaplacian::laplacianGradient`, built on `Simplex::volumeGradient`) through
-    /// first-order eigenvector-perturbation theory and the pseudo-inverse derivative.
-    /// Reproduces the \f$ k = 1 \f$ edge-loop core (`periodGradientOverLoops`) on
-    /// triangle holes to machine precision; certified by the exact Euler identity
+    /// 1-cell (edge) order, certified by the exact Euler identity
     /// \f$ \sum_e l^2_e\,\partial r_U/\partial l^2_e = -r_U \f$ at every register degree
-    /// (finite difference is roundoff-limited and does not converge). \f$ O(n_k^3) \f$.
+    /// (finite difference is roundoff-limited and does not converge). At \f$ k = 1 \f$
+    /// it routes through the **fast** low-rank edge-loop core (`periodGradientOverLoops`,
+    /// which builds the chain complex once) so a relaxation loop stays affordable; at
+    /// \f$ k \ge 2 \f$ it uses the degree-generic `periodGradientGeneral`. The two are
+    /// value-identical at \f$ k = 1 \f$ (verified to 1.7e-15).
     /// @throws std::runtime_error if `targetPeriods.size() != holes.size()`.
     [[nodiscard]] std::vector<double> residualForPeriodsGradient(
         const std::vector<std::vector<std::uint64_t>> &holes,
@@ -740,6 +737,13 @@ class EigenstateSynthesis {
     // d r_U / d l^2 with the cycles given as signed edge-loops.
     [[nodiscard]] std::vector<double> periodGradientOverLoops(
         const std::vector<EdgeLoop> &loops,
+        const std::vector<std::complex<double>> &targetPeriods) const;
+
+    // Degree-generic d r_U / d l^2 over removed-(k+1)-cell holes (M = L_k, the
+    // per-edge analytic dL_k/dl^2). The k >= 2 path of residualForPeriodsGradient;
+    // value-identical to periodGradientOverLoops at k = 1.
+    [[nodiscard]] std::vector<double> periodGradientGeneral(
+        const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
     // Each removed-triangle hole (a 3-vertex tuple) as the oriented boundary loop

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -323,30 +323,20 @@ class EigenstateSynthesis {
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 
-    /// The analytic gradient \f$ \partial r_U / \partial l^2_e \f$ of
-    /// `residualForPeriods` w.r.t. each edge's squared length, returned in
-    /// `cellSimplices()` (\f$ k = 1 \f$ cell) order. Eigendecomposes the metric
-    /// Laplacian \f$ M = L_1 \f$, builds the same carried representative \f$ \psi \f$,
-    /// then propagates the per-edge low-rank \f$ dM/dl^2 \f$ through first-order
-    /// eigenvector perturbation theory and the pseudo-inverse derivative — the C++
-    /// port of the Python relaxation's `drU` (verified against it and a finite
-    /// difference). \f$ O(n_1^3) \f$ (one dense eigensolve plus a per-edge sweep).
+    /// **Arbitrary-degree** exact analytic gradient \f$ \partial r_U / \partial l^2_e \f$
+    /// of `residualForPeriods` w.r.t. each edge's squared length, in `ChainComplex`
+    /// 1-cell (edge) order. Eigendecomposes the metric Laplacian \f$ M = L_k \f$
+    /// (`HodgeLaplacian`), builds the same carried representative \f$ \psi \f$ (period
+    /// covector + leak from each removed-\f$(k\!+\!1)\f$-cell hole's facet boundary),
+    /// then propagates the per-edge analytic \f$ \partial L_k/\partial l^2 \f$
+    /// (`HodgeLaplacian::laplacianGradient`, built on `Simplex::volumeGradient`) through
+    /// first-order eigenvector-perturbation theory and the pseudo-inverse derivative.
+    /// Reproduces the \f$ k = 1 \f$ edge-loop core (`periodGradientOverLoops`) on
+    /// triangle holes to machine precision; certified by the exact Euler identity
+    /// \f$ \sum_e l^2_e\,\partial r_U/\partial l^2_e = -r_U \f$ at every register degree
+    /// (finite difference is roundoff-limited and does not converge). \f$ O(n_k^3) \f$.
     /// @throws std::runtime_error if `targetPeriods.size() != holes.size()`.
     [[nodiscard]] std::vector<double> residualForPeriodsGradient(
-        const std::vector<std::vector<std::uint64_t>> &holes,
-        const std::vector<std::complex<double>> &targetPeriods) const;
-
-    /// **Arbitrary-degree** analytic gradient \f$ \partial r_U / \partial l^2_e \f$
-    /// of `residualForPeriods` — the degree-generic generalization of
-    /// `residualForPeriodsGradient` (which is \f$ k = 1 \f$ only). Eigendecomposes
-    /// \f$ M = L_k \f$ (`HodgeLaplacian`), uses the per-edge analytic
-    /// \f$ \partial L_k/\partial l^2 \f$ (`HodgeLaplacian::laplacianGradient`, built on
-    /// `Simplex::volumeGradient`) through the same first-order eigenvector-perturbation
-    /// derivation, with the period covector + leak read from each removed-\f$(k\!+\!1)\f$-cell
-    /// hole's facet boundary. Returned in `ChainComplex` 1-cell (edge) order. Equals
-    /// the \f$ k = 1 \f$ loop core on triangle holes; validated by the exact Euler
-    /// identity \f$ \sum_e l^2_e\,\partial r_U/\partial l^2_e = -r_U \f$ at every degree.
-    [[nodiscard]] std::vector<double> periodGradientGeneral(
         const std::vector<std::vector<std::uint64_t>> &holes,
         const std::vector<std::complex<double>> &targetPeriods) const;
 

--- a/include/cobordism/HodgeLaplacian.h
+++ b/include/cobordism/HodgeLaplacian.h
@@ -128,6 +128,20 @@ class HodgeLaplacian {
     /// cells still fall back to \f$ +1 \f$ so \f$ W_k \f$ stays invertible).
     [[nodiscard]] std::vector<double> weights(int k, bool lorentzian = false) const;
 
+    /// Exact analytic gradient \f$ \partial L_k^{\text{sym}} / \partial \ell^2_e \f$
+    /// of the symmetric metric Hodge Laplacian (\f$ k \ge 1 \f$) with respect to one
+    /// edge's squared length, as a flat \f$ |C_k|\times|C_k| \f$ row-major matrix in
+    /// the canonical column order. With \f$ L_k = B_k^\top B_k + B_{k+1}B_{k+1}^\top \f$,
+    /// \f$ B_k=\mathrm{diag}(\sqrt{W_{k-1}})\,\partial_k\,\mathrm{diag}(1/\sqrt{W_k}) \f$,
+    /// only the inner-product weights \f$ W_j=|\!\operatorname{vol}| \f$ depend on
+    /// \f$ \ell^2 \f$, so \f$ \partial B_k=\mathrm{diag}(a_{k-1})B_k+B_k\,\mathrm{diag}(b_k) \f$
+    /// with \f$ a_j=\tfrac{\partial W_j}{2W_j} \f$ — and \f$ \partial W_j \f$ is the
+    /// per-simplex `Simplex::volumeGradient` (signed for the `|vol|` weight). The
+    /// degree-generic keystone for the arbitrary-\f$ k \f$ \f$ r_U \f$ gradient.
+    /// Empty for \f$ k < 1 \f$ or an absent edge.
+    [[nodiscard]] std::vector<double> laplacianGradient(
+        int k, std::uint64_t edgeA, std::uint64_t edgeB) const;
+
     /// Whether \f$ \| L - L^\dagger \| \le \text{tol} \f$ (Frobenius norm) for
     /// the \f$ k = 0 \f$ Laplacian. True by construction.
     [[nodiscard]] bool isHermitian(double tol = 1e-12) const;

--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -342,6 +342,20 @@ class Simplex {
     /// discarding it the way |l^2| would.
     [[nodiscard]] double volume() const;
 
+    /// Exact analytic gradient of this simplex's **signed `volume()`** with respect
+    /// to the squared length of each of its edges:
+    /// \f$ \partial V / \partial \ell^2_e \f$, returned as an edge-keyed map (sorted
+    /// `(a,b)` ids). By Jacobi's formula on the Gram determinant
+    /// (\f$ V = \mathrm{sgn}\,\sqrt{|\det G|}/d! \f$, \f$ G \f$ linear in \f$ \ell^2 \f$):
+    /// \f$ \partial V/\partial\ell^2_e = \tfrac{V}{2}\,\mathrm{tr}(G^{-1}\,\partial_e G) \f$,
+    /// the same machinery (`gramMatrix`/`determinant`/`cofactorMatrix`) the
+    /// circumcentric `dualVolumeGradient` (#354) uses. This is the per-degree
+    /// **Hodge inner-product weight** gradient (the weights \f$ W_k \f$ are signed
+    /// simplex volumes), the keystone for an arbitrary-degree analytic
+    /// \f$ \partial L_k/\partial\ell^2 \f$ and hence the general-k \f$ r_U \f$ gradient.
+    [[nodiscard]] std::map<std::pair<std::uint64_t, std::uint64_t>, double>
+    volumeGradient() const;
+
     /// Fail-loudly admissibility check for a purely-spacelike simplex.
     ///
     /// "Spacelike" means every edge has squared length > tol (the Edge

--- a/include/simulations/ReggeSolver.h
+++ b/include/simulations/ReggeSolver.h
@@ -97,6 +97,31 @@ class ReggeSolver {
     /// Asante-Dittrich arXiv:2104.00485.
     [[nodiscard]] std::complex<double> dualReggeAction() const;
 
+    /// The \f$(d\!-\!2)\f$ **hinge** vertex-tuples that are faces of the given top
+    /// \f$d\f$-cells — the set of hinges whose dual-action contribution a move over
+    /// those cells can change. Each input cell is a vertex-id tuple; the result is
+    /// the dedup'd set of \f$(d\!-\!1)\f$-vertex sub-tuples (sorted ids). Pure
+    /// topology (no geometry): the **affected-hinge index** for the incremental
+    /// \f$\Delta S_{\text{Regge}}\f$. Build it from a move's touched cells
+    /// (created ∪ removed ∪ the top cofaces of a perturbed edge) once, then use the
+    /// SAME set for the before/after legs of ``dualReggeActionOverHinges``.
+    [[nodiscard]] std::vector<std::vector<std::uint64_t>> hingeFacesOfCells(
+        const std::vector<std::vector<std::uint64_t>> &cells) const;
+
+    /// The **localized** dual (Sorkin) Regge action
+    /// \f$\sum_{h} |\!\star\! h|\,\varepsilon_h\f$ over only the given
+    /// \f$(d\!-\!2)\f$ hinge tuples that are *genuine* in the live complex (a
+    /// registered simplex with a top coface — orphans contribute 0, exactly as in
+    /// ``dualReggeAction``). Each tuple is resolved by vertex id (order-independent,
+    /// ``findSimplexByVerts``) and the per-term measure is the **same** circumcentric
+    /// ``dualVolume`` as ``dualReggeAction``, so it inherits the dual action by
+    /// construction. This is the before/after leg of the incremental
+    /// \f$\Delta S_{\text{Regge}}\f$: evaluated over a FIXED affected-hinge set
+    /// across a move, \f$\Delta S = S_{\text{after}} - S_{\text{before}}\f$ is exact
+    /// (every hinge outside the set is unchanged and cancels).
+    [[nodiscard]] std::complex<double> dualReggeActionOverHinges(
+        const std::vector<std::vector<std::uint64_t>> &hinges) const;
+
     /// Point-particle matter action: \f$S_{\text{matter}} = -M \sum_{e \in W} \sqrt{-\ell^2_e}\f$.
     [[nodiscard]] double matterAction() const;
 

--- a/include/simulations/ReggeSolver.h
+++ b/include/simulations/ReggeSolver.h
@@ -122,6 +122,31 @@ class ReggeSolver {
     [[nodiscard]] std::complex<double> dualReggeActionOverHinges(
         const std::vector<std::vector<std::uint64_t>> &hinges) const;
 
+    /// The edges whose per-edge action gradient `∂S/∂ℓ²_e` a move over the given top
+    /// cells can change — the **affected-edge index** for the incremental
+    /// `Δ‖∇S_Regge‖²`. A move changes `∂S/∂ℓ²_e` only when an affected hinge
+    /// (`hingeFacesOfCells(cells)`) contributes to `e`, i.e. only for edges that share
+    /// a top cell with an affected hinge. Returns those edges as sorted `(a,b)` id
+    /// pairs (deduped). Build it from a move's touched cells; because cells are
+    /// added/removed, take the **union** of this set evaluated before and after the
+    /// move, then use that fixed set for both legs of `gradientNorm2OverEdges`.
+    [[nodiscard]] std::vector<std::pair<std::uint64_t, std::uint64_t>>
+    affectedEdgesOfCells(
+        const std::vector<std::vector<std::uint64_t>> &cells) const;
+
+    /// The **localized** squared gradient norm `Σ_{e∈edges} |∂S/∂ℓ²_e|²` of the dual
+    /// (Sorkin) Regge action — the geometry term of the optimizer objective
+    /// `F = ‖∇S_Regge‖² + Γ·r_U` (extremize the action, δS=0). Each `∂S/∂ℓ²_e` is the
+    /// **full** per-edge gradient `Σ_{h∋e}[∂|★h|·ε_h + |★h|·∂ε_h]` summed over *all*
+    /// hinges incident to `e` (`e`'s star — local), built from the same per-hinge
+    /// analytic gradients as `actionGradientExact`; **complex** modulus (Re and Im
+    /// together). Over a FIXED affected-edge set across a move,
+    /// `Δ‖∇S_Regge‖² = after − before` is exact (every edge outside the set keeps its
+    /// gradient and cancels). `gradientNorm2OverEdges` over *all* edges equals
+    /// `Σ_e |actionGradientExact()_e|²`.
+    [[nodiscard]] double gradientNorm2OverEdges(
+        const std::vector<std::pair<std::uint64_t, std::uint64_t>> &edges) const;
+
     /// Point-particle matter action: \f$S_{\text{matter}} = -M \sum_{e \in W} \sqrt{-\ell^2_e}\f$.
     [[nodiscard]] double matterAction() const;
 

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -643,6 +643,16 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "the per-edge low-rank dM/dl^2 through eigenvector perturbation theory "
            "and the pseudo-inverse derivative (the C++ port of the relaxation's "
            "Python drU). Raises on a hole/target length mismatch.")
+      .def("periodGradientGeneral",
+           &EigenstateSynthesis::periodGradientGeneral,
+           py::arg("holes"), py::arg("target_periods"),
+           "Arbitrary-degree analytic gradient d r_U / d l^2 of residualForPeriods "
+           "(the general-k generalization of residualForPeriodsGradient, which is "
+           "k=1 only). M = L_k, the per-edge dL_k/dl^2 = HodgeLaplacian."
+           "laplacianGradient (built on Simplex.volumeGradient), same eigenvector-"
+           "perturbation derivation, period covector from each removed-(k+1)-cell "
+           "hole's facets. ChainComplex 1-cell (edge) order. Equals the k=1 path on "
+           "triangle holes; exact (Σ l² ∂r_U = −r_U).")
       .def("residualForPeriodsGradientGpu",
            &EigenstateSynthesis::residualForPeriodsGradientGpu,
            py::arg("holes"), py::arg("target_periods"),

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -637,22 +637,14 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
       .def("residualForPeriodsGradient",
            &EigenstateSynthesis::residualForPeriodsGradient,
            py::arg("holes"), py::arg("target_periods"),
-           "The analytic gradient d r_U / d l^2 of residualForPeriods w.r.t. each "
-           "edge's squared length, in cellSimplices() (k=1 cell) order. "
-           "Eigendecomposes M = L1, builds the same carried psi, then propagates "
-           "the per-edge low-rank dM/dl^2 through eigenvector perturbation theory "
-           "and the pseudo-inverse derivative (the C++ port of the relaxation's "
-           "Python drU). Raises on a hole/target length mismatch.")
-      .def("periodGradientGeneral",
-           &EigenstateSynthesis::periodGradientGeneral,
-           py::arg("holes"), py::arg("target_periods"),
-           "Arbitrary-degree analytic gradient d r_U / d l^2 of residualForPeriods "
-           "(the general-k generalization of residualForPeriodsGradient, which is "
-           "k=1 only). M = L_k, the per-edge dL_k/dl^2 = HodgeLaplacian."
-           "laplacianGradient (built on Simplex.volumeGradient), same eigenvector-"
-           "perturbation derivation, period covector from each removed-(k+1)-cell "
-           "hole's facets. ChainComplex 1-cell (edge) order. Equals the k=1 path on "
-           "triangle holes; exact (Σ l² ∂r_U = −r_U).")
+           "Arbitrary-degree exact analytic gradient d r_U / d l^2 of "
+           "residualForPeriods w.r.t. each edge's squared length, in ChainComplex "
+           "1-cell (edge) order. M = L_k, the per-edge dL_k/dl^2 = HodgeLaplacian."
+           "laplacianGradient (built on Simplex.volumeGradient), through eigenvector-"
+           "perturbation theory; period covector + leak from each removed-(k+1)-cell "
+           "hole's facets. Reproduces the k=1 edge-loop core on triangle holes; "
+           "certified by the exact Euler identity Σ l² ∂r_U = −r_U (FD does not "
+           "converge). Raises on a hole/target length mismatch.")
       .def("residualForPeriodsGradientGpu",
            &EigenstateSynthesis::residualForPeriodsGradientGpu,
            py::arg("holes"), py::arg("target_periods"),

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -285,6 +285,13 @@ Euclidean spectrum/kernel.)doc")
            "column order: per-k-simplex |volume| (W_0 = I). lorentzian=True returns "
            "the signed volume (timelike cells negative). Empty for k<0 or k above "
            "the top dimension.")
+      .def("laplacianGradient", &HodgeLaplacian::laplacianGradient, py::arg("k"),
+           py::arg("edgeA"), py::arg("edgeB"),
+           "Exact analytic dL_k^sym/dl^2_e of the symmetric metric Hodge Laplacian "
+           "(k>=1) w.r.t. one edge's squared length, flat |C_k|x|C_k| row-major. Only "
+           "the weights W_j=|vol| depend on l^2; built via dB_k = diag(a_{k-1})B_k + "
+           "B_k diag(b_k), a_j=dW_j/(2W_j), dW_j = Simplex.volumeGradient. Empty for "
+           "k<1 or an absent edge.")
       .def("isHermitian", &HodgeLaplacian::isHermitian, py::arg("tol") = 1e-12,
            "True iff ||L - L^dagger|| <= tol (Frobenius) for the k=0 Laplacian.")
       .def("unitarityResidual", &HodgeLaplacian::unitarityResidual,

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1560,9 +1560,15 @@ std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
   return grad;
 }
 
-std::vector<double> EigenstateSynthesis::periodGradientGeneral(
+std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
     const std::vector<std::vector<std::uint64_t>> &holes,
     const std::vector<cd> &targetPeriods) const {
+  // Arbitrary-degree exact d r_U / d l^2 over the removed-(k+1)-cell holes. M = L_k,
+  // the per-edge dL_k/dl^2 (HodgeLaplacian::laplacianGradient, on Simplex::volumeGradient)
+  // through first-order eigenvector perturbation, period covector + leak from each
+  // hole's facet boundary (the assembleRegisterReadout convention). Equals the k=1
+  // loop core (periodGradientOverLoops) on triangle holes; certified by the Euler
+  // identity Sum_e l^2_e d r_U/d l^2_e = -r_U.
   using Eigen::Index;
   using Eigen::MatrixXcd;
   using Eigen::MatrixXd;
@@ -1576,7 +1582,7 @@ std::vector<double> EigenstateSynthesis::periodGradientGeneral(
   if (nk == 0 || m == 0) return grad;
   if (targetPeriods.size() != m)
     throw std::runtime_error(
-        "EigenstateSynthesis::periodGradientGeneral: " +
+        "EigenstateSynthesis::residualForPeriodsGradient: " +
         std::to_string(targetPeriods.size()) + " target periods for " +
         std::to_string(m) + " holes");
   static constexpr double kNullTol = 1e-7;
@@ -1602,7 +1608,7 @@ std::vector<double> EigenstateSynthesis::periodGradientGeneral(
     std::sort(h.begin(), h.end());
     if (h.size() != hv)
       throw std::runtime_error(
-          "EigenstateSynthesis::periodGradientGeneral: hole has " +
+          "EigenstateSynthesis::residualForPeriodsGradient: hole has " +
           std::to_string(h.size()) + " vertices, expected " + std::to_string(hv));
     std::vector<std::size_t> walk(hv);
     for (std::size_t i = 0; i < hv; ++i) walk[i] = i;
@@ -1616,7 +1622,7 @@ std::vector<double> EigenstateSynthesis::periodGradientGeneral(
       const auto it = col.find(f);
       if (it == col.end())
         throw std::runtime_error(
-            "EigenstateSynthesis::periodGradientGeneral: a hole facet is not a "
+            "EigenstateSynthesis::residualForPeriodsGradient: a hole facet is not a "
             "k-cell of the complex");
       if (w == 0) leakCol[q] = it->second;
       Q(static_cast<Index>(q), static_cast<Index>(it->second)) +=
@@ -1887,15 +1893,6 @@ std::vector<double> EigenstateSynthesis::periodGapForPeriodsGradient(
       targetPeriods);
 }
 
-std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
-    const std::vector<std::vector<std::uint64_t>> &holes,
-    const std::vector<cd> &targetPeriods) const {
-  // A removed triangle's boundary IS the oriented loop h0 -> h1 -> h2 -> h0
-  // (identical signed covector and leak), so route through the loop core.
-  return periodGradientOverLoops(
-      holeLoops(holes, "EigenstateSynthesis::residualForPeriodsGradient"),
-      targetPeriods);
-}
 
 std::vector<double> EigenstateSynthesis::residualForLoopsGradient(
     const std::vector<EdgeLoop> &loops,

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1560,6 +1560,136 @@ std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
   return grad;
 }
 
+std::vector<double> EigenstateSynthesis::periodGradientGeneral(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+  using Eigen::Index;
+  using Eigen::MatrixXcd;
+  using Eigen::MatrixXd;
+  using Eigen::VectorXcd;
+  using Eigen::VectorXd;
+  const std::size_t nk = order_;                 // # k-cells (rows/cols of L_k)
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const std::vector<std::vector<std::uint64_t>> edges1 = cc.kSimplexVertices(1);
+  std::vector<double> grad(edges1.size(), 0.0);  // d r_U / d l^2_e, 1-cell order
+  const std::size_t m = holes.size();
+  if (nk == 0 || m == 0) return grad;
+  if (targetPeriods.size() != m)
+    throw std::runtime_error(
+        "EigenstateSynthesis::periodGradientGeneral: " +
+        std::to_string(targetPeriods.size()) + " target periods for " +
+        std::to_string(m) + " holes");
+  static constexpr double kNullTol = 1e-7;
+  const Index N = static_cast<Index>(nk);
+
+  // ---- M = L_k (symmetric metric Hodge Laplacian) ----
+  const std::vector<cd> Lflat = HodgeLaplacian(st_).laplacian(k_, /*metric=*/true);
+  MatrixXd M(N, N);
+  for (std::size_t i = 0; i < nk; ++i)
+    for (std::size_t j = 0; j < nk; ++j)
+      M(static_cast<Index>(i), static_cast<Index>(j)) = Lflat[i * nk + j].real();
+
+  // ---- Q (period covector, m x nk) + leak column, the assembleRegisterReadout
+  // boundary convention: a hole is a removed (k+1)-cell; its facets (drop v_j,
+  // sign (-1)^j) are k-cells; the leak is the first facet of the walk. ----
+  std::map<std::vector<std::uint64_t>, std::size_t> col;
+  for (std::size_t i = 0; i < cellOrdering_.size(); ++i) col[cellOrdering_[i]] = i;
+  const std::size_t hv = static_cast<std::size_t>(k_) + 2;
+  MatrixXd Q = MatrixXd::Zero(static_cast<Index>(m), N);
+  std::vector<std::size_t> leakCol(m, 0);
+  for (std::size_t q = 0; q < m; ++q) {
+    std::vector<std::uint64_t> h = holes[q];
+    std::sort(h.begin(), h.end());
+    if (h.size() != hv)
+      throw std::runtime_error(
+          "EigenstateSynthesis::periodGradientGeneral: hole has " +
+          std::to_string(h.size()) + " vertices, expected " + std::to_string(hv));
+    std::vector<std::size_t> walk(hv);
+    for (std::size_t i = 0; i < hv; ++i) walk[i] = i;
+    if (k_ == 1) std::rotate(walk.begin(), walk.end() - 1, walk.end());
+    for (std::size_t w = 0; w < hv; ++w) {
+      const std::size_t j = walk[w];
+      std::vector<std::uint64_t> f;
+      f.reserve(hv - 1);
+      for (std::size_t i = 0; i < hv; ++i)
+        if (i != j) f.push_back(h[i]);
+      const auto it = col.find(f);
+      if (it == col.end())
+        throw std::runtime_error(
+            "EigenstateSynthesis::periodGradientGeneral: a hole facet is not a "
+            "k-cell of the complex");
+      if (w == 0) leakCol[q] = it->second;
+      Q(static_cast<Index>(q), static_cast<Index>(it->second)) +=
+          (j % 2 == 0) ? 1.0 : -1.0;
+    }
+  }
+
+  // ---- harmonic (null) / non-null eigensplit of M ----
+  Eigen::SelfAdjointEigenSolver<MatrixXd> eig(M);
+  const VectorXd lam = eig.eigenvalues();
+  const MatrixXd U = eig.eigenvectors();
+  std::vector<Index> nullIdx, nnIdx;
+  for (Index i = 0; i < N; ++i)
+    (std::abs(lam[i]) < kNullTol ? nullIdx : nnIdx).push_back(i);
+  const Index nd = static_cast<Index>(nullIdx.size());
+  const Index nnd = static_cast<Index>(nnIdx.size());
+  if (nd == 0) return grad;  // no harmonics -> nothing carried
+  MatrixXd Un(N, nd), Unn(N, nnd);
+  for (Index r = 0; r < nd; ++r) Un.col(r) = U.col(nullIdx[r]);
+  for (Index r = 0; r < nnd; ++r) Unn.col(r) = U.col(nnIdx[r]);
+  VectorXd invlam(nnd);
+  for (Index r = 0; r < nnd; ++r) invlam[r] = -1.0 / lam[nnIdx[r]];
+
+  // ---- carried representative psi, p, rho, r_U (same as the loop core) ----
+  VectorXcd target(static_cast<Index>(m));
+  for (std::size_t q = 0; q < m; ++q) target[static_cast<Index>(q)] = targetPeriods[q];
+  const MatrixXd A = Q * Un;                            // m x nd
+  const MatrixXd AtAi = (A.transpose() * A).inverse();  // nd x nd
+  const VectorXcd c = (AtAi * A.transpose()).cast<cd>() * target;
+  VectorXcd psi = Un.cast<cd>() * c;
+  const VectorXcd carried = Q.cast<cd>() * psi;
+  for (std::size_t q = 0; q < m; ++q)
+    psi[static_cast<Index>(leakCol[q])] +=
+        target[static_cast<Index>(q)] - carried[static_cast<Index>(q)];
+  const double nrm = psi.norm();
+  if (nrm <= 0.0) return grad;
+  const VectorXcd p = psi / nrm;
+  const VectorXcd Mp = M.cast<cd>() * p;
+  const double lamR = (p.dot(Mp)).real();
+  const VectorXcd rho = Mp - lamR * p;
+  const double rU = rho.squaredNorm();
+
+  // ---- per-edge analytic gradient: dM_e = laplacianGradient, dense perturbation ----
+  const HodgeLaplacian hl(st_);
+  for (std::size_t je = 0; je < edges1.size(); ++je) {
+    const std::vector<double> dMflat =
+        hl.laplacianGradient(k_, edges1[je][0], edges1[je][1]);
+    if (dMflat.empty()) continue;
+    MatrixXd dM(N, N);
+    for (std::size_t i = 0; i < nk; ++i)
+      for (std::size_t j = 0; j < nk; ++j)
+        dM(static_cast<Index>(i), static_cast<Index>(j)) = dMflat[i * nk + j];
+    const VectorXcd dMp = dM.cast<cd>() * p;
+    // eigenvector perturbation of the harmonic block: dUn = Unn diag(invlam) Unn^T dM Un
+    const MatrixXd core = (Unn.transpose() * dM) * Un;          // nnd x nd
+    const MatrixXd dUn = Unn * (invlam.asDiagonal() * core);    // N x nd
+    const MatrixXd dA = Q * dUn;                                // m x nd
+    const MatrixXd dAplus =
+        -AtAi * (dA.transpose() * A + A.transpose() * dA) * AtAi * A.transpose() +
+        AtAi * dA.transpose();                                  // nd x m
+    const VectorXcd dc = dAplus.cast<cd>() * target;
+    VectorXcd dpsi = dUn.cast<cd>() * c + Un.cast<cd>() * dc;
+    const VectorXcd dcarried = Q.cast<cd>() * dpsi;
+    for (std::size_t q = 0; q < m; ++q)
+      dpsi[static_cast<Index>(leakCol[q])] += -dcarried[static_cast<Index>(q)];
+    const VectorXcd Mdpsi = M.cast<cd>() * dpsi;
+    grad[je] = 2.0 * (rho.dot(dMp)).real() +
+               (2.0 / nrm) * (rho.dot(Mdpsi - lamR * dpsi)).real() -
+               (2.0 * rU / nrm) * (p.dot(dpsi)).real();
+  }
+  return grad;
+}
+
 std::vector<double> EigenstateSynthesis::periodGapForLoopsGradient(
     const std::vector<EdgeLoop> &loops,
     const std::vector<cd> &targetPeriods) const {

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1560,7 +1560,7 @@ std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
   return grad;
 }
 
-std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
+std::vector<double> EigenstateSynthesis::periodGradientGeneral(
     const std::vector<std::vector<std::uint64_t>> &holes,
     const std::vector<cd> &targetPeriods) const {
   // Arbitrary-degree exact d r_U / d l^2 over the removed-(k+1)-cell holes. M = L_k,
@@ -1582,7 +1582,7 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
   if (nk == 0 || m == 0) return grad;
   if (targetPeriods.size() != m)
     throw std::runtime_error(
-        "EigenstateSynthesis::residualForPeriodsGradient: " +
+        "EigenstateSynthesis::periodGradientGeneral: " +
         std::to_string(targetPeriods.size()) + " target periods for " +
         std::to_string(m) + " holes");
   static constexpr double kNullTol = 1e-7;
@@ -1608,7 +1608,7 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
     std::sort(h.begin(), h.end());
     if (h.size() != hv)
       throw std::runtime_error(
-          "EigenstateSynthesis::residualForPeriodsGradient: hole has " +
+          "EigenstateSynthesis::periodGradientGeneral: hole has " +
           std::to_string(h.size()) + " vertices, expected " + std::to_string(hv));
     std::vector<std::size_t> walk(hv);
     for (std::size_t i = 0; i < hv; ++i) walk[i] = i;
@@ -1622,7 +1622,7 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
       const auto it = col.find(f);
       if (it == col.end())
         throw std::runtime_error(
-            "EigenstateSynthesis::residualForPeriodsGradient: a hole facet is not a "
+            "EigenstateSynthesis::periodGradientGeneral: a hole facet is not a "
             "k-cell of the complex");
       if (w == 0) leakCol[q] = it->second;
       Q(static_cast<Index>(q), static_cast<Index>(it->second)) +=
@@ -1694,6 +1694,23 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
                (2.0 * rU / nrm) * (p.dot(dpsi)).real();
   }
   return grad;
+}
+
+std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
+    const std::vector<std::vector<std::uint64_t>> &holes,
+    const std::vector<cd> &targetPeriods) const {
+  // Arbitrary-degree exact d r_U / d l^2, in ChainComplex 1-cell (edge) order.
+  // At k = 1 (triangle holes) route through the fast low-rank edge-loop core
+  // (periodGradientOverLoops): it builds the chain complex once and uses a per-edge
+  // low-rank dM, so a relaxation loop stays affordable. It is value-identical to the
+  // general path (verified to 1.7e-15). For k >= 2 use the degree-generic
+  // periodGradientGeneral (M = L_k, the per-edge analytic dL_k/dl^2). Both satisfy
+  // the exact Euler identity Sum_e l^2_e d r_U/d l^2_e = -r_U.
+  if (k_ == 1)
+    return periodGradientOverLoops(
+        holeLoops(holes, "EigenstateSynthesis::residualForPeriodsGradient"),
+        targetPeriods);
+  return periodGradientGeneral(holes, targetPeriods);
 }
 
 std::vector<double> EigenstateSynthesis::periodGapForLoopsGradient(

--- a/src/cobordism/HodgeLaplacian.cpp
+++ b/src/cobordism/HodgeLaplacian.cpp
@@ -141,6 +141,82 @@ Eigen::MatrixXd metricLaplacian(const Spacetime &K, int k, bool metric) {
   return L;
 }
 
+// Exact analytic dL_k^sym / dl^2_e for the symmetric metric Hodge Laplacian. Only
+// the weights W_j = |vol| (j = k-1, k, k+1) depend on l^2; W_0 = I is constant. With
+// B_k = diag(sqrt W_{k-1}) d_k diag(1/sqrt W_k), dB_k = diag(a_{k-1}) B_k + B_k diag(b_k),
+// a_j = dW_j/(2 W_j), and dL = dB_k^T B_k + B_k^T dB_k + dB_{k+1} B_{k+1}^T + B_{k+1} dB_{k+1}^T.
+// dW_j[i] = sgn(vol_i) * Simplex::volumeGradient(face_i)[e] (signed for the |vol| weight).
+Eigen::MatrixXd metricLaplacianGradient(const Spacetime &K, int k,
+                                        std::uint64_t ea, std::uint64_t eb) {
+  const ChainComplex cc = ChainComplex::fromSpacetime(K);
+  const int n = cc.dimension();
+  const int nk = static_cast<int>(cc.numSimplices(k));
+  Eigen::MatrixXd dL = Eigen::MatrixXd::Zero(nk, nk);
+  if (k < 1 || nk == 0) return dL;
+  const std::vector<std::vector<SimplexPtr>> faces = orderedFaces(K);
+  const std::uint64_t lo = std::min(ea, eb), hi = std::max(ea, eb);
+
+  const auto weightArr = [&](int kk) {
+    const std::vector<double> wv =
+        simplexWeights(faces, kk, static_cast<int>(cc.numSimplices(kk)), /*metric=*/true);
+    Eigen::ArrayXd a(static_cast<Eigen::Index>(wv.size()));
+    for (std::size_t i = 0; i < wv.size(); ++i) a[static_cast<Eigen::Index>(i)] = wv[i];
+    return a;
+  };
+  // dW_j (per-cell weight derivative w.r.t. l^2_(lo,hi)); 0 for k=0 (W_0 const).
+  const auto dWeightArr = [&](int kk) {
+    const int cnt = static_cast<int>(cc.numSimplices(kk));
+    Eigen::ArrayXd dw = Eigen::ArrayXd::Zero(std::max(cnt, 0));
+    if (kk < 1 || kk >= static_cast<int>(faces.size())) return dw;  // W_0 = I
+    const auto &fk = faces[static_cast<std::size_t>(kk)];
+    for (int i = 0; i < cnt && i < static_cast<int>(fk.size()); ++i) {
+      const double vol = fk[static_cast<std::size_t>(i)]->volume();
+      if (std::abs(vol) <= 0.0) continue;  // degenerate weight pinned to 1 (const)
+      const auto g = fk[static_cast<std::size_t>(i)]->volumeGradient();
+      const auto it = g.find({lo, hi});
+      if (it != g.end())
+        dw[i] = (vol < 0.0 ? -1.0 : 1.0) * it->second;  // d|vol| = sgn(vol) dvol
+    }
+    return dw;
+  };
+  const auto boundary = [&](int kk, int rows, int cols) {
+    const std::vector<long> &flat = cc.boundaryMatrix(kk);
+    Eigen::MatrixXd d(rows, cols);
+    for (int r = 0; r < rows; ++r)
+      for (int c = 0; c < cols; ++c)
+        d(r, c) = static_cast<double>(flat[static_cast<std::size_t>(r) * cols + c]);
+    return d;
+  };
+
+  const Eigen::ArrayXd Wk = weightArr(k), dWk = dWeightArr(k);
+  // Term 1 (down): B_k = diag(sqrt W_{k-1}) d_k diag(1/sqrt W_k).
+  const int rows = static_cast<int>(cc.numSimplices(k - 1));
+  if (rows > 0) {
+    const Eigen::ArrayXd Wm = weightArr(k - 1), dWm = dWeightArr(k - 1);
+    const Eigen::MatrixXd Bk = Wm.sqrt().matrix().asDiagonal() * boundary(k, rows, nk) *
+                               Wk.sqrt().inverse().matrix().asDiagonal();
+    const Eigen::VectorXd aL = (dWm / (2.0 * Wm)).matrix();   // rows (k-1)
+    const Eigen::VectorXd bR = (-dWk / (2.0 * Wk)).matrix();  // nk
+    const Eigen::MatrixXd dBk =
+        aL.asDiagonal() * Bk + Bk * bR.asDiagonal();
+    dL.noalias() += dBk.transpose() * Bk + Bk.transpose() * dBk;
+  }
+  // Term 2 (up): B_{k+1} = diag(sqrt W_k) d_{k+1} diag(1/sqrt W_{k+1}).
+  const int cols = (k + 1 <= n) ? static_cast<int>(cc.numSimplices(k + 1)) : 0;
+  if (cols > 0) {
+    const Eigen::ArrayXd Wp = weightArr(k + 1), dWp = dWeightArr(k + 1);
+    const Eigen::MatrixXd Bkp1 = Wk.sqrt().matrix().asDiagonal() *
+                                 boundary(k + 1, nk, cols) *
+                                 Wp.sqrt().inverse().matrix().asDiagonal();
+    const Eigen::VectorXd aL = (dWk / (2.0 * Wk)).matrix();   // nk
+    const Eigen::VectorXd bR = (-dWp / (2.0 * Wp)).matrix();  // cols (k+1)
+    const Eigen::MatrixXd dBkp1 =
+        aL.asDiagonal() * Bkp1 + Bkp1 * bR.asDiagonal();
+    dL.noalias() += dBkp1 * Bkp1.transpose() + Bkp1 * dBkp1.transpose();
+  }
+  return dL;
+}
+
 // Signed-weight (Lorentzian) metric Hodge Laplacian for k >= 0 — the discrete
 // d'Alembertian. With W indefinite the symmetric W^{1/2} similarity breaks, so the
 // operator is assembled directly from the signed metric adjoint
@@ -356,6 +432,18 @@ std::vector<double> HodgeLaplacian::weights(int k, bool lorentzian) const {
   const int m = static_cast<int>(cc.numSimplices(k));
   if (k == 0) return std::vector<double>(static_cast<std::size_t>(m), 1.0);
   return simplexWeights(orderedFaces(*st_), k, m, /*metric=*/true, lorentzian);
+}
+
+std::vector<double> HodgeLaplacian::laplacianGradient(int k, std::uint64_t ea,
+                                                      std::uint64_t eb) const {
+  if (k < 1 || !st_) return {};
+  const Eigen::MatrixXd dL = metricLaplacianGradient(*st_, k, ea, eb);
+  const int nk = static_cast<int>(dL.rows());
+  std::vector<double> out(static_cast<std::size_t>(nk) * nk, 0.0);
+  for (int i = 0; i < nk; ++i)
+    for (int j = 0; j < nk; ++j)
+      out[static_cast<std::size_t>(i) * nk + j] = dL(i, j);
+  return out;
 }
 
 const HodgeLaplacian::MetricSpectrum &HodgeLaplacian::ensureMetricSpectrum(

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -357,6 +357,11 @@ Python-driven materialization corrupted dualVolume(). Reference fixes it
       .def("volume", &Simplex::volume,
            "Signed d-content sqrt(det G)/d! on the honest (non-Wick-rotated) "
            "geometry; negative for a Lorentzian cell with timelike content.")
+      .def("volumeGradient", &Simplex::volumeGradient,
+           "Exact analytic gradient dV/dl^2_e of the signed volume() w.r.t. each "
+           "edge's squared length (edge-keyed map), via Jacobi's formula on the "
+           "Gram determinant: dV = (V/2) tr(G^-1 dG). The per-degree Hodge weight "
+           "gradient (W_k are signed simplex volumes) — keystone for arbitrary-k.")
       .def("circumcenterBarycentric", &Simplex::circumcenterBarycentric,
            "Circumcenter in barycentric coordinates (sum 1), intrinsic from the "
            "signature-aware edge lengths; entry i weights getVertices()[i].")

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -1392,6 +1392,49 @@ double Simplex::dualVolume() const {
 }
 
 std::map<std::pair<std::uint64_t, std::uint64_t>, double>
+Simplex::volumeGradient() const {
+    // dV/dl^2_e = (V/2) tr(G^-1 dG_e), Jacobi's formula on the Gram determinant
+    // (V = sgn sqrt(|det G|)/d!, G linear in l^2 so dG_e is an indicator matrix —
+    // the same dG the #354 dCircumR2 uses). G^-1 via the adjugate (cofactor^T/det),
+    // Eigen-free, matching circumFromGram / volume().
+    std::map<std::pair<std::uint64_t, std::uint64_t>, double> grad;
+    const int d = static_cast<int>(size()) - 1;
+    if (d < 1) return grad;
+    const std::vector<double> G = gramMatrix(/*wickRotate=*/false);
+    if (static_cast<int>(G.size()) != d * d) return grad;
+    const double detG = determinant(G, d);
+    if (std::abs(detG) < 1e-300) return grad;
+    const std::vector<double> cofG = cofactorMatrix(G, d);  // cof[r*d+c] = C_rc
+    const double V = volume();
+    const auto &sv = vertices;
+    for (std::size_t p = 0; p < sv.size(); ++p)
+        for (std::size_t q = p + 1; q < sv.size(); ++q) {
+            const std::uint64_t a = sv[p]->getId(), b = sv[q]->getId();
+            const std::pair<std::uint64_t, std::uint64_t> ek{std::min(a, b),
+                                                             std::max(a, b)};
+            auto ind = [&](int i, int j) -> double {
+                if (i == j) return 0.0;
+                const std::uint64_t x = sv[static_cast<std::size_t>(i)]->getId();
+                const std::uint64_t y = sv[static_cast<std::size_t>(j)]->getId();
+                return (std::min(x, y) == ek.first && std::max(x, y) == ek.second)
+                           ? 1.0 : 0.0;
+            };
+            // tr(G^-1 dG) = sum_ij (G^-1)_ij dG_ji; dG symmetric, (G^-1)_ij=cof_ji/det.
+            double tr = 0.0;
+            for (int i = 0; i < d; ++i)
+                for (int j = 0; j < d; ++j) {
+                    const double dGij =
+                        0.5 * (ind(0, i + 1) + ind(0, j + 1) - ind(i + 1, j + 1));
+                    const double GinvIJ =
+                        cofG[static_cast<std::size_t>(j) * d + i] / detG;
+                    tr += GinvIJ * dGij;
+                }
+            grad[ek] += 0.5 * V * tr;
+        }
+    return grad;
+}
+
+std::map<std::pair<std::uint64_t, std::uint64_t>, double>
 Simplex::dualVolumeGradient() const {
     std::map<std::pair<std::uint64_t, std::uint64_t>, double> grad;
     if (vertices.empty()) return grad;

--- a/src/simulations/Bindings.cpp
+++ b/src/simulations/Bindings.cpp
@@ -274,6 +274,18 @@ Einstein equations).  F ≥ 0, and F = 0 at the solution.)doc")
            "tuples that are genuine (registered, with a top coface; orphans → 0). "
            "Same per-term measure as dualReggeAction. Evaluated over a FIXED hinge "
            "set across a move, ΔS = after − before is exact.")
+      .def("affectedEdgesOfCells", &ReggeSolver::affectedEdgesOfCells,
+           py::arg("cells"),
+           "The edges (sorted (a,b) id pairs) whose ∂S/∂ℓ²_e a move over the given "
+           "top cells can change — the affected-edge index for Δ‖∇S_Regge‖². Union "
+           "the before/after evaluations for a fixed set across the move.")
+      .def("gradientNorm2OverEdges", &ReggeSolver::gradientNorm2OverEdges,
+           py::arg("edges"),
+           "Localized squared gradient norm Σ_e |∂S/∂ℓ²_e|² (the geometry term of "
+           "F = ‖∇S_Regge‖² + Γ·r_U, extremize δS=0). Each ∂S/∂ℓ²_e is the full "
+           "per-edge complex gradient (e's star). Over a FIXED affected-edge set "
+           "across a move, Δ‖∇S‖² = after − before is exact; over all edges it "
+           "equals Σ_e |actionGradientExact()_e|².")
       .def("matterAction", &ReggeSolver::matterAction,
            "Point-particle matter action: S_matter = -M Σ √(-ℓ²) along worldlines.")
       .def("totalAction", &ReggeSolver::totalAction,

--- a/src/simulations/Bindings.cpp
+++ b/src/simulations/Bindings.cpp
@@ -262,6 +262,18 @@ Einstein equations).  F ≥ 0, and F = 0 at the solution.)doc")
            "(d-2)-hinge's circumcentric dual content (Simplex.dualVolume) times "
            "its complex Lorentzian deficit. Returns a Python complex (real = "
            "angle-defect curvature, imag = boost/light-cone content).")
+      .def("hingeFacesOfCells", &ReggeSolver::hingeFacesOfCells, py::arg("cells"),
+           "The (d-2) hinge vertex-tuples that are faces of the given top d-cells "
+           "— the affected-hinge index for the incremental ΔS_Regge. `cells` is a "
+           "list of vertex-id tuples; returns the dedup'd sorted (d-1)-vertex "
+           "sub-tuples. Build from a move's touched cells (created ∪ removed ∪ the "
+           "perturbed edge's top cofaces) and reuse the SAME set before/after.")
+      .def("dualReggeActionOverHinges", &ReggeSolver::dualReggeActionOverHinges,
+           py::arg("hinges"),
+           "Localized dual Regge action Σ |*h|·ε_h over only the given (d-2) hinge "
+           "tuples that are genuine (registered, with a top coface; orphans → 0). "
+           "Same per-term measure as dualReggeAction. Evaluated over a FIXED hinge "
+           "set across a move, ΔS = after − before is exact.")
       .def("matterAction", &ReggeSolver::matterAction,
            "Point-particle matter action: S_matter = -M Σ √(-ℓ²) along worldlines.")
       .def("totalAction", &ReggeSolver::totalAction,

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -213,6 +213,122 @@ std::complex<double> ReggeSolver::dualReggeActionOverHinges(
     return S;
 }
 
+std::vector<std::pair<std::uint64_t, std::uint64_t>>
+ReggeSolver::affectedEdgesOfCells(
+    const std::vector<std::vector<std::uint64_t>> &cells) const {
+    // A move changes ∂S/∂ℓ²_e only where an affected hinge contributes to e, i.e.
+    // for edges sharing a top cell with an affected hinge. So: affected hinges →
+    // their incident top cells → those tops' edges. Top cells are reached through a
+    // hinge vertex's incidences (getSimplices), so this never depends on edges /
+    // hinges being materialized as registered simplices.
+    std::unordered_map<std::uint64_t, VertexPtr> vidx;
+    for (const auto &v : spacetime_->getVertexList()->toVector())
+        if (v != nullptr) vidx.emplace(v->getId(), v);
+    const int topSize =
+        spacetime_->getMetric()->getSignature()->getDimensions() + 1;
+
+    std::set<std::pair<std::uint64_t, std::uint64_t>> E;
+    for (const auto &ht : hingeFacesOfCells(cells)) {
+        const auto v0 = vidx.find(ht[0]);
+        if (v0 == vidx.end()) continue;
+        const std::set<std::uint64_t> need(ht.begin(), ht.end());
+        for (auto *sigma : v0->second->getSimplices()) {
+            if (static_cast<int>(sigma->size()) != topSize) continue;
+            std::set<std::uint64_t> sv;
+            for (const auto &v : sigma->getVertices()) sv.insert(v->getId());
+            if (!std::includes(sv.begin(), sv.end(), need.begin(), need.end()))
+                continue;
+            const auto &tv = sigma->getVertices();
+            for (std::size_t i = 0; i < tv.size(); ++i)
+                for (std::size_t j = i + 1; j < tv.size(); ++j) {
+                    const std::uint64_t a = tv[i]->getId(), b = tv[j]->getId();
+                    E.insert({std::min(a, b), std::max(a, b)});
+                }
+        }
+    }
+    return {E.begin(), E.end()};
+}
+
+double ReggeSolver::gradientNorm2OverEdges(
+    const std::vector<std::pair<std::uint64_t, std::uint64_t>> &edges) const {
+    std::unordered_map<std::uint64_t, VertexPtr> vidx;
+    for (const auto &v : spacetime_->getVertexList()->toVector())
+        if (v != nullptr) vidx.emplace(v->getId(), v);
+
+    std::set<std::pair<std::uint64_t, std::uint64_t>> E;
+    for (const auto &e : edges)
+        E.insert({std::min(e.first, e.second), std::max(e.first, e.second)});
+
+    // Every hinge that contributes to a query edge: the (d-2)-faces of the top cells
+    // containing that edge. The top cells are reached through an edge endpoint's
+    // incidences (getSimplices) — edges are not registered as 1-simplices, so resolve
+    // via the vertex. Summing each query edge's full per-edge gradient over these
+    // hinges is exact: they are precisely e's star for every e in E.
+    const int d = spacetime_->getMetric()->getSignature()->getDimensions();
+    const int topSize = d + 1;
+    const auto hingeSize = static_cast<std::size_t>(d - 1);
+    std::set<std::vector<std::uint64_t>> hinges;
+    for (const auto &e : E) {
+        const auto va = vidx.find(e.first);
+        if (va == vidx.end()) continue;
+        for (auto *sigma : va->second->getSimplices()) {
+            if (static_cast<int>(sigma->size()) != topSize) continue;
+            bool hasB = false;
+            for (const auto &v : sigma->getVertices())
+                if (v->getId() == e.second) { hasB = true; break; }
+            if (!hasB) continue;
+            std::vector<std::uint64_t> cs;
+            for (const auto &v : sigma->getVertices()) cs.push_back(v->getId());
+            std::sort(cs.begin(), cs.end());
+            cs.erase(std::unique(cs.begin(), cs.end()), cs.end());
+            if (cs.size() < hingeSize) continue;
+            std::vector<bool> mask(cs.size(), false);
+            std::fill(mask.begin(),
+                      mask.begin() + static_cast<std::ptrdiff_t>(hingeSize), true);
+            do {
+                std::vector<std::uint64_t> h;
+                h.reserve(hingeSize);
+                for (std::size_t i = 0; i < cs.size(); ++i)
+                    if (mask[i]) h.push_back(cs[i]);
+                hinges.insert(std::move(h));
+            } while (std::prev_permutation(mask.begin(), mask.end()));
+        }
+    }
+
+    // ∂S/∂ℓ²_e = Σ_h [∂|★h|·ε_h + |★h|·∂ε_h], restricted to the query edges (the
+    // full per-edge gradient for every e in E, since E's hinges are all in `hinges`).
+    std::map<std::pair<std::uint64_t, std::uint64_t>, std::complex<double>> g;
+    for (const auto &ht : hinges) {
+        VertexPtrs vp;
+        vp.reserve(ht.size());
+        bool ok = true;
+        for (const std::uint64_t id : ht) {
+            const auto it = vidx.find(id);
+            if (it == vidx.end()) { ok = false; break; }
+            vp.push_back(it->second);
+        }
+        if (!ok) continue;
+        const auto h = spacetime_->findSimplexByVerts(vp);
+        if (h == nullptr || !h->hasTopCoface()) continue;
+        const std::complex<double> eps = h->lorentzianDeficitAngle();
+        const double dv = h->dualVolume();
+        for (const auto &[ed, dEps] : h->lorentzianDeficitAngleGradient()) {
+            const std::pair<std::uint64_t, std::uint64_t> k{
+                std::min(ed.first, ed.second), std::max(ed.first, ed.second)};
+            if (E.count(k)) g[k] += dv * dEps;
+        }
+        for (const auto &[ed, dDv] : h->dualVolumeGradient()) {
+            const std::pair<std::uint64_t, std::uint64_t> k{
+                std::min(ed.first, ed.second), std::max(ed.first, ed.second)};
+            if (E.count(k)) g[k] += dDv * eps;
+        }
+    }
+
+    double s = 0.0;
+    for (const auto &[k, v] : g) s += std::norm(v);  // |∂S/∂ℓ²_e|²
+    return s;
+}
+
 double ReggeSolver::matterAction() const {
     // Point-particle action: S_matter = -M ∫ dτ
     // Timelike edges (between slices) have ℓ² < 0; spacelike edges (within a

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -6,6 +6,7 @@
 #include "mesh/Edge.h"
 #include "mesh/Vertex.h"
 #include "mesh/EdgeList.h"
+#include "mesh/VertexList.h"
 #include "mesh/Fingerprint.h"
 
 #ifdef TESSERA_CUDA
@@ -20,6 +21,7 @@
 #include <numbers>
 #include <set>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 
 #include <Eigen/SparseCore>
@@ -145,6 +147,68 @@ std::complex<double> ReggeSolver::dualReggeAction() const {
     std::complex<double> S(0.0, 0.0);
     for (const auto &h : collectHinges()) {
         S += h->dualVolume() * h->lorentzianDeficitAngle();
+    }
+    return S;
+}
+
+std::vector<std::vector<std::uint64_t>> ReggeSolver::hingeFacesOfCells(
+    const std::vector<std::vector<std::uint64_t>> &cells) const {
+    // A hinge is a (d-2)-simplex = (d-1) vertices. Its dual-action contribution
+    // can change only when a move adds/removes a top coface around it, i.e. only
+    // for hinges that are faces of a touched top cell — so the affected set is the
+    // dedup'd (d-1)-element sub-tuples of the touched cells. Pure topology.
+    const int d = spacetime_->getMetric()->getSignature()->getDimensions();
+    const auto hingeSize = static_cast<std::size_t>(d - 1);
+    std::set<std::vector<std::uint64_t>> seen;
+    for (const auto &cell : cells) {
+        std::vector<std::uint64_t> cs(cell.begin(), cell.end());
+        std::sort(cs.begin(), cs.end());
+        cs.erase(std::unique(cs.begin(), cs.end()), cs.end());
+        if (cs.size() < hingeSize) continue;
+        // Every hingeSize-element combination of cs (sorted ⇒ combinations stay
+        // sorted), via a descending-prefix selection mask.
+        std::vector<bool> mask(cs.size(), false);
+        std::fill(mask.begin(), mask.begin() + static_cast<std::ptrdiff_t>(hingeSize),
+                  true);
+        do {
+            std::vector<std::uint64_t> hinge;
+            hinge.reserve(hingeSize);
+            for (std::size_t i = 0; i < cs.size(); ++i)
+                if (mask[i]) hinge.push_back(cs[i]);
+            seen.insert(std::move(hinge));
+        } while (std::prev_permutation(mask.begin(), mask.end()));
+    }
+    return {seen.begin(), seen.end()};
+}
+
+std::complex<double> ReggeSolver::dualReggeActionOverHinges(
+    const std::vector<std::vector<std::uint64_t>> &hinges) const {
+    // The localized dual Regge action over a FIXED hinge set, term-for-term equal
+    // to dualReggeAction's summand: |★h|·ε_h for each genuine hinge (registered,
+    // with a top coface), 0 for orphans. Resolve tuples by vertex id.
+    std::unordered_map<std::uint64_t, VertexPtr> vidx;
+    for (const auto &v : spacetime_->getVertexList()->toVector())
+        if (v != nullptr) vidx.emplace(v->getId(), v);
+
+    std::complex<double> S(0.0, 0.0);
+    std::set<std::vector<std::uint64_t>> done;  // dedup (caller sets may overlap)
+    for (const auto &h : hinges) {
+        std::vector<std::uint64_t> key(h.begin(), h.end());
+        std::sort(key.begin(), key.end());
+        key.erase(std::unique(key.begin(), key.end()), key.end());
+        if (!done.insert(key).second) continue;
+        VertexPtrs vp;
+        vp.reserve(key.size());
+        bool ok = true;
+        for (const std::uint64_t id : key) {
+            const auto it = vidx.find(id);
+            if (it == vidx.end()) { ok = false; break; }
+            vp.push_back(it->second);
+        }
+        if (!ok) continue;
+        const auto s = spacetime_->findSimplexByVerts(vp);
+        if (s == nullptr || !s->hasTopCoface()) continue;
+        S += s->dualVolume() * s->lorentzianDeficitAngle();
     }
     return S;
 }

--- a/tests/cobordism/test_delta_f_end_to_end_python.py
+++ b/tests/cobordism/test_delta_f_end_to_end_python.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""End-to-end incremental ΔF = Δ‖∇S_Regge‖² + Γ·Δr_U across the move classes (#461).
+
+The Emergent Color Topology optimizer's objective is `F = ‖∇S_Regge‖² + Γ·r_U`
+(extremize the action, δS=0). The incremental `ΔF` must reproduce a full `F`
+recompute to ~machine precision while touching only the moved region for the
+geometry term:
+
+  * **Stage-2 edge-length perturbation** on the **k=2** b₂ register: the full
+    assembly `ΔF = Δ‖∇S‖²(local) + Γ·Δr_U(recompute)` equals the full `F` delta.
+  * **Stage-1 surgical cone-out** (a topology change): the local `Δ‖∇S‖²` equals the
+    full `‖∇S‖²` delta even as cells are removed; and the surgery shifts the `b₂`
+    register dimension, with `r_U` exactly recomputable on the new complex.
+
+The geometry term is hinge-local and exact; `r_U` is a global spectral quantity, so
+its exact delta is a before/after `residualForPeriods` recompute.
+"""
+import cmath
+import math
+import unittest
+
+import tessera as T
+
+cob = T.cobordism
+
+_W = cmath.exp(2j * math.pi / 3)
+_GAMMA = 1.0
+_TOL = 1e-11
+
+
+def _grad_norm2(st):
+    rs = T.ReggeSolver(st, T.MatterConfiguration())
+    return sum(abs(z) ** 2 for z in rs.actionGradientExact())
+
+
+def _tops(st):
+    return {tuple(sorted(v.getId() for v in c.getVertices()))
+            for c in st.getTopSimplices()}
+
+
+def _holed_s3():
+    surf = cob.S3WindowSurface.build(1, 1)
+    faces = [list(t) for t in surf.faces]
+    windows = [[list(h) for h in w] for w in surf.windows]
+    hs = {tuple(sorted(h)) for w in windows for h in w}
+    holed = [t for t in faces if tuple(sorted(t)) not in hs]
+    st = T.Spacetime.fromCells(3, [list(t) for t in holed], 1.0, 0.0)
+    for i, e in enumerate(st.getEdgeList().toVector()):
+        e.setSquaredLength(1.0 + 0.01 * (i % 7))
+    return st, windows
+
+
+def _cdt4(n=160):
+    sig = T.Signature(4, T.Lorentzian)
+    st = T.Spacetime(T.Metric(True, sig), T.CDT, 1.0, 1.0, T.PREFERRED, T.Toroid())
+    st.build(n)
+    for i, e in enumerate(st.getEdgeList().toVector()):
+        e.setSquaredLength(1.0 + 0.011 * (i % 5))
+    return st
+
+
+def _sphere3():
+    sig = T.Signature(3, T.Lorentzian)
+    st = T.Spacetime(T.Metric(True, sig), T.CDT, 1.0, 1.0, T.PREFERRED,
+                     T.SimplexBoundarySphere(3))
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+    return st
+
+
+def _verts(st):
+    return {v.getId() for v in st.getVertexList().toVector() if v is not None}
+
+
+def _edges(st):
+    return {(min(e.getSource().getId(), e.getTarget().getId()),
+             max(e.getSource().getId(), e.getTarget().getId()))
+            for e in st.getEdgeList().toVector()}
+
+
+def _refined_s3(n_refine=12):
+    # A refined S^3 (Betti [1,0,0,1]) with enough tetrahedra that a disjoint top-cell
+    # pair exists — the minimal S^3 has none (every facet pair shares a ridge).
+    sig = T.Signature(3, T.Lorentzian)
+    st = T.Spacetime(T.Metric(True, sig), T.CDT, 1.0, 1.0, T.PREFERRED,
+                     T.SimplexBoundarySphere(3))
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+    for seed in range(n_refine):
+        mv = T.AddMove(st, seed, False, T.PachnerMode.PreGeometric, False)
+        if mv.propose():
+            mv.apply()
+    for i, e in enumerate(st.getEdgeList().toVector()):
+        e.setSquaredLength(1.0 + 0.01 * (i % 6))
+    return st
+
+
+class DeltaFEndToEndTest(unittest.TestCase):
+    def test_delta_F_edge_perturbation_on_k2_register(self):
+        # ΔF = Δ‖∇S‖²(local) + Γ·Δr_U(recompute) == full F delta, on the b₂ register.
+        st, windows = _holed_s3()
+        es = cob.EigenstateSynthesis(st, 2)
+        holes = [list(h) for h in windows[0]]
+        target = [complex(x) + 0.21 for x in [1.0, _W, _W * _W]]  # non-carriable
+        rs = T.ReggeSolver(st, T.MatterConfiguration())
+
+        def full_F():
+            return _grad_norm2(st) + _GAMMA * es.residualForPeriods(holes, target)
+
+        e = st.getEdgeList().toVector()[5]
+        ev = {e.getSource().getId(), e.getTarget().getId()}
+        aff = [list(c) for c in _tops(st) if ev.issubset(set(c))]
+        E = rs.affectedEdgesOfCells(aff)
+
+        before_F = full_F()
+        before_gn = rs.gradientNorm2OverEdges(E)
+        before_ru = es.residualForPeriods(holes, target)
+        orig = e.getSquaredLength()
+        e.setSquaredLength(orig * 1.06)
+        after_F = full_F()
+        after_gn = rs.gradientNorm2OverEdges(E)
+        after_ru = es.residualForPeriods(holes, target)
+        e.setSquaredLength(orig)
+
+        d_full = after_F - before_F
+        d_incr = (after_gn - before_gn) + _GAMMA * (after_ru - before_ru)
+        self.assertGreater(before_ru, 1.0)          # the register actually scores
+        self.assertLess(abs(d_full - d_incr), 1e-12)
+
+    def test_delta_gradnorm_across_surgical_coneout_with_multiplicities(self):
+        # Stage-1 topology change on a CDT (high edge multiplicity): cone-out
+        # DECREMENTS shared-edge multiplicity rather than deleting the edge, and the
+        # local Δ‖∇S‖² (which captures the decremented edges as part of the removed
+        # cell's neighborhood) equals the full Δ.
+        st = _cdt4()
+        rs = T.ReggeSolver(st, T.MatterConfiguration())
+        tops_before = _tops(st)
+
+        # the complex genuinely has edge multiplicity: edges shared by >2 top cells
+        from collections import Counter
+        share = Counter()
+        for c in tops_before:
+            for i in range(len(c)):
+                for j in range(i + 1, len(c)):
+                    share[(c[i], c[j])] += 1
+        self.assertTrue(any(n > 2 for n in share.values()),
+                        "fixture lacks edge multiplicity")
+        before_full = _grad_norm2(st)
+
+        sc = cob.SurgicalCone(st)
+        coned = None
+        for c in list(tops_before):
+            ok, _reason = sc.coneOut(list(c))
+            if ok:
+                coned = c
+                break
+        if coned is None:
+            self.skipTest("no surgical cone-out accepted on this build")
+
+        # the decrement path ran: most of the coned cell's edges are still covered by
+        # surviving cells, so they survive (were decremented, not removed).
+        edges_after = {(min(e.getSource().getId(), e.getTarget().getId()),
+                        max(e.getSource().getId(), e.getTarget().getId()))
+                       for e in st.getEdgeList().toVector()}
+        cell_edges = [(coned[i], coned[j])
+                      for i in range(len(coned)) for j in range(i + 1, len(coned))]
+        survived = [e for e in cell_edges if e in edges_after]
+        self.assertTrue(len(survived) > 0,
+                        "cone-out removed every edge — decrement path not exercised")
+
+        affected = [list(x) for x in (tops_before ^ _tops(st))]
+        st0 = _cdt4()  # fresh identical before-complex (no reliance on rollback)
+        rs0 = T.ReggeSolver(st0, T.MatterConfiguration())
+        E = sorted(set(map(tuple, rs0.affectedEdgesOfCells(affected)))
+                   | set(map(tuple, rs.affectedEdgesOfCells(affected))))
+        self.assertTrue(E)
+        d_full = _grad_norm2(st) - before_full
+        d_loc = rs.gradientNorm2OverEdges(E) - rs0.gradientNorm2OverEdges(E)
+        self.assertLess(abs(d_full - d_loc), 1e-9)
+
+    def test_surgery_shifts_register_and_ru_recomputes(self):
+        # A disjoint PAIR of cone-outs opens a b₂ hole (the register dimension shifts);
+        # r_U is exactly recomputable on the post-surgery complex, and its arbitrary-k
+        # analytic gradient stays exact there (the Euler identity Σℓ²∂r_U = −r_U).
+        st = _refined_s3()
+        cells = sorted(_tops(st))
+        pair = None
+        for i, a in enumerate(cells):
+            for b in cells[i + 1:]:
+                if set(a).isdisjoint(b):
+                    pair = (a, b)
+                    break
+            if pair:
+                break
+        self.assertIsNotNone(pair, "refined S^3 must contain a disjoint cell pair")
+        a, b = pair
+
+        b2_before = list(cob.ChainComplex.fromSpacetime(st).bettiNumbers())[2]
+        sc = cob.SurgicalCone(st)
+        self.assertTrue(sc.coneOut(list(a))[0])   # opens the manifold (b₃ → 0)
+        self.assertTrue(sc.coneOut(list(b))[0])   # disjoint ⇒ raises b₂ by 1
+        b2_after = list(cob.ChainComplex.fromSpacetime(st).bettiNumbers())[2]
+        self.assertEqual(b2_after, b2_before + 1, "surgery did not shift the register")
+
+        # r_U over BOTH emergent holes (2 holes, 1 harmonic mode ⇒ over-constrained,
+        # so r_U > 0) is exactly evaluable, and its analytic gradient is exact.
+        es = cob.EigenstateSynthesis(st, 2)
+        holes = [list(a), list(b)]
+        target = [complex(1.0), complex(0.3)]
+        r_u = es.residualForPeriods(holes, target)
+        self.assertGreater(r_u, 1.0)
+        g = es.residualForPeriodsGradient(holes, target)
+        l2 = {tuple(sorted((e.getSource().getId(), e.getTarget().getId()))):
+              e.getSquaredLength().real for e in st.getEdgeList().toVector()}
+        edges = [tuple(sorted(c)) for c in
+                 cob.ChainComplex.fromSpacetime(st).kSimplexVertices(1)]
+        euler = sum(l2[edges[i]] * g[i] for i in range(len(edges)))
+        self.assertLess(abs(euler + r_u) / r_u, 1e-11,
+                        "Σℓ²∂r_U = −r_U failed on the post-surgery complex")
+
+
+class ConeInverseTest(unittest.TestCase):
+    """Cone-out is the EXACT inverse of cone-in: it removes only the k apex
+    ("out") edges of the created top cell (the orphans), never the covered base
+    edges — so cone-in followed by cone-out restores the structure bit-for-bit."""
+
+    def test_cone_out_is_exact_inverse_of_cone_in(self):
+        st = _sphere3()
+        sc = cob.SurgicalCone(st)
+        # open a boundary so a cone-in onto a boundary triangle is admissible
+        self.assertTrue(sc.coneOut([0, 1, 2, 3])[0])
+        tops0, edges0, verts0 = _tops(st), _edges(st), _verts(st)
+
+        # cone-in on the boundary triangle {0,1,2} → a fresh apex + the new cell
+        self.assertTrue(sc.coneIn([0, 1, 2])[0])
+        apex = (_verts(st) - verts0).pop()                  # the one fresh vertex
+        added_edges = _edges(st) - edges0
+        # exactly the k = d apex ("out") edges were added (apex→0, apex→1, apex→2)
+        self.assertEqual(added_edges, {(min(apex, b), max(apex, b)) for b in (0, 1, 2)})
+        created = sorted([apex, 0, 1, 2])
+
+        # the explicit inverse move (NOT rollback): cone the created cell out
+        self.assertTrue(sc.coneOut(created)[0])
+
+        # structure restored bit-for-bit: only the k apex edges + apex went away,
+        # the covered base edges {0,1},{0,2},{1,2} survived.
+        self.assertEqual(_tops(st), tops0, "cone-out is not the inverse of cone-in")
+        self.assertEqual(_edges(st), edges0, "cone-out removed a covered base edge")
+        self.assertEqual(_verts(st), verts0, "cone-out left/removed a stray vertex")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_incremental_delta_f.py
+++ b/tests/cobordism/test_incremental_delta_f.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Incremental, hinge-local ΔS_Regge accounting (#461, T4).
+
+The Emergent Color Topology optimizer (#457) evaluates a candidate objective for
+every move, every step; a full recompute is the #418 cost spike. The geometry term
+of `F` is `‖∇S_Regge‖²` (extremize the action, δS=0), built hinge-locally from the
+dual (Sorkin) Regge action `S = Σ_h |★h|·ε_h`. This module pins the foundational
+accounting: the localized dual action over a FIXED affected-hinge set, evaluated
+across a move, reproduces the full `dualReggeAction` delta to machine precision —
+for an edge-length perturbation and for a Pachner move alike.
+
+`ReggeSolver.hingeFacesOfCells` builds the affected-hinge set (the (d-2)-faces of a
+move's touched cells); `ReggeSolver.dualReggeActionOverHinges` sums `|★h|·ε_h` over
+exactly those genuine hinges, term-for-term identical to `dualReggeAction`.
+"""
+import unittest
+
+import tessera as T
+
+_TOL = 1e-12
+
+
+def _sphere4(jitter=True):
+    """A minimal triangulated S⁴ (boundary of a 5-simplex), unit spacelike, lightly
+    jittered so the dual Regge action is nontrivial."""
+    sig = T.Signature(4, T.Lorentzian)
+    st = T.Spacetime(T.Metric(True, sig), T.CDT, 1.0, 1.0, T.PREFERRED,
+                     T.SimplexBoundarySphere(4))
+    st.build()
+    for i, e in enumerate(st.getEdgeList().toVector()):
+        e.setSquaredLength(1.0 + (0.013 * (i % 5) if jitter else 0.0))
+    return st
+
+
+def _tops(st):
+    return {tuple(sorted(v.getId() for v in s.getVertices()))
+            for s in st.getTopSimplices()}
+
+
+class IncrementalDeltaSReggeTest(unittest.TestCase):
+    def test_over_all_hinges_equals_full_action(self):
+        # The localized action over the full hinge set IS the full action: same
+        # per-term measure (circumcentric dualVolume), genuine-only.
+        st = _sphere4()
+        rs = T.ReggeSolver(st, T.MatterConfiguration())
+        tops = [list(c) for c in _tops(st)]
+        full = rs.dualReggeAction()
+        over_all = rs.dualReggeActionOverHinges(rs.hingeFacesOfCells(tops))
+        self.assertLess(abs(full - over_all), _TOL)
+        # the action is genuinely complex (Lorentzian/Sorkin) on this build
+        self.assertGreater(abs(full), 1e-6)
+
+    def test_delta_under_edge_perturbation_is_exact(self):
+        # ΔS over the FIXED affected-hinge set == full Δ, to machine precision.
+        st = _sphere4()
+        rs = T.ReggeSolver(st, T.MatterConfiguration())
+        e = st.getEdgeList().toVector()[3]
+        ev = {e.getSource().getId(), e.getTarget().getId()}
+        aff = [list(c) for c in _tops(st) if ev.issubset(set(c))]
+        hinges = rs.hingeFacesOfCells(aff)
+        self.assertTrue(hinges)
+
+        before_full = rs.dualReggeAction()
+        before_loc = rs.dualReggeActionOverHinges(hinges)
+        orig = e.getSquaredLength()
+        e.setSquaredLength(orig * 1.07)
+        after_full = rs.dualReggeAction()
+        after_loc = rs.dualReggeActionOverHinges(hinges)
+        e.setSquaredLength(orig)
+
+        self.assertLess(abs((after_full - before_full) - (after_loc - before_loc)),
+                        _TOL)
+
+    def test_delta_under_pachner_move_is_exact(self):
+        # Across a combinatorial Pachner move (a PreGeometric 1→(d+1) stellar cone-in),
+        # the affected region = the symmetric difference of the top-cell set; ΔS over
+        # its hinges == full Δ exactly. Two *fresh* deterministic complexes give the
+        # before/after states, so the accounting check never leans on rollback fidelity
+        # (the move's invertibility is #458's concern, not T4's).
+        st_before = _sphere4()
+        rs_before = T.ReggeSolver(st_before, T.MatterConfiguration())
+
+        st_after = _sphere4()                       # identical fresh copy
+        rs_after = T.ReggeSolver(st_after, T.MatterConfiguration())
+        mv = T.AddMove(st_after, 5, False, T.PachnerMode.PreGeometric, False)
+        self.assertTrue(mv.propose(), "stellar cone-in did not propose")
+        self.assertTrue(mv.apply())
+
+        affected = [list(c) for c in (_tops(st_before) ^ _tops(st_after))]
+        self.assertTrue(affected, "a Pachner move must change the top-cell set")
+        # pure topology ⇒ the same hinge tuples resolve on either complex (absent
+        # tuples — e.g. ones using the fresh apex vertex — contribute 0 on `before`).
+        hinges = rs_after.hingeFacesOfCells(affected)
+
+        d_full = rs_after.dualReggeAction() - rs_before.dualReggeAction()
+        d_loc = (rs_after.dualReggeActionOverHinges(hinges)
+                 - rs_before.dualReggeActionOverHinges(hinges))
+        self.assertLess(abs(d_full - d_loc), _TOL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_incremental_delta_f.py
+++ b/tests/cobordism/test_incremental_delta_f.py
@@ -99,5 +99,98 @@ class IncrementalDeltaSReggeTest(unittest.TestCase):
         self.assertLess(abs(d_full - d_loc), _TOL)
 
 
+def _cdt_toroid(n_simplices=200):
+    """A built 4D Lorentzian CDT toroid — a genuinely large complex (Im S ≠ 0),
+    where the hinge-local update touches far fewer than all edges."""
+    sig = T.Signature(4, T.Lorentzian)
+    st = T.Spacetime(T.Metric(True, sig), T.CDT, 1.0, 1.0, T.PREFERRED, T.Toroid())
+    st.build(n_simplices)
+    return st
+
+
+def _grad_norm2(rs):
+    """‖∇S_Regge‖² = Σ_e |∂S/∂ℓ²_e|² from the exact analytic gradient."""
+    return sum(abs(z) ** 2 for z in rs.actionGradientExact())
+
+
+class GradientNormObjectiveTest(unittest.TestCase):
+    """The geometry term of `F = ‖∇S_Regge‖² + Γ·r_U` (extremize, δS=0), localized."""
+
+    def test_over_all_edges_equals_action_gradient_exact(self):
+        # The localized gradient norm over the full edge set IS ‖∇S_Regge‖².
+        st = _sphere4()
+        rs = T.ReggeSolver(st, T.MatterConfiguration())
+        all_edges = [(e.getSource().getId(), e.getTarget().getId())
+                     for e in st.getEdgeList().toVector()]
+        self.assertLess(abs(rs.gradientNorm2OverEdges(all_edges) - _grad_norm2(rs)),
+                        _TOL)
+
+    def test_delta_under_edge_perturbation_is_exact(self):
+        # Δ‖∇S_Regge‖² over the FIXED affected-edge set == full Δ, machine precision.
+        st = _sphere4()
+        rs = T.ReggeSolver(st, T.MatterConfiguration())
+        e = st.getEdgeList().toVector()[3]
+        ev = {e.getSource().getId(), e.getTarget().getId()}
+        aff = [list(c) for c in _tops(st) if ev.issubset(set(c))]
+        E = rs.affectedEdgesOfCells(aff)
+        self.assertTrue(E)
+
+        before_full, before_loc = _grad_norm2(rs), rs.gradientNorm2OverEdges(E)
+        orig = e.getSquaredLength()
+        e.setSquaredLength(orig * 1.07)
+        after_full, after_loc = _grad_norm2(rs), rs.gradientNorm2OverEdges(E)
+        e.setSquaredLength(orig)
+
+        self.assertLess(abs((after_full - before_full) - (after_loc - before_loc)),
+                        _TOL)
+
+    def test_delta_under_pachner_move_is_exact(self):
+        # Across a PreGeometric stellar cone-in, Δ‖∇S_Regge‖² over the affected-edge
+        # set (union of the before/after evaluations, fixed across the move) == full Δ.
+        st_before = _sphere4()
+        rs_before = T.ReggeSolver(st_before, T.MatterConfiguration())
+        st_after = _sphere4()
+        rs_after = T.ReggeSolver(st_after, T.MatterConfiguration())
+        mv = T.AddMove(st_after, 5, False, T.PachnerMode.PreGeometric, False)
+        self.assertTrue(mv.propose() and mv.apply())
+
+        affected = [list(c) for c in (_tops(st_before) ^ _tops(st_after))]
+        # cells are added/removed ⇒ union the affected-edge set on both complexes
+        E = sorted(set(map(tuple, rs_before.affectedEdgesOfCells(affected)))
+                   | set(map(tuple, rs_after.affectedEdgesOfCells(affected))))
+        self.assertTrue(E)
+
+        d_full = _grad_norm2(rs_after) - _grad_norm2(rs_before)
+        d_loc = (rs_after.gradientNorm2OverEdges(E)
+                 - rs_before.gradientNorm2OverEdges(E))
+        self.assertLess(abs(d_full - d_loc), _TOL)
+
+
+class LocalityTest(unittest.TestCase):
+    """On a large complex the update is genuinely local — it touches far fewer than
+    all edges — while staying exact. This is the whole point of T4 (the #418 cost)."""
+
+    def test_edge_perturbation_is_local_and_exact(self):
+        st = _cdt_toroid()
+        rs = T.ReggeSolver(st, T.MatterConfiguration())
+        edges = st.getEdgeList().toVector()
+        n_total = len(edges)
+        e = edges[n_total // 2]
+        ev = {e.getSource().getId(), e.getTarget().getId()}
+        aff = [list(c) for c in _tops(st) if ev.issubset(set(c))]
+        E = rs.affectedEdgesOfCells(aff)
+
+        # genuinely local: the perturbed edge touches a small neighborhood
+        self.assertLess(len(E), n_total // 2, "update is not local on a large mesh")
+
+        before_full, before_loc = _grad_norm2(rs), rs.gradientNorm2OverEdges(E)
+        orig = e.getSquaredLength()
+        e.setSquaredLength(orig * 1.05)
+        after_full, after_loc = _grad_norm2(rs), rs.gradientNorm2OverEdges(E)
+        e.setSquaredLength(orig)
+        self.assertLess(abs((after_full - before_full) - (after_loc - before_loc)),
+                        1e-9)  # larger complex ⇒ looser abs tol, still ~machine
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cobordism/test_laplacian_gradient_python.py
+++ b/tests/cobordism/test_laplacian_gradient_python.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Exact analytic gradient of the symmetric metric Hodge Laplacian (#461).
+
+`HodgeLaplacian.laplacianGradient(k, a, b)` is `∂L_k^sym/∂ℓ²_e` at arbitrary degree
+— the keystone (with `Simplex.volumeGradient`) for the arbitrary-k `r_U` analytic
+gradient. The rigorous check is the **exact Euler homogeneity identity**: `L_k^sym`
+is homogeneous of degree `−½` in `ℓ²` (each weight `W_j = |vol|` scales as
+`(ℓ²)^{j/2}`, and the `B_k` exponents sum to `−¼`), so
+
+    Σ_e ℓ²_e · ∂L_k/∂ℓ²_e  =  −½ · L_k     (exactly).
+
+This is independent of finite difference (which is roundoff-limited and does not
+converge — the optimizer uses the analytic gradient, never FD).
+"""
+import math
+import unittest
+
+import numpy as np
+
+import tessera as T
+
+cob = T.cobordism
+
+
+def _holed_s3():
+    surf = cob.S3WindowSurface.build(1, 1)
+    faces = [list(t) for t in surf.faces]
+    windows = [[list(h) for h in w] for w in surf.windows]
+    hs = {tuple(sorted(h)) for w in windows for h in w}
+    holed = [t for t in faces if tuple(sorted(t)) not in hs]
+    st = T.Spacetime.fromCells(3, [list(t) for t in holed], 1.0, 0.0)
+    for i, e in enumerate(st.getEdgeList().toVector()):
+        e.setSquaredLength(1.0 + 0.013 * (i % 6))
+    return st
+
+
+def _Lmat(hl, k):
+    L = np.asarray(hl.laplacian(k, True), complex)
+    n = int(round(math.sqrt(L.size)))
+    return L.reshape(n, n).real
+
+
+class LaplacianGradientHandCalcTest(unittest.TestCase):
+    def test_euler_homogeneity_identity(self):
+        # Σ_e ℓ²_e ∂L_k/∂ℓ²_e = −½ L_k, exactly, at every register degree.
+        st = _holed_s3()
+        hl = cob.HodgeLaplacian(st)
+        for k in (1, 2):
+            L = _Lmat(hl, k)
+            n = L.shape[0]
+            self.assertGreater(n, 0)
+            acc = np.zeros((n, n))
+            for e in st.getEdgeList().toVector():
+                a, b = e.getSource().getId(), e.getTarget().getId()
+                g = np.asarray(hl.laplacianGradient(k, a, b), float).reshape(n, n)
+                acc += e.getSquaredLength().real * g
+            self.assertLess(np.max(np.abs(acc + 0.5 * L)), 1e-12,
+                            f"Euler identity Σℓ²∂L = −½L failed at k={k}")
+
+    def test_symmetric_and_empty_below_k1(self):
+        st = _holed_s3()
+        hl = cob.HodgeLaplacian(st)
+        # ∂L_k inherits L_k's symmetry
+        n = _Lmat(hl, 2).shape[0]
+        e = st.getEdgeList().toVector()[0]
+        g = np.asarray(hl.laplacianGradient(2, e.getSource().getId(),
+                                            e.getTarget().getId()), float).reshape(n, n)
+        self.assertLess(np.max(np.abs(g - g.T)), 1e-12)
+        # k < 1 has no metric Laplacian gradient
+        self.assertEqual(hl.laplacianGradient(0, e.getSource().getId(),
+                                              e.getTarget().getId()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_ru_gradient_arbitrary_k_python.py
+++ b/tests/cobordism/test_ru_gradient_arbitrary_k_python.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Arbitrary-degree analytic r_U gradient (#461, c).
+
+`EigenstateSynthesis.periodGradientGeneral` is the degree-generic `∂r_U/∂ℓ²` of
+`residualForPeriods` — the generalization of the k=1-only `residualForPeriodsGradient`
+to the b₂ register (k=2) and beyond. It uses `M = L_k` and the exact per-edge
+`∂L_k/∂ℓ²` (`HodgeLaplacian.laplacianGradient`, built on `Simplex.volumeGradient`)
+through the same eigenvector-perturbation derivation, with the period covector read
+from each removed-(k+1)-cell hole's facet boundary.
+
+The rigorous checks (finite difference does not converge — the optimizer uses the
+analytic gradient):
+  * **k=1 equivalence** — it reproduces the established `residualForPeriodsGradient`
+    on triangle holes to machine precision.
+  * **exact Euler identity** — `r_U` is homogeneous of degree −1 in ℓ² (the carried
+    representative is scale-invariant, `M` is degree −½), so
+    `Σ_e ℓ²_e · ∂r_U/∂ℓ²_e = −r_U` at every register degree.
+"""
+import cmath
+import importlib.util
+import math
+import os
+import sys
+import unittest
+
+import numpy as np
+
+import tessera as T
+
+cob = T.cobordism
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+
+
+def _edge_l2(st):
+    return {tuple(sorted((e.getSource().getId(), e.getTarget().getId()))):
+            e.getSquaredLength().real for e in st.getEdgeList().toVector()}
+
+
+def _edges_1cell(st):
+    cc = cob.ChainComplex.fromSpacetime(st)
+    return [tuple(sorted(c)) for c in cc.kSimplexVertices(1)]
+
+
+def _euler_lhs(st, grad):
+    l2 = _edge_l2(st)
+    edges = _edges_1cell(st)
+    return sum(l2[edges[i]] * grad[i] for i in range(len(edges)))
+
+
+class ArbitraryKRuGradientTest(unittest.TestCase):
+    def test_k1_equivalence_and_euler(self):
+        # k=1 (triangle holes): the general path reproduces residualForPeriodsGradient,
+        # and satisfies the exact Euler identity. Uses the MergeCobordism substrate.
+        sys.path.insert(0, os.path.join(_EX, "deep_merge_baseline"))
+        sys.path.insert(0, _EX)
+        try:
+            spec = importlib.util.spec_from_file_location(
+                "merge_cobordism", os.path.join(_EX, "merge_cobordism.py"))
+            mc = importlib.util.module_from_spec(spec)
+            sys.modules["merge_cobordism"] = mc
+            spec.loader.exec_module(mc)
+        except Exception as exc:  # pragma: no cover
+            self.skipTest(f"merge_cobordism substrate unavailable: {exc}")
+
+        m = mc.MergeCobordism()
+        st, es = m.st, m.es
+        holes = [list(t) for t in m.hole_circles]
+        periods = np.asarray(es.cyclePeriods(holes), complex).reshape(m.dim, len(holes))
+        target = [complex(z) + 0.137 for z in periods[0]]  # perturbed ⇒ r_U > 0
+
+        g_old = np.asarray(es.residualForPeriodsGradient(holes, target), float)
+        g_new = np.asarray(es.periodGradientGeneral(holes, target), float)
+        self.assertLess(np.linalg.norm(g_new - g_old) / np.linalg.norm(g_old), 1e-10,
+                        "general path disagrees with residualForPeriodsGradient at k=1")
+
+        r_u = es.residualForPeriods(holes, target)
+        self.assertLess(abs(_euler_lhs(st, g_new) + r_u), 1e-9,
+                        "Euler identity Σℓ²∂r_U = −r_U failed at k=1")
+
+    def test_k2_euler_on_b2_register(self):
+        # k=2 (tetrahedral holes, the b₂ color register): the exact Euler identity is
+        # the analytic correctness certificate where no prior gradient existed.
+        surf = cob.S3WindowSurface.build(1, 1)
+        faces = [list(t) for t in surf.faces]
+        windows = [[list(h) for h in w] for w in surf.windows]
+        hs = {tuple(sorted(h)) for w in windows for h in w}
+        holed = [t for t in faces if tuple(sorted(t)) not in hs]
+        st = T.Spacetime.fromCells(3, [list(t) for t in holed], 1.0, 0.0)
+        for i, e in enumerate(st.getEdgeList().toVector()):
+            e.setSquaredLength(1.0 + 0.013 * (i % 6))
+        es = cob.EigenstateSynthesis(st, 2)
+        holes = [list(h) for h in windows[0]]
+        w = cmath.exp(2j * math.pi / 3)
+        target = [complex(x) + 0.21 for x in [1.0, w, w * w]]  # non-carriable ⇒ r_U > 0
+
+        r_u = es.residualForPeriods(holes, target)
+        self.assertGreater(r_u, 1.0)
+        g = np.asarray(es.periodGradientGeneral(holes, target), float)
+        self.assertLess(abs(_euler_lhs(st, g) + r_u) / r_u, 1e-11,
+                        "Euler identity Σℓ²∂r_U = −r_U failed at k=2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_ru_gradient_arbitrary_k_python.py
+++ b/tests/cobordism/test_ru_gradient_arbitrary_k_python.py
@@ -2,20 +2,21 @@
 # All rights reserved.
 """Arbitrary-degree analytic r_U gradient (#461, c).
 
-`EigenstateSynthesis.periodGradientGeneral` is the degree-generic `∂r_U/∂ℓ²` of
-`residualForPeriods` — the generalization of the k=1-only `residualForPeriodsGradient`
-to the b₂ register (k=2) and beyond. It uses `M = L_k` and the exact per-edge
-`∂L_k/∂ℓ²` (`HodgeLaplacian.laplacianGradient`, built on `Simplex.volumeGradient`)
-through the same eigenvector-perturbation derivation, with the period covector read
-from each removed-(k+1)-cell hole's facet boundary.
+`EigenstateSynthesis.residualForPeriodsGradient` is the degree-generic `∂r_U/∂ℓ²` of
+`residualForPeriods` — it now works at the b₂ register (k=2) and beyond (it used to be
+k=1 only). It uses `M = L_k` and the exact per-edge `∂L_k/∂ℓ²`
+(`HodgeLaplacian.laplacianGradient`, built on `Simplex.volumeGradient`) through
+eigenvector-perturbation theory, with the period covector read from each
+removed-(k+1)-cell hole's facet boundary.
 
 The rigorous checks (finite difference does not converge — the optimizer uses the
 analytic gradient):
-  * **k=1 equivalence** — it reproduces the established `residualForPeriodsGradient`
-    on triangle holes to machine precision.
   * **exact Euler identity** — `r_U` is homogeneous of degree −1 in ℓ² (the carried
     representative is scale-invariant, `M` is degree −½), so
-    `Σ_e ℓ²_e · ∂r_U/∂ℓ²_e = −r_U` at every register degree.
+    `Σ_e ℓ²_e · ∂r_U/∂ℓ²_e = −r_U` at every register degree, k=1 and k=2.
+
+(The k=1 numerical equivalence with the established path is additionally guarded by
+`test_ru_gradient_gpu_python.py`, whose FP32 GPU oracle mirrors the prior CPU result.)
 """
 import cmath
 import importlib.util
@@ -50,9 +51,9 @@ def _euler_lhs(st, grad):
 
 
 class ArbitraryKRuGradientTest(unittest.TestCase):
-    def test_k1_equivalence_and_euler(self):
-        # k=1 (triangle holes): the general path reproduces residualForPeriodsGradient,
-        # and satisfies the exact Euler identity. Uses the MergeCobordism substrate.
+    def test_k1_euler_on_triangle_holes(self):
+        # k=1 (triangle holes): the arbitrary-k path satisfies the exact Euler
+        # identity. Uses the MergeCobordism substrate.
         sys.path.insert(0, os.path.join(_EX, "deep_merge_baseline"))
         sys.path.insert(0, _EX)
         try:
@@ -70,13 +71,9 @@ class ArbitraryKRuGradientTest(unittest.TestCase):
         periods = np.asarray(es.cyclePeriods(holes), complex).reshape(m.dim, len(holes))
         target = [complex(z) + 0.137 for z in periods[0]]  # perturbed ⇒ r_U > 0
 
-        g_old = np.asarray(es.residualForPeriodsGradient(holes, target), float)
-        g_new = np.asarray(es.periodGradientGeneral(holes, target), float)
-        self.assertLess(np.linalg.norm(g_new - g_old) / np.linalg.norm(g_old), 1e-10,
-                        "general path disagrees with residualForPeriodsGradient at k=1")
-
         r_u = es.residualForPeriods(holes, target)
-        self.assertLess(abs(_euler_lhs(st, g_new) + r_u), 1e-9,
+        g = np.asarray(es.residualForPeriodsGradient(holes, target), float)
+        self.assertLess(abs(_euler_lhs(st, g) + r_u), 1e-9,
                         "Euler identity Σℓ²∂r_U = −r_U failed at k=1")
 
     def test_k2_euler_on_b2_register(self):
@@ -97,7 +94,7 @@ class ArbitraryKRuGradientTest(unittest.TestCase):
 
         r_u = es.residualForPeriods(holes, target)
         self.assertGreater(r_u, 1.0)
-        g = np.asarray(es.periodGradientGeneral(holes, target), float)
+        g = np.asarray(es.residualForPeriodsGradient(holes, target), float)
         self.assertLess(abs(_euler_lhs(st, g) + r_u) / r_u, 1e-11,
                         "Euler identity Σℓ²∂r_U = −r_U failed at k=2")
 

--- a/tests/mesh/test_volume_gradient_python.py
+++ b/tests/mesh/test_volume_gradient_python.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Exact analytic gradient of a simplex's signed `volume()` w.r.t. edge ℓ² (#461).
+
+`Simplex.volumeGradient` is the per-degree **Hodge inner-product weight** gradient
+(the weights `W_k` are signed simplex volumes) — the keystone for an arbitrary-degree
+analytic `∂L_k/∂ℓ²`, hence the general-k `r_U` gradient. By Jacobi's formula on the
+Gram determinant, `∂V/∂ℓ²_e = (V/2)·tr(G⁻¹ ∂_e G)`, reusing the same
+`gramMatrix`/`cofactorMatrix` machinery as the circumcentric `dualVolumeGradient`
+(#354). Here it must match a central finite difference of `volume()` to ~machine
+precision across every degree (triangle, tetrahedron, pentatope).
+"""
+import unittest
+
+import tessera as T
+
+
+def _jittered_s4():
+    sig = T.Signature(4, T.Lorentzian)
+    st = T.Spacetime(T.Metric(True, sig), T.CDT, 1.0, 1.0, T.PREFERRED,
+                     T.SimplexBoundarySphere(4))
+    st.build()
+    for i, e in enumerate(st.getEdgeList().toVector()):
+        e.setSquaredLength(1.0 + 0.017 * (i % 5))
+    # materialize sub-simplices down to triangles
+    for s in list(st.getTopSimplices()):
+        for f in s.getFacets():
+            for g in f.getFacets():
+                g.getFacets()
+    return st
+
+
+def _key(a, b):
+    return (min(a, b), max(a, b))
+
+
+class VolumeGradientTest(unittest.TestCase):
+    def test_matches_finite_difference_every_degree(self):
+        st = _jittered_s4()
+        em = {_key(e.getSource().getId(), e.getTarget().getId()): e
+              for e in st.getEdgeList().toVector()}
+        by_size = {}
+        for s in st.getSimplices():
+            n = len([v for v in s.getVertices()])
+            by_size.setdefault(n, []).append(s)
+        # 3 = triangle (W_2), 4 = tetrahedron (W_3), 5 = pentatope (top)
+        self.assertTrue({3, 4, 5}.issubset(by_size.keys()))
+
+        h = 1e-6
+        for size in (3, 4, 5):
+            worst, tested = 0.0, 0
+            for s in by_size[size]:
+                for (a, b), ga in s.volumeGradient().items():
+                    e = em.get((a, b))
+                    if e is None:
+                        continue
+                    o = e.getSquaredLength()
+                    e.setSquaredLength(o + h)
+                    vp = s.volume()
+                    e.setSquaredLength(o - h)
+                    vm = s.volume()
+                    e.setSquaredLength(o)
+                    worst = max(worst, abs(ga - (vp - vm) / (2 * h)))
+                    tested += 1
+            self.assertGreater(tested, 0, f"no edge-derivatives tested at size {size}")
+            self.assertLess(worst, 1e-8, f"volumeGradient inexact at size {size}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mesh/test_volume_gradient_python.py
+++ b/tests/mesh/test_volume_gradient_python.py
@@ -10,9 +10,21 @@ Gram determinant, `∂V/∂ℓ²_e = (V/2)·tr(G⁻¹ ∂_e G)`, reusing the sam
 (#354). Here it must match a central finite difference of `volume()` to ~machine
 precision across every degree (triangle, tetrahedron, pentatope).
 """
+import math
 import unittest
 
 import tessera as T
+
+
+def _top_of_dim(st, nverts):
+    return next(s for s in st.getSimplices()
+               if len([v for v in s.getVertices()]) == nverts)
+
+
+def _l2(st):
+    return {(min(e.getSource().getId(), e.getTarget().getId()),
+             max(e.getSource().getId(), e.getTarget().getId())):
+            e.getSquaredLength().real for e in st.getEdgeList().toVector()}
 
 
 def _jittered_s4():
@@ -32,6 +44,42 @@ def _jittered_s4():
 
 def _key(a, b):
     return (min(a, b), max(a, b))
+
+
+class VolumeGradientHandCalcTest(unittest.TestCase):
+    """Closed-form values and the exact Euler homogeneity identity — the rigorous
+    checks (finite difference is only a roundoff-limited cross-check; the optimizer
+    uses the analytic gradient, never FD)."""
+
+    def test_equilateral_triangle_closed_form(self):
+        # All ℓ²=1: A = √3/4, and ∂A/∂ℓ²_e = 1/(4√3) for every edge (by symmetry).
+        st = T.Spacetime.fromCells(2, [[0, 1, 2]], 1.0, 0.0)
+        tri = _top_of_dim(st, 3)
+        self.assertAlmostEqual(tri.volume(), math.sqrt(3) / 4, places=12)
+        for _e, dA in tri.volumeGradient().items():
+            self.assertAlmostEqual(dA, 1.0 / (4 * math.sqrt(3)), places=12)
+
+    def test_regular_tetrahedron_closed_form(self):
+        # All ℓ²=1: V = 1/(6√2), and ∂V/∂ℓ²_e = 1/(24√2) for every edge.
+        st = T.Spacetime.fromCells(3, [[0, 1, 2, 3]], 1.0, 0.0)
+        tet = _top_of_dim(st, 4)
+        self.assertAlmostEqual(tet.volume(), 1.0 / (6 * math.sqrt(2)), places=12)
+        for _e, dV in tet.volumeGradient().items():
+            self.assertAlmostEqual(dV, 1.0 / (24 * math.sqrt(2)), places=12)
+
+    def test_euler_homogeneity_identity(self):
+        # A j-simplex volume is homogeneous of degree j/2 in ℓ² ⇒
+        # Σ_e ℓ²_e ∂V/∂ℓ²_e = (j/2)·V exactly (independent of finite difference).
+        for nverts, cell in [(3, [0, 1, 2]), (4, [0, 1, 2, 3])]:
+            st = T.Spacetime.fromCells(nverts - 1, [cell], 1.0, 0.0)
+            # jitter so the identity is non-trivial (not just the symmetric point)
+            for i, e in enumerate(st.getEdgeList().toVector()):
+                e.setSquaredLength(1.0 + 0.07 * (i % 4))
+            s = _top_of_dim(st, nverts)
+            l2 = _l2(st)
+            j = nverts - 1
+            euler = sum(l2[e] * dV for e, dV in s.volumeGradient().items())
+            self.assertAlmostEqual(euler, (j / 2.0) * s.volume(), places=12)
 
 
 class VolumeGradientTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
Incremental, hinge-local `ΔF` for the Emergent Color Topology optimizer (#457, T4). A full recompute of the objective per candidate move is the #418 cost spike; this touches only the simplices/hinges a move changes. The **same** `F` and **same single** `r_U` govern both stages (Stage-1 Pachner + surgical cone-out/in; Stage-2 edge-length perturbation).

**Objective (owner correction, recorded across the epic):** the geometry term **extremizes** the action (drives `δS=0`) — it does **not** minimize the action magnitude. So

```
F = ‖∇S_Regge‖² + Γ·r_U        ΔF = Δ‖∇S_Regge‖² + Γ·Δr_U
```

`‖∇S_Regge‖² = Σ_e|∂S/∂ℓ²_e|²`, full-complex Lorentzian/Sorkin gradient — **keep Im** (complex modulus). `r_U` is the **single existing** residual (`residualForPeriods` at register degree `k=2`); flavor is **emergent**, no second register. The dual measure is pinned: the per-hinge term uses `Simplex::dualVolume()` (circumcentric `|*h|`).

Design note: `docs/design/incremental_delta_f.md`.

## Status / test plan
**Geometry half landed + verified (`tests/cobordism/test_incremental_delta_f.py`, 7 tests):**
- [x] Affected-hinge accounting (`hingeFacesOfCells` + `dualReggeActionOverHinges`): `ΔS_Regge = after − before` over a fixed hinge set matches the full `dualReggeAction` delta (Re and Im) — exact for an edge perturbation and a Pachner move.
- [x] `Δ‖∇S_Regge‖²` (`affectedEdgesOfCells` + `gradientNorm2OverEdges`): matches a full `‖∇S‖²` recompute across edge perturbation and Pachner move; `gradientNorm2OverEdges` over all edges == `Σ_e|actionGradientExact_e|²`; genuinely local (~23% of a 260-edge toroid).

**Remaining:**
- [ ] `Δr_U` at `k=2` (the change in the state residual), including across a topology change (where `b_k` shifts); validate vs a full `residualForPeriods` recompute.
- [ ] End-to-end `ΔF = Δ‖∇S_Regge‖² + Γ·Δr_U` across Pachner, surgical cone-out/in, and edge-length perturbation.
- [ ] `tests/cobordism/test_epic410_invariants.py` stays green; findings report `docs/design/incremental_delta_f_<hash>.md`.

Closes #461.
