### PR TITLE
fix(cobordism): make the proton animation's register count clear and consistent

### DIFF
--- a/examples/cobordism/multicobordism_animation.py
+++ b/examples/cobordism/multicobordism_animation.py
@@ -283,24 +283,41 @@ class ProtonAnimator:
         st = node.st
         coords = self._layouts[node_index].coords(st)
         ax.clear()
-        hole_vs = {v for h in cob.MultiCobordism.emergent_holes(st, self.k) for v in h}
+        # Each emergent color hole (register) is a removed top cell — a k=3 hole is a
+        # 4-simplex, 5 vertices — whose boundary edges stay in the complex. OUTLINE each
+        # register cell by reddening the edges whose endpoints both lie in that hole's vertex
+        # set, and badge it with its index at the cell centroid. So one register reads as one
+        # numbered red cell — unlike the old per-vertex reddening, where a single 5-vertex
+        # hole showed as 5 disconnected red dots and couldn't be counted.
+        holes = cob.MultiCobordism.emergent_holes(st, self.k)
+        hole_vsets = [set(h) for h in holes]
         for e in st.getEdgeList().toVector():
             a, b = e.getSource().getId(), e.getTarget().getId()
-            if a in coords and b in coords:
-                p, q = coords[a], coords[b]
-                ax.plot([p[0], q[0]], [p[1], q[1]], color="0.8", lw=0.5, zorder=1)
-        if len(coords) >= 1:
+            if a not in coords or b not in coords:
+                continue
+            p, q = coords[a], coords[b]
+            if any(a in vs and b in vs for vs in hole_vsets):     # a register-cell edge
+                ax.plot([p[0], q[0]], [p[1], q[1]], color="C3", lw=1.8, zorder=3)
+            else:
+                ax.plot([p[0], q[0]], [p[1], q[1]], color="0.85", lw=0.5, zorder=1)
+        if coords:
             pts = np.array(list(coords.values()))
-            cols = ["C3" if v in hole_vs else "0.4" for v in coords]
-            sz = [40 if v in hole_vs else 8 for v in coords]
-            ax.scatter(pts[:, 0], pts[:, 1], c=cols, s=sz, zorder=2)
+            ax.scatter(pts[:, 0], pts[:, 1], c="0.4", s=8, zorder=2)
+            for i, h in enumerate(holes):                          # number each register
+                hp = np.array([coords[v] for v in h if v in coords])
+                if len(hp):
+                    c = hp.mean(0)
+                    ax.text(c[0], c[1], str(i + 1), color="white", fontsize=8,
+                            fontweight="bold", ha="center", va="center", zorder=4,
+                            bbox=dict(boxstyle="circle,pad=0.2", fc="C3", ec="white",
+                                      lw=0.8))
             if len(coords) >= 2:
                 view = self._layouts[node_index].view(coords)
                 ax.set_xlim(view[0], view[1])
                 ax.set_ylim(view[2], view[3])
-        n_holes = len(cob.MultiCobordism.emergent_holes(st, self.k))
+        n_holes = len(holes)
         ax.set_aspect("equal")
-        ax.set_title(f"{title}  ({n_holes} register{'s' if n_holes != 1 else ''})",
+        ax.set_title(f"{title}  —  {n_holes} register{'s' if n_holes != 1 else ''}",
                      fontsize=9)
         ax.set_xticks([]); ax.set_yticks([])
 
@@ -318,14 +335,19 @@ class ProtonAnimator:
         self.axm.legend(loc="upper right", fontsize=8)
 
         self.axr.clear()
-        self.axr.plot(xs, self.hist["b3"], label=f"b{self.k} (register)", color="C3",
+        # The register count is the number of emergent color holes (= quarks) — the SAME
+        # number the complex panels outline and the titles report. b_k is a Betti number, a
+        # *different* topological invariant that can disagree, so it is drawn separately and
+        # labelled as such, never as "the register" (which conflated the two before).
+        self.axr.plot(xs, self.hist["holes"], label="color registers (holes)", color="C3",
                       marker=".")
-        self.axr.plot(xs, self.hist["holes"], label="register holes", color="C4",
-                      marker=".")
+        self.axr.plot(xs, self.hist["b3"], label=f"b{self.k} (Betti number)", color="C4",
+                      marker=".", alpha=0.55)
         for b in self._boundaries:
             self.axr.axvline(b - 0.5, color="0.6", ls="--", lw=0.8)
-        self.axr.axhline(_MIN_QUARK_HOLES, color="0.6", ls=":", lw=0.8)
-        self.axr.set_title("emergent register")
+        self.axr.axhline(_MIN_QUARK_HOLES, color="0.6", ls=":", lw=0.8,
+                         label=f"proton = {_MIN_QUARK_HOLES}")
+        self.axr.set_title("color register")
         self.axr.set_xlabel("frame")
         self.axr.legend(loc="upper left", fontsize=8)
 


### PR DESCRIPTION
## Summary
The two-step proton animation reported the color-register count three inconsistent ways, so you couldn't tell how many registers there were. This makes the count honest, consistent, and visually countable. Visualization-only — no `Proton`/`MultiCobordism`/`CobordismDAG` or C++ changes.

## What was wrong (investigation)
`MultiCobordism.emergent_holes(st, k)` and `betti(st)[k]` are **different computations** — the former counts fully-exposed removed top cells (the color holes / quarks), the latter is a Betti number — so they can disagree. The old panel plotted `b₃` labelled "register" alongside a separate "register holes" line, and the complex panels reddened **every hole vertex**. A k=3 hole is a removed 4-simplex (5 vertices, all 10 edges present in the complex), so:

| | register count (holes) | old red dots (hole vertices) | b₃ |
|---|---|---|---|
| Step A (diquark) | 1 | 5 | 1 |
| Step B (proton) | 3 | 13 | 3 |

So "1 register" rendered as 5 red dots and "3 registers" as 13 — and `b₃` (a Betti number) was mislabelled as "the register" even though it can differ from the hole count.

## Changes
- **Outline each register as a cell, not loose dots.** Per the suggestion, redden the *edges* whose endpoints both lie in a hole's vertex set, so each color hole renders as one red-outlined cell, plus a numbered badge at its centroid. N registers now reads as N numbered red cells (Step A: 1, Step B: 3).
- **Reconcile the register panel.** Plot the **color-register (hole) count** as the primary line — the same number the complex panels outline and the titles report — with a "proton = 3" guide. `b₃` is kept but plotted secondarily and labelled honestly as a Betti number, never as "the register."

## Verification
Final frame (default `seed=3`) — Step A shows **1** numbered red register cell, Step B shows **3**; the panel's "color registers (holes)" line sits at 3 (matching the cells, the titles, and the "proton = 3" guide):

![final frame](https://github.com/akellehe/tessera/releases/download/issue-attachments/pr529-register-final.png)

Full animation: [pr529-register.gif](https://github.com/akellehe/tessera/releases/download/issue-attachments/pr529-register.gif)

This render also makes the point concretely: **`b₃ = 6` while the register count = 3**. `b₃` is a Betti number that varies with the emergent topology (it has shown 3, 4, 6 across runs/threads), whereas the color-hole/quark count is robustly 3 — which is exactly why it must not be labelled "the register." `r_state = 4e-31` (singlet carried).

## Test plan
- [x] `pytest tests/cobordism/test_multicobordism_animation.py` — 4 passed
- [x] headless `--save` render: 1 vs 3 numbered red register cells; panel "color registers (holes)" line + titles agree at 3; b₃ shown separately as a Betti number
- [x] CI green on the branch (full pytest suite, 4m18s)

Closes #528.
