### PR TITLE
feat(cobordism): emergent precone count for the seed

### DIFF
--- a/examples/cobordism/multicobordism_animation.py
+++ b/examples/cobordism/multicobordism_animation.py
@@ -66,6 +66,8 @@ which is slower.
     python multicobordism_animation.py --live
     # headless: write a GIF (no display needed):
     python multicobordism_animation.py --save proton.gif
+    # pre-grow each node's single-Δ⁴ seed by 12 gated cone-ins before optimizing:
+    python multicobordism_animation.py --precone 12
 """
 import argparse
 import itertools
@@ -501,15 +503,19 @@ class ProtonAnimator:
         return []
 
 
-def build_proton_nodes(seed=3):
+def build_proton_nodes(seed=3, precone=0):
     """The two `MultiCobordism` nodes the `Proton` class drives, in build order, for the
     animation: Step A recombination then Step B formation, each on its own single-Δ⁴ seed.
 
     Built via `Proton.recombination_node`/`formation_node` — the *same* node setups
     `Proton.build()` uses — with `Proton.build`'s attempt-0 seeds (A = `seed`, B =
     `seed + 1`). The default `seed=3` converges on attempt 0 (Step B grows three quark holes
-    and carries the singlet); the animation reports the live verdict either way."""
-    p = cob.Proton(seed=seed)
+    and carries the singlet); the animation reports the live verdict either way.
+
+    `precone` pre-grows each node's single-Δ⁴ seed by that many gated cone-in moves before
+    optimization (forwarded straight to the C++ `MultiCobordism` constructor via `Proton`);
+    `precone=0` (the default) leaves the bare seed untouched."""
+    p = cob.Proton(seed=seed, precone=precone)
     return [
         (p.recombination_node(seed), "Step A — recombination (→ diquark {1, ω})"),
         (p.formation_node(seed + 1), "Step B — formation (→ proton {1, ω, ω²})"),
@@ -595,8 +601,11 @@ def main():
                     help="evolution-pass (grow_boundaries=False) steps per node")
     ap.add_argument("--stage2", type=int, default=_STAGE2_ITERS,
                     help="geometric-relaxation iterations per node")
+    ap.add_argument("--precone", type=int, default=0,
+                    help="pre-grow each node's single-Δ⁴ seed by this many gated "
+                         "cone-in moves before optimization (0 = bare seed)")
     args = ap.parse_args()
-    nodes = build_proton_nodes(seed=args.seed)
+    nodes = build_proton_nodes(seed=args.seed, precone=args.precone)
     result = run_build(nodes, visualize=args.live, save=args.save, init_steps=args.init,
                        evolve_steps=args.evolve, stage2_iters=args.stage2)
     if not args.live and not args.save:

--- a/include/cobordism/MultiCobordism.h
+++ b/include/cobordism/MultiCobordism.h
@@ -59,12 +59,19 @@ class MultiCobordism {
   /// (diquark ⊔ antidiquark). Each output — like each input — is an emergent
   /// boundary sub-complex carrying its target, scored by its own `r_U`; the bulk
   /// routes the connectivity (which input constituent reaches which output).
+  ///
+  /// `precone` (default 0) pre-grows the host by that many **gated cone-in moves**
+  /// before any optimization — the emergent way to give surgery room to act, in
+  /// place of a prebuilt host refinement. Each cone-in adds one top cell on a fresh
+  /// apex over a random facet and is accepted only through the `dualComplexValid`
+  /// gate (see `preconeCells`); on the single-Δ⁴ seed (a 4-ball) this enlarges the
+  /// 4-ball. Reproducible given `seed`; `precone = 0` leaves the host untouched.
   MultiCobordism(
       std::shared_ptr<Spacetime> host,
       const std::vector<std::vector<std::complex<double>>> &inputTargets,
       const std::vector<std::vector<std::complex<double>>> &outputTargets,
       const std::vector<int> &degrees = {3}, double gamma = 1.0,
-      std::uint64_t seed = 0);
+      std::uint64_t seed = 0, int precone = 0);
 
   // ---- module-level helpers (static; the reference's free functions) ----
   /// Betti numbers (combinatorial, geometry-free).
