### PR TITLE
feat(cobordism): two-way connected-correlator (C_ij) escape-hatch test for composite proton spin (#410)

### DIFF
--- a/docs/design/connected_correlator_escape_hatch_findings.md
+++ b/docs/design/connected_correlator_escape_hatch_findings.md
@@ -1,0 +1,84 @@
+# Connected correlator C_ij, two ways — the escape-hatch test (#512, part of #410)
+
+Falsifiable test of `docs/theory/cobordism/proton-spin/cartan_weyl_gluon.tex` §7: **can the
+composite proton spin be read from inter-hole holonomy alone**, sidestepping the fiber↔cell
+(Whitney/Kähler–Atiyah) point-fiber assembly? Operationally: is the connected two-hole spin
+correlator `C_ij` a *holonomy invariant*?
+
+Module: `examples/cobordism/dk_connected_correlator.py`. Test:
+`tests/cobordism/test_dk_connected_correlator.py`. Transport/extraction reused from
+`dk_composite_spin.py` (#485); instrument cross-checked against `dk_joint_spin.j2_three_qubit`
+(#489).
+
+## 0. The identity this rests on
+
+For three spin-½ holes,
+
+    J² = 9/4 + 2·Σ_{i<j} ⟨S_i·S_j⟩,   with   ⟨S_i·S_j⟩ = ⟨S_i⟩·⟨S_j⟩ + C_ij,
+
+where `C_ij ≡ ⟨S_i·S_j⟩ − ⟨S_i⟩·⟨S_j⟩` is the **connected** correlator. `C_ij = 0` for *any*
+product state. So `C_ij` is exactly the entangling content, and J² in correlator coordinates is
+identical to the validated `j2_three_qubit` operator.
+
+## 1. Instrument — C_ij is the entangling content (exact, hand-fed clean states)
+
+| state | J² (=9/4 + 2Σ⟨S_i·S_j⟩) | Σ C_ij | reading |
+|---|---|---|---|
+| proton `2\|uud⟩−\|udu⟩−\|duu⟩` | **0.75** | **−0.75** | entangled — C_ij carries *all* of the shift |
+| product `\|uud⟩` | 1.75 | 0.00 | product — C_ij = 0 |
+| Δ `\|uuu⟩` | 3.75 | 0.00 | product — C_ij = 0 |
+
+The proton is the **only** one of the three with non-zero `C_ij`; both the product `|uud⟩` (7/4)
+and the Δ (15/4) reach their J² from the *marginals alone*. This both reproduces the #489
+measuring stick and isolates `C_ij` as the quantity a holonomy read would have to supply to
+reach ¾.
+
+## 2. The two routes (on the same emergent geometry)
+
+- **(a) vertical** — reconstruct per-hole spin from the single color-correlated carried
+  representative `carriedRepresentative([h0,h1,h2],[1,ω,ω²])` (`joint_spinors`), transport to a
+  common frame via the `Spin(4)` `wilson_line`, build the 3-qubit state, read `C_ij`. A
+  reconstruction from per-hole spinors is **separable**, so `C_ij = 0` by construction.
+- **(b) horizontal** — predict `⟨S_i·S_j⟩_holo = ¼ cos θ_ij` from the inter-hole Wilson-line
+  SO(3) angle `θ_ij` *alone* (`R_ba = Tr[S_b W S_a W†]`, `cos θ = (Tr R − 1)/2`), with **no**
+  contraction against endpoint spinors. Also computes a color-period estimate `¼ cos Δφ_ij` from
+  the emergent Z₃ phases when available. NB it assigns each pair its own angle, so it is *not*
+  bound by the n=3 frustration floor — the most generous holonomy-only read.
+
+## 3. Result — the escape hatch is CLOSED
+
+| fixture | vertical (joint) J² | vertical (product) J² | horizontal J² | θ_ij | reaches ¾? |
+|---|---|---|---|---|---|
+| `synthetic_b3_3` | 2.79 | 3.15 | 2.26 | 0°, 120°, 120° | **no** |
+| `converged_b3_3` | 2.38 | 2.67 | 1.44 | 101°, 117°, 166° | **no** |
+
+- **Vertical:** `Σ C_ij ≈ 0` on both fixtures (separable, as predicted); J² sits in the
+  three-spin-½ mixture band `[3/2, 15/4]`, never ¾.
+- **Horizontal:** the holonomy reproduces only the **separable, transport-angle** correlation
+  `¼ cos θ_ij` — exactly the `C_ij = 0` content. On `converged_b3_3` it even dips to 1.44, *below*
+  the n=3 separable floor of 3/2, because the pair-independent formula is not a realizable state
+  correlator; it still does not reach ¾. The color-period estimate is inconsistent across
+  fixtures (1.75 vs 3.75) — color phases alone do not supply a stable ¾ either.
+- **Frame-free:** the horizontal J² is GAUGE- and RELABEL-invariant to ~1e-15
+  (`|ΔGAUGE|=4e-16`, `|ΔRELABEL|=2e-15` on `synthetic_b3_3`), so it is a genuine observable, not
+  a frame artifact.
+
+**Neither route reaches the proton ¾.** The holonomy invariants carry the separable
+(transport-angle) part of `⟨S_i·S_j⟩` and nothing of the entangling `C_ij`. This is exactly what
+Claim 1 of `cartan_weyl_gluon.tex` predicts: the Wilson-line transport is `K`-type (a local
+frame rotation), and a `K`-type operation cannot create entanglement — so a correlation built
+from it is separable and floors above ¾.
+
+## 4. Conclusion
+
+`C_ij` is **not** a holonomy invariant. The escape hatch is **closed**: the composite proton
+spin cannot be read from inter-hole holonomy alone, and the fiber↔cell (Whitney/Kähler–Atiyah)
+quantum two-hole lift — a genuine joint `ρ_ij`, not a separable per-hole reconstruction — remains
+necessary to recover ¾. This is a clean negative that *narrows* the open work: it rules out the
+holonomy shortcut and points the total-space operator effort (#477/#495) at the joint-state lift
+specifically, since that is the only place the entangling `C_ij` can come from.
+
+The honest positives this also establishes: (i) `J²` in correlator coordinates reproduces the
+validated instrument, and `C_ij` is demonstrably the entangling content (§1); (ii) the
+holonomy-only `J²` is a well-defined, frame-free observable (§3) — it just measures the wrong
+(separable) thing.

--- a/examples/cobordism/dk_connected_correlator.py
+++ b/examples/cobordism/dk_connected_correlator.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Connected two-hole spin correlator C_ij, two ways — the escape-hatch test (#512, part of #410).
+
+Companion experiment to `docs/theory/cobordism/proton-spin/cartan_weyl_gluon.tex` §7. The
+composite proton spin obeys
+
+    J² = 9/4 + 2·Σ_{i<j} ⟨S_i·S_j⟩,     ⟨S_i·S_j⟩ = ⟨S_i⟩·⟨S_j⟩ + C_ij,
+
+where the **connected** correlator C_ij ≡ ⟨S_i·S_j⟩ − ⟨S_i⟩·⟨S_j⟩ is the entangling content a
+product read zeroes. On (C²)³ this is exact and decisive (`j2_from_pairs`): the proton
+`2|uud⟩−|udu⟩−|duu⟩` carries Σ C_ij = −¾ (so J²=¾), while the product `|uud⟩` (J²=7/4) AND the Δ
+`|uuu⟩` (J²=15/4) are both *product* states with C_ij = 0 — C_ij is precisely what tells the
+entangled proton apart.
+
+The open question (`cartan_weyl_gluon.tex` §6 "the one escape hatch"): can C_ij be read from
+inter-hole **holonomy** alone — sidestepping the fiber↔cell (Whitney/Kähler–Atiyah) point-fiber
+assembly? We compute C_ij two ways on the same emergent geometry and compare both to the proton
+target:
+
+  (a) VERTICAL — reconstruct per-hole spin from the single joint color-correlated carried
+      representative (`dk_composite_spin.joint_spinors`), transport to a common frame via the
+      `Spin(4)` `wilson_line`, build the 3-qubit state and read C_ij. A reconstruction from
+      independent per-hole spinors is separable, so C_ij = 0 by construction — the floor.
+
+  (b) HORIZONTAL — predict ⟨S_i·S_j⟩ from the inter-hole holonomy invariants ALONE: the SO(3)
+      rotation angle θ_ij of the `wilson_line` (`⟨S_i·S_j⟩_holo = ¼ cos θ_ij`), with no
+      contraction against endpoint spinors. Optionally also the emergent color-Z₃ periods.
+
+Agreement *with the proton target* (non-zero C_ij summing to −¾, J²→¾) would mean the escape
+hatch is open. Agreement *only at the floor* (both J² ≥ 3/2, C_ij ≈ 0) means it is closed and
+the quantum two-hole lift is still required. The result is reported as-is.
+
+Validation gates (GAUGE, RELABEL) are run post-hoc, never as a loop condition.
+"""
+import importlib.util
+import math
+import os
+import sys
+
+import cmath
+import numpy as np
+
+import tessera as T
+
+cob = T.cobordism
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_W = cmath.exp(2j * math.pi / 3)
+
+
+def _load(name):
+    sys.path.insert(0, _HERE)
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_HERE, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cs = _load("dk_composite_spin")     # transport + spinor extraction (reused, not reimplemented)
+
+# Clean spin-½ operators on a single qubit (C²); _S = σ/2.
+_PAULI = [np.array([[0, 1], [1, 0]], complex),
+          np.array([[0, -1j], [1j, 0]]),
+          np.array([[1, 0], [0, -1]], complex)]
+_S = [p / 2 for p in _PAULI]
+_I2 = np.eye(2, dtype=complex)
+_PAIRS = [(0, 1), (0, 2), (1, 2)]
+
+
+# ============================================================================
+# Operator layer on (C²)³ — the instrument in "chamber" (correlator) coordinates
+# ============================================================================
+def _s_op(a, i):
+    """Spin operator `S_a` on qubit `i` of three (an 8×8 operator on (C²)³)."""
+    ops = [_I2, _I2, _I2]
+    ops[i] = _S[a]
+    return np.kron(np.kron(ops[0], ops[1]), ops[2])
+
+
+def spin_vector(psi8, i):
+    """The Bloch vector `⟨S_a^(i)⟩`, a real 3-vector, of qubit `i` in the 3-qubit state."""
+    st = psi8 / np.linalg.norm(psi8)
+    return np.array([float((st.conj() @ _s_op(a, i) @ st).real) for a in range(3)])
+
+
+def spin_dot(psi8, i, j):
+    """The full two-point function `⟨S_i·S_j⟩ = Σ_a ⟨S_a^(i) S_a^(j)⟩`."""
+    st = psi8 / np.linalg.norm(psi8)
+    return float(sum((st.conj() @ (_s_op(a, i) @ _s_op(a, j)) @ st).real for a in range(3)))
+
+
+def connected_correlator(psi8, i, j):
+    """`C_ij = ⟨S_i·S_j⟩ − ⟨S_i⟩·⟨S_j⟩` — the connected (entangling) part. 0 for any product."""
+    return spin_dot(psi8, i, j) - float(spin_vector(psi8, i) @ spin_vector(psi8, j))
+
+
+def j2_from_pairs(psi8):
+    """`J² = 9/4 + 2·Σ_{i<j} ⟨S_i·S_j⟩` — identical to the validated `dk_joint_spin.j2_three_qubit`,
+    but expressed through the two-hole correlators this experiment reads."""
+    return 2.25 + 2.0 * sum(spin_dot(psi8, i, j) for i, j in _PAIRS)
+
+
+def correlator_report(psi8):
+    """Per-pair `⟨S_i·S_j⟩`, `C_ij`, the marginal product, and the reconstructed `J²`."""
+    return {
+        "j2": j2_from_pairs(psi8),
+        "sum_sdot": float(sum(spin_dot(psi8, i, j) for i, j in _PAIRS)),
+        "sum_connected": float(sum(connected_correlator(psi8, i, j) for i, j in _PAIRS)),
+        "sdot": {(i, j): spin_dot(psi8, i, j) for i, j in _PAIRS},
+        "connected": {(i, j): connected_correlator(psi8, i, j) for i, j in _PAIRS},
+    }
+
+
+# ============================================================================
+# Mesh helpers — transport between the emergent holes
+# ============================================================================
+def _spinor_to_qubit(s4):
+    """Reduce a 4-component Dirac spinor to a clean spin-½ qubit along its Bloch vector
+    (the spin direction read with the structural generators `cs._SG`)."""
+    s4 = np.asarray(s4, complex)
+    nrm = (s4.conj() @ s4).real
+    if nrm < 1e-30:
+        return np.array([1, 0], complex)
+    n = np.array([(s4.conj() @ cs._SG[a] @ s4).real / nrm for a in range(3)])
+    if np.linalg.norm(n) < 1e-9:
+        return np.array([1, 0], complex)
+    m = sum((n / np.linalg.norm(n))[a] * _PAULI[a] for a in range(3))
+    w, v = np.linalg.eigh(m)
+    return v[:, int(np.argmax(w.real))]
+
+
+def _hole_cells_and_lines(st, holes, top_tuple):
+    """The three hole cells and the `Spin(4)` `wilson_line`s `hole_j → hole_i` for all pairs.
+    Returns `(cells, frames, hc, W)` where `W[(i,j)]` transports hole `j`'s frame to hole `i`'s."""
+    cells = list(st.getTopSimplices())
+    adj = cs._dual_adjacency(cells, top_tuple)
+    frames = cs._frames(cells, top_tuple)
+
+    def cell_of(h):
+        hv = set(h)
+        return max(cells, key=lambda c: len(hv & set(top_tuple(c))))
+
+    hc = [cell_of(h) for h in holes[:3]]
+    W = {}
+    for i, j in _PAIRS:
+        W[(i, j)] = cs.wilson_line(cells, adj, hc[i], hc[j], frames)
+    return cells, frames, hc, W
+
+
+# ============================================================================
+# (a) VERTICAL route — C_ij from the reconstructed joint state
+# ============================================================================
+def vertical_state(st, holes, top_tuple, joint=True):
+    """The 3-qubit state reconstructed from the carried representative: per-hole spinors
+    (`joint=True` → the single color-correlated `[1,ω,ω²]` read) transported to hole 0's frame
+    and reduced to qubits. Separable by construction, so its `C_ij = 0` (the floor)."""
+    spinors = (cs.joint_spinors(st, holes, top_tuple) if joint
+               else cs.emergent_spinors(st, holes, top_tuple))
+    _cells, _frames, _hc, W = _hole_cells_and_lines(st, holes, top_tuple)
+    lines0 = [np.eye(4, dtype=complex) if j == 0 else W[(0, j)] for j in range(3)]
+    if any(u is None for u in lines0):
+        return None
+    qubits = [_spinor_to_qubit(lines0[j] @ spinors[j]) for j in range(3)]
+    state = np.kron(np.kron(qubits[0], qubits[1]), qubits[2])
+    return state / np.linalg.norm(state)
+
+
+def cij_vertical(st, holes, top_tuple, joint=True):
+    """The vertical-route correlator report (reconstructed joint state). `None` if a Wilson
+    line is missing."""
+    state = vertical_state(st, holes, top_tuple, joint=joint)
+    if state is None:
+        return None
+    rep = correlator_report(state)
+    rep["route"] = "vertical(joint)" if joint else "vertical(product)"
+    return rep
+
+
+# ============================================================================
+# (b) HORIZONTAL route — ⟨S_i·S_j⟩ from holonomy invariants only
+# ============================================================================
+def transport_so3(W):
+    """The SO(3) rotation `R` that the `Spin(4)` transport `W` induces on the spin axes:
+    `W S_a W† = Σ_b R_ba S_b`, read as `R_ba = Tr[S_b W S_a W†]` (with `Tr[S_a²]=1` for the
+    structural generators `cs._SG`). Purely a function of the holonomy — no spinor is touched."""
+    Wd = W.conj().T
+    return np.array([[float((cs._SG[b] @ W @ cs._SG[a] @ Wd).trace().real)
+                      for a in range(3)] for b in range(3)])
+
+
+def transport_angle(W):
+    """The rotation angle `θ` of the transport's SO(3) part: `cos θ = (Tr R − 1)/2`."""
+    c = (np.trace(transport_so3(W)) - 1.0) / 2.0
+    return math.acos(max(-1.0, min(1.0, c)))
+
+
+def color_periods(st, holes):
+    """The emergent color phases (arguments of the carried representative's periods over the
+    holes), normalised so phase[0] = 0. Best-effort: returns `None` if the period API is absent."""
+    es = cob.EigenstateSynthesis(st, 3)
+    for getter in ("cyclePeriods", "periods"):
+        fn = getattr(es, getter, None)
+        if fn is None:
+            continue
+        try:
+            per = np.asarray(fn([list(h) for h in holes[:3]]), dtype=complex).ravel()[:3]
+            if per.size == 3 and np.all(np.abs(per) > 1e-12):
+                ph = np.angle(per)
+                return ph - ph[0]
+        except Exception:
+            continue
+    return None
+
+
+def cij_horizontal(st, holes, top_tuple):
+    """The horizontal-route report: `⟨S_i·S_j⟩_holo = ¼ cos θ_ij` from the inter-hole Wilson-line
+    SO(3) angles ALONE (and, if available, the color-Z₃ period estimate `¼ cos Δφ_ij`). `None`
+    if a Wilson line is missing.
+
+    NB this assigns each pair its own transport angle; unlike a realizable separable *state* it
+    is not bound by the n=3 frustration floor, so it is the most generous holonomy-only read."""
+    _cells, _frames, _hc, W = _hole_cells_and_lines(st, holes, top_tuple)
+    if any(W[p] is None for p in _PAIRS):
+        return None
+    theta = {p: transport_angle(W[p]) for p in _PAIRS}
+    sdot = {p: 0.25 * math.cos(theta[p]) for p in _PAIRS}
+    sum_sdot = float(sum(sdot.values()))
+    rep = {"route": "horizontal(spin-transport)",
+           "theta_deg": {p: math.degrees(theta[p]) for p in _PAIRS},
+           "sdot": sdot, "sum_sdot": sum_sdot,
+           "j2": 2.25 + 2.0 * sum_sdot}
+    ph = color_periods(st, holes)
+    if ph is not None:
+        csdot = {p: 0.25 * math.cos(float(ph[p[1]] - ph[p[0]])) for p in _PAIRS}
+        rep["color_phase_deg"] = {p: math.degrees(float(ph[p[1]] - ph[p[0]])) for p in _PAIRS}
+        rep["color_sdot"] = csdot
+        rep["color_j2"] = 2.25 + 2.0 * float(sum(csdot.values()))
+    return rep
+
+
+# ============================================================================
+# Comparison
+# ============================================================================
+_TARGETS = {"proton (J=½)": 0.75, "product floor (n=3)": 1.5,
+            "product |uud⟩": 1.75, "mixture (3·¾)": 2.25, "Δ (J=3/2)": 3.75}
+
+
+def compare(st, holes, top_tuple):
+    """Run both routes on one geometry and report each vs the proton target and the floors."""
+    vert = cij_vertical(st, holes, top_tuple, joint=True)
+    vert_prod = cij_vertical(st, holes, top_tuple, joint=False)
+    horiz = cij_horizontal(st, holes, top_tuple)
+    return {"vertical_joint": vert, "vertical_product": vert_prod, "horizontal": horiz,
+            "targets": _TARGETS}
+
+
+def reaches_proton(rep, tol=0.1):
+    """True iff a route's reconstructed `J²` lands on the proton ¾ (within `tol`) — the
+    operational meaning of "the escape hatch is open" for that route."""
+    return rep is not None and abs(rep["j2"] - 0.75) <= tol
+
+
+# ============================================================================
+# __main__ — instrument + a fixture, with the GAUGE / RELABEL gates
+# ============================================================================
+if __name__ == "__main__":
+    import json
+
+    _UP = np.array([1, 0], complex)
+    _DN = np.array([0, 1], complex)
+
+    def _kr(*a):
+        out = a[0]
+        for x in a[1:]:
+            out = np.kron(out, x)
+        return out
+
+    print("== instrument: J² and Σ C_ij on hand-fed clean states ==")
+    states = {
+        "proton 2|uud⟩−|udu⟩−|duu⟩": 2 * _kr(_UP, _UP, _DN) - _kr(_UP, _DN, _UP) - _kr(_DN, _UP, _UP),
+        "product |uud⟩": _kr(_UP, _UP, _DN),
+        "Δ |uuu⟩": _kr(_UP, _UP, _UP),
+    }
+    for name, psi in states.items():
+        r = correlator_report(psi)
+        print(f"  {name:28s}  J²={r['j2']:.4f}  ΣC_ij={r['sum_connected']:+.4f}  "
+              f"(C_ij {'≠0 entangled' if abs(r['sum_connected'])>1e-9 else '=0 product'})")
+
+    eo = _load("emergent_optimizer")
+    _FIX = os.path.join(_HERE, "..", "..", "tests", "fixtures", "composite_spin")
+
+    def _rebuild(cells, edges, perm=None):
+        if perm is not None:
+            cells = [[perm[v] for v in c] for c in cells]
+            edges = {tuple(sorted((perm[a], perm[b]))): z for (a, b), z in edges.items()}
+        st = T.Spacetime.fromCells(4, cells, 1.0, 0.0)
+        for e in st.getEdgeList().toVector():
+            a, b = e.getSource().getId(), e.getTarget().getId()
+            e.setSquaredLength(edges[(a, b) if a < b else (b, a)])
+        T.ReggeSolver(st, T.MatterConfiguration())
+        return st
+
+    def _load_fixture(name):
+        d = json.load(open(os.path.join(_FIX, name)))
+        cells = [list(c) for c in d["cells"]]
+        edges = {}
+        for k, (re, im) in d["edges"].items():
+            a, b = (int(x) for x in k.split(","))
+            edges[(a, b)] = complex(re, im)
+        st = _rebuild(cells, edges)
+        return d, cells, edges, st, eo.emergent_holes(st, 3)
+
+    for fixture in ("synthetic_b3_3.json", "converged_b3_3.json"):
+        print(f"\n== fixture {fixture} ==")
+        d, cells, edges, st, holes = _load_fixture(fixture)
+        tt = eo._top_tuple
+        out = compare(st, holes, tt)
+        for key in ("vertical_joint", "vertical_product", "horizontal"):
+            rep = out[key]
+            if rep is None:
+                print(f"  {key:18s}: (Wilson line missing)")
+                continue
+            extra = ""
+            if "theta_deg" in rep:
+                extra = "  θ_ij=" + ", ".join(f"{v:.0f}°"
+                                               for v in rep["theta_deg"].values())
+            if "color_j2" in rep:
+                extra += f"  color_J²={rep['color_j2']:.3f}"
+            sc = rep.get("sum_connected")
+            print(f"  {rep['route']:26s} J²={rep['j2']:.4f}"
+                  + (f"  ΣC_ij={sc:+.4f}" if sc is not None else "") + extra)
+        print(f"  proton target J²=0.75 | product floor 1.50 | mixture 2.25")
+        print(f"  reaches ¾?  vertical={reaches_proton(out['vertical_joint'])}  "
+              f"horizontal={reaches_proton(out['horizontal'])}")
+
+    # ---- GAUGE / RELABEL gates on the horizontal read (the new observable) ----
+    print("\n== GAUGE / RELABEL invariance of the horizontal J² (synthetic_b3_3) ==")
+    d, cells, edges, st, holes = _load_fixture("synthetic_b3_3.json")
+    tt = eo._top_tuple
+    base = cij_horizontal(st, holes, tt)["j2"]
+
+    import scipy.linalg as sla
+    rng = np.random.default_rng(7)
+    rmap = {}
+    orig = cs.embed_cell
+
+    def _patched(cell):
+        c = orig(cell)
+        key = tuple(sorted(c))
+        if key not in rmap:
+            aa = rng.standard_normal((4, 4))
+            rmap[key] = sla.expm(aa - aa.T)
+        return {v: rmap[key] @ x for v, x in c.items()}
+
+    cs.embed_cell = _patched
+    try:
+        gauged = cij_horizontal(st, holes, tt)["j2"]
+    finally:
+        cs.embed_cell = orig
+
+    import random
+    allv = sorted({v for s in st.getTopSimplices() for v in tt(s)})
+    shuf = allv[:]
+    random.Random(3).shuffle(shuf)
+    perm = dict(zip(allv, shuf))
+    st2 = _rebuild(cells, edges, perm=perm)
+    holes2 = [tuple(sorted(perm[v] for v in h)) for h in holes[:3]]
+    relabeled = cij_horizontal(st2, holes2, tt)["j2"]
+    print(f"  base J²={base:.4f}  |ΔGAUGE|={abs(gauged-base):.2e}  "
+          f"|ΔRELABEL|={abs(relabeled-base):.2e}")

--- a/tests/cobordism/test_dk_connected_correlator.py
+++ b/tests/cobordism/test_dk_connected_correlator.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The connected-correlator escape-hatch test (#512, part of #410).
+
+See `docs/theory/cobordism/proton-spin/cartan_weyl_gluon.tex` §7 and
+`docs/design/connected_correlator_escape_hatch_findings.md`.
+
+Two layers:
+
+* **Instrument (fast, load-bearing).** `J² = 9/4 + 2·Σ ⟨S_i·S_j⟩` reproduces the validated
+  measuring stick (proton ¾, product 7/4, Δ 15/4), and the connected `C_ij` is exactly the
+  entangling content: it is non-zero (summing to −¾) only for the entangled proton, and zero
+  for both product `|uud⟩` and Δ `|uuu⟩`.
+
+* **Mesh (the escape-hatch result).** On a b₃=3 fixture, neither the vertical (reconstructed
+  joint state) nor the horizontal (holonomy-invariants-only) route reaches the proton ¾; the
+  vertical route's `C_ij` is zero (separable by construction), and the horizontal `J²` is a
+  genuine frame-free observable (GAUGE + RELABEL invariant). The escape hatch is closed.
+"""
+import importlib.util
+import json
+import os
+import random
+import sys
+import unittest
+
+import numpy as np
+import scipy.linalg as sla
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+_FIX = os.path.join(os.path.dirname(__file__), "..", "fixtures", "composite_spin")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cc = _load("dk_connected_correlator")
+dj = _load("dk_joint_spin")          # the independently-validated J² instrument
+_UP = np.array([1, 0], complex)
+_DN = np.array([0, 1], complex)
+
+
+def _kr(*a):
+    out = a[0]
+    for x in a[1:]:
+        out = np.kron(out, x)
+    return out
+
+
+_PROTON = 2 * _kr(_UP, _UP, _DN) - _kr(_UP, _DN, _UP) - _kr(_DN, _UP, _UP)
+_PRODUCT = _kr(_UP, _UP, _DN)
+_DELTA = _kr(_UP, _UP, _UP)
+
+
+class CorrelatorInstrumentTest(unittest.TestCase):
+    """J² via the two-hole correlators reproduces the validated instrument, and C_ij is the
+    entangling content."""
+
+    def test_j2_from_pairs_matches_validated_instrument(self):
+        for psi, want in ((_PROTON, 0.75), (_PRODUCT, 1.75), (_DELTA, 3.75)):
+            self.assertAlmostEqual(cc.j2_from_pairs(psi), want, places=9)
+            # identical to the independently-validated operator read
+            self.assertAlmostEqual(cc.j2_from_pairs(psi), dj.j2_three_qubit(psi), places=9)
+
+    def test_connected_correlator_is_the_entangling_content(self):
+        # the proton carries the entanglement: Σ C_ij = −¾, all of the J² shift
+        pr = cc.correlator_report(_PROTON)
+        self.assertAlmostEqual(pr["sum_connected"], -0.75, places=9)
+        self.assertGreater(abs(pr["sum_connected"]), 1e-6)
+        # both product |uud⟩ and Δ |uuu⟩ are product states: C_ij = 0 for every pair
+        for psi in (_PRODUCT, _DELTA):
+            rep = cc.correlator_report(psi)
+            self.assertAlmostEqual(rep["sum_connected"], 0.0, places=9)
+            for pair in [(0, 1), (0, 2), (1, 2)]:
+                self.assertAlmostEqual(rep["connected"][pair], 0.0, places=9)
+
+    def test_connected_correlator_zero_on_random_products(self):
+        rng = np.random.default_rng(512)
+        for _ in range(5):
+            qs = [rng.normal(size=2) + 1j * rng.normal(size=2) for _ in range(3)]
+            qs = [q / np.linalg.norm(q) for q in qs]
+            psi = _kr(*qs)
+            for pair in [(0, 1), (0, 2), (1, 2)]:
+                self.assertAlmostEqual(cc.connected_correlator(psi, *pair), 0.0, places=9)
+
+
+class EscapeHatchMeshTest(unittest.TestCase):
+    """Both routes on a b₃=3 fixture: neither reaches ¾ (the hatch is closed)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.eo = _load("emergent_optimizer")
+        cls.T = cls.eo.T
+
+    def _rebuild(self, cells, edges, perm=None):
+        T = self.T
+        if perm is not None:
+            cells = [[perm[v] for v in c] for c in cells]
+            edges = {tuple(sorted((perm[a], perm[b]))): z for (a, b), z in edges.items()}
+        st = T.Spacetime.fromCells(4, cells, 1.0, 0.0)
+        for e in st.getEdgeList().toVector():
+            a, b = e.getSource().getId(), e.getTarget().getId()
+            e.setSquaredLength(edges[(a, b) if a < b else (b, a)])
+        T.ReggeSolver(st, T.MatterConfiguration())
+        return st
+
+    def _load_fixture(self, name):
+        d = json.load(open(os.path.join(_FIX, name)))
+        cells = [list(c) for c in d["cells"]]
+        edges = {}
+        for k, (re, im) in d["edges"].items():
+            a, b = (int(x) for x in k.split(","))
+            edges[(a, b)] = complex(re, im)
+        st = self._rebuild(cells, edges)
+        return d, cells, edges, st, self.eo.emergent_holes(st, 3)
+
+    def test_neither_route_reaches_three_quarters(self):
+        _d, _c, _e, st, holes = self._load_fixture("synthetic_b3_3.json")
+        tt = self.eo._top_tuple
+        vert = cc.cij_vertical(st, holes, tt, joint=True)
+        horiz = cc.cij_horizontal(st, holes, tt)
+        self.assertIsNotNone(vert)
+        self.assertIsNotNone(horiz)
+        # the escape hatch is closed: neither route lands on the proton ¾
+        self.assertFalse(cc.reaches_proton(vert))
+        self.assertFalse(cc.reaches_proton(horiz))
+        self.assertGreater(vert["j2"], 0.75 + 0.2)
+        self.assertGreater(horiz["j2"], 0.75 + 0.2)
+
+    def test_vertical_connected_correlator_is_zero(self):
+        # a reconstruction from per-hole spinors is separable — C_ij vanishes (the floor)
+        _d, _c, _e, st, holes = self._load_fixture("synthetic_b3_3.json")
+        vert = cc.cij_vertical(st, holes, self.eo._top_tuple, joint=True)
+        self.assertAlmostEqual(vert["sum_connected"], 0.0, places=6)
+
+    def test_horizontal_j2_is_frame_invariant(self):
+        # the holonomy-only J² is a genuine frame-free observable (GAUGE + RELABEL)
+        _d, cells, edges, st, holes = self._load_fixture("synthetic_b3_3.json")
+        tt = self.eo._top_tuple
+        base = cc.cij_horizontal(st, holes, tt)["j2"]
+
+        rng = np.random.default_rng(7)
+        rmap = {}
+        orig = cc.cs.embed_cell
+
+        def patched(cell):
+            c = orig(cell)
+            key = tuple(sorted(c))
+            if key not in rmap:
+                a = rng.standard_normal((4, 4))
+                rmap[key] = sla.expm(a - a.T)
+            return {v: rmap[key] @ x for v, x in c.items()}
+
+        cc.cs.embed_cell = patched
+        try:
+            gauged = cc.cij_horizontal(st, holes, tt)["j2"]
+        finally:
+            cc.cs.embed_cell = orig
+
+        allv = sorted({v for s in st.getTopSimplices() for v in tt(s)})
+        shuf = allv[:]
+        random.Random(3).shuffle(shuf)
+        perm = dict(zip(allv, shuf))
+        st2 = self._rebuild(cells, edges, perm=perm)
+        holes2 = [tuple(sorted(perm[v] for v in h)) for h in holes[:3]]
+        relabeled = cc.cij_horizontal(st2, holes2, tt)["j2"]
+
+        self.assertLess(abs(gauged - base), 1e-5)
+        self.assertLess(abs(relabeled - base), 1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Falsifiable test of `docs/theory/cobordism/proton-spin/cartan_weyl_gluon.tex` §7: is the connected two-hole spin correlator `C_ij` a **holonomy invariant**? Computes `C_ij` two ways on the emergent geometry and compares both to the proton target.

**Result: the escape hatch is CLOSED.** Neither route reaches the proton ½ (`J²=¾`) on the b₃=3 fixtures, so the composite proton spin is **not** readable from inter-hole holonomy alone — the fiber↔cell quantum two-hole lift (#477/#495) remains necessary. Clean negative: it rules out the shortcut and points the total-space-operator effort at the joint-state lift specifically.

## What's here
- `examples/cobordism/dk_connected_correlator.py` — operator layer (`J² = 9/4 + 2·Σ⟨S_i·S_j⟩`, `C_ij`), the **vertical** route (reconstructed joint state) and the **horizontal** route (holonomy-only `¼·cos θ_ij` from the Wilson-line SO(3) angle), plus `compare`.
- `tests/cobordism/test_dk_connected_correlator.py` — 6 tests, all green (~2s).
- `docs/design/connected_correlator_escape_hatch_findings.md` — the finding.

## Findings
- **Instrument (exact, on (C²)³):** `J²` reproduces ¾ / 7/4 / 15/4; `C_ij` is the entangling content — non-zero (Σ = −¾) **only** for the entangled proton, and **zero** for the product `|uud⟩` *and* the Δ `|uuu⟩`. Cross-checked against the validated `dk_joint_spin.j2_three_qubit`.
- **Vertical route:** separable by construction → `Σ C_ij ≈ 0`, `J² ≈ 2.4–3.1`.
- **Horizontal route:** reproduces only the separable transport-angle correlation; GAUGE/RELABEL-invariant to ~1e-15; `J² ≈ 1.4–2.3` (even dips below the 3/2 floor on `converged_b3_3` because pair-independent angles aren't a realizable state).
- **Neither reaches ¾** → hatch closed, consistent with Claim 1 of the doc (`K`-type transport cannot entangle).

| fixture | vertical (joint) J² | horizontal J² | θ_ij | reaches ¾? |
|---|---|---|---|---|
| `synthetic_b3_3` | 2.79 | 2.26 | 0°, 120°, 120° | no |
| `converged_b3_3` | 2.38 | 1.44 | 101°, 117°, 166° | no |

## Test plan
- [x] `C_ij`→`J²` returns ¾ / 7/4 / 15/4 on hand-fed clean states (vs `dk_joint_spin.j2_three_qubit`)
- [x] `C_ij` non-zero only for the proton; zero for product & Δ
- [x] horizontal-route `J²` GAUGE + RELABEL invariant (~1e-15) on `synthetic_b3_3`
- [x] vertical-route `Σ C_ij ≈ 0` (separable) on `synthetic_b3_3`
- [x] both routes run on synthetic + converged b₃=3; neither reaches ¾
- [x] design note written

## Scope note
The `cartan_weyl_gluon.tex` §7 *Outcome* paragraph is updated in the `docs/theory` tree (managed separately as part of the proton-spin docs, not on this branch). This PR is the code + test + design-note deliverable.

Closes #512.
