### PR TITLE
feat(cobordism): RL that carries the proton singlet (>=3 holes, r_state -> 0)

### DIFF
--- a/examples/cobordism/rl/objective_env.py
+++ b/examples/cobordism/rl/objective_env.py
@@ -187,8 +187,9 @@ class CobordismObjectiveEnv:
         terminate_on_carry: bool = True,
         directed_grow: bool = False,
         cone_strategy: str = "greedy",
-        cone_max_candidates: int = 200,
+        cone_max_candidates: int = 80,
         cone_overshoot: int = 2,
+        cone_probe_openers: int = 6,
     ):
         # Default target = the proton singlet on the formation (2→1) node. `gamma` MUST
         # match the factory's node so F = gradN2 + gamma·r_u is reconstructed exactly; the
@@ -241,6 +242,9 @@ class CobordismObjectiveEnv:
         # cone-in that leaves the lowest singlet r_state) — register selection, not just
         # growth (so the policy can drop a sub-optimal hole and keep a better one).
         self.cone_overshoot = int(cone_overshoot)
+        # The cone-out probe stops scanning candidates once this many hole-openers are found
+        # (interior-first ordering surfaces them up front), so the probe stays affordable.
+        self.cone_probe_openers = int(cone_probe_openers)
 
         # Gym-style space descriptors (no gymnasium dependency).
         self.observation_space = _Box(
@@ -497,6 +501,7 @@ class CobordismObjectiveEnv:
 
             cells = sorted(self._top_cell_tuples(st), key=_order_key)[:self.cone_max_candidates]
             best = None  # (score, cell)
+            openers_found = 0
             for cell in cells:
                 ok, _reason = cone.coneOut(cell)
                 if not ok:
@@ -515,6 +520,13 @@ class CobordismObjectiveEnv:
                 if best is None or score > best[0]:
                     best = (score, cell)
                 cone.rollback()
+                # Early stop: the interior-first ordering surfaces hole-creators up front, so
+                # once a few openers are in hand the best is almost surely among them — bail
+                # rather than scan the (mostly non-opening) tail. Keeps the probe affordable.
+                if delta > 0:
+                    openers_found += 1
+                    if openers_found >= self.cone_probe_openers:
+                        break
             if best is None or best[0][0] <= 0:  # nothing opens a new hole
                 break
             ok, _reason = cone.coneOut(best[1])

--- a/examples/cobordism/rl/objective_env.py
+++ b/examples/cobordism/rl/objective_env.py
@@ -152,7 +152,11 @@ class CobordismObjectiveEnv:
 
     Reward: ``reward_scale · (slog(F_before) − slog(F_after))`` (a monotone, bounded
     surrogate for −ΔF whose episode sum telescopes to the total log-reduction of F), plus
-    a one-time ``carry_bonus`` the step the target is first carried.
+    a one-time ``carry_bonus`` the step the target is first carried, plus two OPTIONAL dense
+    proton-shaping terms (off by default): ``hole_reward_weight`` for progress toward
+    ``target_holes`` (capped) and ``rstate_reward_weight`` for driving the singlet residual
+    ``r_state`` down. The shaping is a *training signal* — it never changes F, the engine, or
+    the carry verdict; with both weights 0 the reward is exactly the foundation's −ΔF drop.
 
     Episode ends (``done``) when the action budget ``max_actions`` is spent (truncation) or
     the target is carried (termination).
@@ -178,6 +182,8 @@ class CobordismObjectiveEnv:
         target_holes: int = 3,
         carry_bonus: float = 3.0,
         reward_scale: float = 1.0,
+        hole_reward_weight: float = 0.0,
+        rstate_reward_weight: float = 0.0,
     ):
         # Default target = the proton singlet on the formation (2→1) node. `gamma` MUST
         # match the factory's node so F = gradN2 + gamma·r_u is reconstructed exactly; the
@@ -200,6 +206,14 @@ class CobordismObjectiveEnv:
         self.target_holes = int(target_holes)
         self.carry_bonus = float(carry_bonus)
         self.reward_scale = float(reward_scale)
+        # Dense proton-shaping weights (a TRAINING SIGNAL only — they never touch F, the
+        # engine, or the carry verdict). `hole_reward_weight` rewards each unit of progress
+        # toward `target_holes` (capped, so over-growing past the target earns nothing);
+        # `rstate_reward_weight` rewards driving the singlet residual `r_state` down. Both
+        # default to 0, so the base env's reward stays exactly `−ΔF` (+ carry bonus) and the
+        # foundation's reward contract (telescoping log-reduction of F) is unchanged.
+        self.hole_reward_weight = float(hole_reward_weight)
+        self.rstate_reward_weight = float(rstate_reward_weight)
 
         # Gym-style space descriptors (no gymnasium dependency).
         self.observation_space = _Box(
@@ -306,6 +320,7 @@ class CobordismObjectiveEnv:
         intensity = float(params[0]) if params.size > 0 else 0.5
         knob = float(params[1]) if params.size > 1 else 0.5
 
+        prev_metrics = self._last_metrics  # the state BEFORE this macro-action
         F_before = self._F
         engine_error = None
         try:
@@ -334,15 +349,41 @@ class CobordismObjectiveEnv:
         F_after = metrics["F"]
         self._F = F_after
 
-        # Reward: monotone, bounded surrogate for −ΔF (drop in the true objective). The
-        # per-step rewards telescope, so the episode return = total log-reduction of F.
-        reward = self.reward_scale * (_slog(F_before) - _slog(F_after))
-        if engine_error is not None:
-            reward -= 0.1  # discourage actions that fault the engine (e.g. degenerate relax)
+        # Reward = the dense −ΔF term (a monotone, bounded surrogate for the drop in the
+        # true objective; its per-step values telescope to the episode's total log-reduction
+        # of F) + the dense PROTON-SHAPING terms (a training signal that points the policy at
+        # the carry outcome F alone is too flat to find — see __init__) + the one-time carry
+        # bonus. The shaping weights default to 0, so the base contract (reward == −ΔF drop)
+        # is recovered exactly when they are off.
+        dF_term = self.reward_scale * (_slog(F_before) - _slog(F_after))
+
+        # Hole-progress: reward closing the gap to `target_holes`, capped so over-growing
+        # past 3 holes earns nothing (the proton wants exactly the 3-quark register). The
+        # capped differences telescope to `w·(min(final,T) − min(initial,T))` over an episode.
+        hole_term = 0.0
+        if self.hole_reward_weight != 0.0:
+            prev_h = min(int(prev_metrics.get("holes", 0)), self.target_holes)
+            cur_h = min(int(metrics["holes"]), self.target_holes)
+            hole_term = self.hole_reward_weight * float(cur_h - prev_h)
+
+        # Singlet-residual descent: reward driving `r_state` toward 0 (only meaningful for a
+        # whole-cobordism target). slog compresses the wide range (full leak ≈ ‖t‖² = 3 down
+        # to ~0 when carried); the per-step values telescope to the total slog-drop of r_state.
+        rstate_term = 0.0
+        if self.rstate_reward_weight != 0.0 and self.target_state is not None:
+            prev_r = prev_metrics.get("rstate", math.nan)
+            cur_r = metrics["rstate"]
+            if math.isfinite(prev_r) and math.isfinite(cur_r):
+                rstate_term = self.rstate_reward_weight * (_slog(prev_r) - _slog(cur_r))
+
+        error_term = -0.1 if engine_error is not None else 0.0  # discourage faulting moves
 
         carried_now = self._is_carried(metrics)
-        if carried_now and not self._carried:
-            reward += self.carry_bonus  # one-time terminal bonus for first carrying the target
+        # One-time bonus the step the target is FIRST carried (the proton criterion).
+        carry_term = self.carry_bonus if (carried_now and not self._carried) else 0.0
+
+        reward = dF_term + hole_term + rstate_term + error_term + carry_term
+
         terminated = carried_now
         self._carried = carried_now
         truncated = self._steps_taken >= self.max_actions
@@ -356,6 +397,8 @@ class CobordismObjectiveEnv:
             "n_top_cells": metrics["n_top_cells"], "n_edges": metrics["n_edges"],
             "carried": carried_now, "terminated": terminated, "truncated": truncated,
             "steps_taken": self._steps_taken, "engine_error": engine_error,
+            "reward_terms": {"dF": dF_term, "hole": hole_term, "rstate": rstate_term,
+                             "error": error_term, "carry": carry_term},
         }
         return self._observation(metrics), float(reward), done, info
 