@@ -190,6 +197,16 @@ class MultiCobordism {
   /// (residual < inputCarriedTolerance_) is left alone, so it stops growing once it
   /// represents its state.
   void growBoundaryRegions();
+  /// Pre-grow the seed by `count` **gated cone-in moves** before any optimization
+  /// (the constructor calls this once when `precone > 0`): each cones a fresh apex
+  /// onto a random codim-1 facet of a random top cell and is committed only through
+  /// `applyMoveSpecification`'s `dualComplexValid` gate — the same gate stage 1 and
+  /// the trap door use, so nothing is inserted by fiat. It enlarges the complex so
+  /// surgery has room to act — the emergent analogue of a prebuilt host refinement.
+  /// `count <= 0` is a no-op (RNG untouched). Best-effort: a draw onto an already-
+  /// saturated facet is rejected by the gate and retried; if no valid cone-in is
+  /// found for a cell, it stops early.
+  void preconeCells(int count);
 
   std::shared_ptr<Spacetime> spacetime_;
   std::vector<std::vector<std::complex<double>>> inputTargets_;

--- a/include/cobordism/Proton.h
+++ b/include/cobordism/Proton.h
@@ -62,8 +62,13 @@ class Proton {
   ///                        register is never driven to carry).
   ///   * `inputWeight`    — weight on the input residuals so the diquark/quark
   ///                        inputs are driven to carry rather than dissolve.
+  ///   * `precone`        — pre-grow each step's single-Δ⁴ seed by this many gated
+  ///                        cone-in moves before optimization (forwarded to the
+  ///                        `MultiCobordism` ctor of every node), giving surgery
+  ///                        room to act without prebuilding a host. Default 0.
   explicit Proton(std::uint64_t seed = 0, int registerDegree = 3,
-                  double gamma = 50.0, double inputWeight = 20.0);
+                  double gamma = 50.0, double inputWeight = 20.0,
+                  int precone = 0);
 
   /// Build the proton, restarting across seeds until step B's whole cobordism
   /// carries the singlet with `≥ minQuarkHoles` holes (or `maxRestarts` is
@@ -126,6 +131,7 @@ class Proton {
   int registerDegree_;
   double gamma_;
   double inputResidualWeight_;
+  int precone_;  // gated cone-ins pre-grown into each node's seed (ctor → nodes)
 
   // ---- build state (populated by build()) ----
   bool attempted_ = false;

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -795,10 +795,10 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
       .def(py::init<std::shared_ptr<Spacetime>,
                     std::vector<std::vector<std::complex<double>>>,
                     std::vector<std::vector<std::complex<double>>>,
-                    std::vector<int>, double, std::uint64_t>(),
+                    std::vector<int>, double, std::uint64_t, int>(),
            py::arg("host"), py::arg("input_targets"), py::arg("output_targets"),
            py::arg("degrees") = std::vector<int>{3}, py::arg("gamma") = 1.0,
-           py::arg("seed") = 0)
+           py::arg("seed") = 0, py::arg("precone") = 0)
       .def_static("betti", &MultiCobordism::betti, py::arg("st"))
       .def_static("emergent_holes", &MultiCobordism::emergentHoles,
                   py::arg("st"), py::arg("k"))
@@ -865,9 +865,9 @@ seeds until step B's proton block carries the singlet with >=3 color holes. The
 accessors lazily trigger build() on first use, so `Proton().block()` just works.
 Observable readers (charge/mass/radius/spin) read OFF block() in their own
 tickets.)doc")
-      .def(py::init<std::uint64_t, int, double, double>(), py::arg("seed") = 0,
+      .def(py::init<std::uint64_t, int, double, double, int>(), py::arg("seed") = 0,
            py::arg("register_degree") = 3, py::arg("gamma") = 50.0,
-           py::arg("input_weight") = 20.0)
+           py::arg("input_weight") = 20.0, py::arg("precone") = 0)
       .def_static("omega", &Proton::omega, "omega = exp(2*pi*i/3).")
       .def_static("singlet", &Proton::singlet,
                   "The proton color singlet {1, w, w*w}.")

