### PR TITLE
refactor(cobordism): animate the two-step proton through the Proton class

### DIFF
--- a/examples/cobordism/multicobordism_animation.py
+++ b/examples/cobordism/multicobordism_animation.py
@@ -1,45 +1,49 @@
 # Copyright (c) 2026 Twin Vector Labs LLC.
 # All rights reserved.
-"""Real-time animation of a `MultiCobordism` optimization (#493).
+"""Real-time animation of the canonical two-step **Proton** build (#522).
 
-The demo is a 2→2 recombination: two q-q̄ pairs ⟶ a diquark ⊔ an anti-diquark
-(#491), built with the established `seed_inputs`/`seed_outputs` flow. Watch
-the emergent register grow and the objective converge **as it runs**: this drives the
-engine's two stages one move/iteration at a time and refreshes a live matplotlib figure
-each step. Three panels:
+Supersedes the old MultiCobordism recombination demo: this drives the actual
+`tessera.cobordism.Proton` class and animates the proton assembling in two steps, each
+growing its whole topology from a single Δ⁴ simplex via the trap door —
+
+  * **Step A — recombination** (`Proton.recombination_node`): two neutral q-q̄ pairs ⟶
+    a colored diquark `{1, ω}` ⊔ anti-diquark `{1, ω²}`;
+  * **Step B — formation** (`Proton.formation_node`): the diquark `{1, ω}` + the third
+    quark `{ω²}` ⟶ the colorless proton singlet `{1, ω, ω²}` (ω = exp(2πi/3)).
+
+The two nodes are animated in sequence, one move/iteration at a time, in a live
+three-panel matplotlib figure:
 
   * **metrics** — the objective `F`, the Regge stationarity term `‖∇S‖²`, and the
-    realizability residual `r_U`, traced vs step;
-  * **register** — the Betti `b₃` (the emergent color register) and the
-    register-hole count, traced vs step;
-  * **complex** — a 2-D projection (classical MDS on the dual/edge graph using the
-    relaxed edge lengths) of the current 1-skeleton, with the vertices on the
-    register holes highlighted. Each frame is Procrustes-aligned to the previous one
-    and eased toward it, so the layout glides instead of bouncing and incremental
-    changes are easy to read.
+    realizability residual `r_U` vs step (a dashed line marks the Step A → Step B
+    boundary);
+  * **register** — the Betti `b₃` (the emergent color register) and the register-hole
+    count vs step;
+  * **complex** — a 2-D classical-MDS projection of the current 1-skeleton (using the
+    relaxed edge lengths), register-hole vertices highlighted. Each frame is
+    Procrustes-aligned to the previous and eased toward it so the layout glides; the
+    continuity resets at the Step A → Step B boundary (Step B starts a fresh simplex).
 
-It drives only the **public** `MultiCobordism` API (`run_stage1`/`run_stage2`
-with single-step counts — which continue the optimizer state across calls —
-plus `betti`, `emergent_holes`, `regge_action_gradient`, `r_u`, `objective`, `st`). The C++
-engine is untouched.
+It drives only the **public** `Proton` (the `recombination_node`/`formation_node`
+factories) and `MultiCobordism` (`run_stage1`/`run_stage2` with single-step counts, which
+continue the optimizer state across calls, plus `betti`, `emergent_holes`,
+`regge_action_gradient`, `r_u`, `objective`, `st`) APIs — the *same* node setups
+`Proton.build()` uses, so the animation shows the real class. The C++ engine is untouched,
+and there is no dependency on the (retiring) `emergent_optimizer`.
 
-**Visualization is off by default** — `run_optimization(opt)` takes the fast
-batched path with no per-step plotting overhead. Opt in with `visualize=True`
-(or `--live`/`--save`) to animate, which is slower.
+**Visualization is off by default** — `run_build(...)` takes the fast batched path with no
+per-step plotting overhead. Opt in with `visualize=True` (or `--live`/`--save`) to
+animate, which is slower.
 
-    # default: run the optimization fast, no visualization
+    # default: run the two-step build fast, no visualization
     python multicobordism_animation.py
     # live (interactive backend):
     python multicobordism_animation.py --live
     # headless: write a GIF (no display needed):
-    python multicobordism_animation.py --save recombination.gif
+    python multicobordism_animation.py --save proton.gif
 """
 import argparse
-import cmath
-import importlib.util
 import math
-import os
-import sys
 
 import numpy as np
 from scipy.sparse.csgraph import shortest_path
@@ -47,28 +51,6 @@ from scipy.sparse.csgraph import shortest_path
 import tessera
 
 cob = tessera.cobordism
-_W = cmath.exp(2j * math.pi / 3)
-_HERE = os.path.dirname(os.path.abspath(__file__))
-
-# The 2→2 recombination this demo animates: two neutral q-q̄ pairs in, a diquark ⊔
-# anti-diquark out (#491/#503). A diquark is COLORED (a 2-quark object, an SU(3) 3̄),
-# so its target is the 2-vector {1, ω} — NOT the colorless singlet; the anti-diquark
-# is {1, ω²}. ω = exp(2πi/3). (The dimension tracks the constituent count: 2 quarks
-# → a 2-vector here; the 3-quark proton is the 3-vector singlet {1, ω, ω²}.)
-_PAIRS = [[1, -1, 0], [1, 0, -1]]                  # two neutral q-q̄ color combos (Σ = 0)
-_DIQUARK = [1.0, _W]                               # colored diquark, 2-vector (#503)
-_ANTIDIQUARK = [1.0, _W * _W]                      # colored anti-diquark, 2-vector
-
-
-def _load(name):
-    spec = importlib.util.spec_from_file_location(name, os.path.join(_HERE, name + ".py"))
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[name] = mod
-    spec.loader.exec_module(mod)
-    return mod
-
-
-eo = _load("emergent_optimizer")
 
 
 def _mds_layout(st):
@@ -100,48 +82,61 @@ def _mds_layout(st):
     return {vids[i]: coords[i] for i in range(n)}
 
 
-class MultiCobordismAnimator:
-    """Steps a `MultiCobordism` and records/draws its progress one step at a time."""
+class ProtonAnimator:
+    """Steps a SEQUENCE of `MultiCobordism` nodes — the proton's Step A (recombination)
+    then Step B (formation) — one move/iteration at a time, recording and drawing the
+    progress. Each node runs `stage1_steps` surgery steps then `stage2_iters` relaxation
+    iterations; the complex-layout continuity resets at each node boundary (the next node
+    starts from a fresh single simplex)."""
 
-    # What each stage is doing, for the on-figure labels.
     _STAGE_NAMES = {1: "combinatorial surgery", 2: "geometric relaxation"}
 
-    def __init__(self, opt, degree=3, stage1_steps=40, stage1_candidates=8,
+    def __init__(self, nodes, degree=3, stage1_steps=40, stage1_candidates=8,
                  stage2_iters=30, stage2_beta=1.0):
-        self.opt = opt
+        self.nodes = nodes                  # [(MultiCobordism, "Step A: ..."), ...] in order
         self.k = degree
         self.s1, self.s1c = stage1_steps, stage1_candidates
         self.s2, self.s2_beta = stage2_iters, stage2_beta
-        self.hist = {"F": [], "gradN2": [], "rU": [], "b3": [], "holes": [], "stage": []}
-        self._frames = stage1_steps + stage2_iters
+        self._per_node = stage1_steps + stage2_iters
+        self._frames = len(nodes) * self._per_node
+        self.hist = {"F": [], "gradN2": [], "rU": [], "b3": [], "holes": [],
+                     "stage": [], "node": []}
+        self._boundaries = []       # step indices where a later node begins (trace markers)
         self._prev = None           # previous frame's drawn positions (for continuity)
         self._ease = 0.3            # how fast vertices glide to new targets (0=frozen, 1=snap)
         self._view = None           # complex-panel bbox; only grows, so the view never jitters
         self._done = False          # so "done" is announced exactly once
+        self._cur, self._cur_label = nodes[0]   # node currently being animated
 
-    # ---- one optimizer step (stage 1 = surgery, then stage 2 = relaxation) ----
+    # ---- one optimizer step on the current node (stage 1 = surgery, stage 2 = relax) ----
     def _advance(self, frame):
-        if frame < self.s1:
-            # Exactly one greedy surgery step per frame — the animation advances "one move
-            # at a time" (see the module docstring). Keep this at 1: each step grows the
+        node_index, local = divmod(frame, self._per_node)
+        node, label = self.nodes[node_index]
+        if local == 0 and node_index > 0:        # a NEW node starts: reset layout continuity
+            self._prev = None
+            self._view = None
+            self._boundaries.append(len(self.hist["F"]))
+        self._cur, self._cur_label = node, label
+        if local < self.s1:
+            # Exactly one greedy surgery step per frame. Keep this at 1: each step grows the
             # complex and re-evaluates the global spectral r_U, so the per-frame cost climbs
-            # super-linearly with max_steps (a 70-step frame measured ~360x a 1-step frame,
-            # turning the ~9 s surgery phase into ~52 min). patience is irrelevant at 1 step.
-            self.opt.run_stage1(max_steps=1, n_candidate_moves=self.s1c, patience=10 ** 9)
+            # super-linearly with max_steps. patience is irrelevant at 1 step.
+            node.run_stage1(max_steps=1, n_candidate_moves=self.s1c, patience=10 ** 9)
             stage = 1
         else:
-            self.opt.run_stage2(beta=self.s2_beta, max_iters=1)
+            node.run_stage2(beta=self.s2_beta, max_iters=1)
             stage = 2
-        self._record(stage)
+        self._record(node, stage, node_index)
 
-    def _record(self, stage):
-        st = self.opt.st
-        self.hist["F"].append(float(self.opt.objective()))
+    def _record(self, node, stage, node_index):
+        st = node.st
+        self.hist["F"].append(float(node.objective()))
         self.hist["gradN2"].append(float(cob.MultiCobordism.regge_action_gradient(st)))
-        self.hist["rU"].append(float(self.opt.r_u(st)))
+        self.hist["rU"].append(float(node.r_u(st)))
         self.hist["b3"].append(int(cob.MultiCobordism.betti(st)[self.k]))
         self.hist["holes"].append(len(cob.MultiCobordism.emergent_holes(st, self.k)))
         self.hist["stage"].append(stage)
+        self.hist["node"].append(node_index)
 
     # ---- stable layout ----
     def _stable_coords(self, st):
@@ -154,13 +149,13 @@ class MultiCobordismAnimator:
         whole cloud. Two steps tame that:
 
         * **align** the new embedding onto the previous frame over *all* shared vertices
-          via full Procrustes (scale + rotation + reflection) — this removes MDS's
-          orientation/scale ambiguity, the dominant source of bounce;
+          via full Procrustes (scale + rotation + reflection);
         * **ease** each vertex from its old position a fraction `self._ease` of the way to
-          the aligned target (exponential smoothing) — residual hops become smooth glides.
+          the aligned target (exponential smoothing).
 
         New vertices (from surgery) start directly at their aligned position; removed ones
-        simply drop out."""
+        simply drop out. `_prev` is reset to None at a node boundary, so the next node's
+        fresh simplex defines its own frame instead of being aligned to the old complex."""
         coords = _mds_layout(st)
         if len(coords) < 2:
             return coords
@@ -190,9 +185,8 @@ class MultiCobordismAnimator:
 
     # ---- drawing ----
     def _setup(self, plt):
-        self.fig, (self.axm, self.axr, self.axg) = plt.subplots(
-            1, 3, figsize=(15, 5))
-        self.fig.suptitle("MultiCobordism optimization — live")
+        self.fig, (self.axm, self.axr, self.axg) = plt.subplots(1, 3, figsize=(15, 5))
+        self.fig.suptitle("Proton build (two-step) — live")
         return self.fig
 
     def _redraw(self):
@@ -201,6 +195,8 @@ class MultiCobordismAnimator:
         self.axm.plot(xs, self.hist["F"], label="F (objective)", color="C0")
         self.axm.plot(xs, self.hist["gradN2"], label="‖∇S‖²", color="C1")
         self.axm.plot(xs, self.hist["rU"], label="r_U", color="C2")
+        for b in self._boundaries:
+            self.axm.axvline(b - 0.5, color="0.6", ls="--", lw=0.8)
         self.axm.set_yscale("symlog")
         self.axm.set_title("metrics")
         self.axm.set_xlabel("step")
@@ -211,12 +207,14 @@ class MultiCobordismAnimator:
                       marker=".")
         self.axr.plot(xs, self.hist["holes"], label="register holes", color="C4",
                       marker=".")
+        for b in self._boundaries:
+            self.axr.axvline(b - 0.5, color="0.6", ls="--", lw=0.8)
         self.axr.set_title("emergent register")
         self.axr.set_xlabel("step")
         self.axr.legend(loc="upper left", fontsize=8)
 
         self.axg.clear()
-        st = self.opt.st
+        st = self._cur.st
         coords = self._stable_coords(st)
         hole_vs = {v for h in cob.MultiCobordism.emergent_holes(st, self.k) for v in h}
         for e in st.getEdgeList().toVector():
@@ -241,7 +239,7 @@ class MultiCobordismAnimator:
             self.axg.set_ylim(self._view[2], self._view[3])
         self.axg.set_aspect("equal")
         stage = self.hist["stage"][-1] if self.hist["stage"] else 1
-        self.axg.set_title(f"complex — stage {stage}: {self._STAGE_NAMES[stage]} "
+        self.axg.set_title(f"{self._cur_label} — {self._STAGE_NAMES[stage]} "
                            f"(red = register holes)")
         self.axg.set_xticks([]); self.axg.set_yticks([])
 
@@ -249,47 +247,40 @@ class MultiCobordismAnimator:
         self._advance(frame)
         self._redraw()
         stage = self.hist["stage"][-1]
-        label = f"stage {stage}: {self._STAGE_NAMES[stage]}"
-        # A visible heartbeat: a step counter + stage name in the title and a flushed
-        # stdout line. Stage-2 frames are several seconds of real compute (a dense Regge
-        # Hessian over every edge) during which the GUI window can't repaint — without this
-        # it looks hung even though it's advancing. The terminal line updates even while
-        # the window is frozen mid-frame.
+        label = f"{self._cur_label} · {self._STAGE_NAMES[stage]}"
+        # A visible heartbeat: a step counter + label in the title and a flushed stdout line.
+        # Stage-2 frames are several seconds of real compute (a dense Regge Hessian over
+        # every edge) during which the GUI window can't repaint — the terminal line updates
+        # even while the window is frozen mid-frame.
         if frame >= self._frames - 1 and not self._done:   # last step: announce done
             self._done = True
-            self.fig.suptitle(f"MultiCobordism optimization — {label} — done")
+            self.fig.suptitle(f"Proton build (two-step) — {label} — done")
             print(f"\rstep {frame + 1}/{self._frames} ({label}) — done")
         elif not self._done:
             self.fig.suptitle(
-                f"MultiCobordism optimization — step {frame + 1}/{self._frames} · "
-                f"{label}")
-            print(f"\rstep {frame + 1}/{self._frames} ({label})",
-                  end="", flush=True)
+                f"Proton build (two-step) — step {frame + 1}/{self._frames} · {label}")
+            print(f"\rstep {frame + 1}/{self._frames} ({label})", end="", flush=True)
         return []
 
 
-def build_demo_recombination(seed=3, n_refine=16, rounds=10):
-    """A small demo system: recombine two neutral q-q̄ pairs into a colored diquark
-    `{1, ω}` ⊔ anti-diquark `{1, ω²}` (a 2→2 event, #491/#503).
+def build_proton_nodes(seed=3):
+    """The two `MultiCobordism` nodes the `Proton` class drives, in build order, for the
+    animation: Step A recombination then Step B formation, each on its own single-Δ⁴ seed.
 
-    `seed_inputs` builds the two input pairs and `seed_outputs` the two output
-    blocks (diquark, anti-diquark); the animation then drives the two stages —
-    `run_stage1` (combinatorial surgery, including the trap door that grows the complex
-    on a stall) and `run_stage2` (geometric relaxation) — one step at a time so you
-    watch the register grow and the objective converge. Γ is chosen so the realizability
-    residual `Γ·r_U` sits on the same order as the Regge term `‖∇S‖²`; otherwise ∇S
-    dominates and the register is never driven to carry its state."""
-    host = eo.build_closed_s4(n_refine=n_refine, seed=seed)
-    opt = cob.MultiCobordism(host, _PAIRS, [_DIQUARK, _ANTIDIQUARK],
-                             degrees=[3], gamma=50.0, seed=seed)
-    sv = [v.getId() for v in host.getVertexList().toVector()]
-    opt.seed_inputs(sv[:2])
-    opt.seed_outputs(sv[2:4])
-    return opt
+    Built via `Proton.recombination_node`/`formation_node` — the *same* node setups
+    `Proton.build()` uses — with `Proton.build`'s attempt-0 seeds (A = `seed`,
+    B = `seed + 1`). The animation then drives each node's two stages (`run_stage1`
+    combinatorial surgery, including the trap door that grows the complex from one simplex
+    on a stall; `run_stage2` geometric relaxation) one step at a time."""
+    p = cob.Proton(seed=seed)
+    return [
+        (p.recombination_node(seed), "Step A: recombination (→ diquark {1, ω})"),
+        (p.formation_node(seed + 1), "Step B: formation (→ proton {1, ω, ω²})"),
+    ]
 
 
-def animate(opt, save=None, interval=200, **kw):
-    """Animate `opt`'s optimization. `save` → write a GIF/MP4 (headless, Agg);
+def animate(nodes, save=None, interval=200, **kw):
+    """Animate the proton node sequence. `save` → write a GIF/MP4 (headless, Agg);
     otherwise show a live interactive window. Returns the animator."""
     import matplotlib
     if save:
@@ -297,7 +288,7 @@ def animate(opt, save=None, interval=200, **kw):
     import matplotlib.pyplot as plt
     from matplotlib.animation import FuncAnimation
 
-    anim_state = MultiCobordismAnimator(opt, **kw)
+    anim_state = ProtonAnimator(nodes, **kw)
     anim_state._setup(plt)
     fa = FuncAnimation(anim_state.fig, anim_state.update,
                        frames=anim_state._frames, interval=interval,
@@ -312,27 +303,30 @@ def animate(opt, save=None, interval=200, **kw):
     return anim_state
 
 
-def run_optimization(opt, visualize=False, save=None, degree=3, stage1_steps=70,
-                     stage1_candidates=10, stage2_iters=100, stage2_beta=1.0,
-                     interval=200):   # ms/frame; keep > 0 — GIF/MP4 save() uses fps = 1000/interval
-    """Run the two-stage optimization.
+def run_build(nodes, visualize=False, save=None, degree=3, stage1_steps=70,
+              stage1_candidates=10, stage2_iters=100, stage2_beta=1.0,
+              interval=200):   # ms/frame; keep > 0 — GIF/MP4 save() uses fps = 1000/interval
+    """Run the two-step proton build over `nodes`.
 
-    Visualization is **off by default**: with ``visualize=False`` (and no
-    ``save``) this takes the fast **batched** path — `run_stage1`/`run_stage2`
-    run to completion in one call each, with no per-step layout/redraw overhead —
-    and returns the final metrics. Opt in with ``visualize=True`` (live window) or
-    ``save=...`` (GIF/MP4) to animate it step-by-step (slower); that returns the
-    per-step history."""
+    Visualization is **off by default**: with ``visualize=False`` (and no ``save``) this
+    takes the fast **batched** path — each node's `run_stage1`/`run_stage2` run to
+    completion in one call each, no per-step layout/redraw overhead — and returns each
+    node's final metrics. Opt in with ``visualize=True`` (live window) or ``save=...``
+    (GIF/MP4) to animate it step-by-step (slower); that returns the per-step history."""
     if not visualize and not save:
-        opt.run_stage1(max_steps=stage1_steps, n_candidate_moves=stage1_candidates)
-        opt.run_stage2(beta=stage2_beta, max_iters=stage2_iters)
-        st = opt.st
-        return {"F": float(opt.objective()),
+        out = []
+        for node, label in nodes:
+            node.run_stage1(max_steps=stage1_steps, n_candidate_moves=stage1_candidates)
+            node.run_stage2(beta=stage2_beta, max_iters=stage2_iters)
+            st = node.st
+            out.append((label, {
+                "F": float(node.objective()),
                 "gradN2": float(cob.MultiCobordism.regge_action_gradient(st)),
-                "rU": float(opt.r_u(st)),
+                "rU": float(node.r_u(st)),
                 "b3": int(cob.MultiCobordism.betti(st)[degree]),
-                "holes": len(cob.MultiCobordism.emergent_holes(st, degree))}
-    return animate(opt, save=save, degree=degree, stage1_steps=stage1_steps,
+                "holes": len(cob.MultiCobordism.emergent_holes(st, degree))}))
+        return out
+    return animate(nodes, save=save, degree=degree, stage1_steps=stage1_steps,
                    stage1_candidates=stage1_candidates, stage2_iters=stage2_iters,
                    stage2_beta=stage2_beta, interval=interval).hist
 
@@ -344,17 +338,17 @@ def main():
                     help="show the live animation window (slower than the default)")
     ap.add_argument("--save", help="write a GIF/MP4 of the animation (slower)")
     ap.add_argument("--seed", type=int, default=3)
-    ap.add_argument("--refine", type=int, default=16)
     ap.add_argument("--stage1", type=int, default=40)
     ap.add_argument("--stage2", type=int, default=30)
     args = ap.parse_args()
-    opt = build_demo_recombination(seed=args.seed, n_refine=args.refine)
-    result = run_optimization(opt, visualize=args.live, save=args.save,
-                              stage1_steps=args.stage1, stage2_iters=args.stage2)
+    nodes = build_proton_nodes(seed=args.seed)
+    result = run_build(nodes, visualize=args.live, save=args.save,
+                       stage1_steps=args.stage1, stage2_iters=args.stage2)
     if not args.live and not args.save:
-        print("optimization finished (visualization off by default — pass --live "
+        print("two-step proton build finished (visualization off by default — pass --live "
               "or --save to watch it):")
-        print("  " + "  ".join(f"{k}={v}" for k, v in result.items()))
+        for label, metrics in result:
+            print(f"  {label}:  " + "  ".join(f"{k}={v}" for k, v in metrics.items()))
 
 
 if __name__ == "__main__":

--- a/include/cobordism/Proton.h
+++ b/include/cobordism/Proton.h
@@ -14,6 +14,8 @@ namespace tessera::spacetime { class Spacetime; }
 namespace tessera::cobordism {
 using ::tessera::spacetime::Spacetime;
 
+class MultiCobordism;  // returned (seeded, not run) by the node factories below
+
 /// # Proton
 ///
 /// A high-level, footgun-free builder for **the** emergent proton, composing
@@ -73,6 +75,17 @@ class Proton {
              int evolveSteps = 60, int stage1CandidateMoves = 8, int stage1Patience = 15,
              double stage2Beta = 1.0, int stage2MaxIters = 10,
              double colorTolerance = 0.5, int minQuarkHoles = 3);
+
+  /// A fresh, seeded — but NOT yet run — Step A node (recombination, 2→2): two neutral
+  /// q-q̄ pairs `{1,-1,0}` ⊔ `{1,0,-1}` → a diquark `{1,ω}` ⊔ antidiquark `{1,ω²}`, on a
+  /// single Δ⁴ seed (inputs at v0,v1; outputs at v2,v3; input weight set). `build()` and
+  /// the animation both drive this exact setup via `runStage1`/`runStage2` — the single
+  /// source of truth for the recombination step.
+  [[nodiscard]] std::shared_ptr<MultiCobordism> recombinationNode(std::uint64_t seed) const;
+  /// A fresh, seeded — but NOT yet run — Step B node (formation, 2→1): the diquark
+  /// `{1,ω}` + the third quark `{ω²}` → the proton singlet `{1,ω,ω²}`, on a single Δ⁴
+  /// seed (inputs at v0,v1; the single output is read off the WHOLE, so no `seedOutputs`).
+  [[nodiscard]] std::shared_ptr<MultiCobordism> formationNode(std::uint64_t seed) const;
 
   /// True iff the whole step-B cobordism carries the singlet (`colorResidual() <
   /// colorTolerance`) with `≥ minQuarkHoles` holes. Triggers `build()`.

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -785,7 +785,7 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
                              [](const MultiCobordism::BoundaryBlock &block) {
                                return block.target;
                              });
-  py::class_<MultiCobordism>(m, "MultiCobordism",
+  py::class_<MultiCobordism, std::shared_ptr<MultiCobordism>>(m, "MultiCobordism",
       "The C++ port of emergent_optimizer.MultiCobordism (#491): merge as a "
       "fully emergent optimization. From a bare host it grows the register by "
       "gated surgical moves under F = ||grad S||^2 + gamma*(r_U(output) + "
@@ -880,6 +880,14 @@ tickets.)doc")
            "Restart across seeds until the whole step-B cobordism carries the singlet "
            "with >= min_quark_holes holes. Each step runs an init pass (grow the "
            "boundary until it carries) then an evolution pass (boundary frozen).")
+      .def("recombination_node", &Proton::recombinationNode, py::arg("seed"),
+           "A fresh, seeded (not-yet-run) Step A node: two neutral q-qbar pairs -> a "
+           "diquark {1,w} + antidiquark {1,w*w}, on a single Delta^4 seed. Drive it with "
+           "run_stage1/run_stage2 -- the exact node build() uses for recombination.")
+      .def("formation_node", &Proton::formationNode, py::arg("seed"),
+           "A fresh, seeded (not-yet-run) Step B node: the diquark {1,w} + the third "
+           "quark {w*w} -> the proton singlet, on a single Delta^4 seed (output read off "
+           "the whole). Drive it with run_stage1/run_stage2.")
       .def("converged", &Proton::converged,
            "True iff step B's proton block carries the singlet with enough holes.")
       .def("seed", &Proton::seed, "Base seed of the converged (or best) attempt.")

--- a/src/cobordism/Proton.cpp
+++ b/src/cobordism/Proton.cpp
@@ -62,31 +62,60 @@ std::shared_ptr<Spacetime> Proton::buildMinimalSeed() {
   return host;
 }
 
+std::shared_ptr<MultiCobordism> Proton::recombinationNode(std::uint64_t seed) const {
+  // Step A inputs: two neutral q-q̄ pairs (Σ = 0). Outputs: a colored diquark {1,ω} ⊔
+  // antidiquark {1,ω²} (2-vectors — NOT the singlet). Seeded on a fresh single-Δ⁴ seed,
+  // inputs at v0,v1 and outputs at v2,v3; NOT run (the caller drives it).
+  const complexd w = omega();
+  const std::vector<std::vector<complexd>> pairs = {
+      {complexd(1.0, 0.0), complexd(-1.0, 0.0), complexd(0.0, 0.0)},
+      {complexd(1.0, 0.0), complexd(0.0, 0.0), complexd(-1.0, 0.0)}};
+  const std::vector<complexd> diquark = {complexd(1.0, 0.0), w};
+  const std::vector<complexd> antidiquark = {complexd(1.0, 0.0), w * w};
+  auto host = buildMinimalSeed();
+  auto verts = host->getVertexList()->toVector();
+  auto node = std::make_shared<MultiCobordism>(
+      host, pairs, std::vector<std::vector<complexd>>{diquark, antidiquark},
+      std::vector<int>{registerDegree_}, gamma_, seed);
+  node->setInputResidualWeight(inputResidualWeight_);
+  node->seedInputs({verts[0]->getId(), verts[1]->getId()});
+  node->seedOutputs({verts[2]->getId(), verts[3]->getId()});
+  return node;
+}
+
+std::shared_ptr<MultiCobordism> Proton::formationNode(std::uint64_t seed) const {
+  // Step B inputs: the diquark {1,ω} + the third quark {ω²}. Output: the proton singlet,
+  // read off the WHOLE cobordism (no seedOutputs). Seeded on a fresh single-Δ⁴ seed,
+  // inputs at v0,v1; NOT run (the caller drives it).
+  const complexd w = omega();
+  const std::vector<complexd> diquark = {complexd(1.0, 0.0), w};
+  const std::vector<complexd> thirdQuark = {w * w};
+  auto host = buildMinimalSeed();
+  auto verts = host->getVertexList()->toVector();
+  auto node = std::make_shared<MultiCobordism>(
+      host, std::vector<std::vector<complexd>>{diquark, thirdQuark},
+      std::vector<std::vector<complexd>>{singlet()},
+      std::vector<int>{registerDegree_}, gamma_, seed);
+  node->setInputResidualWeight(inputResidualWeight_);
+  node->seedInputs({verts[0]->getId(), verts[1]->getId()});
+  return node;
+}
+
 void Proton::build(int maxRestarts, int initSteps, int evolveSteps,
                    int stage1CandidateMoves, int stage1Patience, double stage2Beta,
                    int stage2MaxIters, double colorTolerance, int minQuarkHoles) {
   if (attempted_) return;
   attempted_ = true;
 
-  const complexd w = omega();
-  // Step A inputs: two neutral q-q̄ pairs (Σ = 0). Step A outputs: a colored diquark
-  // {1,ω} ⊔ antidiquark {1,ω²} (2-vectors — NOT the singlet).
-  const std::vector<std::vector<complexd>> pairsA = {
-      {complexd(1.0, 0.0), complexd(-1.0, 0.0), complexd(0.0, 0.0)},
-      {complexd(1.0, 0.0), complexd(0.0, 0.0), complexd(-1.0, 0.0)}};
-  const std::vector<complexd> diquark = {complexd(1.0, 0.0), w};
-  const std::vector<complexd> antidiquark = {complexd(1.0, 0.0), w * w};
-  // Step B inputs: the diquark (2-vec) + the third quark (1-vec). Output: the proton.
-  const std::vector<complexd> thirdQuark = {w * w};
   const std::vector<complexd> protonSinglet = singlet();
 
-  // One node's run: weight the inputs, an INITIALIZATION pass that grows the boundary
+  // Drive one already-seeded node: an INITIALIZATION pass that grows the boundary
   // regions until they carry (grow_boundaries=true), an EVOLUTION pass with ∂W frozen
-  // (grow_boundaries=false), then the geometric relaxation. runStage1 self-recovers
-  // from unproductive grow bursts internally (revert + reseed + retry), so one call
-  // per pass is as robust as many short ones.
+  // (grow_boundaries=false), then the geometric relaxation. runStage1 self-recovers from
+  // unproductive grow bursts internally, so one call per pass is robust. (Node setup —
+  // seed, targets, seeding, input weight — lives in recombinationNode/formationNode, the
+  // same factories the animation drives.)
   const auto runNode = [&](MultiCobordism &node) {
-    node.setInputResidualWeight(inputResidualWeight_);
     node.runStage1(initSteps, stage1CandidateMoves, stage1Patience, /*growBoundaries=*/true);
     node.runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
                    /*growBoundaries=*/false);
@@ -99,32 +128,15 @@ void Proton::build(int maxRestarts, int initSteps, int evolveSteps,
     const std::uint64_t seedA = baseSeed_ + 2ULL * static_cast<std::uint64_t>(attempt);
     const std::uint64_t seedB = seedA + 1ULL;
 
-    // ---- Step A — recombination (2 → 2): the diquark ⊔ antidiquark form. Run as a
-    // best-effort validation; its r_U is reported (diquarkResidual), not gated. ----
-    double diquarkR = std::numeric_limits<double>::quiet_NaN();
-    auto hostA = buildMinimalSeed();
-    auto vertsA = hostA->getVertexList()->toVector();
-    if (vertsA.size() >= 4) {
-      MultiCobordism stepA(hostA, pairsA, {diquark, antidiquark}, {registerDegree_},
-                           gamma_, seedA);
-      stepA.seedInputs({vertsA[0]->getId(), vertsA[1]->getId()});
-      stepA.seedOutputs({vertsA[2]->getId(), vertsA[3]->getId()});
-      runNode(stepA);
-      diquarkR = stepA.rU(stepA.spacetime());
-    }
+    // ---- Step A — recombination: best-effort; its r_U is reported, not gated. ----
+    auto stepA = recombinationNode(seedA);
+    runNode(*stepA);
+    const double diquarkR = stepA->rU(stepA->spacetime());
 
-    // ---- Step B — formation (2 → 1): the proton, read off the WHOLE cobordism ----
-    auto hostB = buildMinimalSeed();
-    auto vertsB = hostB->getVertexList()->toVector();
-    if (vertsB.size() < 3) continue;
-    MultiCobordism stepB(hostB, {diquark, thirdQuark}, {protonSinglet}, {registerDegree_},
-                         gamma_, seedB);
-    stepB.seedInputs({vertsB[0]->getId(), vertsB[1]->getId()});
-    runNode(stepB);  // no seedOutputs — the single output IS the whole
-
-    // The proton is the harmonic of the WHOLE cobordism (the inputs are held by their
-    // residual, the bulk evolves to carry the singlet). Read it off the relaxed whole.
-    auto whole = stepB.spacetime();
+    // ---- Step B — formation: the proton, read off the WHOLE cobordism ----
+    auto stepB = formationNode(seedB);
+    runNode(*stepB);
+    auto whole = stepB->spacetime();
     const double colorR = MultiCobordism::residualOfTargetStateAgainstHarmonic(
         whole, registerDegree_, protonSinglet);
     auto holes = MultiCobordism::emergentHoles(*whole, registerDegree_);

--- a/tests/cobordism/test_multicobordism_animation.py
+++ b/tests/cobordism/test_multicobordism_animation.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2026 Twin Vector Labs LLC.
 # All rights reserved.
-"""Smoke test for the real-time MultiCobordism animation (#493).
+"""Smoke test for the two-step Proton animation (#522).
 
-Drives a few optimization steps headless (Agg) and checks that the per-step
-history advances, the MDS layout produces 2-D coordinates, and a GIF is written.
-The animation only reads the public MultiCobordism API, so this also guards that
-single-step `run_stage1`/`run_stage2` keep advancing the optimizer state.
+Drives a few optimization steps of the proton's Step A (recombination) and Step B
+(formation) nodes headless (Agg) and checks that the per-step history advances across
+the node boundary, the MDS layout produces 2-D coordinates, and a GIF is written. The
+animation only reads the public `Proton` (node factories) + `MultiCobordism` API, so this
+also guards that single-step `run_stage1`/`run_stage2` keep advancing the optimizer state
+and that the proton's whole topology grows from a single simplex.
 """
 import importlib.util
 import os
@@ -33,40 +35,47 @@ class MultiCobordismAnimationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.mca = _load("multicobordism_animation")
-        cls.opt = cls.mca.build_demo_recombination(seed=3, n_refine=12)
 
-    def test_steps_advance_history(self):
-        anim = self.mca.MultiCobordismAnimator(
-            self.opt, stage1_steps=3, stage2_iters=3)
-        for f in range(4):
+    def test_steps_advance_across_both_nodes(self):
+        # Two Proton nodes (Step A, Step B); per_node = stage1_steps + stage2_iters = 4,
+        # so node 0 is frames 0-3 (3 surgery + 1 relax) and node 1 begins at frame 4.
+        nodes = self.mca.build_proton_nodes(seed=3)
+        anim = self.mca.ProtonAnimator(nodes, stage1_steps=3, stage2_iters=1)
+        for f in range(6):                  # all of node 0, then 2 surgery frames of node 1
             anim._advance(f)
-        self.assertEqual(len(anim.hist["F"]), 4)
-        # every recorded metric series advances in lock-step
-        for key in ("gradN2", "rU", "b3", "holes", "stage"):
-            self.assertEqual(len(anim.hist[key]), 4)
-        # stage flips from 1 (surgery) to 2 (relaxation) at the boundary
-        self.assertEqual(anim.hist["stage"], [1, 1, 1, 2])
+        self.assertEqual(len(anim.hist["F"]), 6)
+        for key in ("gradN2", "rU", "b3", "holes", "stage", "node"):
+            self.assertEqual(len(anim.hist[key]), 6)
+        # surgery×3 then relax on node 0, then node 1's surgery
+        self.assertEqual(anim.hist["stage"], [1, 1, 1, 2, 1, 1])
+        self.assertEqual(anim.hist["node"], [0, 0, 0, 0, 1, 1])
+        self.assertEqual(anim._boundaries, [4])   # Step B began at step index 4
         self.assertTrue(all(isinstance(v, float) for v in anim.hist["F"]))
 
     def test_default_is_no_visualization(self):
-        # visualize defaults to OFF: run_optimization takes the fast batched path
-        # (one run_stage1 + one run_stage2, no per-step plotting) and returns the
-        # final metrics dict rather than an animation.
-        res = self.mca.run_optimization(self.opt, stage1_steps=2, stage2_iters=2)
-        self.assertIsInstance(res, dict)
-        for key in ("F", "gradN2", "rU", "b3", "holes"):
-            self.assertIn(key, res)
+        # visualize defaults OFF: run_build takes the fast batched path (one run_stage1 +
+        # one run_stage2 per node) and returns a list of (label, metrics) — one entry per
+        # step (Step A, Step B) — rather than an animation.
+        nodes = self.mca.build_proton_nodes(seed=3)
+        res = self.mca.run_build(nodes, stage1_steps=2, stage2_iters=1)
+        self.assertEqual(len(res), 2)
+        for label, metrics in res:
+            self.assertIsInstance(label, str)
+            for key in ("F", "gradN2", "rU", "b3", "holes"):
+                self.assertIn(key, metrics)
 
     def test_mds_layout_is_2d(self):
-        coords = self.mca._mds_layout(self.opt.st)
+        nodes = self.mca.build_proton_nodes(seed=3)
+        coords = self.mca._mds_layout(nodes[0][0].st)   # the single-Δ⁴ seed (5 vertices)
         self.assertGreater(len(coords), 0)
         for v in coords.values():
             self.assertEqual(v.shape, (2,))
 
     def test_headless_save_writes_gif(self):
+        nodes = self.mca.build_proton_nodes(seed=3)
         with tempfile.TemporaryDirectory() as d:
-            out = os.path.join(d, "anim.gif")
-            self.mca.animate(self.opt, save=out, stage1_steps=2, stage2_iters=2)
+            out = os.path.join(d, "proton.gif")
+            self.mca.animate(nodes, save=out, stage1_steps=2, stage2_iters=1)
             self.assertTrue(os.path.exists(out))
             self.assertGreater(os.path.getsize(out), 0)
 


### PR DESCRIPTION
## Summary
Supersede the `MultiCobordism` recombination animation with the canonical two-step **Proton**: animate Step A recombination (q-q̄ pairs → diquark) then Step B formation (→ the colorless singlet) growing from a single Δ⁴ simplex, by driving the actual `Proton` class's two node setups. Drops the `emergent_optimizer` / `build_closed_s4` dependency.

The proton's two `MultiCobordism` node setups are exposed as `Proton.recombination_node(seed)` / `formation_node(seed)`; `Proton.build()` now routes through them (one source of truth, convergence unchanged). `MultiCobordism` is now `shared_ptr`-held so the factories return it to Python.

## Test plan
- [x] `Proton.recombination_node` / `formation_node` return seeded nodes; `build()` routes through them, convergence unchanged — `test_proton_cpp` + `test_multi_cobordism` + `test_trap_door`: **15 passed**
- [x] animation runs headless (`--save`) on the single-simplex two-step and writes a GIF — `test_headless_save_writes_gif` + batched smoke
- [x] `test_multicobordism_animation.py` updated for the two-step flow + green — **4 passed**

All 4 tests touching `MultiCobordism`/`Proton` pass; the `shared_ptr`-holder blast radius is fully covered.

Closes #522.
