### PR TITLE
fix(cobordism): relative-tolerance stationarity stop in MultiCobordism geometric relaxation

### DIFF
--- a/include/cobordism/MultiCobordism.h
+++ b/include/cobordism/MultiCobordism.h
@@ -117,8 +117,17 @@ class MultiCobordism {
   /// run the bulk EVOLUTION with it false, so ∂W stays frozen.
   std::vector<double> runStage1(int maxSteps = 200, int nCandidateMoves = 12,
                                 int patience = 8, bool growBoundaries = false);
-  std::vector<double> runStage2(double beta = 1.0, int maxIters = 40,
-                                  double alpha0 = 0.05);
+  /// Stage 2 (geometric): relax every (complex) edge `ℓ²` toward a stationary point of
+  /// `β‖∇S‖² + Γ·r_U` (Wirtinger steepest descent, backtracking line search). The line
+  /// search accepts a step only when it lowers `F` by more than `relTol·max(|F|,1)` — a
+  /// RELATIVE stationarity test (an absolute floor of `relTol` for `|F| < 1`), so the
+  /// criterion scales with the objective rather than the absolute `convergenceTolerance_`
+  /// the surgery stages use (for `F ≈ 100` that absolute `1e-9` accepted ~`1e-11` relative
+  /// steps — the rounding floor). "No line-search step beats the threshold" is the
+  /// stationary stop; `maxIters` is the safety budget cap. `lastStage2Stationary()` reports
+  /// which of the two ended the run. Returns the `F` trace.
+  std::vector<double> runStage2(double beta = 1.0, int maxIters = 200,
+                                  double alpha0 = 0.05, double relTol = 1e-9);
 
   [[nodiscard]] std::shared_ptr<Spacetime> spacetime() const { return spacetime_; }
   [[nodiscard]] const std::vector<BoundaryBlock> &inputs() const {
@@ -127,6 +136,11 @@ class MultiCobordism {
   [[nodiscard]] const std::vector<BoundaryBlock> &outputs() const {
     return outputBlocks_;
   }
+  /// Whether the last `runStage2` ended on the relative-tolerance stationarity test (no
+  /// line-search step lowered `F` by more than `relTol·max(|F|,1)`) — `true` — versus
+  /// hitting the `maxIters` budget cap — `false`. Lets a caller report "stopped:
+  /// stationary" vs "stopped: budget". `false` before the first `runStage2`.
+  [[nodiscard]] bool lastStage2Stationary() const { return lastStage2Stationary_; }
 
  private:
   using Snapshot =
@@ -226,6 +240,9 @@ class MultiCobordism {
   /// The move/restart random source driving stage 1 and block construction.
   std::mt19937_64 randomNumberGenerator_;
   double convergenceTolerance_ = 1e-9;
+  /// Set by `runStage2`: `true` iff its last call stopped on the relative-tolerance
+  /// stationarity test, `false` iff it hit the `maxIters` budget. See lastStage2Stationary.
+  bool lastStage2Stationary_ = false;
   std::vector<BoundaryBlock> inputBlocks_;
   std::vector<BoundaryBlock> outputBlocks_;
 };

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -815,14 +815,26 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            py::arg("n_candidate_moves") = 12, py::arg("patience") = 8,
            py::arg("grow_boundaries") = false)
       .def("run_stage2", &MultiCobordism::runStage2, py::arg("beta") = 1.0,
-           py::arg("max_iters") = 40, py::arg("alpha0") = 0.05)
+           py::arg("max_iters") = 200, py::arg("alpha0") = 0.05,
+           py::arg("rel_tol") = 1e-9,
+           "Stage 2 (geometric): relax every edge l^2 toward a stationary point of "
+           "beta*||grad S||^2 + gamma*r_U (Wirtinger steepest descent, backtracking "
+           "line search). Stops on the RELATIVE stationarity test -- no line-search "
+           "step lowers F by more than rel_tol*max(|F|,1) -- or the max_iters budget "
+           "cap. Read last_stage2_stationary for which one ended the run. Returns the "
+           "F trace.")
       .def_property_readonly("st", &MultiCobordism::spacetime)
       .def_property_readonly("inputs", &MultiCobordism::inputs,
                              py::return_value_policy::reference_internal,
                              "The emergent input blocks (each a MultiCobordismBlock).")
       .def_property_readonly("outputs", &MultiCobordism::outputs,
                              py::return_value_policy::reference_internal,
-                             "The emergent output blocks (each a MultiCobordismBlock).");
+                             "The emergent output blocks (each a MultiCobordismBlock).")
+      .def_property_readonly("last_stage2_stationary",
+                             &MultiCobordism::lastStage2Stationary,
+                             "True iff the last run_stage2 stopped on the relative-"
+                             "tolerance stationarity test (delta_rel < rel_tol); False "
+                             "if it hit the max_iters budget cap.");
 
   // === CobordismDAG (#491): chain emergent merges, output -> input ===
   py::class_<CobordismDAG>(m, "CobordismDAG",

--- a/src/cobordism/MultiCobordism.cpp
+++ b/src/cobordism/MultiCobordism.cpp
@@ -609,7 +609,7 @@ void MultiCobordism::seedBlocks(
 }
 
 std::vector<double> MultiCobordism::runStage2(double beta, int maxIters,
-                                                 double alpha0) {
+                                                 double alpha0, double relTol) {
   auto edges = spacetime_->getEdgeList()->toVector();
   const std::size_t edgeCount = edges.size();
   auto fullObjective = [&]() {
@@ -617,6 +617,7 @@ std::vector<double> MultiCobordism::runStage2(double beta, int maxIters,
   };
   std::vector<double> objectiveTrace = {fullObjective()};
   double stepScale = alpha0;
+  lastStage2Stationary_ = false;  // set true only on the stationary break below
   for (int iterationIndex = 0; iterationIndex < maxIters; ++iterationIndex) {
     ReggeSolver reggeSolver(spacetime_, MatterConfiguration());
     const auto gradientComponents = reggeSolver.actionGradientExact();
@@ -635,6 +636,12 @@ std::vector<double> MultiCobordism::runStage2(double beta, int maxIters,
     for (std::size_t edgeIndex = 0; edgeIndex < edgeCount; ++edgeIndex)
       squaredLengths(edgeIndex) = edges[edgeIndex]->getSquaredLength();
     const double currentObjective = objectiveTrace.back();
+    // Relative stationarity: accept a step only when it lowers F by more than relTol
+    // scaled by the current magnitude (an absolute floor of relTol when |F| < 1). The
+    // old absolute convergenceTolerance_ accepted ~1e-11 *relative* steps for F ~ 100
+    // — the rounding floor; this scales the threshold with the objective instead.
+    const double improvementThreshold =
+        relTol * std::max(std::abs(currentObjective), 1.0);
     double trialStepScale = stepScale;
     bool objectiveImproved = false;
     for (int lineSearchIndex = 0; lineSearchIndex < 24; ++lineSearchIndex) {
@@ -653,7 +660,7 @@ std::vector<double> MultiCobordism::runStage2(double beta, int maxIters,
       } catch (...) {
         trialObjective = std::numeric_limits<double>::infinity();
       }
-      if (trialObjective < currentObjective - convergenceTolerance_) {
+      if (trialObjective < currentObjective - improvementThreshold) {
         objectiveTrace.push_back(trialObjective);
         stepScale = std::min(stepScale * 1.3, 1.0);
         objectiveImproved = true;
@@ -664,6 +671,7 @@ std::vector<double> MultiCobordism::runStage2(double beta, int maxIters,
     if (!objectiveImproved) {
       for (std::size_t edgeIndex = 0; edgeIndex < edgeCount; ++edgeIndex)
         edges[edgeIndex]->setSquaredLength(squaredLengths(edgeIndex));
+      lastStage2Stationary_ = true;  // no line-search step beat the relative threshold
       break;
     }
   }

--- a/tests/cobordism/test_multi_cobordism_python.py
+++ b/tests/cobordism/test_multi_cobordism_python.py
@@ -65,6 +65,35 @@ class MultiCobordismCxxTest(unittest.TestCase):
         opt.run_stage1(max_steps=20, n_candidate_moves=8, patience=8)
         self.assertGreaterEqual(list(CXX.betti(opt.st))[3], 1)  # a b₃ register emerged
 
+    def test_run_stage2_stops_on_relative_stationarity(self):
+        # run_stage2 stops on a RELATIVE stationarity test — no line-search step lowers F
+        # by more than rel_tol·max(|F|,1) — and last_stage2_stationary reports whether the
+        # run ended that way (True) or hit the max_iters budget cap (False). Only this
+        # geometric tail is relative; the surgery stages keep the absolute tolerance.
+        CXX, w = self.CXX, self.w
+        host = self.eo.build_closed_s4(n_refine=12, seed=3)
+        opt = CXX(host, [[1, w, w * w], [1, w * w, w]], [[1, w, w * w]],
+                  degrees=[3], gamma=1.0, seed=3)
+        opt.seed_inputs([v.getId() for v in host.getVertexList().toVector()][:2])
+
+        # Budget cap: one iteration under a tight tol on the fresh, jittered (non-
+        # stationary) geometry takes a single improving step and stops on the iteration
+        # budget — NOT the stationarity test. last_stage2_stationary is False.
+        t_budget = opt.run_stage2(beta=1.0, max_iters=1, alpha0=0.05, rel_tol=1e-13)
+        self.assertFalse(opt.last_stage2_stationary)         # stopped: budget
+        self.assertLess(t_budget[-1], t_budget[0])           # the step strictly lowered F
+
+        # Stationary stop: with the relative threshold wider than any achievable decrease
+        # (F = ||grad S||^2 + gamma*r_U >= 0, so no edge step can lower F by 10*max(|F|,1)),
+        # the first line search accepts nothing and run_stage2 stops on the stationarity
+        # test — reported by the accessor — before exhausting max_iters. This exercises the
+        # exact "no step beats relTol*max(|F|,1)" branch the relative criterion introduced.
+        t_stat = opt.run_stage2(beta=1.0, max_iters=50, alpha0=0.05, rel_tol=10.0)
+        self.assertTrue(opt.last_stage2_stationary)          # stopped: stationary
+        self.assertLess(len(t_stat), 51)                     # broke before the budget cap
+        self.assertTrue(all(t_stat[i + 1] <= t_stat[i]       # never increases
+                            for i in range(len(t_stat) - 1)))
+
     def test_two_step_proton_via_canonical_class(self):
         # Retrofit of the old hand-rolled proton-shaped DAG smoke (#503): the
         # canonical two-step proton build now goes through tessera.cobordism.Proton


### PR DESCRIPTION
## Summary
`MultiCobordism::runStage2` (the geometric Regge relaxation) decided convergence with the **absolute** `convergenceTolerance_ = 1e-9` the surgery stages use: the line search accepted a step only if `trialObjective < currentObjective - 1e-9`, and stopped (stationary) when no step beat that. Because it's absolute it doesn't scale with `F` — for `F ≈ 100` the last accepted improvements were ~`1e-11` *relative*, i.e. the rounding floor (numerical noise).

This makes the stage-2 tail stop on a **relative** stationarity test and report which way it stopped. Scope is `runStage2` only; the surgery move-acceptance sites (`step()`, `runStage1`) keep the absolute tolerance, and the objective `F = ‖∇S_Regge‖² + Γ·r_U` and all physics are unchanged — only the stopping criterion.

### What changed
- `runStage2` accepts/continues only while a step lowers `F` by more than `relTol·max(|F|,1)` (an absolute floor of `relTol` for `|F| < 1`); "no line-search step beats that" is the stationary stop. New `relTol` parameter (default `1e-9`, bound `rel_tol`); `maxIters` default raised `40 → 200` so the tail can reach stationarity rather than budget-capping.
- New member `lastStage2Stationary_` + accessor `lastStage2Stationary()` (Python property `last_stage2_stationary`): `True` on the relative-stationarity break, `False` on the `maxIters` budget cap.
- `Bindings.cpp`: `run_stage2` gains `rel_tol`; new `last_stage2_stationary` read-only property.

Files: `include/cobordism/MultiCobordism.h`, `src/cobordism/MultiCobordism.cpp`, `src/cobordism/Bindings.cpp` (+ a new test, to follow).

## Test plan
- [ ] C++ builds in an isolated worktree venv (`pip install -e ".[dev]"`).
- [ ] New test: `run_stage2` stops on the relative-tolerance stationarity test and `last_stage2_stationary` reports it (and a 1-iteration tight-tol run reports the budget cap).
- [ ] Full `pytest tests/ -q` green; any golden-constant shift caused ONLY by the criterion change is re-baselined in this PR with the functional outcome preserved.
- [ ] Sanity: `Proton().formation_node(4)` driven through stage 1 (init+evolve) then stage 2 — before/after stage-2 iteration counts + stop reason under absolute vs relative tolerance; proton still converges (holes, r_state≈0).

Closes #540.