### PR TITLE
feat(cobordism): revive DiracKahler + loops-as-quarks composite-spin readout on MultiCobordism (#410)

### DIFF
--- a/include/cobordism/DiracKahler.h
+++ b/include/cobordism/DiracKahler.h
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_COBORDISM_DIRACKAHLER_H
+#define TESSERA_COBORDISM_DIRACKAHLER_H
+
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime { class Spacetime; }
+namespace tessera::cobordism {
+using namespace ::tessera::spacetime;
+
+/// # DiracKahler
+///
+/// The discrete **Dirac-Kahler operator** \f$ D = d + \delta \f$ on the
+/// inhomogeneous cochain complex \f$ \Omega = \bigoplus_{k=0}^{n}\Omega^k \f$ of
+/// a `Spacetime` — the principled, label-independent square root of the
+/// `HodgeLaplacian`. It is the natural **distinguished frame** the deferred
+/// operator read-out (`MergeCobordism::operatorU()`/`choiState()`) lacks, and it
+/// bridges the electric-charge current \f$ j^0 \f$ to the candidate flavor/taste
+/// index (the 4-fold Dirac-Kahler "doubling").
+///
+/// ## The operator
+///
+/// On the **total** cochain space \f$ \Phi \in \bigoplus_k \Omega^k \f$ (flat
+/// dimension \f$ \sum_k |C_k| \f$) the operator is assembled block-by-block from
+/// the same integer boundary maps \f$ \partial_k \f$ (`ChainComplex`) and
+/// diagonal inner-product weights \f$ W_k \f$ (`HodgeLaplacian::weights`) the
+/// `HodgeLaplacian` already uses, in the boundary convention `HodgeLaplacian`
+/// squares (`include/cobordism/HodgeLaplacian.h:31-46,48-68`):
+///
+///  - the **boundary** part \f$ \partial \f$ (degree-lowering) has block
+///    \f$ \Omega^k \to \Omega^{k-1} \f$ equal to \f$ \partial_k \f$
+///    (the integer `ChainComplex::boundaryMatrix(k)`, rows \f$|C_{k-1}|\f$,
+///    cols \f$|C_k|\f$);
+///  - the **codifferential** part \f$ \delta = \partial^* \f$ (degree-raising)
+///    has block \f$ \Omega^{k-1} \to \Omega^k \f$ equal to the metric adjoint
+///    \f$ \partial_k^* = W_k^{-1}\partial_k^{\top}W_{k-1} \f$.
+///
+/// Then, because \f$ \partial^2 = 0 \f$ and \f$ \delta^2 = (\partial^*)^2 = 0 \f$,
+/// the square is **block-diagonal per degree** and reproduces the Hodge Laplacian
+/// exactly:
+/// \f$ (d+\delta)^2 = \delta\partial + \partial\delta = L_k \f$, with
+/// \f$ L_k = W_k^{-1}\partial_k^{\top}W_{k-1}\partial_k
+///       + \partial_{k+1}W_{k+1}^{-1}\partial_{k+1}^{\top}W_k \f$ —
+/// the directly-assembled `HodgeLaplacian` (`signedLaplacian`). On a complex
+/// whose per-degree weights are uniform (e.g. the uniform \f$ l^2=1 \f$ metric,
+/// where \f$ W_k = c_k I \f$) this coincides block-for-block with the symmetric
+/// metric `HodgeLaplacian::laplacian(k, metric=true)`; the `lorentzian` path
+/// reproduces the signed-weight d'Alembertian blocks (\f$ k\ge 1 \f$). The
+/// matrix is rebuilt from the current edge weights on each call (matching the
+/// `HodgeLaplacian` lazy convention).
+///
+/// The \f$ k=0 \f$ block of \f$ D^2 \f$ is the **0-form Hodge Laplacian**
+/// \f$ \partial_1 W_1^{-1}\partial_1^{\top} \f$, which equals
+/// `HodgeLaplacian::laplacian(0)` (the Hermitian U(1)-graph Laplacian \f$ D-A \f$)
+/// only for unit, real edge weights; under the `lorentzian` (signed-weight)
+/// path the graph Laplacian and the signed 0-form d'Alembertian differ, so the
+/// reproduction is asserted over the \f$ k\ge 1 \f$ d'Alembertian blocks there.
+///
+/// ## Clifford / gamma structure and the 4-fold multiplicity
+///
+/// The gamma generators are the **Clifford action of unit 1-cochains** on the
+/// Kahler-Atiyah form fiber \f$ \Lambda(\mathbb{R}^d) \f$ (dimension \f$ 2^d \f$):
+/// \f$ \gamma^a = \varepsilon(e^a) + \eta^{aa}\,\iota(e^a) \f$, exterior
+/// multiplication plus (metric) interior multiplication by the \f$ a \f$-th basis
+/// 1-form. They satisfy the Clifford algebra
+/// \f$ \{\gamma^a,\gamma^b\} = 2\eta^{ab} I \f$ exactly (Euclidean
+/// \f$ \eta=\delta \f$, or the Lorentzian \f$ \mathrm{diag}(-1,+1,\dots) \f$ under
+/// the `lorentzian` flag), and \f$ D = \gamma^\mu\partial_\mu \f$ is the discrete
+/// Dirac operator. The framework spacetime dimension is \f$ d=4 \f$: the fiber is
+/// \f$ 2^4 = 16 \f$-dimensional and decomposes as \f$ 16 = 4\times 4 \f$ —
+/// **4 Dirac spinor components** \f$ \times \f$ **4 degenerate copies**. That
+/// 4-fold "doubling" is the `multiplicity()`, the candidate **flavor/taste
+/// index**.
+///
+/// ## The conserved current \f$ j^0 \f$ (charge density)
+///
+/// The U(1) Noether current of the Dirac-Kahler field is
+/// \f$ j^a = \bar\Phi\,\gamma^a\Phi \f$; its time component
+/// \f$ j^0 = \bar\Phi\,\gamma^0\Phi = \pm\,\Phi^\dagger\Phi \f$ is the **charge
+/// density**, realized per cell as \f$ j^0_c = W_c\,|\Phi_c|^2 \f$ (the
+/// \f$ W \f$-weighted modulus). Summed over a closed slice it integrates to the
+/// carried U(1) charge \f$ \langle\Phi,\Phi\rangle_W \f$; on a single closed
+/// harmonic \f$ \Phi \f$ (a `HodgeLaplacian::harmonicMatrix` row lifted to the
+/// total space) this is the harmonic's carried charge. The eventual Gauss-law
+/// cross-check (the electric-charge-density ticket) compares this to the
+/// period-derived charge; until then the consistency check is that the summed
+/// \f$ j^0 \f$ equals \f$ \langle\Phi,\Phi\rangle_W \f$.
+///
+/// ## Reduced-dimension caveat
+///
+/// The current `S^2 x I` cobordism is **2+1 D** (reduced): the full \f$ 4\times4 \f$
+/// Dirac and the \f$ E \f$/\f$ B \f$ field-strength split need a 3+1 D
+/// \f$ S^3 \f$-spatial-slice mesh. This class assembles \f$ D \f$ and the
+/// \f$ D^2=L \f$ verification generically in \f$ n \f$ D from the mesh, while the
+/// gamma/Clifford framework and `multiplicity()` report the **4D** values (a
+/// fixed property of the Dirac-Kahler framework, not of the reduced mesh).
+class DiracKahler {
+  public:
+    /// Construct over a triangulation. Edge weights are read lazily (at each
+    /// matrix/current query), so the spacetime must outlive the operator; the
+    /// held `shared_ptr` keeps it alive.
+    explicit DiracKahler(std::shared_ptr<Spacetime> st);
+
+    /// The mesh top dimension \f$ n \f$ (largest \f$ k \f$ with a \f$ k \f$-cell),
+    /// or \f$ -1 \f$ for the empty complex.
+    [[nodiscard]] int meshDimension() const;
+
+    /// The total cochain dimension \f$ \sum_{k=0}^{n}|C_k| \f$ — the side length
+    /// of the \f$ D \f$ matrix.
+    [[nodiscard]] std::size_t totalDimension() const;
+
+    /// Block offsets \f$ (o_0,\dots,o_{n+1}) \f$, length \f$ n+2 \f$, with
+    /// \f$ o_k = \sum_{j<k}|C_j| \f$ and \f$ o_{n+1} = \text{totalDimension()} \f$:
+    /// degree-\f$ k \f$ components occupy rows/cols \f$ [o_k, o_{k+1}) \f$ in the
+    /// canonical `ChainComplex` cell order (`kSimplexVertices(k)`).
+    [[nodiscard]] std::vector<std::size_t> blockOffsets() const;
+
+    /// The Dirac-Kahler operator \f$ D = d+\delta \f$ as a flat row-major
+    /// \f$ \text{totalDimension()}^2 \f$ complex array (real entries; imag 0).
+    /// Block \f$ (\Omega^k\to\Omega^{k-1}) = \partial_k \f$ and block
+    /// \f$ (\Omega^{k-1}\to\Omega^k) = W_k^{-1}\partial_k^{\top}W_{k-1} \f$.
+    /// `metric = false` uses unit weights (the combinatorial Dirac operator);
+    /// `lorentzian = true` uses the signed `HodgeLaplacian::weights(k, true)`
+    /// (timelike cells negative), so the square is the signed d'Alembertian.
+    [[nodiscard]] std::vector<std::complex<double>> matrix(
+        bool metric = true, bool lorentzian = false) const;
+
+    /// The square \f$ D^2 \f$ as a flat row-major
+    /// \f$ \text{totalDimension()}^2 \f$ complex array. Block-diagonal per
+    /// degree, each block the degree-\f$ k \f$ `HodgeLaplacian` (see the class
+    /// docstring); the cross-degree blocks vanish (\f$ \partial^2=\delta^2=0 \f$).
+    [[nodiscard]] std::vector<std::complex<double>> square(
+        bool metric = true, bool lorentzian = false) const;
+
+    /// The maximal Frobenius residual \f$ \max_k \| (D^2)_k - L_k \| \f$ between
+    /// the degree-\f$ k \f$ diagonal block of \f$ D^2 \f$ and the independently
+    /// assembled `HodgeLaplacian::laplacian(k, metric, lorentzian)`. Iterated over
+    /// \f$ k = 0..n \f$ for the Euclidean path and \f$ k = 1..n \f$ for the
+    /// `lorentzian` path (the \f$ k=0 \f$ `HodgeLaplacian` is the Hermitian graph
+    /// Laplacian, not the signed 0-form d'Alembertian; see the class docstring).
+    /// ~0 confirms \f$ (d+\delta)^2 = L \f$.
+    [[nodiscard]] double laplacianResidual(
+        bool metric = true, bool lorentzian = false) const;
+
+    /// The framework spacetime dimension \f$ d = 4 \f$ (the 4D Dirac-Kahler
+    /// framework; fixed, independent of the reduced mesh dimension).
+    [[nodiscard]] int frameworkDimension() const;
+
+    /// The Kahler-Atiyah form-fiber dimension \f$ 2^d = 16 \f$ (in 4D): the side
+    /// length of each gamma matrix.
+    [[nodiscard]] std::size_t gammaDimension() const;
+
+    /// The 4-fold Dirac-Kahler **multiplicity** (the "doubling"):
+    /// \f$ 2^{d/2} = 4 \f$ in 4D — the number of degenerate Dirac copies in
+    /// \f$ \Lambda(\mathbb{C}^4) = 16 = 4_{\text{spinor}}\times 4_{\text{taste}} \f$.
+    /// The candidate flavor/taste index. Pinned to 4 in the 4D framework.
+    [[nodiscard]] int multiplicity() const;
+
+    /// The metric signature \f$ \eta \f$ as a flat row-major
+    /// \f$ d\times d \f$ array: Euclidean \f$ \delta_{ab} \f$, or the Lorentzian
+    /// \f$ \mathrm{diag}(-1,+1,+1,+1) \f$ under `lorentzian = true`.
+    [[nodiscard]] std::vector<double> signature(bool lorentzian = false) const;
+
+    /// The \f$ d=4 \f$ gamma generators — the Clifford action of the unit
+    /// 1-cochains on the form fiber \f$ \Lambda(\mathbb{R}^4) \f$ — as a list of
+    /// \f$ \text{gammaDimension()}\times\text{gammaDimension()} \f$ flat
+    /// row-major real matrices \f$ \gamma^a = \varepsilon(e^a)+\eta^{aa}\iota(e^a) \f$.
+    /// They satisfy \f$ \{\gamma^a,\gamma^b\}=2\eta^{ab}I \f$ against
+    /// `signature(lorentzian)`.
+    [[nodiscard]] std::vector<std::vector<std::complex<double>>> gammas(
+        bool lorentzian = false) const;
+
+    /// \note **Where the 4x4 irreducible Dirac matrices would slot in.** `gammas()`
+    /// exposes the \f$ 16\times 16 \f$ *Clifford action* on the form fiber (the literal
+    /// "Clifford action of 1-cochains"). That fiber is
+    /// \f$ \Lambda(\mathbb{C}^4)\cong M_4(\mathbb{C}) \f$ — four commuting copies of the
+    /// irreducible \f$ 4\times 4 \f$ Dirac representation, one per `multiplicity()`
+    /// *taste*. To switch approach from the Clifford action to the relativistic Dirac
+    /// matrices, add a sibling accessor here, e.g.
+    /// `diracMatrices(lorentzian)` returning the \f$ 4\times 4 \f$
+    /// \f$ \gamma^\mu \f$ — the image of these same generators under the Chevalley /
+    /// Kahler-Atiyah isomorphism \f$ \Lambda(\mathbb{C}^4)\to M_4(\mathbb{C}) \f$
+    /// (equivalently the restriction of the \f$ 16\times 16 \f$ action to one minimal
+    /// left ideal / taste block) — with a `tasteProjector()` for the four commuting
+    /// copies. The operator \f$ D \f$ and the current \f$ j^0 \f$ are
+    /// representation-independent; only `gammas()` / `gammaDimension()` would change
+    /// (\f$ 16\to 4 \f$) and `multiplicity()` would become the explicit taste
+    /// degeneracy. The Clifford and multiplicity tests pass for either form.
+
+    /// The Clifford anticommutator residual
+    /// \f$ \max_{a,b}\|\{\gamma^a,\gamma^b\} - 2\eta^{ab}I\|_F \f$ for the
+    /// generators of `gammas(lorentzian)` against `signature(lorentzian)`. ~0.
+    [[nodiscard]] double cliffordResidual(bool lorentzian = false) const;
+
+    /// Lift a degree-\f$ k \f$ cochain `component` (length \f$ |C_k| \f$) into a
+    /// total-space field (length `totalDimension()`), zero in every other degree.
+    /// @throws std::runtime_error if `component` has the wrong length.
+    [[nodiscard]] std::vector<std::complex<double>> lift(
+        int k, const std::vector<std::complex<double>> &component) const;
+
+    /// The per-cell charge density \f$ j^0_c = W_c\,|\Phi_c|^2 \f$ of a total-space
+    /// field `field` (length `totalDimension()`), in the same flat block layout
+    /// (`blockOffsets`). `metric = false` uses unit weights. The time component is
+    /// the (positive) \f$ |\text{volume}| \f$-weighted modulus — the Dirac
+    /// current's \f$ j^0 = \bar\Phi\gamma^0\Phi \f$ in any signature.
+    /// @throws std::runtime_error if `field` has the wrong length.
+    [[nodiscard]] std::vector<double> chargeDensity(
+        const std::vector<std::complex<double>> &field, bool metric = true) const;
+
+    /// The carried U(1) charge \f$ \sum_c j^0_c = \langle\Phi,\Phi\rangle_W \f$ —
+    /// the charge density summed over the slice. On a closed harmonic this is the
+    /// carried charge (the Gauss-law cross-check, deferred to the
+    /// electric-charge-density ticket, compares it to the period-derived charge).
+    /// @throws std::runtime_error if `field` has the wrong length.
+    [[nodiscard]] double charge(
+        const std::vector<std::complex<double>> &field, bool metric = true) const;
+
+  private:
+    std::shared_ptr<Spacetime> st_;
+
+    // Per-degree cell counts |C_k| (length n+1) and the block offsets (length
+    // n+2), built lazily from the ChainComplex on demand.
+    [[nodiscard]] std::vector<std::size_t> cellCounts() const;
+};
+
+}  // namespace tessera::cobordism
+
+#endif  // TESSERA_COBORDISM_DIRACKAHLER_H

--- a/include/cobordism/MultiCobordism.h
+++ b/include/cobordism/MultiCobordism.h
@@ -112,6 +112,22 @@ class MultiCobordism {
     return outputs_;
   }
 
+  /// # Composite spin — loops-as-quarks closed-loop holonomy (#517)
+  /// The total-spin Casimir \f$ J^2 \f$ of output block `outputBlockIndex`, read in the
+  /// edge (loops-as-quarks) basis. The pair-encircling loop \f$ \gamma_{ij} \f$ is the
+  /// Poincare dual of the complementary hole \f$ k \f$, so its closed-loop spin holonomy is
+  /// the deficit \f$ \varepsilon_k \f$ at hole \f$ k \f$ (sum of `deficitAngle` over the
+  /// hole's hinges), lifted through the Dirac-Kahler spin-1/2 double cover to the pairwise
+  /// correlation \f$ \langle S_i\cdot S_j\rangle = \tfrac14\cos\varepsilon_k \f$. Then
+  /// \f[ J^2 = 3\cdot\tfrac34 + 2\sum_{i<j}\langle S_i\cdot S_j\rangle
+  ///         = \tfrac94 + \tfrac12\sum_k \cos\varepsilon_k, \f]
+  /// the \f$ \tfrac34 \f$ being the structural spin-1/2 Casimir of one `DiracKahler` fiber.
+  /// Honest: this reduces to the closed-loop holonomy / pairwise correlator and **floors**
+  /// above the entangled proton \f$ \tfrac34 \f$ (it does not bypass the fiber-cells kernel);
+  /// the value now lives on the source-of-truth class. Throws if the block has no 3-hole
+  /// (\f$ b_3 \f$) register.
+  [[nodiscard]] double compositeSpinJ2(std::size_t outputBlockIndex = 0) const;
+
  private:
   using Snapshot =
       std::pair<std::vector<std::vector<std::uint64_t>>,
@@ -141,6 +157,17 @@ class MultiCobordism {
                        std::vector<BoundaryBlock> &destinationBlocks, int rounds);
   // All pinned boundary (input + output) vertices — none may be removed by a move.
   [[nodiscard]] std::set<std::uint64_t> boundaryVerts() const;
+
+  /// The structural spin-1/2 Casimir Sum_a S_a^2 = 3/4 of one Dirac-Kahler constituent,
+  /// from the spatial rotation generators Sigma_ij = 1/4 [gamma_i, gamma_j] of `DiracKahler`.
+  [[nodiscard]] static double diracKahlerSpinCasimir(
+      const std::shared_ptr<Spacetime> &spacetime);
+  /// The closed-loop spin holonomy of the pair-loop dual to `hole`: the total deficit at the
+  /// hole, Sum of `deficitAngle` over its hinge (triangle) faces, on the already-materialized
+  /// `spacetime` (skeleton built by a ReggeSolver in `compositeSpinJ2`).
+  [[nodiscard]] static double holeDeficit(
+      const std::shared_ptr<Spacetime> &spacetime,
+      const std::vector<std::uint64_t> &hole);
 
   [[nodiscard]] Snapshot snapshotOf(const Spacetime &spacetime) const;
   [[nodiscard]] Snapshot snapshot() const;

--- a/include/cobordism/MultiCobordism.h
+++ b/include/cobordism/MultiCobordism.h
@@ -114,14 +114,15 @@ class MultiCobordism {
 
   /// # Composite spin — loops-as-quarks closed-loop holonomy (#517)
   /// The total-spin Casimir \f$ J^2 \f$ of output block `outputBlockIndex`, read in the
-  /// edge (loops-as-quarks) basis. The two-quark pair-loop \f$ \gamma_{ij} \f$ LITERALLY
-  /// encircles holes \f$ i,j \f$; by cycle additivity \f$ \gamma_{ij}=\gamma_i+\gamma_j \f$,
-  /// so the deficit it encloses is \f$ \varepsilon_i+\varepsilon_j \f$ (the curvature at the
-  /// two encircled holes; each `holeDeficit` sums `deficitAngle` over a hole's hinges),
-  /// lifted through the Dirac-Kahler spin-1/2 double cover to the pairwise correlation
-  /// \f$ \langle S_i\cdot S_j\rangle = \tfrac14\cos(\varepsilon_i+\varepsilon_j) \f$. Then
+  /// edge (loops-as-quarks) basis. The two-quark pair-loop \f$ \gamma_{ij} \f$ encircles holes
+  /// \f$ i,j \f$; the deficit it ENCLOSES is the curvature of their combined nearest-hole
+  /// territory \f$ \varepsilon_{ij}=\mathrm{region}(i)+\mathrm{region}(j) \f$
+  /// (`holeRegionDeficits`) -- the holes' own concentrated curvature plus the bulk nearest
+  /// them, i.e. the fully-literal enclosed deficit over every hinge -- lifted through the
+  /// Dirac-Kahler spin-1/2 double cover to
+  /// \f$ \langle S_i\cdot S_j\rangle = \tfrac14\cos\varepsilon_{ij} \f$. Then
   /// \f[ J^2 = 3\cdot\tfrac34 + 2\sum_{i<j}\langle S_i\cdot S_j\rangle
-  ///         = \tfrac94 + \tfrac12\sum_{i<j}\cos(\varepsilon_i+\varepsilon_j), \f]
+  ///         = \tfrac94 + \tfrac12\sum_{i<j}\cos\varepsilon_{ij}, \f]
   /// the \f$ \tfrac34 \f$ being the structural spin-1/2 Casimir of one `DiracKahler` fiber.
   /// Honest: this reduces to the closed-loop holonomy / pairwise correlator and **floors**
   /// above the entangled proton \f$ \tfrac34 \f$ (it does not bypass the fiber-cells kernel);
@@ -163,13 +164,16 @@ class MultiCobordism {
   /// from the spatial rotation generators Sigma_ij = 1/4 [gamma_i, gamma_j] of `DiracKahler`.
   [[nodiscard]] static double diracKahlerSpinCasimir(
       const std::shared_ptr<Spacetime> &spacetime);
-  /// The total deficit at a single hole: Sum of `deficitAngle` over its hinge (triangle)
-  /// faces, on the already-materialized `spacetime` (skeleton built by a ReggeSolver in
-  /// `compositeSpinJ2`). A two-quark pair-loop's enclosed deficit is the sum over the two
-  /// holes it encircles.
-  [[nodiscard]] static double holeDeficit(
+  /// The nearest-hole (Voronoi) region deficit of each hole. Every hinge (triangle) of the
+  /// materialized `spacetime` is assigned to the hole whose seed cell is nearest in the dual
+  /// graph (multi-source BFS from one distinct max-overlap cell per hole), and its
+  /// `deficitAngle` added to that hole's region. So a region's deficit is the FULL curvature
+  /// of the hole's territory -- the hole's own concentrated curvature PLUS the bulk nearest it
+  /// -- not merely the hole's boundary hinges. A two-quark pair-loop encircling holes i,j
+  /// encloses `region(i) + region(j)`. Returns one value per input hole.
+  [[nodiscard]] static std::vector<double> holeRegionDeficits(
       const std::shared_ptr<Spacetime> &spacetime,
-      const std::vector<std::uint64_t> &hole);
+      const std::vector<std::vector<std::uint64_t>> &holes);
 
   [[nodiscard]] Snapshot snapshotOf(const Spacetime &spacetime) const;
   [[nodiscard]] Snapshot snapshot() const;

--- a/include/cobordism/MultiCobordism.h
+++ b/include/cobordism/MultiCobordism.h
@@ -114,13 +114,14 @@ class MultiCobordism {
 
   /// # Composite spin — loops-as-quarks closed-loop holonomy (#517)
   /// The total-spin Casimir \f$ J^2 \f$ of output block `outputBlockIndex`, read in the
-  /// edge (loops-as-quarks) basis. The pair-encircling loop \f$ \gamma_{ij} \f$ is the
-  /// Poincare dual of the complementary hole \f$ k \f$, so its closed-loop spin holonomy is
-  /// the deficit \f$ \varepsilon_k \f$ at hole \f$ k \f$ (sum of `deficitAngle` over the
-  /// hole's hinges), lifted through the Dirac-Kahler spin-1/2 double cover to the pairwise
-  /// correlation \f$ \langle S_i\cdot S_j\rangle = \tfrac14\cos\varepsilon_k \f$. Then
+  /// edge (loops-as-quarks) basis. The two-quark pair-loop \f$ \gamma_{ij} \f$ LITERALLY
+  /// encircles holes \f$ i,j \f$; by cycle additivity \f$ \gamma_{ij}=\gamma_i+\gamma_j \f$,
+  /// so the deficit it encloses is \f$ \varepsilon_i+\varepsilon_j \f$ (the curvature at the
+  /// two encircled holes; each `holeDeficit` sums `deficitAngle` over a hole's hinges),
+  /// lifted through the Dirac-Kahler spin-1/2 double cover to the pairwise correlation
+  /// \f$ \langle S_i\cdot S_j\rangle = \tfrac14\cos(\varepsilon_i+\varepsilon_j) \f$. Then
   /// \f[ J^2 = 3\cdot\tfrac34 + 2\sum_{i<j}\langle S_i\cdot S_j\rangle
-  ///         = \tfrac94 + \tfrac12\sum_k \cos\varepsilon_k, \f]
+  ///         = \tfrac94 + \tfrac12\sum_{i<j}\cos(\varepsilon_i+\varepsilon_j), \f]
   /// the \f$ \tfrac34 \f$ being the structural spin-1/2 Casimir of one `DiracKahler` fiber.
   /// Honest: this reduces to the closed-loop holonomy / pairwise correlator and **floors**
   /// above the entangled proton \f$ \tfrac34 \f$ (it does not bypass the fiber-cells kernel);
@@ -162,9 +163,10 @@ class MultiCobordism {
   /// from the spatial rotation generators Sigma_ij = 1/4 [gamma_i, gamma_j] of `DiracKahler`.
   [[nodiscard]] static double diracKahlerSpinCasimir(
       const std::shared_ptr<Spacetime> &spacetime);
-  /// The closed-loop spin holonomy of the pair-loop dual to `hole`: the total deficit at the
-  /// hole, Sum of `deficitAngle` over its hinge (triangle) faces, on the already-materialized
-  /// `spacetime` (skeleton built by a ReggeSolver in `compositeSpinJ2`).
+  /// The total deficit at a single hole: Sum of `deficitAngle` over its hinge (triangle)
+  /// faces, on the already-materialized `spacetime` (skeleton built by a ReggeSolver in
+  /// `compositeSpinJ2`). A two-quark pair-loop's enclosed deficit is the sum over the two
+  /// holes it encircles.
   [[nodiscard]] static double holeDeficit(
       const std::shared_ptr<Spacetime> &spacetime,
       const std::vector<std::uint64_t> &hole);

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -914,9 +914,10 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
       .def("composite_spin_j2", &MultiCobordism::compositeSpinJ2,
            py::arg("output_block_index") = 0,
            "Loops-as-quarks composite spin J^2 of an output block: the two-quark pair-loop "
-           "literally encircles holes i,j (= gamma_i + gamma_j), so it encloses the deficit "
-           "eps_i + eps_j, lifted through the DiracKahler spin-1/2 double cover to "
-           "<S_i.S_j> = 1/4 cos(eps_i + eps_j); J^2 = 9/4 + 1/2 Sum_{i<j} cos(eps_i + eps_j). "
+           "encircles holes i,j, so it encloses region(i)+region(j) -- the fully-literal "
+           "nearest-hole (Voronoi) curvature of the two holes' territory, every hinge "
+           "included -- lifted through the DiracKahler spin-1/2 double cover to "
+           "<S_i.S_j> = 1/4 cos(region(i)+region(j)); J^2 = 9/4 + 1/2 Sum_{i<j} cos(.). "
            "Reduces to the closed-loop holonomy / pairwise C_ij (floors above the entangled "
            "proton 3/4). Raises if the block has no 3-hole register.");
 

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -913,12 +913,12 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
                              "The emergent output blocks (each a MultiCobordismBlock).")
       .def("composite_spin_j2", &MultiCobordism::compositeSpinJ2,
            py::arg("output_block_index") = 0,
-           "Loops-as-quarks composite spin J^2 of an output block: the pair-loop "
-           "closed-loop holonomy is the deficit at the Poincare-dual (complementary) "
-           "hole, lifted through the DiracKahler spin-1/2 double cover to "
-           "<S_i.S_j> = 1/4 cos(eps_k); J^2 = 9/4 + 1/2 Sum_k cos(eps_k). Reduces to the "
-           "closed-loop holonomy / pairwise C_ij (floors above the entangled proton 3/4). "
-           "Raises if the block has no 3-hole register.");
+           "Loops-as-quarks composite spin J^2 of an output block: the two-quark pair-loop "
+           "literally encircles holes i,j (= gamma_i + gamma_j), so it encloses the deficit "
+           "eps_i + eps_j, lifted through the DiracKahler spin-1/2 double cover to "
+           "<S_i.S_j> = 1/4 cos(eps_i + eps_j); J^2 = 9/4 + 1/2 Sum_{i<j} cos(eps_i + eps_j). "
+           "Reduces to the closed-loop holonomy / pairwise C_ij (floors above the entangled "
+           "proton 3/4). Raises if the block has no 3-hole register.");
 
   // === CobordismDAG (#491): chain emergent merges, output -> input ===
   py::class_<CobordismDAG>(m, "CobordismDAG",

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -910,7 +910,15 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
                              "The emergent input blocks (each a MultiCobordismBlock).")
       .def_property_readonly("outputs", &MultiCobordism::outputs,
                              py::return_value_policy::reference_internal,
-                             "The emergent output blocks (each a MultiCobordismBlock).");
+                             "The emergent output blocks (each a MultiCobordismBlock).")
+      .def("composite_spin_j2", &MultiCobordism::compositeSpinJ2,
+           py::arg("output_block_index") = 0,
+           "Loops-as-quarks composite spin J^2 of an output block: the pair-loop "
+           "closed-loop holonomy is the deficit at the Poincare-dual (complementary) "
+           "hole, lifted through the DiracKahler spin-1/2 double cover to "
+           "<S_i.S_j> = 1/4 cos(eps_k); J^2 = 9/4 + 1/2 Sum_k cos(eps_k). Reduces to the "
+           "closed-loop holonomy / pairwise C_ij (floors above the entangled proton 3/4). "
+           "Raises if the block has no 3-hole register.");
 
   // === CobordismDAG (#491): chain emergent merges, output -> input ===
   py::class_<CobordismDAG>(m, "CobordismDAG",

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -17,6 +17,7 @@
 #include "cobordism/Cochain.h"
 #include "cobordism/CombinatorialDimension.h"
 #include "cobordism/CobordismDAG.h"
+#include "cobordism/DiracKahler.h"
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/MultiCobordism.h"
 #include "cobordism/HodgeLaplacian.h"
@@ -345,6 +346,95 @@ Euclidean spectrum/kernel.)doc")
            "representatives, one per column of lorentzianHarmonics (same order). "
            "A value ~0 flags a NULL (lightlike) harmonic; all positive on an "
            "all-spacelike complex.");
+
+  // ----- §4a Dirac-Kahler operator: D = d+delta, gammas, conserved current (#415) -----
+  py::class_<DiracKahler>(m, "DiracKahler",
+      R"doc(The discrete Dirac-Kahler operator D = d + delta on the inhomogeneous
+cochain complex of a Spacetime — the label-independent square root of the
+HodgeLaplacian, and the distinguished frame the deferred operator read-out lacks.
+
+On the total cochain space Phi in (+)_k Omega^k (flat dim sum_k |C_k|), D is
+assembled block-by-block from the integer boundary maps d_k (ChainComplex) and
+diagonal weights W_k (HodgeLaplacian.weights): the boundary part (degree-lowering)
+block Omega^k -> Omega^{k-1} is d_k; the codifferential part d_k* = W_k^-1 d_k^T
+W_{k-1} (degree-raising) block Omega^{k-1} -> Omega^k. Since d^2 = (d*)^2 = 0 the
+square is block-diagonal per degree and reproduces the HodgeLaplacian:
+(d+delta)^2 = L_k. On uniform per-degree weights (e.g. l^2 = 1, W_k = c_k I) this
+matches the symmetric metric laplacian(k); the lorentzian path reproduces the
+signed d'Alembertian blocks (k>=1). Rebuilt from current edge weights each call.
+
+Clifford/gamma structure: the gammas are the Clifford action of unit 1-cochains on
+the Kahler-Atiyah form fiber Lambda(R^d), gamma^a = eps(e^a) + eta^aa iota(e^a),
+satisfying {gamma^a, gamma^b} = 2 eta^ab I exactly. The framework dimension is d=4:
+the fiber is 2^4 = 16 = 4 (Dirac spinor) x 4 (taste) and multiplicity() = 4 is the
+candidate flavor/taste index. The conserved U(1) current j^a = bar(Phi) gamma^a Phi
+has time component j^0 = W_c |Phi_c|^2 (charge density); summed over a closed slice
+it integrates to the carried charge <Phi,Phi>_W.
+
+Reduced-dimension caveat: the current S^2 x I cobordism is 2+1 D; D and the D^2 = L
+check are generic in n D, while the gamma/Clifford framework and multiplicity report
+the fixed 4D values.)doc")
+      .def(py::init<std::shared_ptr<Spacetime>>(), py::arg("spacetime"),
+           "Build the Dirac-Kahler operator over a triangulation.")
+      .def("meshDimension", &DiracKahler::meshDimension,
+           "The mesh top dimension n (largest k with a k-cell), or -1 if empty.")
+      .def("totalDimension", &DiracKahler::totalDimension,
+           "The total cochain dimension sum_k |C_k| (side length of D).")
+      .def("blockOffsets", &DiracKahler::blockOffsets,
+           "Block offsets (o_0..o_{n+1}), o_k = sum_{j<k} |C_j|: degree-k "
+           "components occupy [o_k, o_{k+1}) in canonical ChainComplex cell order.")
+      .def("matrix", &DiracKahler::matrix, py::arg("metric") = true,
+           py::arg("lorentzian") = false,
+           "The operator D = d+delta as a flat row-major totalDimension^2 complex "
+           "array (real; imag 0). metric=False uses unit weights (combinatorial); "
+           "lorentzian=True uses signed weights (the square is the d'Alembertian).")
+      .def("square", &DiracKahler::square, py::arg("metric") = true,
+           py::arg("lorentzian") = false,
+           "The square D^2 as a flat row-major totalDimension^2 complex array: "
+           "block-diagonal per degree, each block the degree-k HodgeLaplacian; "
+           "cross-degree blocks vanish (d^2 = delta^2 = 0).")
+      .def("laplacianResidual", &DiracKahler::laplacianResidual,
+           py::arg("metric") = true, py::arg("lorentzian") = false,
+           "max_k ||(D^2)_k - laplacian(k, metric, lorentzian)||_F over k=0..n "
+           "(Euclidean) or k=1..n (lorentzian; the k=0 HodgeLaplacian is the "
+           "Hermitian graph Laplacian, not the signed 0-form d'Alembertian). ~0 "
+           "confirms (d+delta)^2 = L.")
+      .def("frameworkDimension", &DiracKahler::frameworkDimension,
+           "The framework spacetime dimension d=4 (fixed; independent of the "
+           "reduced mesh dimension).")
+      .def("gammaDimension", &DiracKahler::gammaDimension,
+           "The Kahler-Atiyah form-fiber dimension 2^d = 16 (side length of each "
+           "gamma matrix).")
+      .def("multiplicity", &DiracKahler::multiplicity,
+           "The 4-fold Dirac-Kahler multiplicity 2^{d/2} = 4: the degenerate Dirac "
+           "copies in Lambda(C^4) = 16 = 4_spinor x 4_taste (candidate flavor "
+           "index). Pinned to 4 in the 4D framework.")
+      .def("signature", &DiracKahler::signature, py::arg("lorentzian") = false,
+           "The metric signature eta as a flat row-major d*d array: Euclidean "
+           "delta_ab, or Lorentzian diag(-1,+1,+1,+1) under lorentzian=True.")
+      .def("gammas", &DiracKahler::gammas, py::arg("lorentzian") = false,
+           "The d=4 gamma generators (Clifford action of unit 1-cochains on "
+           "Lambda(R^4)) as a list of gammaDimension*gammaDimension flat row-major "
+           "complex matrices gamma^a = eps(e^a) + eta^aa iota(e^a). Satisfy "
+           "{gamma^a, gamma^b} = 2 eta^ab I against signature(lorentzian).")
+      .def("cliffordResidual", &DiracKahler::cliffordResidual,
+           py::arg("lorentzian") = false,
+           "max_{a,b} ||{gamma^a, gamma^b} - 2 eta^ab I||_F for gammas(lorentzian) "
+           "against signature(lorentzian). ~0.")
+      .def("lift", &DiracKahler::lift, py::arg("k"), py::arg("component"),
+           "Lift a degree-k cochain (length |C_k|) into a total-space field "
+           "(length totalDimension), zero in every other degree. Raises if the "
+           "component length is wrong.")
+      .def("chargeDensity", &DiracKahler::chargeDensity, py::arg("field"),
+           py::arg("metric") = true,
+           "Per-cell charge density j^0_c = W_c |Phi_c|^2 of a total-space field "
+           "(length totalDimension) in the blockOffsets layout. metric=False uses "
+           "unit weights. Raises if the field length is wrong.")
+      .def("charge", &DiracKahler::charge, py::arg("field"),
+           py::arg("metric") = true,
+           "The carried U(1) charge sum_c j^0_c = <Phi,Phi>_W (j^0 summed over the "
+           "slice). On a closed harmonic this is the carried charge. Raises if the "
+           "field length is wrong.");
 
   // ----- §4b eigenstate synthesis: residual + parameter access (#133) -----
   auto eigenstateSynthesis = py::class_<EigenstateSynthesis>(m, "EigenstateSynthesis",

--- a/src/cobordism/DiracKahler.cpp
+++ b/src/cobordism/DiracKahler.cpp
@@ -1,0 +1,312 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "cobordism/DiracKahler.h"
+
+#include <Eigen/Dense>
+
+#include <bitset>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "cobordism/ChainComplex.h"
+#include "cobordism/HodgeLaplacian.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::cobordism {
+
+using cd = std::complex<double>;
+
+namespace {
+
+// The framework spacetime dimension of the Dirac-Kahler construction: 4D. The
+// gamma/Clifford structure and the taste multiplicity are fixed properties of
+// this 4D framework, independent of the reduced mesh dimension.
+constexpr int kFrameworkDim = 4;
+
+// Diagonal weights W_k (length |C_k|) used by both the operator and the current.
+// Mirrors HodgeLaplacian: W_0 = I; for k >= 1 the per-cell |volume| (metric) or
+// signed volume (lorentzian); metric == false ⇒ unit weights (combinatorial).
+std::vector<double> degreeWeights(const HodgeLaplacian &hl, int k,
+                                  std::size_t count, bool metric,
+                                  bool lorentzian) {
+  if (!metric || k == 0)
+    return std::vector<double>(count, 1.0);
+  std::vector<double> w = hl.weights(k, lorentzian);
+  if (w.size() != count) w.assign(count, 1.0);  // defensive: above top dim
+  return w;
+}
+
+// The boundary matrix d_k (rows |C_{k-1}|, cols |C_k|) as an Eigen matrix.
+Eigen::MatrixXd boundaryMatrix(const ChainComplex &cc, int k, int rows, int cols) {
+  Eigen::MatrixXd d = Eigen::MatrixXd::Zero(rows, cols);
+  if (rows == 0 || cols == 0) return d;
+  const std::vector<long> &flat = cc.boundaryMatrix(k);
+  for (int r = 0; r < rows; ++r)
+    for (int c = 0; c < cols; ++c)
+      d(r, c) = static_cast<double>(flat[static_cast<std::size_t>(r) * cols + c]);
+  return d;
+}
+
+}  // namespace
+
+DiracKahler::DiracKahler(std::shared_ptr<Spacetime> st) : st_(std::move(st)) {}
+
+std::vector<std::size_t> DiracKahler::cellCounts() const {
+  if (!st_) return {};
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const int n = cc.dimension();
+  std::vector<std::size_t> counts;
+  counts.reserve(static_cast<std::size_t>(n + 1));
+  for (int k = 0; k <= n; ++k) counts.push_back(cc.numSimplices(k));
+  return counts;
+}
+
+int DiracKahler::meshDimension() const {
+  if (!st_) return -1;
+  return ChainComplex::fromSpacetime(*st_).dimension();
+}
+
+std::vector<std::size_t> DiracKahler::blockOffsets() const {
+  const std::vector<std::size_t> counts = cellCounts();
+  std::vector<std::size_t> off(counts.size() + 1, 0);
+  for (std::size_t k = 0; k < counts.size(); ++k) off[k + 1] = off[k] + counts[k];
+  return off;
+}
+
+std::size_t DiracKahler::totalDimension() const {
+  const std::vector<std::size_t> off = blockOffsets();
+  return off.empty() ? 0 : off.back();
+}
+
+std::vector<cd> DiracKahler::matrix(bool metric, bool lorentzian) const {
+  const std::vector<std::size_t> counts = cellCounts();
+  const std::vector<std::size_t> off = blockOffsets();
+  const std::size_t total = off.empty() ? 0 : off.back();
+  std::vector<cd> out(total * total, cd(0.0, 0.0));
+  if (total == 0 || !st_) return out;
+
+  const ChainComplex cc = ChainComplex::fromSpacetime(*st_);
+  const HodgeLaplacian hl(st_);
+  const int n = static_cast<int>(counts.size()) - 1;
+
+  for (int k = 1; k <= n; ++k) {
+    const int rows = static_cast<int>(counts[static_cast<std::size_t>(k - 1)]);
+    const int cols = static_cast<int>(counts[static_cast<std::size_t>(k)]);
+    if (rows == 0 || cols == 0) continue;
+    const Eigen::MatrixXd dk = boundaryMatrix(cc, k, rows, cols);
+
+    const std::vector<double> wk =
+        degreeWeights(hl, k, static_cast<std::size_t>(cols), metric, lorentzian);
+    const std::vector<double> wkm1 = degreeWeights(
+        hl, k - 1, static_cast<std::size_t>(rows), metric, lorentzian);
+
+    // Boundary block partial_k: rows in degree k-1, cols in degree k.
+    const std::size_t r0 = off[static_cast<std::size_t>(k - 1)];
+    const std::size_t c0 = off[static_cast<std::size_t>(k)];
+    for (int r = 0; r < rows; ++r)
+      for (int c = 0; c < cols; ++c)
+        out[(r0 + static_cast<std::size_t>(r)) * total + (c0 + static_cast<std::size_t>(c))] +=
+            cd(dk(r, c), 0.0);
+
+    // Codifferential block partial_k* = W_k^-1 d_k^T W_{k-1}: rows in degree k,
+    // cols in degree k-1.
+    for (int i = 0; i < cols; ++i)
+      for (int j = 0; j < rows; ++j) {
+        const double v = (1.0 / wk[static_cast<std::size_t>(i)]) * dk(j, i) *
+                         wkm1[static_cast<std::size_t>(j)];
+        out[(c0 + static_cast<std::size_t>(i)) * total + (r0 + static_cast<std::size_t>(j))] +=
+            cd(v, 0.0);
+      }
+  }
+  return out;
+}
+
+std::vector<cd> DiracKahler::square(bool metric, bool lorentzian) const {
+  const std::size_t total = totalDimension();
+  std::vector<cd> out(total * total, cd(0.0, 0.0));
+  if (total == 0) return out;
+  const std::vector<cd> Dflat = matrix(metric, lorentzian);
+  Eigen::MatrixXcd D(total, total);
+  for (std::size_t i = 0; i < total; ++i)
+    for (std::size_t j = 0; j < total; ++j)
+      D(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+          Dflat[i * total + j];
+  const Eigen::MatrixXcd D2 = D * D;
+  for (std::size_t i = 0; i < total; ++i)
+    for (std::size_t j = 0; j < total; ++j)
+      out[i * total + j] =
+          D2(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+  return out;
+}
+
+double DiracKahler::laplacianResidual(bool metric, bool lorentzian) const {
+  const std::vector<std::size_t> counts = cellCounts();
+  const std::vector<std::size_t> off = blockOffsets();
+  const std::size_t total = off.empty() ? 0 : off.back();
+  if (total == 0 || !st_) return 0.0;
+
+  const std::vector<cd> sq = square(metric, lorentzian);
+  const HodgeLaplacian hl(st_);
+  const int n = static_cast<int>(counts.size()) - 1;
+  // The k=0 HodgeLaplacian is the Hermitian graph Laplacian, which equals the
+  // signed 0-form d'Alembertian only for unit/real weights; skip it on the
+  // lorentzian path (compare the d'Alembertian blocks k>=1).
+  const int kStart = lorentzian ? 1 : 0;
+
+  double worst = 0.0;
+  for (int k = kStart; k <= n; ++k) {
+    const std::size_t m = counts[static_cast<std::size_t>(k)];
+    if (m == 0) continue;
+    const std::vector<cd> lk = hl.laplacian(k, metric, lorentzian);
+    const std::size_t o = off[static_cast<std::size_t>(k)];
+    double sumSq = 0.0;
+    for (std::size_t i = 0; i < m; ++i)
+      for (std::size_t j = 0; j < m; ++j) {
+        const cd diff = sq[(o + i) * total + (o + j)] - lk[i * m + j];
+        sumSq += std::norm(diff);
+      }
+    worst = std::max(worst, std::sqrt(sumSq));
+  }
+  return worst;
+}
+
+int DiracKahler::frameworkDimension() const { return kFrameworkDim; }
+
+std::size_t DiracKahler::gammaDimension() const {
+  return static_cast<std::size_t>(1) << kFrameworkDim;
+}
+
+int DiracKahler::multiplicity() const { return 1 << (kFrameworkDim / 2); }
+
+std::vector<double> DiracKahler::signature(bool lorentzian) const {
+  const int d = kFrameworkDim;
+  std::vector<double> eta(static_cast<std::size_t>(d) * d, 0.0);
+  for (int a = 0; a < d; ++a) {
+    const double s = (lorentzian && a == 0) ? -1.0 : 1.0;
+    eta[static_cast<std::size_t>(a) * d + a] = s;
+  }
+  return eta;
+}
+
+std::vector<std::vector<cd>> DiracKahler::gammas(bool lorentzian) const {
+  const int d = kFrameworkDim;
+  const std::size_t dim = gammaDimension();
+  std::vector<std::vector<cd>> gs;
+  gs.reserve(static_cast<std::size_t>(d));
+  for (int a = 0; a < d; ++a) {
+    std::vector<cd> g(dim * dim, cd(0.0, 0.0));
+    const double etaAA = (lorentzian && a == 0) ? -1.0 : 1.0;
+    const unsigned bit = 1u << a;
+    const unsigned below = bit - 1u;  // bits 0..a-1
+    for (unsigned S = 0; S < dim; ++S) {
+      // sign = (-1)^popcount(S & bits below a) — the Koszul sign of e^a in e^S.
+      const double sign =
+          (std::bitset<32>(S & below).count() % 2 == 0) ? 1.0 : -1.0;
+      if ((S & bit) == 0) {
+        // exterior multiplication: add basis 1-form e^a (raises degree).
+        const unsigned T = S | bit;
+        g[static_cast<std::size_t>(T) * dim + S] += cd(sign, 0.0);
+      } else {
+        // interior multiplication (contraction) by e^a, with the metric eta^aa.
+        const unsigned T = S & ~bit;
+        g[static_cast<std::size_t>(T) * dim + S] += cd(etaAA * sign, 0.0);
+      }
+    }
+    gs.push_back(std::move(g));
+  }
+  return gs;
+}
+
+double DiracKahler::cliffordResidual(bool lorentzian) const {
+  const int d = kFrameworkDim;
+  const std::size_t dim = gammaDimension();
+  const std::vector<std::vector<cd>> gs = gammas(lorentzian);
+  const std::vector<double> eta = signature(lorentzian);
+
+  std::vector<Eigen::MatrixXcd> G;
+  G.reserve(gs.size());
+  for (const auto &gflat : gs) {
+    Eigen::MatrixXcd M(dim, dim);
+    for (std::size_t i = 0; i < dim; ++i)
+      for (std::size_t j = 0; j < dim; ++j)
+        M(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+            gflat[i * dim + j];
+    G.push_back(std::move(M));
+  }
+  const Eigen::MatrixXcd I =
+      Eigen::MatrixXcd::Identity(static_cast<Eigen::Index>(dim),
+                                 static_cast<Eigen::Index>(dim));
+  double worst = 0.0;
+  for (int a = 0; a < d; ++a)
+    for (int b = 0; b < d; ++b) {
+      const Eigen::MatrixXcd anti = G[static_cast<std::size_t>(a)] * G[static_cast<std::size_t>(b)] +
+                                    G[static_cast<std::size_t>(b)] * G[static_cast<std::size_t>(a)];
+      const double etaAB = eta[static_cast<std::size_t>(a) * d + b];
+      worst = std::max(worst, (anti - 2.0 * etaAB * I).norm());
+    }
+  return worst;
+}
+
+std::vector<cd> DiracKahler::lift(int k,
+                                  const std::vector<cd> &component) const {
+  const std::vector<std::size_t> counts = cellCounts();
+  const std::vector<std::size_t> off = blockOffsets();
+  const std::size_t total = off.empty() ? 0 : off.back();
+  if (k < 0 || k >= static_cast<int>(counts.size()))
+    throw std::runtime_error("DiracKahler::lift: degree k=" + std::to_string(k) +
+                             " is out of range [0, " +
+                             std::to_string(static_cast<int>(counts.size()) - 1) +
+                             "]");
+  const std::size_t m = counts[static_cast<std::size_t>(k)];
+  if (component.size() != m)
+    throw std::runtime_error(
+        "DiracKahler::lift: component length " +
+        std::to_string(component.size()) + " != |C_k| " + std::to_string(m));
+  std::vector<cd> field(total, cd(0.0, 0.0));
+  const std::size_t o = off[static_cast<std::size_t>(k)];
+  for (std::size_t c = 0; c < m; ++c) field[o + c] = component[c];
+  return field;
+}
+
+std::vector<double> DiracKahler::chargeDensity(const std::vector<cd> &field,
+                                               bool metric) const {
+  const std::vector<std::size_t> counts = cellCounts();
+  const std::vector<std::size_t> off = blockOffsets();
+  const std::size_t total = off.empty() ? 0 : off.back();
+  if (field.size() != total)
+    throw std::runtime_error(
+        "DiracKahler::chargeDensity: field length " +
+        std::to_string(field.size()) + " != totalDimension " +
+        std::to_string(total));
+  std::vector<double> density(total, 0.0);
+  if (total == 0 || !st_) return density;
+
+  const HodgeLaplacian hl(st_);
+  const int n = static_cast<int>(counts.size()) - 1;
+  for (int k = 0; k <= n; ++k) {
+    const std::size_t m = counts[static_cast<std::size_t>(k)];
+    if (m == 0) continue;
+    // j^0 uses the positive |volume| charge measure (the time component of the
+    // Dirac current is the positive-definite probability/charge density).
+    const std::vector<double> wk =
+        degreeWeights(hl, k, m, metric, /*lorentzian=*/false);
+    const std::size_t o = off[static_cast<std::size_t>(k)];
+    for (std::size_t c = 0; c < m; ++c)
+      density[o + c] = wk[c] * std::norm(field[o + c]);  // std::norm = |.|^2
+  }
+  return density;
+}
+
+double DiracKahler::charge(const std::vector<cd> &field, bool metric) const {
+  const std::vector<double> density = chargeDensity(field, metric);
+  double q = 0.0;
+  for (const double d : density) q += d;
+  return q;
+}
+
+}  // namespace tessera::cobordism

--- a/src/cobordism/MultiCobordism.cpp
+++ b/src/cobordism/MultiCobordism.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <limits>
 #include <numeric>
+#include <queue>
 
 #include <Eigen/Dense>
 
@@ -221,21 +222,99 @@ double MultiCobordism::diracKahlerSpinCasimir(
   return casimir.trace().real() / static_cast<double>(fiberDimension);  // -> 3/4
 }
 
-double MultiCobordism::holeDeficit(const std::shared_ptr<Spacetime> &spacetime,
-                                   const std::vector<std::uint64_t> &hole) {
-  const std::set<std::uint64_t> holeVertexSet(hole.begin(), hole.end());
-  double totalDeficit = 0.0;
+std::vector<double> MultiCobordism::holeRegionDeficits(
+    const std::shared_ptr<Spacetime> &spacetime,
+    const std::vector<std::vector<std::uint64_t>> &holes) {
+  const auto &cells = spacetime->getTopSimplices();
+  const std::size_t cellCount = cells.size();
+  const std::size_t holeCount = holes.size();
+  std::vector<double> regionDeficit(holeCount, 0.0);
+  if (cellCount == 0 || holeCount == 0) return regionDeficit;
+
+  std::vector<std::set<std::uint64_t>> cellVertexSets(cellCount);
+  for (std::size_t c = 0; c < cellCount; ++c) {
+    const auto cellTuple = topTuple(*cells[c]);
+    cellVertexSets[c] =
+        std::set<std::uint64_t>(cellTuple.begin(), cellTuple.end());
+  }
+
+  // Dual adjacency: two top cells share a (d-1)-facet (4 common vertices in 4D).
+  std::vector<std::vector<std::size_t>> adjacency(cellCount);
+  for (std::size_t a = 0; a < cellCount; ++a)
+    for (std::size_t b = a + 1; b < cellCount; ++b) {
+      std::size_t shared = 0;
+      for (auto vertexId : cellVertexSets[a])
+        if (cellVertexSets[b].count(vertexId)) ++shared;
+      if (shared == 4) {
+        adjacency[a].push_back(b);
+        adjacency[b].push_back(a);
+      }
+    }
+
+  // Seed one DISTINCT max-overlap cell per hole, then multi-source BFS labels every cell
+  // with its nearest hole (ties resolved to the lower hole index, holes processed in order).
+  std::vector<int> nearestHole(cellCount, -1);
+  std::vector<int> hopDistance(cellCount, std::numeric_limits<int>::max());
+  std::set<std::size_t> seededCells;
+  std::queue<std::size_t> frontier;
+  for (std::size_t h = 0; h < holeCount; ++h) {
+    const std::set<std::uint64_t> holeSet(holes[h].begin(), holes[h].end());
+    std::size_t seedCell = cellCount;
+    std::size_t bestOverlap = 0;
+    for (std::size_t c = 0; c < cellCount; ++c) {
+      if (seededCells.count(c)) continue;
+      std::size_t overlap = 0;
+      for (auto vertexId : cellVertexSets[c])
+        if (holeSet.count(vertexId)) ++overlap;
+      if (overlap > bestOverlap) {
+        bestOverlap = overlap;
+        seedCell = c;
+      }
+    }
+    if (seedCell == cellCount) continue;
+    seededCells.insert(seedCell);
+    nearestHole[seedCell] = static_cast<int>(h);
+    hopDistance[seedCell] = 0;
+    frontier.push(seedCell);
+  }
+  while (!frontier.empty()) {
+    const std::size_t c = frontier.front();
+    frontier.pop();
+    for (auto neighbor : adjacency[c])
+      if (hopDistance[neighbor] > hopDistance[c] + 1) {
+        hopDistance[neighbor] = hopDistance[c] + 1;
+        nearestHole[neighbor] = nearestHole[c];
+        frontier.push(neighbor);
+      }
+  }
+
+  // Each hinge (triangle) is added to the region of its nearest containing cell's hole, so
+  // the partition covers ALL curvature (the holes' own hinges and the bulk between them).
   for (const auto &simplex : spacetime->getSimplices()) {
     if (simplex->getVertices().size() != 3) continue;  // hinges (triangles) in 4D
-    bool insideHole = true;
+    std::set<std::uint64_t> hingeVertices;
     for (const auto *vertex : simplex->getVertices())
-      if (!holeVertexSet.count(vertex->getId())) {
-        insideHole = false;
-        break;
+      hingeVertices.insert(vertex->getId());
+    int chosenHole = -1;
+    int chosenDistance = std::numeric_limits<int>::max();
+    for (std::size_t c = 0; c < cellCount; ++c) {
+      if (nearestHole[c] < 0) continue;
+      bool hingeInCell = true;
+      for (auto vertexId : hingeVertices)
+        if (!cellVertexSets[c].count(vertexId)) {
+          hingeInCell = false;
+          break;
+        }
+      if (hingeInCell && hopDistance[c] < chosenDistance) {
+        chosenDistance = hopDistance[c];
+        chosenHole = nearestHole[c];
       }
-    if (insideHole) totalDeficit += simplex->deficitAngle();
+    }
+    if (chosenHole >= 0)
+      regionDeficit[static_cast<std::size_t>(chosenHole)] +=
+          simplex->deficitAngle();
   }
-  return totalDeficit;
+  return regionDeficit;
 }
 
 double MultiCobordism::compositeSpinJ2(std::size_t outputBlockIndex) const {
@@ -255,18 +334,22 @@ double MultiCobordism::compositeSpinJ2(std::size_t outputBlockIndex) const {
   const ReggeSolver reggeSolver(blockSubcomplex, MatterConfiguration());
   (void)reggeSolver;
   const double spinHalfCasimir = diracKahlerSpinCasimir(blockSubcomplex);  // 3/4
-  // The two-quark pair-loop gamma_ij LITERALLY encircles holes i and j; by cycle additivity
-  // gamma_ij = gamma_i + gamma_j, so the deficit it encloses is eps_i + eps_j (the curvature
-  // at the two encircled holes), and <S_i.S_j> = 1/4 cos(eps_i + eps_j). No duality assumed
-  // (this differs from the complementary-hole proxy by the Gauss-Bonnet constant).
-  double holeDeficits[3];
-  for (std::size_t holeIndex = 0; holeIndex < 3; ++holeIndex)
-    holeDeficits[holeIndex] = holeDeficit(blockSubcomplex, holes[holeIndex]);
+  // The two-quark pair-loop gamma_ij encircles holes i and j; the deficit it ENCLOSES is the
+  // curvature of their combined nearest-hole territory, region(i) + region(j) -- the holes'
+  // own concentrated curvature PLUS the bulk nearest them (the fully-literal enclosed deficit,
+  // covering every hinge, not just the holes' boundary triangles). <S_i.S_j> = 1/4 cos(.).
+  // (The host S^4-minus-cells is simply connected, so there is no canonical non-contractible
+  // loop; the enclosed region is fixed by the nearest-hole partition, and the bulk term
+  // vanishes for a flat relaxed interior.)
+  std::vector<std::vector<std::uint64_t>> threeHoles(holes.begin(),
+                                                     holes.begin() + 3);
+  const std::vector<double> regionDeficit =
+      holeRegionDeficits(blockSubcomplex, threeHoles);
   static const int pair[3][2] = {{0, 1}, {0, 2}, {1, 2}};
   double crossTermSum = 0.0;
   for (const auto &twoQuarkLoop : pair)
-    crossTermSum +=
-        0.25 * std::cos(holeDeficits[twoQuarkLoop[0]] + holeDeficits[twoQuarkLoop[1]]);
+    crossTermSum += 0.25 * std::cos(regionDeficit[twoQuarkLoop[0]] +
+                                    regionDeficit[twoQuarkLoop[1]]);
   return 3.0 * spinHalfCasimir + 2.0 * crossTermSum;
 }
 

--- a/src/cobordism/MultiCobordism.cpp
+++ b/src/cobordism/MultiCobordism.cpp
@@ -11,6 +11,7 @@
 #include <Eigen/Dense>
 
 #include "cobordism/ChainComplex.h"
+#include "cobordism/DiracKahler.h"
 #include "cobordism/EigenstateSynthesis.h"
 #include "cobordism/SurgicalCone.h"
 #include "matter/MatterConfiguration.h"
@@ -184,6 +185,83 @@ double MultiCobordism::residualOfTargetStateAgainstHarmonic(
   } while (std::next_permutation(targetPermutation.begin(),
                                  targetPermutation.end()));
   return bestResidual;
+}
+
+double MultiCobordism::diracKahlerSpinCasimir(
+    const std::shared_ptr<Spacetime> &spacetime) {
+  DiracKahler diracKahler(spacetime);
+  const auto flatGammas = diracKahler.gammas(/*lorentzian=*/false);
+  const std::size_t fiberDimension = diracKahler.gammaDimension();
+  std::vector<Eigen::MatrixXcd> gamma;
+  gamma.reserve(flatGammas.size());
+  for (const auto &flat : flatGammas) {
+    Eigen::MatrixXcd matrix(static_cast<int>(fiberDimension),
+                            static_cast<int>(fiberDimension));
+    for (std::size_t row = 0; row < fiberDimension; ++row)
+      for (std::size_t col = 0; col < fiberDimension; ++col)
+        matrix(static_cast<int>(row), static_cast<int>(col)) =
+            flat[row * fiberDimension + col];
+    gamma.push_back(std::move(matrix));
+  }
+  // S_a = -i Sigma_{jk} over the spatial plane perpendicular to axis a (cyclic over the
+  // spatial gammas 1,2,3); Sigma_ij = 1/4 [gamma_i, gamma_j] has eigenvalues +/- i/2, so
+  // S_a has +/- 1/2 and the Casimir Sum_a S_a^2 = 3/4 * I on the spin-1/2 fiber.
+  const int spatialPlane[3][2] = {{2, 3}, {3, 1}, {1, 2}};
+  Eigen::MatrixXcd casimir = Eigen::MatrixXcd::Zero(
+      static_cast<int>(fiberDimension), static_cast<int>(fiberDimension));
+  for (int axis = 0; axis < 3; ++axis) {
+    const int i = spatialPlane[axis][0];
+    const int j = spatialPlane[axis][1];
+    const Eigen::MatrixXcd sigma =
+        0.25 * (gamma[i] * gamma[j] - gamma[j] * gamma[i]);
+    const Eigen::MatrixXcd spinComponent =
+        std::complex<double>(0.0, -1.0) * sigma;
+    casimir += spinComponent * spinComponent;
+  }
+  return casimir.trace().real() / static_cast<double>(fiberDimension);  // -> 3/4
+}
+
+double MultiCobordism::holeDeficit(const std::shared_ptr<Spacetime> &spacetime,
+                                   const std::vector<std::uint64_t> &hole) {
+  const std::set<std::uint64_t> holeVertexSet(hole.begin(), hole.end());
+  double totalDeficit = 0.0;
+  for (const auto &simplex : spacetime->getSimplices()) {
+    if (simplex->getVertices().size() != 3) continue;  // hinges (triangles) in 4D
+    bool insideHole = true;
+    for (const auto *vertex : simplex->getVertices())
+      if (!holeVertexSet.count(vertex->getId())) {
+        insideHole = false;
+        break;
+      }
+    if (insideHole) totalDeficit += simplex->deficitAngle();
+  }
+  return totalDeficit;
+}
+
+double MultiCobordism::compositeSpinJ2(std::size_t outputBlockIndex) const {
+  if (outputBlockIndex >= outputs_.size())
+    throw std::runtime_error(
+        "MultiCobordism::compositeSpinJ2: output block index out of range");
+  const auto blockSubcomplex =
+      subcomplexWithinVertexSet(spacetime_, outputs_[outputBlockIndex].vertices);
+  if (!blockSubcomplex)
+    throw std::runtime_error(
+        "MultiCobordism::compositeSpinJ2: output block has no sub-complex");
+  const auto holes = emergentHoles(*blockSubcomplex, 3);
+  if (holes.size() < 3)
+    throw std::runtime_error(
+        "MultiCobordism::compositeSpinJ2: output block has no 3-hole (b3) register");
+  // Materialize the skeleton once so the hinges carry deficit angles.
+  const ReggeSolver reggeSolver(blockSubcomplex, MatterConfiguration());
+  (void)reggeSolver;
+  const double spinHalfCasimir = diracKahlerSpinCasimir(blockSubcomplex);  // 3/4
+  // The pair-loop gamma_ij is the Poincare dual of the complementary hole k, so each of
+  // the three holes is dual to exactly one pair: Sum_{i<j} <S_i.S_j> = Sum_k 1/4 cos(eps_k).
+  double crossTermSum = 0.0;
+  for (std::size_t holeIndex = 0; holeIndex < 3; ++holeIndex)
+    crossTermSum +=
+        0.25 * std::cos(holeDeficit(blockSubcomplex, holes[holeIndex]));
+  return 3.0 * spinHalfCasimir + 2.0 * crossTermSum;
 }
 
 std::shared_ptr<Spacetime> MultiCobordism::subcomplexWithinVertexSet(

--- a/src/cobordism/MultiCobordism.cpp
+++ b/src/cobordism/MultiCobordism.cpp
@@ -255,12 +255,18 @@ double MultiCobordism::compositeSpinJ2(std::size_t outputBlockIndex) const {
   const ReggeSolver reggeSolver(blockSubcomplex, MatterConfiguration());
   (void)reggeSolver;
   const double spinHalfCasimir = diracKahlerSpinCasimir(blockSubcomplex);  // 3/4
-  // The pair-loop gamma_ij is the Poincare dual of the complementary hole k, so each of
-  // the three holes is dual to exactly one pair: Sum_{i<j} <S_i.S_j> = Sum_k 1/4 cos(eps_k).
-  double crossTermSum = 0.0;
+  // The two-quark pair-loop gamma_ij LITERALLY encircles holes i and j; by cycle additivity
+  // gamma_ij = gamma_i + gamma_j, so the deficit it encloses is eps_i + eps_j (the curvature
+  // at the two encircled holes), and <S_i.S_j> = 1/4 cos(eps_i + eps_j). No duality assumed
+  // (this differs from the complementary-hole proxy by the Gauss-Bonnet constant).
+  double holeDeficits[3];
   for (std::size_t holeIndex = 0; holeIndex < 3; ++holeIndex)
+    holeDeficits[holeIndex] = holeDeficit(blockSubcomplex, holes[holeIndex]);
+  static const int pair[3][2] = {{0, 1}, {0, 2}, {1, 2}};
+  double crossTermSum = 0.0;
+  for (const auto &twoQuarkLoop : pair)
     crossTermSum +=
-        0.25 * std::cos(holeDeficit(blockSubcomplex, holes[holeIndex]));
+        0.25 * std::cos(holeDeficits[twoQuarkLoop[0]] + holeDeficits[twoQuarkLoop[1]]);
   return 3.0 * spinHalfCasimir + 2.0 * crossTermSum;
 }
 

--- a/tests/cobordism/test_dk_spin.py
+++ b/tests/cobordism/test_dk_spin.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Structural spin-½ of the Dirac-Kahler fiber (#415/#477) — the revived C++ DiracKahler.
+
+The Kahler-Atiyah fiber of a d=4 mesh is 16 = 4 spinor x 4 taste; the gammas close as a
+Clifford algebra ({gamma^a, gamma^b} = 2 eta^ab); every spatial rotation generator
+Sigma_ij = 1/4 [gamma_i, gamma_j] has eigenvalues exactly +/- 1/2 (the spin-1/2 signature —
+not 0/scalar, not +/-1/vector); and (d + delta)^2 reproduces the Hodge Laplacian.
+
+Structural: no convergence needed. This tests the C++ `DiracKahler` class directly; the retired
+Python `spin_report` / `emergent_optimizer` examples are deliberately NOT brought back.
+"""
+import unittest
+
+import numpy as np
+
+import tessera as T
+
+cob = T.cobordism
+
+
+def _host():
+    """Any valid 4D complex — the Clifford framework is the fixed 4D structure, so two
+    pentatopes sharing a facet suffice."""
+    return T.Spacetime.fromCells(4, [[0, 1, 2, 3, 4], [1, 2, 3, 4, 5]], 1.0, 0.0)
+
+
+class DiracKahlerSpinTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dk = cob.DiracKahler(_host())
+
+    def test_fiber_is_16_with_taste_4(self):
+        self.assertEqual(self.dk.frameworkDimension(), 4)
+        self.assertEqual(self.dk.gammaDimension(), 16)     # 2^4
+        self.assertEqual(self.dk.multiplicity(), 4)        # 16 = 4 spinor x 4 taste
+
+    def test_gammas_close_as_clifford(self):
+        self.assertLess(self.dk.cliffordResidual(), 1e-9)
+
+    def test_spatial_rotation_generators_are_spin_half(self):
+        n = self.dk.gammaDimension()
+        g = [np.array(m, dtype=complex).reshape(n, n) for m in self.dk.gammas()]
+        for i in range(1, 4):                               # spatial planes (1,2,3)
+            for j in range(i + 1, 4):
+                sigma = 0.25 * (g[i] @ g[j] - g[j] @ g[i])  # Sigma_ij = 1/4 [g_i, g_j]
+                mags = sorted({round(abs(e), 6) for e in np.linalg.eigvals(sigma)})
+                self.assertEqual(mags, [0.5])               # only +/- 1/2
+
+    def test_square_reproduces_hodge_laplacian(self):
+        self.assertLess(self.dk.laplacianResidual(), 1e-6)  # (d + delta)^2 = L
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_multicobordism_spin.py
+++ b/tests/cobordism/test_multicobordism_spin.py
@@ -3,9 +3,10 @@
 """Loops-as-quarks composite-spin readout on MultiCobordism (#517, part of #410).
 
 `MultiCobordism.composite_spin_j2` reads the total-spin Casimir of an output block in the
-edge (loops-as-quarks) basis: the pair-loop is the Poincare dual of the complementary hole, so
-its closed-loop spin holonomy is that hole's deficit, lifted through the revived DiracKahler
-spin-1/2 double cover to <S_i.S_j> = 1/4 cos(eps_k); J^2 = 9/4 + 1/2 sum_k cos(eps_k).
+edge (loops-as-quarks) basis: the two-quark pair-loop literally encircles holes i,j
+(= gamma_i + gamma_j by cycle additivity), so it encloses the deficit eps_i + eps_j, lifted
+through the revived DiracKahler spin-1/2 double cover to <S_i.S_j> = 1/4 cos(eps_i + eps_j);
+J^2 = 9/4 + 1/2 sum_{i<j} cos(eps_i + eps_j).
 
 Two checks: a fast error-path test (raises without a 3-hole register), and a slow build test
 that drives the simultaneous pair-creation build and confirms the readout lands in the
@@ -72,7 +73,7 @@ class CompositeSpinReadoutTest(unittest.TestCase):
         if result is None:
             self.skipTest("no converged 3-hole proton block in the seed range")
         self.assertTrue(math.isfinite(result))
-        # J^2 = 9/4 + 1/2 sum_k cos(eps_k), cos in [-1,1] over 3 holes -> [3/4, 15/4]
+        # J^2 = 9/4 + 1/2 sum_{i<j} cos(eps_i+eps_j), cos in [-1,1] over 3 pairs -> [3/4, 15/4]
         self.assertGreaterEqual(result, 0.75 - 1e-6)
         self.assertLessEqual(result, 3.75 + 1e-6)
 

--- a/tests/cobordism/test_multicobordism_spin.py
+++ b/tests/cobordism/test_multicobordism_spin.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Loops-as-quarks composite-spin readout on MultiCobordism (#517, part of #410).
+
+`MultiCobordism.composite_spin_j2` reads the total-spin Casimir of an output block in the
+edge (loops-as-quarks) basis: the pair-loop is the Poincare dual of the complementary hole, so
+its closed-loop spin holonomy is that hole's deficit, lifted through the revived DiracKahler
+spin-1/2 double cover to <S_i.S_j> = 1/4 cos(eps_k); J^2 = 9/4 + 1/2 sum_k cos(eps_k).
+
+Two checks: a fast error-path test (raises without a 3-hole register), and a slow build test
+that drives the simultaneous pair-creation build and confirms the readout lands in the
+three-spin-1/2 baryon range J^2 in [3/4, 15/4]. As documented (cartan_weyl_gluon.tex /
+pair_loop_quarks.tex), this reduces to the closed-loop holonomy and floors above the entangled
+proton 3/4 -- the value now lives on the source-of-truth class, not retired Python.
+"""
+import importlib.util
+import math
+import os
+import sys
+import unittest
+
+import cmath
+
+import tessera as T
+
+cob = T.cobordism
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+eo = _load("emergent_optimizer")
+_W = cmath.exp(2j * math.pi / 3)
+_PAIRS = [[1, -1, 0], [1, 0, -1], [0, 1, -1]]      # three neutral q-qbar pairs (Sigma=0)
+_PROTON = [1, _W, _W * _W]
+_ANTIPROTON = [1, _W * _W, _W]
+
+
+class CompositeSpinReadoutTest(unittest.TestCase):
+    def test_raises_without_three_hole_register(self):
+        # fast: an output block with no emerged 3-hole (b3) register has no composite spin
+        host = eo.build_closed_s4(n_refine=8, seed=0)
+        opt = cob.MultiCobordism(host, [[1, -1, 0]], [_PROTON], degrees=[3],
+                                 gamma=1.0, seed=0)
+        with self.assertRaises(RuntimeError):
+            opt.composite_spin_j2(0)              # outputs not constructed -> raises
+
+    def test_composite_spin_in_baryon_range(self):
+        # slow: build the proton by simultaneous pair creation, read the composite spin
+        result = None
+        for seed in range(3, 14):
+            host = eo.build_closed_s4(n_refine=18, seed=seed)
+            opt = cob.MultiCobordism(host, _PAIRS, [_PROTON, _ANTIPROTON], degrees=[3],
+                                     gamma=1.0, seed=seed)
+            sv = [v.getId() for v in host.getVertexList().toVector()]
+            opt.construct_inputs(sv[:3], rounds=20)
+            opt.construct_outputs(sv[3:5], rounds=20)
+            opt.run_stage1(max_steps=60, n_candidates=10, patience=12)
+            opt.run_stage2(beta=1.0, max_iters=20)
+            try:
+                result = opt.composite_spin_j2(0)
+                break
+            except RuntimeError:
+                continue
+        if result is None:
+            self.skipTest("no converged 3-hole proton block in the seed range")
+        self.assertTrue(math.isfinite(result))
+        # J^2 = 9/4 + 1/2 sum_k cos(eps_k), cos in [-1,1] over 3 holes -> [3/4, 15/4]
+        self.assertGreaterEqual(result, 0.75 - 1e-6)
+        self.assertLessEqual(result, 3.75 + 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_multicobordism_spin.py
+++ b/tests/cobordism/test_multicobordism_spin.py
@@ -3,10 +3,10 @@
 """Loops-as-quarks composite-spin readout on MultiCobordism (#517, part of #410).
 
 `MultiCobordism.composite_spin_j2` reads the total-spin Casimir of an output block in the
-edge (loops-as-quarks) basis: the two-quark pair-loop literally encircles holes i,j
-(= gamma_i + gamma_j by cycle additivity), so it encloses the deficit eps_i + eps_j, lifted
-through the revived DiracKahler spin-1/2 double cover to <S_i.S_j> = 1/4 cos(eps_i + eps_j);
-J^2 = 9/4 + 1/2 sum_{i<j} cos(eps_i + eps_j).
+edge (loops-as-quarks) basis: the two-quark pair-loop encircles holes i,j, so it encloses
+region(i) + region(j) -- the fully-literal nearest-hole (Voronoi) curvature of the two holes'
+territory, every hinge included -- lifted through the revived DiracKahler spin-1/2 double cover
+to <S_i.S_j> = 1/4 cos(region(i)+region(j)); J^2 = 9/4 + 1/2 sum_{i<j} cos(.).
 
 Two checks: a fast error-path test (raises without a 3-hole register), and a slow build test
 that drives the simultaneous pair-creation build and confirms the readout lands in the
@@ -73,7 +73,7 @@ class CompositeSpinReadoutTest(unittest.TestCase):
         if result is None:
             self.skipTest("no converged 3-hole proton block in the seed range")
         self.assertTrue(math.isfinite(result))
-        # J^2 = 9/4 + 1/2 sum_{i<j} cos(eps_i+eps_j), cos in [-1,1] over 3 pairs -> [3/4, 15/4]
+        # J^2 = 9/4 + 1/2 sum_{i<j} cos(region_i+region_j), cos in [-1,1] over 3 pairs -> [3/4, 15/4]
         self.assertGreaterEqual(result, 0.75 - 1e-6)
         self.assertLessEqual(result, 3.75 + 1e-6)
 


### PR DESCRIPTION
## Summary
Loops-as-quarks composite-spin readout, implemented on the C++ source-of-truth class `MultiCobordism`. (The original Python "shared dual-bridge" scope is obsolete — the pre-MultiCobordism modules it built on were retired from `main` in #509; the semantics now live on the class.) Two parts:

1. **Revived `DiracKahler`** (retired in `568b4b4`) — the Clifford / spin-½ substrate — as a C++ class + pybind bindings + a structural test. Its deps (`HodgeLaplacian`/`ChainComplex`/`Spacetime`) are all present → no cascade revival; the retired `emergent_optimizer`/`dk_spin_readout` the old test loaded are **not** brought back.
2. **`MultiCobordism::composite_spin_j2(output_block_index)`** — the loops-as-quarks readout. The two-quark pair-loop `γ_ij` encircles holes `i,j`; the deficit it **encloses** is the curvature of their combined **nearest-hole (Voronoi) territory** `region(i)+region(j)` (`holeRegionDeficits`: a multi-source dual-graph BFS assigns *every* hinge to its nearest hole, so this is the fully-literal enclosed curvature — the holes' own concentrated deficit **plus the bulk nearest them**, not just the holes' boundary triangles), lifted through the `DiracKahler` spin-½ double cover to `⟨S_i·S_j⟩ = ¼cos(region(i)+region(j))`; `J² = 9/4 + ½·Σ_{i<j} cos(·)`, the `9/4` being 3× the `DiracKahler` structural spin-½ Casimir. Semantics on the class (`diracKahlerSpinCasimir`, `holeRegionDeficits`); reuses `emergentHoles`/`subcomplexWithinVertexSet`/`ReggeSolver`.

## A geometric caveat (in the docs)
The host (`S⁴` minus 3 cells) is **simply connected** (`b₁=0`), so there is **no canonical non-contractible loop** around two holes — every such loop contracts, and the doc's additivity `∮_{γ_ij}ψ=w_i+w_j` is really over the holes' boundary 3-cycles (`ψ` is degree-3). "Sum the deficit it encloses" is therefore well-defined only via a region convention; the **nearest-hole Voronoi partition** is the deterministic, bulk-inclusive choice taken here.

## Result (seed-6 pair-creation proton block)
- `DiracKahler` structural test: 16-dim fiber, Clifford closure, `Σ_ij` eigenvalues ±½, `D²=L` — 4/4 pass.
- `composite_spin_j2 = 2.980` (fully-literal Voronoi). For comparison: the holes-only literal `ε_i+ε_j` gave 1.592, the complementary-hole proxy 2.355 — the spread is the bulk-curvature term, which is significant (the relaxed interior is not perfectly flat). Raises cleanly on blocks with no 3-hole register (seeds 3–5).
- As documented (`cartan_weyl_gluon.tex` / `pair_loop_quarks.tex`), this **reduces to the closed-loop holonomy** and **floors well above** the entangled proton ¾ — it does not bypass the fiber↔cells kernel. The readout now lives on the source-of-truth class.

## Test plan
- [x] `DiracKahler` structural test (`test_dk_spin.py`) — 4/4
- [x] `composite_spin_j2` error path: raises without a 3-hole register
- [x] `composite_spin_j2` ∈ baryon range `[¾, 15/4]` on a built proton (slow build test; verified `J²=2.980`)
- [x] builds clean in the worktree venv (exit 0)

Closes #517.