--- a/examples/cobordism/rl/objective_env.py
+++ b/examples/cobordism/rl/objective_env.py
@@ -485,9 +485,8 @@ class CobordismObjectiveEnv:
             holes = cob.MultiCobordism.emergent_holes(st, self.k)
             if len(holes) >= open_target:  # over-open; EVOLVE's cone-in selects the best 3
                 break
-            hole_vertices = {v for hole in holes for v in hole}
+            hole_vertices = {int(v) for hole in holes for v in hole}
             boundary = {tuple(sorted(int(v) for v in f)) for f in st.getBoundary()}
-            hole_vertices = {int(v) for v in hole_vertices}
 
             def _order_key(cell):
                 cellset = set(cell)
@@ -531,6 +530,12 @@ class CobordismObjectiveEnv:
                 break
             ok, _reason = cone.coneOut(best[1])
             if not ok:
+                break
+            # Defensive re-check on the COMMITTED move (probing rolled every candidate back,
+            # so the keep is a fresh coneOut): never leave a pinned vertex stranded.
+            committed = {int(v.getId()) for v in st.getVertexList().toVector()}
+            if not pinned.issubset(committed):
+                cone.rollback()
                 break
             opened += 1
         return opened

--- a/examples/cobordism/rl/objective_env.py
+++ b/examples/cobordism/rl/objective_env.py
@@ -184,6 +184,11 @@ class CobordismObjectiveEnv:
         reward_scale: float = 1.0,
         hole_reward_weight: float = 0.0,
         rstate_reward_weight: float = 0.0,
+        terminate_on_carry: bool = True,
+        directed_grow: bool = False,
+        cone_strategy: str = "greedy",
+        cone_max_candidates: int = 200,
+        cone_overshoot: int = 2,
     ):
         # Default target = the proton singlet on the formation (2→1) node. `gamma` MUST
         # match the factory's node so F = gradN2 + gamma·r_u is reconstructed exactly; the
@@ -214,6 +219,28 @@ class CobordismObjectiveEnv:
         # foundation's reward contract (telescoping log-reduction of F) is unchanged.
         self.hole_reward_weight = float(hole_reward_weight)
         self.rstate_reward_weight = float(rstate_reward_weight)
+        # When True (the #539 default), carrying the target ENDS the episode. The proton arc
+        # is grow → evolve → RELAX, though, and the carry happens at the GROW stage — so the
+        # carry profile sets this False to let the policy keep going (relax the geometry,
+        # lower F) after forming the register, learning the full arc rather than stopping the
+        # instant the holes appear. The carry verdict (read off the final state, as
+        # `Proton.build()` does) is unaffected: once carried, GROW/EVOLVE early-break and
+        # RELAX preserves the register, so the register persists to the episode's end.
+        self.terminate_on_carry = bool(terminate_on_carry)
+        # Directed cone-out probe (#546): when on, a GROW first runs the random-draw
+        # `run_stage1` to build the bulk, then DELIBERATELY opens the register holes the
+        # random draws left short of `target_holes` — choosing each cone-out cell by a gated
+        # `SurgicalCone` probe (`directed_cone_out`) instead of hoping a random draw hits a
+        # disjoint cell. Off by default (pure #539 random growth); the carry profile turns it
+        # on. `cone_strategy` ∈ {"greedy", "bfs"}.
+        self.directed_grow = bool(directed_grow)
+        self.cone_strategy = str(cone_strategy)
+        self.cone_max_candidates = int(cone_max_candidates)
+        # GROW (directed) may OVER-open up to `target_holes + cone_overshoot` register holes;
+        # EVOLVE (directed) then SELECTS the best `target_holes` by capping the worst (the
+        # cone-in that leaves the lowest singlet r_state) — register selection, not just
+        # growth (so the policy can drop a sub-optimal hole and keep a better one).
+        self.cone_overshoot = int(cone_overshoot)
 
         # Gym-style space descriptors (no gymnasium dependency).
         self.observation_space = _Box(
@@ -329,11 +356,19 @@ class CobordismObjectiveEnv:
                 self.node.run_stage1(max_steps=max(1, max_steps),
                                      n_candidate_moves=self.n_candidate_moves,
                                      patience=self.patience, grow_boundaries=True)
+                if self.directed_grow:
+                    # Finish the register the random draws left short: deliberately open the
+                    # remaining holes with the gated directed cone-out probe (#546).
+                    self.directed_cone_out(self.cone_strategy)
             elif move == EVOLVE:
                 max_steps = int(round(_lerp(*self.evolve_steps, intensity)))
                 self.node.run_stage1(max_steps=max(1, max_steps),
                                      n_candidate_moves=self.n_candidate_moves,
                                      patience=self.patience, grow_boundaries=False)
+                if self.directed_grow:
+                    # Select the register: cap the worst hole(s) back toward target_holes,
+                    # dropping a sub-optimal hole GROW may have over-opened (#546).
+                    self.directed_cone_in(self.cone_strategy)
             else:  # RELAX
                 max_iters = int(round(_lerp(*self.relax_iters, intensity)))
                 beta = _lerp(*self.beta_range, knob)
@@ -384,7 +419,7 @@ class CobordismObjectiveEnv:
 
         reward = dF_term + hole_term + rstate_term + error_term + carry_term
 
-        terminated = carried_now
+        terminated = carried_now and self.terminate_on_carry
         self._carried = carried_now
         truncated = self._steps_taken >= self.max_actions
         done = bool(terminated or truncated)
@@ -401,6 +436,144 @@ class CobordismObjectiveEnv:
                              "error": error_term, "carry": carry_term},
         }
         return self._observation(metrics), float(reward), done, info