--- a/src/cobordism/MultiCobordism.cpp
+++ b/src/cobordism/MultiCobordism.cpp
@@ -56,7 +56,8 @@ MultiCobordism::MultiCobordism(
     std::shared_ptr<Spacetime> host,
     const std::vector<std::vector<complexd>> &inputTargets,
     const std::vector<std::vector<complexd>> &outputTargets,
-    const std::vector<int> &degrees, double gamma, std::uint64_t seed)
+    const std::vector<int> &degrees, double gamma, std::uint64_t seed,
+    int precone)
     : spacetime_(std::move(host)),
       inputTargets_(inputTargets),
       outputTargets_(outputTargets),
@@ -67,7 +68,13 @@ MultiCobordism::MultiCobordism(
               : *std::max_element(registerDegrees_.begin(),
                                   registerDegrees_.end())),
       gamma_(gamma),
-      randomNumberGenerator_(seed) {}
+      randomNumberGenerator_(seed) {
+  // Pre-grow the seed by `precone` gated cone-ins before any optimization, so the
+  // stage-1 search starts from a larger complex grown emergently from the host (no
+  // input/output block is seeded yet, so nothing is pinned — the gate is the only
+  // constraint). `precone <= 0` leaves the host and RNG untouched.
+  if (precone > 0) preconeCells(precone);
+}
 
 std::vector<int> MultiCobordism::betti(const Spacetime &spacetime) {
   return ChainComplex::fromSpacetime(spacetime).bettiNumbers();
@@ -451,6 +458,40 @@ double MultiCobordism::trapDoorMove(int attempts) {
     return objectiveDelta;
   }
   return std::numeric_limits<double>::quiet_NaN();
+}
+
+void MultiCobordism::preconeCells(int count) {
+  // Each cone-in cones a fresh apex onto a random codim-1 facet (a top cell with one
+  // vertex dropped) and is committed only through applyMoveSpecification's
+  // dualComplexValid gate — the same gated primitive the trap door uses, so the
+  // pre-growth is sound (nothing inserted by fiat). On the single-Δ⁴ seed (a 4-ball)
+  // a cone-in over a boundary facet is valid, so this enlarges the 4-ball; a draw
+  // onto an already-saturated interior facet is rejected by the gate and retried.
+  constexpr int kAttemptsPerCone = 16;  // gated tries before giving up on one cone
+  for (int conedSoFar = 0; conedSoFar < count; ++conedSoFar) {
+    std::vector<std::vector<std::uint64_t>> topCellTuples;
+    for (const auto &topSimplex : spacetime_->getTopSimplices())
+      topCellTuples.push_back(topTuple(*topSimplex));
+    if (topCellTuples.empty()) return;  // nothing to cone onto
+    bool coned = false;
+    for (int attempt = 0; attempt < kAttemptsPerCone && !coned; ++attempt) {
+      const auto &chosenCell =
+          topCellTuples[randomNumberGenerator_() % topCellTuples.size()];
+      const std::size_t droppedVertexIndex =
+          randomNumberGenerator_() % chosenCell.size();
+      std::vector<std::uint64_t> coneInFace;  // a codim-1 facet: drop one vertex
+      for (std::size_t vertexIndex = 0; vertexIndex < chosenCell.size();
+           ++vertexIndex)
+        if (vertexIndex != droppedVertexIndex)
+          coneInFace.push_back(chosenCell[vertexIndex]);
+      auto candidateSpacetime = build(snapshot());
+      if (applyMoveSpecification(candidateSpacetime, {"cone_in", coneInFace})) {
+        spacetime_ = build(snapshotOf(*candidateSpacetime));
+        coned = true;
+      }
+    }
+    if (!coned) return;  // no valid cone-in found for this cell; stop early
+  }
 }
 
 void MultiCobordism::growBoundaryRegions() {

--- a/src/cobordism/Proton.cpp
+++ b/src/cobordism/Proton.cpp
@@ -39,11 +39,12 @@ std::vector<std::complex<double>> Proton::singlet() {
 }
 
 Proton::Proton(std::uint64_t seed, int registerDegree, double gamma,
-               double inputWeight)
+               double inputWeight, int precone)
     : baseSeed_(seed),
       registerDegree_(registerDegree),
       gamma_(gamma),
