### PR TITLE
fix(cobordism): residualForPeriodsGradientGpu is sensitive to hole vertex order

### DIFF
--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -2008,10 +2008,15 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradientGpu(
   };
 
   // ---- Q (hole-boundary covector) + each hole's leak column ----
+  // Sort each hole's vertices first, exactly as the CPU oracle does (holeLoops /
+  // periodGradientGeneral): the facet signs and the leak edge are defined on the
+  // sorted order, so an unsorted hole would scramble Q and pick the wrong leak
+  // column -- an O(1)-wrong gradient, not an FP32 error.
   MatrixXd Q = MatrixXd::Zero(static_cast<Index>(m), N);
   std::vector<std::size_t> leakCol(m);
   for (std::size_t q = 0; q < m; ++q) {
-    const auto &h = holes[q];
+    std::vector<std::uint64_t> h = holes[q];
+    std::sort(h.begin(), h.end());
     for (int j = 0; j < 3; ++j) {
       std::vector<std::uint64_t> facet;
       for (int i = 0; i < 3; ++i)


### PR DESCRIPTION
## Summary
`test_ru_gradient_gpu_python.py` failed 17 cases on a CUDA box because the FP32 GPU r_U gradient is **input-order-sensitive** where the FP64 CPU oracle is not: `holeLoops`/`periodGradientGeneral` sort each hole's vertices before building the period covector `Q` and leak column, but the GPU mirror used the holes as passed. An unsorted hole scrambles its facet signs and picks the wrong leak edge → garbage carried representative ψ → an O(1)-wrong gradient even at the realizable base (‖g_gpu‖≈4.0 where the true gradient is ~1e-16; the exact Euler identity Σ l²·∂r_U = −r_U is violated by ~8.5 while the CPU path satisfies it to machine precision). Latent since the GPU path landed (#348); exposed when the test migrated onto the `_holed_surface` fixture (9c3c852), which supplies unsorted holes.

Fix: sort each hole's vertices in `residualForPeriodsGradientGpu` before building `Q`/`leakCol`, restoring the "mirrors the CPU oracle verbatim" contract. No change to the CPU paths, the readout convention, or the test.

## Test plan
- [x] Rebuild C++ (CUDA on) in the worktree venv.
- [x] `pytest tests/cobordism/test_ru_gradient_gpu_python.py` fully green on this box's GPU: **6 passed, 1 skipped (opt-in slow level-2), 16 subtests passed** (was 17 failed / 5 passed).
- [x] Euler-identity probe with the fixture's unsorted holes: GPU now satisfies Σ l²·∂r_U = −r_U (−2.760659e-01 vs −2.760660e-01, FP32-exact); sorted-vs-unsorted GPU gradients agree with the CPU oracle to 2.7e-22.
- [x] `pytest tests/cobordism`: **375 passed, 1 skipped, 674 subtests passed, 0 failures** — no regressions.

Closes #571.