+
+    # ------------------------------------------------------------------ directed probe
+    def _pinned_vertex_ids(self) -> set:
+        """Every pinned input/output block vertex — a directed cone-out must never strand
+        one (the engine's own move gate also forbids removing a pinned boundary vertex)."""
+        pinned = set()
+        for block in list(self.node.inputs) + list(self.node.outputs):
+            pinned.update(int(v) for v in block.vertices)
+        return pinned
+
+    @staticmethod
+    def _top_cell_tuples(st) -> list:
+        """The current top cells as sorted vertex-id tuples — the `coneOut` input form."""
+        return [sorted(int(v.getId()) for v in s.getVertices())
+                for s in st.getTopSimplices()]
+
+    def directed_cone_out(self, strategy: str = "greedy", max_open: int = 6) -> int:
+        """Open register holes by a DIRECTED, gated cone-out probe (#546) instead of
+        `run_stage1`'s random cone draws. `run_stage1` picks ``cone_out`` only 1/6 of the
+        time, on a UNIFORMLY RANDOM cell, and keeps it only if it lowers F — but opening a
+        new disjoint hole can transiently RAISE F, so greedy-ΔF growth misses it and the
+        register stalls below `target_holes`. This probe instead enumerates candidate top
+        cells, tries each with a gated `SurgicalCone.coneOut` (rolled back), and keeps the
+        one that best advances the proton: opens a NEW emergent hole and (tie-break) lowers
+        the singlet `r_state`.
+
+        Candidates are ordered INTERIOR-FIRST — by how many of the cell's facets are already
+        on the boundary, ascending. Coning out a fully-interior cell turns all of its facets
+        into boundary at once, which is exactly what forms a new emergent-hole tuple; a
+        boundary-adjacent cell does not (and only a few percent of cells are interior
+        hole-creators, so a deliberate ordering matters far more than a random draw).
+        ``strategy='bfs'`` additionally prefers cells disjoint from the existing holes
+        (fewest shared vertices), so the holes grow well-separated. Every `coneOut` is gated
+        on `dualComplexValid` and a pinned input/output vertex is never stranded (the
+        candidate is rolled back if it would). Returns the number of holes opened; a no-op
+        once `target_holes` already exist (the carry wants exactly the 3-quark register)."""
+        st = self.node.st
+        pinned = self._pinned_vertex_ids()
+        cone = cob.SurgicalCone(st)
+        opened = 0
+        open_target = self.target_holes + max(0, self.cone_overshoot)
+        for _ in range(int(max_open)):
+            holes = cob.MultiCobordism.emergent_holes(st, self.k)
+            if len(holes) >= open_target:  # over-open; EVOLVE's cone-in selects the best 3
+                break
+            hole_vertices = {v for hole in holes for v in hole}
+            boundary = {tuple(sorted(int(v) for v in f)) for f in st.getBoundary()}
+            hole_vertices = {int(v) for v in hole_vertices}
+
+            def _order_key(cell):
+                cellset = set(cell)
+                # facets already on the boundary (interior cells = 0 → hole-creators first)
+                n_boundary_facets = sum(
+                    1 for i in range(len(cell))
+                    if tuple(c for j, c in enumerate(cell) if j != i) in boundary)
+                shared = len(cellset & hole_vertices)  # overlap with existing holes
+                return (n_boundary_facets, shared) if strategy == "bfs" \
+                    else (n_boundary_facets,)
+
+            cells = sorted(self._top_cell_tuples(st), key=_order_key)[:self.cone_max_candidates]
+            best = None  # (score, cell)
+            for cell in cells:
+                ok, _reason = cone.coneOut(cell)
+                if not ok:
+                    continue
+                current = {int(v.getId()) for v in st.getVertexList().toVector()}
+                if not pinned.issubset(current):  # would strand a pinned vertex: skip
+                    cone.rollback()
+                    continue
+                delta = len(cob.MultiCobordism.emergent_holes(st, self.k)) - len(holes)
+                if delta > 0 and self.target_state is not None:
+                    rstate = float(cob.MultiCobordism.r_state(
+                        st, self.k, self.target_state))
+                    score = (delta, -rstate)
+                else:
+                    score = (delta, 0.0)
+                if best is None or score > best[0]:
+                    best = (score, cell)
+                cone.rollback()
+            if best is None or best[0][0] <= 0:  # nothing opens a new hole
+                break
+            ok, _reason = cone.coneOut(best[1])
+            if not ok:
+                break
+            opened += 1
+        return opened
+
+    def directed_cone_in(self, strategy: str = "greedy", max_close: int = 6) -> int:
+        """Refine the register by DIRECTED, gated cone-in (#546, register SELECTION): cap an
+        existing emergent hole — `coneIn` on one of its boundary facets adds a cell that
+        covers the facet, so that hole's tuple is no longer all-boundary and the hole closes
+        (lowers `b_{d-1}`). The candidates surfaced FIRST are exactly the boundary facets of
+        the current holes (the hole-CAPPING cone-ins), as first-class moves: this lets the
+        policy DROP a sub-optimal register hole and keep a better one, rather than only ever
+        growing structure. While more than `target_holes` holes exist (e.g. after GROW
+        over-opened), the cap chosen is the one leaving the LOWEST singlet `r_state` — i.e.
+        the WORST hole is dropped, selecting the best `target_holes` that carry the singlet.
+        Gated on `dualComplexValid`; cone-in only adds a fresh vertex, so nothing pinned is
+        stranded. Returns the number of holes capped (a no-op at/below `target_holes`)."""
+        st = self.node.st
+        cone = cob.SurgicalCone(st)
+        closed = 0
+        for _ in range(int(max_close)):
+            holes = cob.MultiCobordism.emergent_holes(st, self.k)
+            if len(holes) <= self.target_holes:  # keep exactly the target register
+                break
+            boundary = {tuple(sorted(int(v) for v in f)) for f in st.getBoundary()}
+            # Hole-capping cone-ins, surfaced first: every drop-one facet of a current hole
+            # that is on the boundary (capping it closes that hole).
+            cap_facets = []
+            seen = set()
+            for hole in holes:
+                for i in range(len(hole)):
+                    facet = tuple(c for j, c in enumerate(hole) if j != i)
+                    if facet in boundary and facet not in seen:
+                        seen.add(facet)
+                        cap_facets.append(list(facet))
+            best = None  # (score, facet) — score = (-r_state) of the result; drop the worst
+            for facet in cap_facets[:self.cone_max_candidates]:
+                ok, _reason = cone.coneIn(facet)
+                if not ok:
+                    continue
+                if len(cob.MultiCobordism.emergent_holes(st, self.k)) >= len(holes):
+                    cone.rollback()  # did not actually close a hole
+                    continue
+                rstate = (float(cob.MultiCobordism.r_state(st, self.k, self.target_state))
+                          if self.target_state is not None else 0.0)
+                score = (-rstate,)
+                if best is None or score > best[0]:
+                    best = (score, facet)
+                cone.rollback()
+            if best is None:
+                break
+            ok, _reason = cone.coneIn(best[1])
+            if not ok:
+                break
+            closed += 1
+        return closed
 
     # ------------------------------------------------------------------ helpers
     def dual_complex_valid(self):

