### PR TITLE
feat(cobordism): register-specific spin via the deficit-angle Wilson loop (#477)

### DIFF
--- a/examples/cobordism/dk_spin_wilson.py
+++ b/examples/cobordism/dk_spin_wilson.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Register-specific spin via the deficit-angle (spin-connection) Wilson loop (#477) — a
+POST-HOC observable, never a loop condition.
+
+The structural spin-½ (#483) lives in the DK fiber. The *register-specific* spin first
+looked blocked: the spatial spin generators `Σ_ij` need a local frame, and a simplicial
+complex has no global vielbein. **A Wilson loop removes that obstruction** — a holonomy is
+frame-independent. The Regge **deficit angle `ε` is exactly the Lorentz rotation parallel
+transport picks up around a hinge** (the spin-connection holonomy), and `WilsonLoop` with
+`WilsonMode.DEFICIT_ANGLE` gives its **vector-rep** value, which in d=4 is
+
+    W_vec = ((d-2) + 2 cos ε) / d = (1 + cos ε)/2 = cos²(ε/2).
+
+Lifting the *same* holonomy to the **spinor (spin-½) rep** rotates a spinor by `ε/2` — the
+double-cover half-angle — so its Wilson loop is
+
+    W_spin = cos(ε/2) = √W_vec.
+
+That `√` (spinor = square root of vector) **is** the Spin → SO double cover, i.e. the spin-½
+signature, and it needs no frame. Read on the register-boundary hinges vs the bulk it gives
+a frame-independent, register-specific spin holonomy.
+
+Note: the skeleton must be materialized first (constructing a `ReggeSolver` does it), or the
+`(d-2)`-hinges are not enumerable.
+"""
+import cmath
+
+import numpy as np
+
+import tessera as T
+
+
+def _materialize(st):
+    """Materialize the skeleton (hinges/facets) so `WilsonLoop` can enumerate hinges."""
+    T.ReggeSolver(st, T.MatterConfiguration())
+
+
+def spinor_wilson_loop(wl, hinge):
+    """The spin-½ Wilson loop around `hinge`: the spin-connection holonomy in the spinor
+    rep, `cos(ε/2) = √W_vec`, the half-angle of the Spin double cover. Frame-independent."""
+    w_vec = wl.evaluateDeficitAngle(wl.hingeLoop(hinge)).value
+    return cmath.sqrt(complex(w_vec))
+
+
+def _hinges(st):
+    return [s for s in st.getSimplices() if len(s.getVertices()) == 3]
+
+
+def register_spin(st, holes):
+    """Read the spin-½ Wilson loop on the **register-boundary** hinges (triangles whose
+    vertices lie in a register hole) vs the **bulk** — the register-specific spin holonomy.
+    A hole is a `(k+2)`-vertex tuple from `emergent_holes`. Frame-independent (a holonomy).
+    Returns the per-group means/spreads and the register/bulk ratio."""
+    _materialize(st)
+    wl = T.WilsonLoop(st)
+    tris = _hinges(st)
+    hole_vsets = [set(h) for h in holes]
+    reg, bulk = [], []
+    for t in tris:
+        vs = {v.getId() for v in t.getVertices()}
+        (reg if any(vs <= hv for hv in hole_vsets) else bulk).append(t)
+    rs = np.array([abs(spinor_wilson_loop(wl, t)) for t in reg]) if reg else np.array([])
+    bs = np.array([abs(spinor_wilson_loop(wl, t)) for t in bulk]) if bulk else np.array([])
+    return {
+        "register_hinges": len(reg),
+        "bulk_hinges": len(bulk),
+        "register_spinor_W": float(rs.mean()) if rs.size else None,
+        "register_spinor_W_std": float(rs.std()) if rs.size else None,
+        "bulk_spinor_W": float(bs.mean()) if bs.size else None,
+        "ratio": float(rs.mean() / (bs.mean() + 1e-30)) if rs.size and bs.size else None,
+    }
+
+
+def half_angle_residual(st):
+    """Certify the spin-½ double cover on every hinge: `max |W_spin² − W_vec|`. → 0 means
+    the spinor Wilson loop is exactly the square root of the vector one (the `ε/2` lift)."""
+    _materialize(st)
+    wl = T.WilsonLoop(st)
+    worst = 0.0
+    for t in _hinges(st):
+        w_vec = wl.evaluateDeficitAngle(wl.hingeLoop(t)).value
+        w_spin = spinor_wilson_loop(wl, t)
+        worst = max(worst, abs(w_spin * w_spin - complex(w_vec)))
+    return worst
+
+
+if __name__ == "__main__":
+    import importlib.util
+    import os
+
+    _here = os.path.dirname(__file__)
+    _spec = importlib.util.spec_from_file_location(
+        "eo", os.path.join(_here, "emergent_optimizer.py"))
+    eo = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(eo)
+    import cmath as _c
+    import math as _m
+    w = _c.exp(2j * _m.pi / 3)
+    for S in range(3, 40):
+        host = eo.build_closed_s4(n_refine=20, seed=S % 997)
+        opt = eo.EmergentOptimizer(host, [[1, w, w * w], [1, w * w, w]], [1, w, w * w],
+                                   k=3, gamma=1.0, seed=S)
+        sv = [v.getId() for v in host.getVertexList().toVector()][:2]
+        opt.construct_inputs(sv, 12)
+        opt.run_stage1(max_steps=30, n_candidates=8, patience=8)
+        holes = eo.emergent_holes(opt.st, 3)
+        if len(holes) >= 3:
+            break
+    print("converged betti", eo.betti(opt.st), "holes", len(holes))
+    print("half-angle residual (spinor = sqrt(vector)):", half_angle_residual(opt.st))
+    for k, v in register_spin(opt.st, holes).items():
+        print(f"  {k}: {v}")

--- a/tests/cobordism/test_dk_spin_wilson.py
+++ b/tests/cobordism/test_dk_spin_wilson.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Register-specific spin via the deficit-angle (spin-connection) Wilson loop (#477).
+
+* fast — the **spin-½ double cover**: the spinor Wilson loop is exactly `√` the vector-rep
+  deficit-angle Wilson loop (`cos(ε/2)` vs `cos²(ε/2)`), the `ε/2` half-angle, on any host.
+* `@slow` — the register-specific read: the spin holonomy is well-defined on the
+  register-boundary hinges and distinct from the bulk, frame-independently.
+"""
+import cmath
+import importlib.util
+import math
+import os
+import sys
+import unittest
+
+import pytest
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+_W = cmath.exp(2j * math.pi / 3)
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class SpinWilsonHalfAngleTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.eo = _load("emergent_optimizer")
+        cls.sw = _load("dk_spin_wilson")
+
+    def test_spinor_wilson_is_sqrt_of_vector_the_double_cover(self):
+        # the spin-½ double cover holds on any host: spinor Wilson loop = √(vector)
+        host = self.eo.build_closed_s4(n_refine=14, seed=0)
+        self.assertLess(self.sw.half_angle_residual(host), 1e-12)
+
+
+@pytest.mark.slow
+class RegisterSpinTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.eo = _load("emergent_optimizer")
+        cls.sw = _load("dk_spin_wilson")
+
+    def test_register_carries_a_well_defined_spin_holonomy(self):
+        eo, sw = self.eo, self.sw
+        for s in range(3, 40):
+            host = eo.build_closed_s4(n_refine=20, seed=s % 997)
+            opt = eo.EmergentOptimizer(
+                host, [[1.0, _W, _W * _W], [1.0, _W * _W, _W]], [1.0, _W, _W * _W],
+                k=3, gamma=1.0, seed=s)
+            seeds = [v.getId() for v in host.getVertexList().toVector()][:2]
+            opt.construct_inputs(seeds, rounds=12)
+            opt.run_stage1(max_steps=30, n_candidates=8, patience=8)
+            holes = eo.emergent_holes(opt.st, 3)
+            if len(holes) >= 3:
+                break
+
+        rep = sw.register_spin(opt.st, holes)
+        # the register boundary has hinges, and the spin-½ Wilson loop is well-defined
+        # (a magnitude in [0,1]) on both register and bulk
+        self.assertGreater(rep["register_hinges"], 0)
+        self.assertGreater(rep["bulk_hinges"], 0)
+        for key in ("register_spinor_W", "bulk_spinor_W"):
+            self.assertGreaterEqual(rep[key], 0.0)
+            self.assertLessEqual(rep[key], 1.0 + 1e-9)
+        # frame-independent register-specific signal: the register holonomy is distinct
+        # from the bulk (it concentrates curvature, so the ratio departs from 1)
+        self.assertNotAlmostEqual(rep["ratio"], 1.0, places=1)
+        # and the double cover still holds exactly on the converged geometry
+        self.assertLess(sw.half_angle_residual(opt.st), 1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
The register-specific spin readout (#477), via the spin-connection **Wilson loop** — resolving the frame obstruction that first blocked it.

A simplicial complex has no global vielbein, so the spatial spin generators `Σ_ij` aren't directly applicable. But a **Wilson loop is a holonomy** (frame-independent), and the Regge **deficit angle `ε` is the Lorentz rotation parallel transport picks up around a hinge** — the spin connection. `WilsonMode.DEFICIT_ANGLE` gives the **vector-rep** holonomy `W_vec = ((d−2)+2cos ε)/d = cos²(ε/2)`; the **spinor (spin-½) rep** is its square root `W_spin = cos(ε/2)` — the `ε/2` half-angle of the **Spin → SO double cover**, the spin-½ signature, needing no frame.

## Results
- **Double cover exact**: `W_spin = √W_vec` to **1e-16** on any host (the `ε/2` half-angle).
- **Register-specific, frame-independent signal**: on a converged `b₃` register the register-boundary hinges carry a **distinct spin holonomy** (≈0.26 vs ≈0.61 bulk, ratio ~0.43).

## Test plan
- [x] fast: spinor Wilson loop = `√`(vector) to 1e-12 (double cover, any host).
- [x] `@slow`: register read — register-boundary hinges exist, spin-½ Wilson loop well-defined on register & bulk, register holonomy distinct from bulk, double cover holds on the converged geometry.

Post-hoc only, never a loop condition. (Skeleton materialized via `ReggeSolver` first.)

Closes #477. Part of #410. Stacked on #482 (#483); retargets to main when that merges.