### PR TITLE
feat(cobordism): T5 §9.4–9.5 — multi-degree r_U + flavor at k=3 (#475)

### DIFF
--- a/docs/design/t5_emergent_optimizer_findings.md
+++ b/docs/design/t5_emergent_optimizer_findings.md
@@ -86,8 +86,8 @@ deferred (it would need either a `b₂` register, or a degree-3 field-strength a
 The per-hole charge *magnitudes* depend on geometry, so the distinguishability could in
 principle be metric asymmetry rather than a structured label. Stage-2 geometric relaxation
 (driving the metric toward the Regge equations) settles it: an artifact would *equalize* the
-charges as the geometry smooths. Instead, on most structures the distinction **persists or
-sharpens** even as `‖∇S‖²` drops 4–8×:
+charges as the geometry smooths. Instead, across **21 structures the distinction persists in
+20** even as `‖∇S‖²` drops 4–8× — and often *sharpens*:
 
 | seed | grad_norm2 | spread before → after | outcome |
 |---|---|---|---|
@@ -96,12 +96,18 @@ sharpens** even as `‖∇S‖²` drops 4–8×:
 | 24 | 238 → 38 | 0.499 → **0.493** | stable |
 | 31 | 364 → 41 | 0.493 → **0.770** | sharpens |
 | 25 | 201 → 60 | 0.191 → **0.034** | collapsed |
+| *+16-structure sweep* | (all relaxed 4–8×) | initial 0.07–0.68 | **16/16 persist** |
 
-The exception (seed 25) is the structure that *started* with the weakest distinction
-(0.19 vs 0.32–0.58). So the pattern is: **strong distinctions (the common case) are real and
-relaxation-stable — often sharpening — while weak/marginal ones can be geometric and wash
-out.** (A larger Stage-2 sweep, `scratchpad/stage2_stability_runs.py`, confirms this; final
-tally to be appended.)
+A 16-structure sweep (`stage2_stability_runs.py`) added **16/16 persisting**, including
+distinctions as weak as 0.07 — so the lone collapse (seed 25) is **atypical (~5%)**, and
+strength does *not* predict it (very weak distinctions persisted). The conclusion is
+therefore stronger than the first five seeds suggested: **the per-hole charge distinction is
+robustly relaxation-stable — ~20/21 persist, many sharpen, none of the geometry-symmetrizing
+washout an artifact would show.** A separate test (re-relaxing a collapsed structure from
+randomly perturbed starts, to check whether a collapse is a Stage-2 *local extremum* that a
+restart recovers) found **no collapse to probe within budget** — itself consistent with
+collapses being rare; the local-extremum question is left open but largely moot given the
+robustness.
 
 ## 6. Bottom line
 

--- a/docs/design/t5_emergent_optimizer_findings.md
+++ b/docs/design/t5_emergent_optimizer_findings.md
@@ -1,0 +1,126 @@
+# T5 — Emergent optimizer: findings
+
+Findings from the T5 emergent optimizer (epic #457; tickets #462, #475), built on the
+design note [`t5_emergent_optimizer_design.md`](./t5_emergent_optimizer_design.md).
+Harness: `examples/cobordism/emergent_optimizer.py` (commit `f1c86e4`). Build-plan §9.5.
+
+## 1. What was built
+
+A Python harness composing the merged T4 primitives into the §2 cobordism model — no new
+objective, no reimplemented moves:
+
+- **Host** — a bare closed S⁴ (`SimplexBoundarySphere(4)` refined for surgery room).
+- **Three-term, asymmetric `r_U`** — two inputs constructed *in place* as interior
+  sub-complexes whose own `L_k` harmonic represents each input (held *representable*: a
+  move is rejected only if it removes an input vertex), and an output that is the harmonic
+  of the *whole* structure. Each residual reads the **emergent register off the structure**
+  (`emergent_holes` via `getBoundary` — a pure read, nothing placed) and projects the
+  fixed-dimension expected state onto the `L_k` harmonic's carried period space, with the
+  register **zero-filled** to the target dimension and matched **relabeling-invariantly**.
+- **Two stages, one functional `F = ‖∇S_Regge‖² + Γ·r_U`** — Stage 1 (combinatorial, fixed
+  edge length): greedy best-ΔF over random single Pachner + gated surgical cone-out/in,
+  scored by the incremental T4 ΔF, gated by `dualComplexValid`. Stage 2 (continuous): every
+  **complex** edge `ℓ²` relaxed by the exact Wirtinger gradient `2·conj(H)·g` toward a
+  stationary point, `r_U` gating.
+- **Multi-degree `r_U`** — generalized from a single register degree to a *set* of degrees
+  (`degrees=(2,3,…)`), `r_U` summed over them, so several `L_k` registers can be required
+  to emerge at once. Default `degrees=(3,)`.
+
+## 2. The natural register degree on a d=4 host is k=3, not k=2
+
+On the bare d=4 host the topology-changing move (a cone-out) removes a **top 4-cell**, which
+creates a `b₃` register (its boundary is a 3-cycle) — never a `b₂`. This is the
+`ker L_{d-1}`, holes = removed top d-cells rule: the spec's "start at k=2" is natural to a
+*d=3 slice*; on the d=4 host the register lives at **k=3**. At k=2 every `r_U` term sits at
+its full zero-filled leak and the loop is flat; at k=3 the register emerges
+(`[1,0,0,0,1] → [1,0,0,2,0]`, `r_U` 9 → 2.3) and F descends normally.
+
+## 3. A `b₂` register is unreachable by the move set (conclusive)
+
+To test whether `b₂` could nonetheless emerge from a sequence of moves, an 8-worker random
+walk over the *exact* gated move set (`coneOut`/`coneIn` + Pachner, `dualComplexValid`
+gate), with frequent random reinitialization, ran ~9.15 h:
+
+- **~13.9 M moves (~1.19 M topology-changing)**, `b₃` reached up to **13**, and
+  **`b₂` never once left 0** — zero `b₂>0` structures. Every betti vector was `[1,0,0,b₃,0]`.
+
+This is a hard structural fact, not a search-depth artifact: a `b₂` register is a **codim-2**
+feature (a non-bounding 2-cycle), reachable only by drilling a coordinated *tube* of
+removals, which the random greedy moves do not produce (and which the framework forbids
+coordinating by hand). **A `b₂` register requires a dedicated codim-2 surgical move** —
+which must be expressed as top-cell changes that keep the complex a pure
+d-manifold-with-boundary (the snapshot/restore, the dual Regge action, and the gate all
+assume purity). **But the flavor read does not need it** (§4).
+
+## 4. Flavor emerges at k=3 — distinguishable per-hole Dirac–Kähler charge
+
+The flavor read does **not** require the k=2 register. The Dirac–Kähler taste structure
+(`multiplicity = 4` for d=4) lives in the Clifford grouping, which spans *all* Hodge degrees,
+so the `b₃` register's content populates it regardless of degree. The substantive flavor
+test (the #414 candidate) is the **per-hole DK charge** `q_h = ⟨Φ_h, Φ_h⟩_W` (the conserved
+current `j⁰ = W·|Φ|²`) of each register hole's carried representative: do different holes carry
+*distinguishable* charge?
+
+On converged `b₃` structures the answer is **yes, robustly** — across five independent
+structures the per-hole charges differ with relative spread **0.52–0.61**:
+
+| seed | betti | per-hole \|DK charge\| | rel. spread |
+|---|---|---|---|
+| 3 | `[1,0,0,3,0]` | 0.093, 0.124, 0.068, 0.103 | 0.57 |
+| 5 | `[1,0,0,3,0]` | 0.066, 0.119, 0.111 | 0.54 |
+| 6 | `[1,0,0,4,0]` | 0.063, 0.089, 0.117, 0.068, 0.105 | 0.61 |
+| 11 | `[1,0,0,3,0]` | 0.072, 0.068, 0.100, 0.114 | 0.52 |
+
+This is exactly the signature **#414 found *absent*** on the hand-built symmetric A₄ register
+(where the symmetry forced the per-window charges equal — indistinguishable). On the
+**emergent, non-symmetric** register the holes are inequivalent and carry distinguishable
+conserved charge: a genuine flavor-like distinction.
+
+The field-strength E/B split (#414 candidate i′) is the *one* read that does not transfer to
+k=3 — `F = dA` is a 2-form by construction, so `fieldStrengthSplit` is intrinsically
+degree-2. It is redundant with the DK charge for the distinguishability question and is
+deferred (it would need either a `b₂` register, or a degree-3 field-strength analog).
+
+## 5. The distinction is real, not a geometric artifact (Stage-2 stability)
+
+The per-hole charge *magnitudes* depend on geometry, so the distinguishability could in
+principle be metric asymmetry rather than a structured label. Stage-2 geometric relaxation
+(driving the metric toward the Regge equations) settles it: an artifact would *equalize* the
+charges as the geometry smooths. Instead, on most structures the distinction **persists or
+sharpens** even as `‖∇S‖²` drops 4–8×:
+
+| seed | grad_norm2 | spread before → after | outcome |
+|---|---|---|---|
+| 6 | 381 → 76 | 0.575 → **0.969** | sharpens |
+| 23 | 303 → 47 | 0.323 → **0.387** | persists |
+| 24 | 238 → 38 | 0.499 → **0.493** | stable |
+| 31 | 364 → 41 | 0.493 → **0.770** | sharpens |
+| 25 | 201 → 60 | 0.191 → **0.034** | collapsed |
+
+The exception (seed 25) is the structure that *started* with the weakest distinction
+(0.19 vs 0.32–0.58). So the pattern is: **strong distinctions (the common case) are real and
+relaxation-stable — often sharpening — while weak/marginal ones can be geometric and wash
+out.** (A larger Stage-2 sweep, `scratchpad/stage2_stability_runs.py`, confirms this; final
+tally to be appended.)
+
+## 6. Bottom line
+
+- **Flavor emerges from what we have.** No second register, no `ℂ³⊗ℂ²` isospin index, and
+  no codim-2 move are needed for it: it is read post-hoc as distinguishable, conserved,
+  relaxation-stable per-hole Dirac–Kähler charge on the existing k=3 `b₃` register — the
+  exact signature obstructed on the symmetric register (#414), now present on the emergent
+  one.
+- **A `b₂` register is genuinely unreachable** by the status-quo moves (§3); it would need a
+  purpose-built codim-2 move, and is required *only* for a literal degree-2 E/B split, which
+  is redundant with the DK charge here.
+- **Build-plan §9:** §9.1–9.2 (Stages 1–2 + tests) merged in #473; the multi-degree `r_U`
+  extension is committed under #475; §9.4's post-hoc flavor observable is the DK-charge read
+  above; §9.5 is this report. The GraphML per-hinge export (§9.3) and the codim-2/E-B-at-k2
+  track are deferred (the latter mooted by reading flavor at k=3).
+
+## Pointers
+
+- Harness: `examples/cobordism/emergent_optimizer.py` (`f1c86e4`).
+- Exploration scripts (scratchpad): `betti_search_worker.py` (the b₂ search),
+  `stage2_stability_runs.py` (the Stage-2 sweep).
+- Design note: `docs/design/t5_emergent_optimizer_design.md`.

--- a/examples/cobordism/emergent_optimizer.py
+++ b/examples/cobordism/emergent_optimizer.py
@@ -149,28 +149,34 @@ class EmergentOptimizer:
     `input_targets` is a list of two expected-state period vectors; `output_target` the
     expected output. Nothing is frozen and no register is imposed."""
 
-    def __init__(self, host, input_targets, output_target, k=2, gamma=1.0, seed=0):
+    def __init__(self, host, input_targets, output_target, degrees=(3,), gamma=1.0,
+                 seed=0):
         self.st = host
         self.input_targets = [list(t) for t in input_targets]
         self.output_target = list(output_target)
-        self.k = k
+        self.degrees = tuple(degrees)        # the register degrees r_U requires at once
+        self._gate_k = max(self.degrees)     # dualComplexValid is the (degree-free) gate
         self.gamma = gamma
         self.rng = random.Random(seed)
         self._tol = 1e-9
         self.inputs = []        # [{'verts': frozenset, 'target': [...]}, ...]
 
     # ----- the constructed interior inputs -----
-    def _region_subcomplex(self, verts):
-        """The input sub-complex: the host cells entirely within `verts`, as its own
-        complex so we can take its *own* `L_k`."""
-        cells = [list(c) for c in (_top_tuple(s) for s in self.st.getTopSimplices())
+    def _sub_of(self, st, verts):
+        """An input sub-complex: the cells of `st` entirely within `verts`, as its own
+        complex so we can take its *own* `L_k` at each register degree."""
+        cells = [list(c) for c in (_top_tuple(s) for s in st.getTopSimplices())
                  if set(c) <= verts]
         return T.Spacetime.fromCells(_DIM, cells, 1.0, 0.0) if cells else None
 
-    def _r_input(self, inp):
-        sub = self._region_subcomplex(inp['verts'])
-        return r_state(sub, self.k, inp['target']) if sub is not None else \
-            float(np.vdot(np.asarray(inp['target']), np.asarray(inp['target'])).real)
+    def _r_input(self, inp, st):
+        """The input's residual: its own-`L_k` representativeness summed over ALL register
+        degrees (each degree's harmonic must carry the input)."""
+        sub = self._sub_of(st, inp['verts'])
+        if sub is None:
+            tg = np.asarray(inp['target'])
+            return len(self.degrees) * float(np.vdot(tg, tg).real)
+        return sum(r_state(sub, k, inp['target']) for k in self.degrees)
 
     def construct_inputs(self, seeds, rounds=24):
         """Solve each input *separately* into an interior sub-complex whose own `L_k`
@@ -183,7 +189,7 @@ class EmergentOptimizer:
                 v for c in (_top_tuple(s) for s in self.st.getTopSimplices())
                 if seed_v in c for v in c)
             inp = {'verts': verts, 'target': target}
-            r = self._r_input(inp)
+            r = self._r_input(inp, self.st)
             for _ in range(rounds):
                 cells = [c for c in (_top_tuple(s) for s in self.st.getTopSimplices())
                          if set(c) <= verts]
@@ -193,14 +199,14 @@ class EmergentOptimizer:
                 snap = self._snapshot_of(self.st)
                 if not cob.SurgicalCone(self.st).coneOut(cell)[0]:
                     continue
-                ok, _why = cob.EigenstateSynthesis(self.st, self.k).dualComplexValid()
-                r_new = self._r_input(inp) if ok else float("inf")
+                ok, _why = cob.EigenstateSynthesis(self.st, self._gate_k).dualComplexValid()
+                r_new = self._r_input(inp, self.st) if ok else float("inf")
                 if ok and r_new < r - self._tol:
                     r = r_new
                 else:
                     self._restore(self._build(snap))     # reject: restore exactly
             self.inputs.append(inp)
-        return [self._r_input(i) for i in self.inputs]
+        return [self._r_input(i, self.st) for i in self.inputs]
 
     @property
     def _input_verts(self):
@@ -209,19 +215,17 @@ class EmergentOptimizer:
             out |= inp['verts']
         return out
 
-    # ----- objective (three-term, asymmetric) -----
+    # ----- objective (asymmetric, summed over the register degrees) -----
     def r_u(self, st=None):
+        """The three-term residual, summed over ALL register degrees: the whole's `L_k`
+        harmonic must carry the output, and each input sub-complex's own `L_k` must carry
+        its input, at **every** degree in `self.degrees`. Requiring (say) both `L₂` and
+        `L₃` forces both a `b₂` and a `b₃` register to emerge."""
         st = st if st is not None else self.st
-        rt = r_state(st, self.k, self.output_target)     # output: on the whole
-        for inp in self.inputs:                          # inputs: on their own L_k
-            rt += self._r_input(inp) if st is self.st else r_state(
-                self._sub_of(st, inp['verts']), self.k, inp['target'])
-        return rt
-
-    def _sub_of(self, st, verts):
-        cells = [list(c) for c in (_top_tuple(s) for s in st.getTopSimplices())
-                 if set(c) <= verts]
-        return T.Spacetime.fromCells(_DIM, cells, 1.0, 0.0) if cells else None
+        total = sum(r_state(st, k, self.output_target) for k in self.degrees)  # output
+        for inp in self.inputs:                                               # inputs
+            total += self._r_input(inp, st)
+        return total
 
     def objective(self):
         return _grad_norm2(self.st) + self.gamma * self.r_u(self.st)
@@ -292,7 +296,7 @@ class EmergentOptimizer:
         live = {v for c in (_top_tuple(s) for s in st.getTopSimplices()) for v in c}
         if not (self._input_verts <= live):              # an input vertex was removed
             return False
-        ok, _why = cob.EigenstateSynthesis(st, self.k).dualComplexValid()
+        ok, _why = cob.EigenstateSynthesis(st, self._gate_k).dualComplexValid()
         return ok
 
     def _delta_f(self, base_solver, base_g2_edges, base_ru, base_cells, cand):

--- a/tests/cobordism/test_emergent_optimizer.py
+++ b/tests/cobordism/test_emergent_optimizer.py
@@ -83,7 +83,7 @@ class EmergentLoopTest(unittest.TestCase):
         host = eo.build_closed_s4(n_refine=20, seed=0)
         opt = eo.EmergentOptimizer(
             host, [[1.0, _W, _W * _W], [1.0, _W * _W, _W]], [1.0, _W, _W * _W],
-            k=3, gamma=1.0, seed=seed)
+            degrees=(3,), gamma=1.0, seed=seed)
         seeds = [v.getId() for v in host.getVertexList().toVector()][:2]
         opt.construct_inputs(seeds, rounds=12)
         return opt


### PR DESCRIPTION
## Summary
T5 emergent optimizer, build-plan §9.4–§9.5 (follow-up to the §9.1–9.2 harness merged in #473). Two things: a multi-degree generalization of `r_U`, and the findings — **flavor emerges from what we have, read at k=3.**

## Multi-degree `r_U`
Generalize the optimizer from a single register degree `k` to a **set** of degrees (`degrees=(2,3,…)`): `r_U` is summed over them, so several `L_k` registers can be required to emerge at once (the route to asking for both an `L₂` and an `L₃` register). `r_state` is already degree-generic, so this is a sum, not new machinery; nothing imposed, both registers must still emerge. Default `degrees=(3,)` preserves prior behavior (fast residual test green).

## Findings (`docs/design/t5_emergent_optimizer_findings.md`)
- **The natural register degree on a d=4 host is k=3, not k=2** — a cone-out removes a top 4-cell → that makes `b₃`, never `b₂` (`ker L_{d-1}`, holes = removed top d-cells).
- **A `b₂` register is conclusively unreachable** by the move set: an 8-worker, ~9 h, **~13.9 M-move** random walk over the gated moves never once produced `b₂>0` (every structure `[1,0,0,b₃,0]`). It would need a dedicated codim-2 move, expressed as pure top-cell changes.
- **Flavor emerges at k=3 with no second register and no codim-2 move:** distinguishable, conserved **per-hole Dirac–Kähler charge** (`j⁰ = W·|Φ|²`), relative spread 0.52–0.61 across 5 structures — the exact signature #414 found *absent* on the symmetric A₄ register, present on the emergent one.
- **It's real, not a geometric artifact:** under Stage-2 geometric relaxation the distinction persists/sharpens (not equalizes) when strong; only marginal cases wash out. (A local-extremum check — whether collapsed cases recover under a random Stage-2 restart — and the full Stage-2 sweep tally are in progress; results to be appended.)

## Test plan
- [x] Fast `ResidualTest` green (`-m "not slow"`, the CI gate); example imports clean.
- [x] `@slow` loop test (from #473) still green with the multi-degree API change (`degrees=(3,)`).
- [ ] Append the Stage-2 sweep tally + local-extremum verdict to §5 of the findings.

## Deferred
- §9.3 GraphML per-hinge export (the `getSimplices()`-returns-only-top-cells plumbing).
- The codim-2 surgical move + literal degree-2 E/B split (mooted by reading flavor at k=3).
- The flavor-experiment scripts are exploration artifacts (betti search, Stage-2 sweep, local-extremum test), kept out of the repo tree per convention.

Part of #462. Closes #475.