--- a/examples/cobordism/rl/train.py
+++ b/examples/cobordism/rl/train.py
@@ -258,7 +258,7 @@ def _print_comparison(result: dict) -> None:
 # (patience 15, n_candidate_moves 8) match `Proton.build()`'s init/evolve drive, so the RL
 # arc and the reference build see the identical engine.
 CARRY_PROFILE = dict(
-    max_actions=4, hole_reward_weight=2.0, rstate_reward_weight=1.0, carry_bonus=10.0,
+    max_actions=3, hole_reward_weight=2.0, rstate_reward_weight=1.0, carry_bonus=10.0,
     entropy_coef=0.03, entropy_coef_final=0.005,
     # grow_steps caps a single GROW: high enough to form the register (carriers converge in
     # ~50-120 engine steps, then run_stage1 breaks early once carried -- a carrying GROW

--- a/examples/cobordism/rl/train.py
+++ b/examples/cobordism/rl/train.py
@@ -1,21 +1,25 @@
 # Copyright (c) 2026 Twin Vector Labs LLC.
 # All rights reserved.
-"""Train the PPO policy and benchmark it against the random baseline (#537).
+"""Train the PPO policy and benchmark it against the random + grow-only baselines (#537,
+extended for proton carry in #546).
 
-The baseline is the *current* search policy at the macro level: choose each surgery /
-relaxation macro-action (and its parameters) uniformly at random — the engine still draws
-and greedily keeps the actual gated moves inside `run_stage1`. The RL policy instead
-LEARNS which macro-action to take. Both run under the identical environment and action
-budget, so the comparison is apples-to-apples; the headline metric is how far each drives
-the true objective F down from the (fixed) seed state, plus how often the target color
-state is carried.
+Two baselines bracket the learned policy: the **random** macro-level policy (uniform move +
+params — the engine still draws and greedily keeps the gated moves inside `run_stage1`) and
+the **grow-only** policy (always GROW at full intensity — what #539's learned policy
+collapsed to). All run under the identical environment + budget, so the only difference is
+the policy. The #539 headline was how far each drives the true objective F down; the #546
+headline is the PROTON CRITERION — the **carry rate** (fraction of eval seeds that carry the
+singlet over ≥3 emergent colour holes with `r_state` below tol), plus mean holes / mean
+`r_state` / final F.
 
     # quick smoke (seconds): tiny env + 1 training iteration
     python examples/cobordism/rl_objective_search.py --smoke
 
-    # a real (minutes) benchmark on the small formation target
-    python examples/cobordism/rl_objective_search.py --target formation \
-        --iterations 22 --episodes-per-iter 6 --eval-seeds 12
+    # the proton-carry benchmark (#546, ~30-45 min) — the default profile
+    python examples/cobordism/rl_objective_search.py --target formation
+
+    # the #539 fast F-reduction benchmark (~2-4 min)
+    python examples/cobordism/rl_objective_search.py --profile fast
 
 The flat launcher ``examples/cobordism/rl_objective_search.py`` puts ``examples/cobordism``
 on ``sys.path`` so this package's relative imports resolve; ``python -m rl.train`` also
@@ -31,7 +35,8 @@ from typing import Callable, List
 import numpy as np
 
 from .objective_env import (
-    CobordismObjectiveEnv, make_formation_env, make_recombination_env, N_MOVES, PARAM_DIM)
+    CobordismObjectiveEnv, make_formation_env, make_recombination_env,
+    GROW, N_MOVES, PARAM_DIM)
 from .ppo_agent import PPO, set_seed
 
 
@@ -44,6 +49,15 @@ def random_policy(obs):
     move = int(np.random.randint(N_MOVES))
     params = np.random.rand(PARAM_DIM).astype(np.float32)
     return move, params
+
+
+def grow_only_policy(obs):
+    """The #539 grow-dominant baseline: always GROW at full intensity. #539's learned
+    policy collapsed to all-GROW (60/0/0 over its eval), so this is the strongest
+    *non-adaptive* policy and the right "did learning add anything" control for the carry
+    benchmark — with a large grow budget it forms the register, but it never relaxes the
+    geometry or adapts the budget per seed."""
+    return GROW, np.array([1.0, 0.5], np.float32)
 
 
 def run_episode(env: CobordismObjectiveEnv, policy: Callable, seed: int) -> dict:
@@ -136,24 +150,32 @@ def benchmark(target: str = "formation", iterations: int = 18, episodes_per_iter
               eval_seeds: int = 12, max_actions: int = 5, hidden: int = 64, lr: float = 7e-4,
               update_epochs: int = 8, entropy_coef: float = 0.01,
               entropy_coef_final: float = None, eval_deterministic: bool = True,
-              agent_seed: int = 0, env_kwargs: dict = None, verbose: bool = True) -> dict:
-    """Train PPO and compare it to the random baseline on the chosen small target.
+              agent_seed: int = 0, hole_reward_weight: float = 0.0,
+              rstate_reward_weight: float = 0.0, carry_bonus: float = None,
+              eval_grow_only: bool = True, env_kwargs: dict = None,
+              verbose: bool = True) -> dict:
+    """Train PPO and compare it to the random AND grow-only baselines on the chosen target.
 
-    Returns a dict with the RL-vs-random evaluation summaries and the training history. The
-    same env (same config) and the same held-out evaluation seeds are used for both
-    policies, so the only difference is the policy.
+    Returns a dict with the RL / random / grow-only evaluation summaries and the training
+    history. The same env (same config) and the same held-out evaluation seeds are used for
+    every policy, so the only difference is the policy.
 
-    The default knobs are tuned so the comparison is decisive: a low entropy bonus lets the
-    policy COMMIT to the high-reward macro-move rather than stay near-uniform, and the
-    surgery/relaxation step ranges put the optimizer in the regime where the learnable
-    strategy (front-load the register-growing surgery) clearly out-reduces F vs spending
-    the same budget on random macro-moves."""
+    The proton-carry knobs (#546): pass ``hole_reward_weight`` / ``rstate_reward_weight`` to
+    turn on the dense shaping that points the policy at the carry outcome, ``carry_bonus`` to
+    weight the terminal carry reward, and big ``grow_steps`` in ``env_kwargs`` so a single
+    GROW has enough budget to actually form the 3-quark register (the foundation's tiny
+    ``grow_steps`` is exactly why no hole ever formed). Defaults keep the original
+    F-reduction config (shaping off), so existing callers are unchanged."""
     env_kwargs = dict(env_kwargs or {})
     env_kwargs.setdefault("max_actions", max_actions)
     env_kwargs.setdefault("grow_steps", (3, 6))
     env_kwargs.setdefault("evolve_steps", (3, 6))
     env_kwargs.setdefault("relax_iters", (2, 4))
     env_kwargs.setdefault("n_candidate_moves", 4)
+    env_kwargs.setdefault("hole_reward_weight", hole_reward_weight)
+    env_kwargs.setdefault("rstate_reward_weight", rstate_reward_weight)
+    if carry_bonus is not None:
+        env_kwargs.setdefault("carry_bonus", carry_bonus)
     builder = make_recombination_env if target == "recombination" else make_formation_env
 
     set_seed(agent_seed)
@@ -181,48 +203,71 @@ def benchmark(target: str = "formation", iterations: int = 18, episodes_per_iter
         env, lambda o: ppo.select_action(o, deterministic=eval_deterministic), held_out)
     set_seed(agent_seed + 1)  # independent randomness for the baseline
     rand_eval = evaluate(env, random_policy, held_out)
+    grow_eval = evaluate(env, grow_only_policy, held_out) if eval_grow_only else None
 
     result = {"target": target, "train_time_s": train_time, "history": history,
-              "rl": rl_eval, "random": rand_eval, "eval_seeds": held_out}
+              "rl": rl_eval, "random": rand_eval, "grow_only": grow_eval,
+              "eval_seeds": held_out}
     if verbose:
         _print_comparison(result)
     return result
 
 
 def _print_comparison(result: dict) -> None:
-    rl, rnd = result["rl"], result["random"]
-    print("\n=== RL vs random baseline "
+    rl, rnd, grow = result["rl"], result["random"], result.get("grow_only")
+    cols = [("RL (learned)", rl), ("random", rnd)]
+    if grow is not None:
+        cols.append(("grow-only", grow))
+    print("\n=== carry benchmark "
           f"({result['target']}, {len(result['eval_seeds'])} held-out seeds, "
           f"trained in {result['train_time_s']:.1f}s) ===")
-    print(f"{'metric':<26}{'RL (learned)':>16}{'random baseline':>18}")
+    header = f"{'metric':<32}" + "".join(f"{name:>16}" for name, _ in cols)
+    print(header)
+    # The PROTON criterion (#546) leads; the F-proxy metrics follow as context.
     rows = [
-        ("median final F (lower=better)", "median_F_final", "{:.2f}"),
-        ("mean final F (lower=better)", "mean_F_final", "{:.2f}"),
-        ("std final F", "std_F_final", "{:.2f}"),
+        ("carry rate (proton criterion)", "carry_rate", "{:.2f}"),
+        ("mean emergent holes (->3)", "mean_holes", "{:.2f}"),
+        ("mean r_state (->0)", "mean_rstate", "{:.3f}"),
+        ("median final F (lower=better)", "median_F_final", "{:.1f}"),
+        ("mean final F (lower=better)", "mean_F_final", "{:.1f}"),
         ("median log-reduction of F", "median_log_reduction", "{:+.3f}"),
-        ("mean log-reduction of F", "mean_log_reduction", "{:+.3f}"),
         ("mean episode reward", "mean_reward", "{:+.3f}"),
-        ("mean r_state (target)", "mean_rstate", "{:.3f}"),
-        ("mean emergent holes", "mean_holes", "{:.2f}"),
-        ("carry rate", "carry_rate", "{:.2f}"),
     ]
     for label, key, fmt in rows:
-        print(f"{label:<30}{fmt.format(rl[key]):>16}{fmt.format(rnd[key]):>18}")
-    # Median final F is the robust headline (the final-F distribution is heavy-tailed).
-    better = rl["median_F_final"] < rnd["median_F_final"]
-    print(f"\nRL drives F lower than random (median): {better} "
-          f"(RL {rl['median_F_final']:.2f} vs random {rnd['median_F_final']:.2f}, "
-          f"Δ={rnd['median_F_final'] - rl['median_F_final']:+.2f})")
+        line = f"{label:<32}" + "".join(f"{fmt.format(ev[key]):>16}" for _, ev in cols)
+        print(line)
+    print(f"\nPROTON carry rate -- RL {rl['carry_rate']:.2f} vs random "
+          f"{rnd['carry_rate']:.2f}" +
+          (f" vs grow-only {grow['carry_rate']:.2f}" if grow is not None else "") +
+          f"  (mean holes RL {rl['mean_holes']:.2f}, r_state RL {rl['mean_rstate']:.3f})")
+
+
+# The proton-carry training profile (#546): the long-horizon, proton-shaped config under
+# which the policy actually forms the singlet. A single GROW gets a big `run_stage1` budget
+# (the foundation's tiny `grow_steps` never formed a hole — `run_stage1`'s grow-burst
+# recovery + patience only act WITHIN one call); dense hole + r_state shaping plus a strong
+# terminal carry bonus point the policy at the carry outcome F alone is too flat to find; a
+# short action horizon (grow, then relax) keeps each episode affordable. The engine knobs
+# (patience 15, n_candidate_moves 8) match `Proton.build()`'s init/evolve drive, so the RL
+# arc and the reference build see the identical engine.
+CARRY_PROFILE = dict(
+    max_actions=6, hole_reward_weight=2.0, rstate_reward_weight=1.0, carry_bonus=10.0,
+    entropy_coef=0.03, entropy_coef_final=0.005,
+    env_kwargs=dict(grow_steps=(60, 180), evolve_steps=(10, 40), relax_iters=(3, 8),
+                    n_candidate_moves=8, patience=15),
+)
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--target", choices=["formation", "recombination"], default="formation")
-    ap.add_argument("--iterations", type=int, default=18)
-    ap.add_argument("--episodes-per-iter", type=int, default=6)
-    ap.add_argument("--eval-seeds", type=int, default=12)
-    ap.add_argument("--max-actions", type=int, default=5)
+    ap.add_argument("--profile", choices=["carry", "fast"], default="carry",
+                    help="carry (#546): long-horizon + proton shaping that forms the singlet "
+                         "(~30-45 min); fast (#539): short-horizon F-reduction (~2-4 min)")
+    ap.add_argument("--iterations", type=int, default=None)
+    ap.add_argument("--episodes-per-iter", type=int, default=None)
+    ap.add_argument("--eval-seeds", type=int, default=None)
     ap.add_argument("--hidden", type=int, default=64)
     ap.add_argument("--lr", type=float, default=7e-4)
     ap.add_argument("--agent-seed", type=int, default=0)
@@ -232,13 +277,24 @@ def main():
 
     if args.smoke:
         benchmark(target=args.target, iterations=1, episodes_per_iter=1, eval_seeds=1,
-                  max_actions=2, hidden=16,
+                  max_actions=2, hidden=16, hole_reward_weight=2.0, rstate_reward_weight=1.0,
                   env_kwargs=dict(grow_steps=(2, 4), evolve_steps=(2, 4), relax_iters=(1, 2)))
         return
-    benchmark(target=args.target, iterations=args.iterations,
-              episodes_per_iter=args.episodes_per_iter, eval_seeds=args.eval_seeds,
-              max_actions=args.max_actions, hidden=args.hidden, lr=args.lr,
-              agent_seed=args.agent_seed)
+
+    if args.profile == "carry":
+        cfg = dict(CARRY_PROFILE)
+        iterations = args.iterations or 10
+        episodes_per_iter = args.episodes_per_iter or 4
+        eval_seeds = args.eval_seeds or 8
+    else:  # fast: the #539 F-reduction config (shaping off, short horizon)
+        cfg = dict(max_actions=5)
+        iterations = args.iterations or 18
+        episodes_per_iter = args.episodes_per_iter or 6
+        eval_seeds = args.eval_seeds or 12
+
+    benchmark(target=args.target, iterations=iterations,
+              episodes_per_iter=episodes_per_iter, eval_seeds=eval_seeds,
+              hidden=args.hidden, lr=args.lr, agent_seed=args.agent_seed, **cfg)
 
 
 if __name__ == "__main__":

--- a/examples/cobordism/rl/train.py
+++ b/examples/cobordism/rl/train.py
@@ -69,16 +69,22 @@ def run_episode(env: CobordismObjectiveEnv, policy: Callable, seed: int) -> dict
     done = False
     info: dict = {}
     moves: List[int] = []
+    carried_ever = False
     while not done:
         move, params = policy(obs)
         obs, reward, done, info = env.step((move, params))
         total_reward += reward
         moves.append(int(move))
+        carried_ever = carried_ever or bool(info["carried"])
     return {
         "seed": seed, "F0": F0, "F_final": info["F"],
         "log_reduction": _slog(F0) - _slog(info["F"]),
         "reward": total_reward, "rstate": info["rstate"], "holes": info["holes"],
-        "carried": bool(info["carried"]), "n_actions": len(moves),
+        # `carried` = the proton verdict on the FINAL state (what `Proton.build()` reads);
+        # `carried_ever` = carried at any step, so the two agreeing confirms a later relax
+        # never un-carries the register.
+        "carried": bool(info["carried"]), "carried_ever": carried_ever,
+        "n_actions": len(moves),
         "move_counts": [moves.count(m) for m in range(N_MOVES)],
     }
 
@@ -99,6 +105,7 @@ def evaluate(env: CobordismObjectiveEnv, policy: Callable, seeds: List[int]) -> 
         "mean_rstate": float(np.nanmean(arr("rstate"))),
         "mean_holes": float(arr("holes").mean()),
         "carry_rate": float(arr("carried").mean()),
+        "carry_rate_ever": float(arr("carried_ever").mean()),
     }
 
 
@@ -251,10 +258,23 @@ def _print_comparison(result: dict) -> None:
 # (patience 15, n_candidate_moves 8) match `Proton.build()`'s init/evolve drive, so the RL
 # arc and the reference build see the identical engine.
 CARRY_PROFILE = dict(
-    max_actions=6, hole_reward_weight=2.0, rstate_reward_weight=1.0, carry_bonus=10.0,
+    max_actions=4, hole_reward_weight=2.0, rstate_reward_weight=1.0, carry_bonus=10.0,
     entropy_coef=0.03, entropy_coef_final=0.005,
-    env_kwargs=dict(grow_steps=(60, 180), evolve_steps=(10, 40), relax_iters=(3, 8),
-                    n_candidate_moves=8, patience=15),
+    # grow_steps caps a single GROW: high enough to form the register (carriers converge in
+    # ~50-120 engine steps, then run_stage1 breaks early once carried -- a carrying GROW
+    # costs ~40-60s, and any further GROW on a carried state is a ~1s no-op), but bounded so
+    # a NON-carrying seed -- which runs the full budget on an ever-growing complex -- does
+    # not blow up the wall-clock. terminate_on_carry=False lets the policy keep going after
+    # the carry to relax the geometry (the grow -> evolve -> relax arc); since post-carry
+    # GROW/EVOLVE early-break, the full arc is nearly free on carrying episodes.
+    # directed_grow on: a GROW finishes the register the random draws left short by a gated
+    # DIRECTED cone-out probe (open the missing hole deliberately), and an EVOLVE SELECTS the
+    # best target_holes by a gated cone-in probe (cap the worst over-opened hole). This
+    # rescues a fraction of seeds whose random growth stalls below 3 holes (carrier seeds are
+    # unaffected -- post-carry cone-out/in are no-ops), raising the carry rate.
+    env_kwargs=dict(grow_steps=(50, 130), evolve_steps=(10, 40), relax_iters=(3, 8),
+                    n_candidate_moves=8, patience=15, terminate_on_carry=False,
+                    directed_grow=True, cone_strategy="greedy", cone_overshoot=2),
 )
 
 