-      inputResidualWeight_(inputWeight) {}
+      inputResidualWeight_(inputWeight),
+      precone_(precone) {}
 
 std::shared_ptr<Spacetime> Proton::buildMinimalSeed() {
   using namespace ::tessera::spacetime;
@@ -73,13 +74,19 @@ std::shared_ptr<MultiCobordism> Proton::recombinationNode(std::uint64_t seed) co
   const std::vector<complexd> diquark = {complexd(1.0, 0.0), w};
   const std::vector<complexd> antidiquark = {complexd(1.0, 0.0), w * w};
   auto host = buildMinimalSeed();
-  auto verts = host->getVertexList()->toVector();
+  // Capture the seed vertex IDS (not Vertex*) BEFORE constructing the node: with
+  // precone_ > 0 the ctor regrows spacetime_ into a fresh complex, destroying the
+  // original host's Vertex objects — but the seed ids persist through the rebuilds
+  // (build() preserves vertex ids), so the input/output anchors stay valid.
+  std::vector<std::uint64_t> seedVertexIds;
+  for (const auto *vertex : host->getVertexList()->toVector())
+    seedVertexIds.push_back(vertex->getId());
   auto node = std::make_shared<MultiCobordism>(
       host, pairs, std::vector<std::vector<complexd>>{diquark, antidiquark},
-      std::vector<int>{registerDegree_}, gamma_, seed);
+      std::vector<int>{registerDegree_}, gamma_, seed, precone_);
   node->setInputResidualWeight(inputResidualWeight_);
-  node->seedInputs({verts[0]->getId(), verts[1]->getId()});
-  node->seedOutputs({verts[2]->getId(), verts[3]->getId()});
+  node->seedInputs({seedVertexIds[0], seedVertexIds[1]});
+  node->seedOutputs({seedVertexIds[2], seedVertexIds[3]});
   return node;
 }
 
@@ -91,13 +98,17 @@ std::shared_ptr<MultiCobordism> Proton::formationNode(std::uint64_t seed) const 
   const std::vector<complexd> diquark = {complexd(1.0, 0.0), w};
   const std::vector<complexd> thirdQuark = {w * w};
   auto host = buildMinimalSeed();
-  auto verts = host->getVertexList()->toVector();
+  // Capture the seed vertex IDS before constructing the node (see recombinationNode):
+  // precone_ > 0 regrows the complex in the ctor, but the seed ids persist.
+  std::vector<std::uint64_t> seedVertexIds;
+  for (const auto *vertex : host->getVertexList()->toVector())
+    seedVertexIds.push_back(vertex->getId());
   auto node = std::make_shared<MultiCobordism>(
       host, std::vector<std::vector<complexd>>{diquark, thirdQuark},
       std::vector<std::vector<complexd>>{singlet()},
-      std::vector<int>{registerDegree_}, gamma_, seed);
+      std::vector<int>{registerDegree_}, gamma_, seed, precone_);
   node->setInputResidualWeight(inputResidualWeight_);
-  node->seedInputs({verts[0]->getId(), verts[1]->getId()});
+  node->seedInputs({seedVertexIds[0], seedVertexIds[1]});
   return node;
 }
 

--- a/tests/cobordism/test_multicobordism_animation.py
+++ b/tests/cobordism/test_multicobordism_animation.py
@@ -90,6 +90,16 @@ class MultiCobordismAnimationTest(unittest.TestCase):
             self.assertTrue(os.path.exists(out))
             self.assertGreater(os.path.getsize(out), 0)
 
