### PR TITLE
feat(cobordism): spin-½ readout from the Dirac–Kähler spinor sector (#477)

### DIFF
--- a/examples/cobordism/dk_spin_readout.py
+++ b/examples/cobordism/dk_spin_readout.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Spin readout from the Dirac–Kähler spinor sector (#477) — a POST-HOC observable on an
+emergent register, never a loop condition.
+
+The DK fiber `Λ(ℝᵈ)` is `2ᵈ`-dimensional; for d=4 it is `16 = 4 (Dirac spinor) × 4 (taste)`.
+The **taste** factor is the flavor index (the per-hole DK charge, T5 findings); this module
+reads the **spinor** factor — the spin. The spin of a field is carried by the Clifford
+rotation generators
+
+    Σ_ij = ¼ [γ_i, γ_j]          (i, j spatial)
+
+whose eigenvalues are `±½` exactly when the field is **spin-½** (a Dirac spinor sits in
+`(½,0) ⊕ (0,½)`, so every `Σ_ij` has eigenvalues `±½`; a scalar would give `0`, a vector
+`0, ±1`). This reads off the `DiracKahler.gammas` of any d=4 mesh — the spin-½ capacity is a
+structural property of the Kähler–Atiyah construction, the spin analog of `multiplicity = 4`
+giving it the taste capacity.
+
+The register-**specific** spin *state* (which spin sector the converged register populates,
+the analog of the per-hole flavor charge) needs the discrete spin operator promoted to the
+full DK total space (the fiber↔cells map), which the form degrees of a generic simplicial
+complex do not align point-by-point — that is left as a follow-up rather than hacked here.
+"""
+import numpy as np
+
+import tessera as T
+
+cob = T.cobordism
+
+# In the d = 1+3 convention, axis 0 is time and 1,2,3 are the spatial axes whose rotations
+# generate spin; the proton is spin-½ under those spatial rotations.
+_SPATIAL = (1, 2, 3)
+
+
+def _gamma_matrices(dk, lorentzian=False):
+    d = dk.gammaDimension()
+    return [np.asarray(g, dtype=complex).reshape(d, d) for g in dk.gammas(lorentzian)]
+
+
+def clifford_residual(dk, lorentzian=False):
+    """Max deviation of the gammas from the Clifford algebra `{γ^a, γ^b} = 2 η^ab I` —
+    `→ 0` certifies the generators close (so an `Σ_ij` eigenvalue of `±½` is meaningful)."""
+    g = _gamma_matrices(dk, lorentzian)
+    n = len(g)
+    eta = np.asarray(dk.signature(lorentzian), dtype=float).reshape(n, n)
+    eye = np.eye(dk.gammaDimension())
+    worst = 0.0
+    for a in range(n):
+        for b in range(n):
+            anti = g[a] @ g[b] + g[b] @ g[a]
+            worst = max(worst, float(np.max(np.abs(anti - 2.0 * eta[a, b] * eye))))
+    return worst
+
+
+def spin_generators(dk, lorentzian=False):
+    """The spatial Clifford rotation generators `Σ_ij = ¼[γ_i, γ_j]`, keyed by `(i, j)`."""
+    g = _gamma_matrices(dk, lorentzian)
+    return {(i, j): 0.25 * (g[i] @ g[j] - g[j] @ g[i])
+            for a, i in enumerate(_SPATIAL) for j in _SPATIAL[a + 1:]}
+
+
+def spin_eigenvalue_magnitudes(dk, lorentzian=False, decimals=6):
+    """For each spatial rotation plane, the distinct `|eigenvalue|`s of `Σ_ij` — `{0.5}`
+    for a spin-½ field."""
+    out = {}
+    for plane, sigma in spin_generators(dk, lorentzian).items():
+        ev = np.linalg.eigvals(sigma)
+        out[plane] = sorted({round(abs(e), decimals) for e in ev})
+    return out
+
+
+def is_spin_half(dk, lorentzian=False, tol=1e-6):
+    """`True` iff every spatial rotation generator `Σ_ij` has eigenvalues exactly `±½` —
+    the spin-½ signature (and nothing else: no `0`, no `±1`)."""
+    return all(len(mags) == 1 and abs(mags[0] - 0.5) < tol
+               for mags in spin_eigenvalue_magnitudes(dk, lorentzian).values())
+
+
+def spin_report(st, lorentzian=False):
+    """Read the spin-½ signature off the Dirac–Kähler structure of `st` (post-hoc)."""
+    dk = cob.DiracKahler(st)
+    return {
+        "mesh_dim": dk.meshDimension(),
+        "gamma_dim": dk.gammaDimension(),
+        "taste_multiplicity": dk.multiplicity(),
+        "clifford_residual": clifford_residual(dk, lorentzian),
+        "spin_eigenvalue_magnitudes": spin_eigenvalue_magnitudes(dk, lorentzian),
+        "spin_half": is_spin_half(dk, lorentzian),
+    }
+
+
+if __name__ == "__main__":
+    import importlib.util
+    import os
+
+    _here = os.path.dirname(__file__)
+    _spec = importlib.util.spec_from_file_location(
+        "eo", os.path.join(_here, "emergent_optimizer.py"))
+    eo = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(eo)
+    host = eo.build_closed_s4(n_refine=12, seed=0)
+    rep = spin_report(host)
+    for k, v in rep.items():
+        print(f"{k}: {v}")

--- a/tests/cobordism/test_dk_spin.py
+++ b/tests/cobordism/test_dk_spin.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Spin-½ readout from the Dirac–Kähler spinor sector (#477).
+
+A fast structural check: the Kähler–Atiyah fiber of a d=4 mesh is `16 = 4 spinor × 4 taste`,
+the gammas close as a Clifford algebra, and every spatial rotation generator
+`Σ_ij = ¼[γ_i, γ_j]` has eigenvalues exactly `±½` — the spin-½ signature. No convergence
+needed: this is a structural property of the DK construction.
+"""
+import importlib.util
+import os
+import sys
+import unittest
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class DiracKahlerSpinTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.eo = _load("emergent_optimizer")
+        cls.sp = _load("dk_spin_readout")
+
+    def test_spin_half_from_clifford_rotation_generators(self):
+        host = self.eo.build_closed_s4(n_refine=12, seed=0)
+        rep = self.sp.spin_report(host)
+
+        # the fiber is 16 = 4 Dirac spinor × 4 taste
+        self.assertEqual(rep["gamma_dim"], 16)
+        self.assertEqual(rep["taste_multiplicity"], 4)
+
+        # the gammas close as a Clifford algebra (so the Σ_ij eigenvalues are meaningful)
+        self.assertLess(rep["clifford_residual"], 1e-9)
+
+        # spin-½: every spatial rotation generator Σ_ij has eigenvalues exactly ±½ —
+        # and nothing else (no 0 → not scalar, no ±1 → not spin-1)
+        for _plane, mags in rep["spin_eigenvalue_magnitudes"].items():
+            self.assertEqual(len(mags), 1)
+            self.assertAlmostEqual(mags[0], 0.5, places=6)
+        self.assertTrue(rep["spin_half"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Reads spin from the emergent k=3 `b₃` register's Dirac–Kähler structure — the spin analog of the per-hole flavor charge (T5 findings). The DK fiber `Λ(ℝ⁴)` is `16 = 4 Dirac-spinor × 4 taste`; the flavor (taste) side is already read, this reads the **spinor (spin)** side.

The spin-½ test is the Clifford rotation generator `Σ_ij = ¼[γ_i,γ_j]`: eigenvalues `±½` iff spin-½ (scalar → 0, spin-1 → 0,±1). On a d=4 mesh's `DiracKahler.gammas`: Clifford residual **0.0** (closes exactly), all three spatial `Σ_ij` eigenvalue magnitudes **½** → **spin-½**.

## Test plan
- [x] `tests/cobordism/test_dk_spin.py` (fast): fiber `16 = 4×4`, Clifford residual `< 1e-9`, every spatial `Σ_ij` eigenvalue `±½`, `spin_half` True.

Post-hoc only, never a loop condition. Reuses the validated DK machinery.

Closes #483. The register-specific spin *state* (which sector the converged register populates) is the follow-up #477. Part of #410.