@@ -283,9 +303,9 @@ def main():
 
     if args.profile == "carry":
         cfg = dict(CARRY_PROFILE)
-        iterations = args.iterations or 10
-        episodes_per_iter = args.episodes_per_iter or 4
-        eval_seeds = args.eval_seeds or 8
+        iterations = args.iterations or 8
+        episodes_per_iter = args.episodes_per_iter or 3
+        eval_seeds = args.eval_seeds or 6
     else:  # fast: the #539 F-reduction config (shaping off, short horizon)
         cfg = dict(max_actions=5)
         iterations = args.iterations or 18

--- a/examples/cobordism/rl_objective_search.py
+++ b/examples/cobordism/rl_objective_search.py
@@ -23,9 +23,13 @@ Examples::
     # quick smoke (seconds): tiny env + 1 short training iteration
     python examples/cobordism/rl_objective_search.py --smoke
 
-    # a real (minutes) benchmark on the small formation target (diquark + q → singlet)
-    python examples/cobordism/rl_objective_search.py --target formation \
-        --iterations 20 --episodes-per-iter 6 --eval-seeds 10
+    # the proton-carry benchmark (#546, ~30-45 min): long horizon + proton shaping, so the
+    # learned policy actually FORMS the singlet (≥3 colour holes, r_state below tol) — the
+    # default profile. Compares carry rate / holes / r_state vs random and grow-only.
+    python examples/cobordism/rl_objective_search.py --target formation
+
+    # the #539 fast F-reduction benchmark (~2-4 min): short horizon, shaping off
+    python examples/cobordism/rl_objective_search.py --profile fast
 
 Requires the ``rl`` extra (PyTorch): ``pip install -e ".[rl]"`` (or ``".[dev]"``, which
 includes it).
@@ -46,7 +50,8 @@ from rl.objective_env import (  # noqa: E402,F401
 )
 from rl.ppo_agent import PPO, HybridActorCritic, set_seed  # noqa: E402,F401
 from rl.train import (  # noqa: E402,F401
-    benchmark, train, evaluate, run_episode, random_policy, main,
+    benchmark, train, evaluate, run_episode, random_policy, grow_only_policy,
+    CARRY_PROFILE, main,
 )
 
 

--- a/tests/cobordism/test_rl_objective_env.py
+++ b/tests/cobordism/test_rl_objective_env.py
@@ -165,5 +165,76 @@ class EnvStepTest(unittest.TestCase):
         self.assertAlmostEqual(total, log_red, places=5)
 
 