+    def test_precone_pre_grows_the_seed(self):
+        # The --precone flag flows build_proton_nodes(precone=N) -> Proton(precone=N) ->
+        # the C++ MultiCobordism ctor, so each node's single-Δ⁴ seed is pre-grown before
+        # any optimization. precone=0 leaves the bare seed (one top cell).
+        bare = self.mca.build_proton_nodes(seed=3, precone=0)
+        grown = self.mca.build_proton_nodes(seed=3, precone=6)
+        self.assertEqual(len(bare[0][0].st.getTopSimplices()), 1)
+        self.assertGreater(len(grown[0][0].st.getTopSimplices()), 1)
+        self.assertGreater(len(grown[1][0].st.getTopSimplices()), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cobordism/test_multicobordism_precone.py
+++ b/tests/cobordism/test_multicobordism_precone.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The `precone` knob (#533): pre-grow the emergent seed by N gated cone-in moves
+before optimization.
+
+`precone` is a constructor argument on the C++ `MultiCobordism` (the source of truth),
+threaded through `Proton` (which builds the animation's nodes from a single Δ⁴ seed) and
+surfaced as `--precone` on the animation. Each pre-cone adds one top cell on a fresh apex
+over a facet and is accepted only through the same `dualComplexValid` gate stage 1 uses, so
+the pre-growth stays a valid manifold-with-boundary — nothing is inserted by fiat. It is the
+emergent analogue of a prebuilt host refinement.
+"""
+import unittest
+
+import tessera
+
+cob = tessera.cobordism
+
+_DIM = 4
+
+
+def _single_delta4():
+    """A single Δ⁴ simplex (one pentatope: 5 vertices, 1 top cell, Betti [1,0,0,0,0], a
+    contractible 4-ball) with a uniform ℓ²=1 metric — the same minimal emergent seed
+    `Proton.buildMinimalSeed` grows the proton out of."""
+    sig = tessera.Signature(_DIM, tessera.Lorentzian)
+    st = tessera.Spacetime(tessera.Metric(True, sig), tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.SolidSimplex(_DIM))
+    st.build()
+    for e in st.getEdgeList().toVector():
+        e.setSquaredLength(1.0)
+    return st
+
+
+def _n_cells(st):
+    return len(st.getTopSimplices())
+
+
+def _is_manifold(st, k=3):
+    ok, _why = cob.EigenstateSynthesis(st, k).dualComplexValid()
+    return ok
+
+
+# Minimal, well-formed targets — precone runs in the ctor irrespective of the states, so a
+# 1-vector input and output are enough to construct a MultiCobordism.
+_IN = [[complex(1.0, 0.0)]]
+_OUT = [[complex(1.0, 0.0)]]
+
+
+class PreconeMultiCobordismTest(unittest.TestCase):
+    """The `precone` flag directly on the `MultiCobordism` constructor."""
+
+    def _mc(self, seed, precone):
+        return cob.MultiCobordism(_single_delta4(), _IN, _OUT, degrees=[3],
+                                  gamma=1.0, seed=seed, precone=precone)
+
+    def test_zero_is_a_noop(self):
+        # precone=0 leaves the single-Δ⁴ seed untouched: exactly one top cell.
+        mc = self._mc(seed=1, precone=0)
+        self.assertEqual(_n_cells(mc.st), 1)
+        self.assertEqual(list(cob.MultiCobordism.betti(mc.st)), [1, 0, 0, 0, 0])
+
+    def test_precone_grows_the_complex(self):
+        # precone=N cones N fresh top cells into the seed (gated; best-effort), so the
+        # complex grows well beyond the bare seed.
+        mc = self._mc(seed=1, precone=8)
+        self.assertGreater(_n_cells(mc.st), 1)
+        self.assertGreaterEqual(_n_cells(mc.st), 1 + 4)   # most gated cone-ins succeed
+
+    def test_precone_stays_a_valid_manifold_and_contractible(self):
+        # Every accepted cone-in passes the dualComplexValid gate, so the grown complex
+        # is still a manifold-with-boundary; cone-in caps (never opens) so the 4-ball
+        # stays contractible (Betti [1,0,0,0,0]) — no register hole is created.
+        mc = self._mc(seed=2, precone=10)
+        self.assertTrue(_is_manifold(mc.st))
+        self.assertEqual(list(cob.MultiCobordism.betti(mc.st)), [1, 0, 0, 0, 0])
+
+    def test_more_precone_grows_at_least_as_much(self):
+        small = _n_cells(self._mc(seed=4, precone=3).st)
+        large = _n_cells(self._mc(seed=4, precone=12).st)
+        self.assertGreater(large, small)
+
+    def test_reproducible_given_seed(self):
+        # Same (seed, precone) → identical pre-growth (the RNG is the ctor seed).
+        a = _n_cells(self._mc(seed=7, precone=6).st)
+        b = _n_cells(self._mc(seed=7, precone=6).st)
+        self.assertEqual(a, b)
+
+
+class PreconeThroughProtonTest(unittest.TestCase):
+    """`precone` threaded through `Proton` into both node factories — the path the
+    animation drives. Also guards the id-capture fix: with precone>0 the ctor regrows the
+    complex, so the factories must anchor `seed_inputs`/`seed_outputs` by vertex id (stable
+    across the rebuild), not by a stale Vertex handle."""
+
+    def test_recombination_node_precone_grows_and_seeds(self):
+        bare = cob.Proton(seed=3, precone=0).recombination_node(3)
+        grown = cob.Proton(seed=3, precone=8).recombination_node(3)
+        self.assertEqual(_n_cells(bare.st), 1)              # bare single-Δ⁴ seed
+        self.assertGreater(_n_cells(grown.st), 1)           # pre-grown
+        self.assertTrue(_is_manifold(grown.st))
+        # The id-capture fix held: the two inputs and two outputs were seeded on the grown
+        # complex (non-empty regions), not lost to a dangling handle.
+        self.assertEqual(len(grown.inputs), 2)
+        self.assertEqual(len(grown.outputs), 2)
+        for block in list(grown.inputs) + list(grown.outputs):
+            self.assertTrue(list(block.vertices))
+
+    def test_formation_node_precone_grows_and_seeds(self):
+        bare = cob.Proton(seed=5, precone=0).formation_node(6)
+        grown = cob.Proton(seed=5, precone=8).formation_node(6)
+        self.assertEqual(_n_cells(bare.st), 1)
+        self.assertGreater(_n_cells(grown.st), 1)
+        self.assertTrue(_is_manifold(grown.st))
+        self.assertEqual(len(grown.inputs), 2)              # diquark + third quark
+        for block in grown.inputs:
+            self.assertTrue(list(block.vertices))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a `precone` knob that pre-grows the **emergent seed** by N **gated cone-in moves** before optimization starts — the emergent analogue of a prebuilt host refinement. The canonical flag lives on the C++ `MultiCobordism` constructor (the source of truth); it threads through `Proton` (which builds the animation's nodes from a single Δ⁴) and is surfaced as `--precone N` on `multicobordism_animation.py`.

Each pre-cone adds one top cell on a fresh apex over a facet and is committed only through the same `dualComplexValid` gate stage 1 and the trap door use — so the pre-growth stays a valid manifold-with-boundary and nothing is inserted by fiat. On the single-Δ⁴ seed (a 4-ball, boundary `∂Δ⁴ = S³`) a cone-in over a boundary facet is gate-valid, so "cone N simplices *into* the complex" is well-defined.

### Changes
- **`MultiCobordism`** — new trailing `int precone = 0` ctor arg + private `preconeCells(int)` (gated cone-in loop, best-effort, RNG-reproducible). `precone=0` leaves the host and RNG untouched.
- **`Proton`** — `precone` ctor arg, forwarded by `recombinationNode`/`formationNode` to the `MultiCobordism` ctor. Because `precone>0` regrows `spacetime_` inside the ctor, the factories now anchor `seedInputs`/`seedOutputs` by **vertex id** (stable across the rebuild) rather than a stale `Vertex*` — a use-after-free the feature would otherwise introduce.
- **pybind** — `precone` exposed on both ctors (default 0).
- **animation** — `--precone N` → `build_proton_nodes(precone=N)` → `cob.Proton(precone=N)`.
- **tests** — new `test_multicobordism_precone.py` + an animation smoke check.

### Out of scope (deliberate)
Retiring the prebuilt-S⁴ host / `build_closed_s4` / `EmergentOptimizer` — handled by the open **#525**. This PR avoids those files to prevent redundant work + merge conflicts.

## Test plan
- [x] `test_multicobordism_precone.py` (7) + `test_multicobordism_animation.py` (5) — green locally
- [x] `test_multi_cobordism_python.py` — parity/regression green (MultiCobordism + Proton + CobordismDAG through the modified ctors)
- [ ] `test_proton_cpp_python.py` (@slow full Proton build) — running locally
- [ ] CI full suite

Closes #533.