### PR TITLE
fix(cobordism): restore fast, working multicobordism_animation (per-frame surgery + --save interval)

### DIFF
--- a/examples/cobordism/multicobordism_animation.py
+++ b/examples/cobordism/multicobordism_animation.py
@@ -121,7 +121,12 @@ class MultiCobordismAnimator:
     # ---- one optimizer step (stage 1 = surgery, then stage 2 = relaxation) ----
     def _advance(self, frame):
         if frame < self.s1:
-            self.opt.run_stage1(max_steps=70, n_candidates=self.s1c, patience=10 ** 9)
+            # Exactly one greedy surgery step per frame — the animation advances "one move
+            # at a time" (see the module docstring). Keep this at 1: each step grows the
+            # complex and re-evaluates the global spectral r_U, so the per-frame cost climbs
+            # super-linearly with max_steps (a 70-step frame measured ~360x a 1-step frame,
+            # turning the ~9 s surgery phase into ~52 min). patience is irrelevant at 1 step.
+            self.opt.run_stage1(max_steps=1, n_candidates=self.s1c, patience=10 ** 9)
             stage = 1
         else:
             self.opt.run_stage2(beta=self.s2_beta, max_iters=1)
@@ -305,7 +310,7 @@ def animate(opt, save=None, interval=200, **kw):
 
 def run_optimization(opt, visualize=False, save=None, degree=3, stage1_steps=70,
                      stage1_candidates=10, stage2_iters=100, stage2_beta=1.0,
-                     interval=0):
+                     interval=200):   # ms/frame; keep > 0 — GIF/MP4 save() uses fps = 1000/interval
     """Run the two-stage optimization.
 
     Visualization is **off by default**: with ``visualize=False`` (and no


### PR DESCRIPTION
## Summary
The refactor in `85a2d4e` left `examples/cobordism/multicobordism_animation.py` with **two regressions**, both breaking the animation it advertises. This restores it with two surgical one-liners (plus guard comments). The C++ engine and the no-arg batched path are untouched.

### Regression 1 — `--live` is ~360x slower per surgery frame (the "super slow")
`MultiCobordismAnimator._advance` ran `run_stage1(max_steps=70)` per frame instead of `max_steps=1`, contradicting the module's documented "one move/iteration at a time" contract. With `patience=10**9` (no early stop) every frame ran the full 70 greedy steps, and since each step grows the complex and re-evaluates a global spectral `r_U`, the cost compounds:

| per animated stage-1 frame | time |
|---|---|
| `max_steps=1` (intended) | **0.22 s** |
| `max_steps=70` (current) | **77.8 s** (~360x) |

→ the 40-frame surgery phase went **~9 s → ~52 min**. Fix: restore `max_steps=1`.

### Regression 2 — `--save` crashes instantly
`run_optimization` gained an `interval=0` default and threaded it into `FuncAnimation`, so `fa.save()` raised `ZeroDivisionError` (`fps = 1000 / interval`) before writing a single frame. The original `animate()` default of `200` worked. Fix: default `interval=200`.

## Verification (headless, `Agg`)
- `--save recomb.gif --stage1 8 --stage2 4` → valid **1350×450, 12-frame GIF** in 23.5 s (previously: crash). Last frame renders all three panels (metrics / emergent register / complex with register-hole vertices highlighted).
- One stage-1 frame measured back to **~0.2 s** (was 77.8 s).
- No-arg batched default path unchanged.

## Test plan
- [x] `--save` renders a valid multi-frame GIF (no `ZeroDivisionError`)
- [x] stage-1 frame cost back to ~0.2 s (was ~78 s)
- [x] 3-panel figure renders correctly (visual check of final frame)
- [ ] `--live` smoke check on a machine with a display (same `update()` path as `--save`, exercised above)

## Out of scope
The **no-arg batched default** (`python multicobordism_animation.py`) takes ~90–112 s, dominated by stage-2's dense Regge Hessian (~66 s / 30 iters). That is genuine compute from the deliberate 2→2 recombination demo (#491), **not** this regression; trimming its iteration counts trades demo fidelity and should be a separate, deliberate change. Happy to follow up if a faster default is wanted.

Closes #510.