+class RewardShapingTest(unittest.TestCase):
+    """The #546 dense proton-shaping reward terms (hole-progress + r_state descent). These
+    are a TRAINING SIGNAL only — they never touch F, the engine, or the carry verdict. The
+    formula checks validate the terms against the engine's own holes/r_state regardless of
+    whether the tiny budget here actually forms a hole, so they stay fast + robust."""
+
+    @staticmethod
+    def _slog(x):
+        return math.copysign(math.log1p(abs(x)), x)
+
+    def test_weights_default_off(self):
+        env = _tiny_env()
+        self.assertEqual(env.hole_reward_weight, 0.0)
+        self.assertEqual(env.rstate_reward_weight, 0.0)
+
+    def test_shaping_off_zeroes_those_terms(self):
+        # Default weights ⇒ the hole/r_state terms are exactly 0, so the reward is the
+        # foundation's −ΔF (+ carry) and the breakdown still sums to the reward.
+        env = _tiny_env()
+        env.reset(seed=5)
+        _o, reward, _d, info = env.step((oe.GROW, [1.0, 0.5]))
+        terms = info["reward_terms"]
+        self.assertEqual(terms["hole"], 0.0)
+        self.assertEqual(terms["rstate"], 0.0)
+        self.assertAlmostEqual(sum(terms.values()), reward, places=6)
+
+    def test_terms_sum_to_reward_with_shaping_on(self):
+        env = _tiny_env(hole_reward_weight=2.0, rstate_reward_weight=1.5, carry_bonus=7.0)
+        env.reset(seed=6)
+        for action in [(oe.GROW, [1.0, 0.5]), (oe.RELAX, [0.5, 0.4])]:
+            _o, reward, _d, info = env.step(action)
+            self.assertAlmostEqual(sum(info["reward_terms"].values()), reward, places=6)
+
+    def test_hole_term_matches_capped_progress(self):
+        # hole term == w·(min(holes, T) − min(prev_holes, T)); tracking the holes sequence
+        # validates the formula AND its cap (no reward past T holes) vs the engine's count.
+        W, T = 3.0, 3
+        env = _tiny_env(hole_reward_weight=W, target_holes=T, rstate_reward_weight=0.0)
+        env.reset(seed=7)
+        prev_h = env.metrics["holes"]
+        for action in [(oe.GROW, [1.0, 0.5]), (oe.GROW, [1.0, 0.5]), (oe.RELAX, [0.5, 0.4])]:
+            _o, _r, _d, info = env.step(action)
+            cur_h = info["holes"]
+            expected = W * (min(cur_h, T) - min(prev_h, T))
+            self.assertAlmostEqual(info["reward_terms"]["hole"], expected, places=6)
+            prev_h = cur_h
+
+    def test_rstate_term_matches_slog_descent(self):
+        W = 1.25
+        env = _tiny_env(rstate_reward_weight=W, hole_reward_weight=0.0)
+        env.reset(seed=8)
+        prev_r = env.metrics["rstate"]
+        for action in [(oe.GROW, [1.0, 0.5]), (oe.RELAX, [0.5, 0.4])]:
+            _o, _r, _d, info = env.step(action)
+            cur_r = info["rstate"]
+            if math.isfinite(prev_r) and math.isfinite(cur_r):
+                expected = W * (self._slog(prev_r) - self._slog(cur_r))
+                self.assertAlmostEqual(info["reward_terms"]["rstate"], expected, places=5)
+            prev_r = cur_r
+
+    def test_rstate_term_off_without_whole_target(self):
+        # The recombination node has no whole-cobordism target, so r_state shaping is a
+        # no-op even with a positive weight (there is nothing to fit the singlet against).
+        env = oe.make_recombination_env(max_actions=2, grow_steps=(2, 3),
+                                        evolve_steps=(2, 3), relax_iters=(1, 2),
+                                        n_candidate_moves=3, rstate_reward_weight=2.0)
+        env.reset(seed=9)
+        _o, _r, _d, info = env.step((oe.GROW, [1.0, 0.5]))
+        self.assertEqual(info["reward_terms"]["rstate"], 0.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cobordism/test_rl_objective_env.py
+++ b/tests/cobordism/test_rl_objective_env.py
@@ -236,5 +236,103 @@ class RewardShapingTest(unittest.TestCase):
         self.assertEqual(info["reward_terms"]["rstate"], 0.0)
 
 
+class TerminationFlagTest(unittest.TestCase):
+    """`terminate_on_carry` gates whether forming the proton ENDS the episode. The carry
+    happens at the GROW stage, but the full proton arc is grow → evolve → relax, so the
+    carry profile keeps going past the carry to relax. White-box: force the carry verdict so
+    the logic is tested without a real (slow) carry."""
+
+    def test_default_terminates_on_carry(self):
+        env = _tiny_env()  # default terminate_on_carry=True (#539 behavior)
+        self.assertTrue(env.terminate_on_carry)
+        env.reset(seed=11)
+        env._is_carried = lambda metrics: True  # force the carry verdict
+        _o, _r, done, info = env.step((oe.RELAX, [0.5, 0.5]))
+        self.assertTrue(info["carried"])
+        self.assertTrue(info["terminated"])
+        self.assertTrue(done)
+
+    def test_flag_off_keeps_episode_running_after_carry(self):
+        # With the flag off, carrying does NOT end the episode (only the budget does), so the
+        # policy can relax after forming the register. The one-time carry bonus still fires.
+        env = _tiny_env(terminate_on_carry=False, carry_bonus=5.0)
+        self.assertFalse(env.terminate_on_carry)
+        env.reset(seed=12)
+        env._is_carried = lambda metrics: True
+        _o, _r, done, info = env.step((oe.RELAX, [0.5, 0.5]))
+        self.assertTrue(info["carried"])
+        self.assertFalse(info["terminated"])   # flag off → no termination
+        self.assertFalse(done)                 # step 1 of max_actions=3, so not truncated
+        self.assertEqual(info["reward_terms"]["carry"], 5.0)  # bonus still fires once
+
+
+class DirectedConeOutTest(unittest.TestCase):
+    """The #546 directed cone-out probe — deliberate, gated hole creation (SurgicalCone)
+    instead of run_stage1's random cone draws."""
+
+    def test_config_stored(self):
+        env = _tiny_env(directed_grow=True, cone_strategy="bfs", cone_overshoot=2)
+        self.assertTrue(env.directed_grow)
+        self.assertEqual(env.cone_strategy, "bfs")
+        self.assertEqual(env.cone_overshoot, 2)
+        self.assertFalse(_tiny_env().directed_grow)  # default off (pure #539 growth)
+
+    def test_no_cone_on_bare_seed(self):
+        # The bare Δ⁴ seed has a single top cell; coneOut refuses to remove the last cell, so
+        # the probe opens nothing and leaves the complex untouched + valid.
+        env = _tiny_env()
+        env.reset(seed=4)
+        self.assertEqual(env.metrics["n_top_cells"], 1)
+        self.assertEqual(env.directed_cone_out("greedy"), 0)
+        self.assertTrue(env.dual_complex_valid()[0])
+
+    def test_probe_opens_holes_and_keeps_complex_valid(self):
+        # On a grown complex the directed cone-out probe opens holes (or no-ops), never
+        # closes them, stops by `target_holes + cone_overshoot`, always leaves a valid
+        # manifold-with-boundary, and never strands a pinned input vertex. Both strategies.
+        for strategy in ("greedy", "bfs"):
+            env = oe.make_formation_env(max_actions=2, grow_steps=(8, 12),
+                                        evolve_steps=(3, 5), relax_iters=(1, 2),
+                                        n_candidate_moves=4, target_holes=3, cone_overshoot=2)
+            env.reset(seed=2)
+            env.step((oe.GROW, [1.0, 0.5]))            # build some bulk (random draws)
+            pinned = env._pinned_vertex_ids()
+            holes_before = env.metrics["holes"]
+            opened = env.directed_cone_out(strategy)
+            self.assertGreaterEqual(opened, 0)
+            holes_after = len(oe.cob.MultiCobordism.emergent_holes(env.node.st, env.k))
+            self.assertGreaterEqual(holes_after, holes_before)   # never closes holes
+            self.assertLessEqual(holes_after, env.target_holes + env.cone_overshoot)
+            self.assertTrue(env.dual_complex_valid()[0])         # still a valid manifold
+            current = {int(v.getId()) for v in env.node.st.getVertexList().toVector()}
+            self.assertTrue(pinned.issubset(current))            # no pinned vertex stranded
+
+    def test_cone_in_noop_at_or_below_target(self):
+        # directed_cone_in (register selection) only trims when MORE than target_holes exist;
+        # the bare seed has 1 hole ≤ 3, so it is a no-op and leaves a valid complex.
+        env = _tiny_env()
+        env.reset(seed=4)
+        self.assertEqual(env.directed_cone_in("greedy"), 0)
+        self.assertTrue(env.dual_complex_valid()[0])
+
+    def test_directed_cone_in_caps_to_target_and_stays_valid(self):
+        # On a grown complex, over-open with cone-out (target + overshoot) then cone-in
+        # SELECTS back toward target_holes: it never leaves more holes than it started with,
+        # never drops below target while holes remain above it, and keeps a valid manifold.
+        env = oe.make_formation_env(max_actions=3, grow_steps=(8, 12), evolve_steps=(3, 5),
+                                    relax_iters=(1, 2), n_candidate_moves=4, target_holes=3,
+                                    cone_overshoot=2)
+        env.reset(seed=2)
+        env.step((oe.GROW, [1.0, 0.5]))
+        env.directed_cone_out("greedy")
+        holes_open = len(oe.cob.MultiCobordism.emergent_holes(env.node.st, env.k))
+        closed = env.directed_cone_in("greedy")
+        holes_sel = len(oe.cob.MultiCobordism.emergent_holes(env.node.st, env.k))
+        self.assertGreaterEqual(closed, 0)
+        self.assertLessEqual(holes_sel, holes_open)              # cone-in only closes
+        self.assertGreaterEqual(holes_sel, min(holes_open, env.target_holes))
+        self.assertTrue(env.dual_complex_valid()[0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cobordism/test_rl_ppo_agent.py
+++ b/tests/cobordism/test_rl_ppo_agent.py
@@ -120,6 +120,24 @@ class RandomPolicyTest(unittest.TestCase):
             self.assertTrue(np.all((params >= 0) & (params <= 1)))
 
 
+class GrowOnlyPolicyTest(unittest.TestCase):
+    """The #546 grow-only baseline (#539's learned policy collapsed to all-GROW)."""
+
+    def test_grow_only_always_grows_full_intensity(self):
+        for _ in range(5):
+            move, params = train.grow_only_policy(np.zeros(oe.OBS_DIM, np.float32))
+            self.assertEqual(move, oe.GROW)
+            self.assertEqual(params.shape, (oe.PARAM_DIM,))
+            self.assertEqual(float(params[0]), 1.0)  # full grow intensity
+
+    def test_carry_profile_has_big_grow_budget(self):
+        # The carry profile's defining fix: a single GROW gets a big run_stage1 budget so a
+        # hole can actually form (the foundation's tiny grow_steps never did).
+        self.assertGreaterEqual(train.CARRY_PROFILE["env_kwargs"]["grow_steps"][1], 100)
+        self.assertGreater(train.CARRY_PROFILE["hole_reward_weight"], 0.0)
+        self.assertGreater(train.CARRY_PROFILE["rstate_reward_weight"], 0.0)
+
+
 class TrainSmokeTest(unittest.TestCase):
     """A tiny end-to-end run: the real engine, but a couple of macro-actions and one
     training iteration, so the train → evaluate → compare pipeline is exercised fast."""
@@ -139,6 +157,23 @@ class TrainSmokeTest(unittest.TestCase):
         # The seed Δ⁴ objective is ~3150; any rollout leaves F finite and non-negative.
         self.assertGreaterEqual(result["rl"]["mean_F_final"], 0.0)
         self.assertTrue(np.isfinite(result["random"]["mean_F_final"]))
+
+    def test_carry_smoke_grow_only_and_carry_metrics(self):
+        # The #546 carry-profile pipeline: shaping on, the grow-only baseline is evaluated,
+        # and every policy reports the proton-criterion metrics (carry rate / holes /
+        # r_state). Tiny budgets keep it fast (no hole need actually form here).
+        result = train.benchmark(
+            target="formation", iterations=1, episodes_per_iter=1, eval_seeds=1,
+            max_actions=2, hidden=16, lr=1e-2, agent_seed=0, verbose=False,
+            hole_reward_weight=2.0, rstate_reward_weight=1.0, carry_bonus=5.0,
+            env_kwargs=dict(grow_steps=(2, 3), evolve_steps=(2, 3),
+                            relax_iters=(1, 1), n_candidate_moves=3))
+        self.assertIsNotNone(result["grow_only"])
+        for side in ("rl", "random", "grow_only"):
+            for key in ("carry_rate", "mean_holes", "mean_rstate"):
+                self.assertIn(key, result[side])
+        self.assertGreaterEqual(result["rl"]["carry_rate"], 0.0)
+        self.assertLessEqual(result["rl"]["carry_rate"], 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Stacks on #539 (base `feat/rl-objective-search`). The #539 foundation beats random on the
F-proxy but has **carry rate 0** (~0.25 emergent holes): in its short-horizon, grow-only regime
no colour hole ever forms — the GROW macro called `run_stage1` with `max_steps` ≈ 3–6 across
*separate* calls, and `run_stage1`'s grow-burst recovery + patience only act WITHIN one call, so
the register never grows. This PR extends the RL foundation so the learned policy actually
**forms the proton** — carries the colour singlet `{1, ω, ω²}` over **≥ 3 emergent colour holes**
with `r_state` below the colour tolerance.

No engine / physics / objective-`F` change. The shaping is a **training signal in the env's
reward only**; every topology move (including the new directed probes) stays gated on
`dualComplexValid`; `torch` stays in the `rl` extra (the agent test keeps
`pytest.importorskip("torch")`).

### What changed (all in `examples/cobordism/rl/`)
- **Longer horizon / bigger budgets** (`train.CARRY_PROFILE`): a single GROW now gets a large
  `run_stage1` budget (`grow_steps` up to 130; `Proton.build()` uses `initSteps=180`) — enough
  for the 3-quark register to form. A carrying GROW costs ~40–60 s, then `run_stage1` breaks
  early (rU < 1e-3) so any further GROW on a carried state is a ~1 s no-op.
- **Dense proton-shaping reward** (`CobordismObjectiveEnv`, off by default): `hole_reward_weight`
  rewards progress toward `target_holes` (capped); `rstate_reward_weight` rewards driving the
  singlet residual `r_state` → 0; the one-time terminal carry bonus is kept and `−ΔF` stays the
  dense base term. `info["reward_terms"]` exposes the per-term breakdown. With both weights 0 the
  reward is **exactly** the foundation's `−ΔF`.
- **Full grow → relax arc** (`terminate_on_carry`, default `True` = #539): the carry happens at
  the GROW stage, so the carry profile sets it `False` to let the policy keep relaxing the
  geometry after forming the register; the carry verdict is read off the final state, and
  `run_episode` tracks `carried_ever` to confirm relax never un-carries.
- **Directed cone-surgery probes** (coordinator lever — deliberate gated `SurgicalCone` moves
  instead of `run_stage1`'s random cone draws, which pick `cone_out` only 1/6 of the time on a
  uniformly random cell and keep it only if it lowers F):
  - `directed_cone_out` augments GROW — opens the holes random growth left short, scanning
    candidate cells **interior-first** (coning out a fully-interior cell exposes a new
    all-boundary tuple = a hole) and keeping the gated one that raises `emergent_holes` and lowers
    `r_state`. Over-opens to `target_holes + cone_overshoot`.
  - `directed_cone_in` augments EVOLVE — **selects** the register: caps the worst over-opened hole
    (the cone-in leaving the lowest `r_state`; hole-capping cone-ins surfaced first), so a
    sub-optimal hole is dropped and a better one kept.
- **Grow-only baseline** (`grow_only_policy`) — the strongest non-adaptive control (#539's learned
  policy collapsed to all-GROW). `benchmark()` reports the **proton criterion** (carry rate / mean
  holes / mean `r_state`) for RL vs random vs grow-only.

### Directed cone-surgery: within-complex A/B (same grown complex, then directed surgery)
Random GROW(120) builds the bulk; the directed probe then opens/selects on that same complex:

| seed | random GROW base | + directed cone-out | + directed cone-in (select) |
|---|---|---|---|
| 1 (carrier) | 3 holes, carry ✓ | 4 holes, carry ✓ | 3 holes, carry ✓ |
| 7 (carrier) | 3 holes, carry ✓ | 5 holes, carry ✓ | 3 holes, carry ✓ |
| 5 | 2 holes, **✗** (r=1.0) | **3 holes, carry ✓** (r≈0) | 3 holes, carry ✓ |
| 3 | 2 holes, ✗ | 2 holes, ✗ (no openable cell) | — |
| 6 | 1 hole, ✗ | 1 hole, ✗ | — |
| 8 | 2 holes, ✗ | 2 holes, ✗ | — |

The probes **never regress a carrier** (over-open then cone-in trims back to the best 3, carry
intact) and **rescue a fraction of stalled seeds** (seed 5: 2 → 3 holes → carry). On the rest the
hole-creating interior cells are non-removable — the gate would pinch the thin grown complex — so
cone-out cannot help. Net: a real, gated, partial lever that lifts the carry rate without ever
breaking a carrier.

### RL carry benchmark (held-out seeds, proton criterion)
PPO trained on the carry profile (5×2 episodes, ~190 s; directed probe on, `max_actions=3`),
evaluated deterministically on held-out seeds 0–5 vs the random and grow-only baselines (all in
the same env):

| metric (6 held-out seeds) | RL (learned) | random | grow-only |
|---|---:|---:|---:|
| **carry rate** (≥3 holes & r_state<tol) | **1.00** | 0.67 | 1.00 |
| mean emergent holes (→3) | 3.00 | 2.33 | 3.17 |
| mean r_state (→0) | ~0 (3.8e-31) | 1.000 | ~0 |
| median final F | 256.1 | 673.1 | 263.9 |
| mean final F | 273.1 | 1323.0 | 253.4 |
| mean episode reward | +17.93 | +11.32 | +17.93 |

The **learned policy carries the proton singlet on every held-out seed** (exactly 3 colour holes,
r_state ≈ 0) — up from #539's **carry rate 0**. Per seed it uses a GROW (+EVOLVE select) mix, e.g.
seed 1 = 1×GROW + 2×EVOLVE; random instead fails on seeds 2 and 5 (it spent the budget on
EVOLVE/RELAX, never GROW → 0 holes), hence 0.67. Grow-only (always GROW) also reaches 1.00 — the
carry is driven by the long-horizon directed GROW, and the RL policy *learns from the shaping
signal to commit to it* (matching grow-only, beating random).

**Contrast — the #539 short-horizon regime** (same eval seeds, `grow_steps=(3,6)`, shaping off):
grow-only **carry 0.00** (0.5 holes, r_state 2.5), random **carry 0.00** (0.17 holes, r_state 2.8)
— reproducing the foundation's result. The carry comes from the longer horizon + directed growth,
which the policy learns to exploit.

### Honest assessment
The singlet **is carried** (carry rate 1.0). Two caveats kept in view: (1) with the long horizon
the carry is *easy* enough that grow-only also reaches 1.0, so RL's measured edge here is over
random (0.67) and in learning the strategy unaided, not over the strongest scripted baseline;
(2) the directed cone-out is gate-limited (it rescues stalled seeds only when a hole-creating
interior cell is removable — ~1/4 of failures in the A/B), so its lift is on the margin; the bulk
of the carry is the long-horizon directed GROW. Next steps: a harder target (the full two-step
proton / a larger seed where the register does not form so readily) to expose a real RL-vs-grow-only
gap, and interleaving the directed probe *during* growth rather than as a post-grow finisher.

## Test plan
- [x] `pytest tests/cobordism/test_rl_objective_env.py tests/cobordism/test_rl_ppo_agent.py`
      under `.[rl]` — 35 passed (19 existing + shaping / termination / directed cone-out /
      directed cone-in / grow-only / carry-smoke).
- [x] RL carry benchmark run (table above).
- [x] `--smoke` launcher path runs in seconds.

Closes #546.
