### PR TITLE
feat(cobordism): joint 3-pair formation node — Z₃-orbit inputs, baryon ⊔ antibaryon outputs (#560)

### DIFF
--- a/include/cobordism/ProtonIngredients.h
+++ b/include/cobordism/ProtonIngredients.h
@@ -5,6 +5,7 @@
 #define TESSERA_COBORDISM_PROTON_INGREDIENTS_H
 
 #include <complex>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -37,6 +38,16 @@ class MultiCobordism;  // returned (seeded, not run) by the node factories below
 ///   * **Step B — formation, nothing pinned**: the same ideal diquark `{1,ω}` + third
 ///     quark `{ω²}` inputs on the same single-Δ⁴ seed as `Proton::formationNode`, but
 ///     with an **empty output-target list** — no singlet anywhere in the drive.
+///
+/// The class also hosts the **joint arm** (#560, rung 1 of the design note): the
+/// two-step event graph collapsed into ONE co-optimized node (`jointNode` /
+/// `buildJoint`) — inputs = the Z₃-orbit neutral triple, outputs = a baryon ⊔
+/// antibaryon block pair — driven by the same per-node drive and judged by the same
+/// stationarity + persistence convergence as `build()`. Exactly one variable then
+/// differs from `Proton::build()`: the event graph (joint vs two-step). Microcausality
+/// lives in the **move history** (every accepted change is one gated local move), not
+/// in the boundary-block count, so the joint node is physically admissible (epic #559
+/// decision log).
 ///
 /// The seed stays uniform and all-spacelike (`ℓ² = +1`) **by design**: at initialization
 /// no time has passed — causal structure marks sequences of events (in the causal-set
@@ -75,6 +86,20 @@ class ProtonIngredients {
              double stage2Beta = 1.0, int stage2MaxIters = 10,
              double persistRelTol = 0.05);
 
+  /// Build the JOINT arm (#560): identical to `build()` — the same per-node drive, the
+  /// same stationarity + persistence convergence, the same restart policy — except each
+  /// attempt drives ONE `jointNode` instead of the A-then-B pair (restart `i` seeds it
+  /// at `seed + i`; there is only one node, so the enumeration is dense). Observables
+  /// are read after the fact exactly as in `build()`, plus the per-output-block singlet
+  /// residuals `baryonResidual()`/`antibaryonResidual()`; `diquarkResidual()` is NaN
+  /// (the diquark intermediate is collapsed away — nothing measured it). Idempotent,
+  /// and mutually exclusive with `build()`: whichever runs first claims the instance
+  /// (the accessors' lazy default remains the two-step `build()`).
+  void buildJoint(int maxRestarts = 16, int initSteps = 180, int evolveSteps = 60,
+                  int stage1CandidateMoves = 8, int stage1Patience = 15,
+                  double stage2Beta = 1.0, int stage2MaxIters = 10,
+                  double persistRelTol = 0.05);
+
   /// Step A verbatim: `Proton::recombinationNode` on the composed canonical `Proton` —
   /// the identical seeded (not-yet-run) 2→2 node `Proton::build()` drives.
   [[nodiscard]] std::shared_ptr<MultiCobordism> recombinationNode(std::uint64_t seed) const;
@@ -82,6 +107,19 @@ class ProtonIngredients {
   /// third quark `{ω²}` inputs as `Proton::formationNode`, but `outputTargets = {}` —
   /// the final state emerges and is read off the whole afterwards.
   [[nodiscard]] std::shared_ptr<MultiCobordism> formationNode(std::uint64_t seed) const;
+  /// The JOINT formation node (#560, rung 1): the #489 two-step event graph collapsed
+  /// into ONE fresh, seeded, NOT-run co-optimized node. Inputs = the **Z₃-orbit neutral
+  /// triple** `{1,-1,0}`, `{0,1,-1}`, `{-1,0,1}` (the #398 symmetric-input lesson),
+  /// seeded at the Δ⁴ seed's v0,v1,v2. Outputs = **two localized blocks** (the
+  /// multi-output `rU` branch, exactly as the 2→2 recombination): the baryon
+  /// `[1,ω,ω²]` at v3 ⊔ the antibaryon `[1,ω̄,ω̄²]` at v4 — with three pairs the whole
+  /// must also host the conjugate sector, so a single whole-read singlet would fight
+  /// the antibaryon's periods. **Conjugation subtlety:** `[1,ω̄,ω̄²]` is a
+  /// component-permutation of `[1,ω,ω²]` (ω̄ = ω²) and the block residual is
+  /// relabeling-invariant, so the two targets score identically as multisets — the
+  /// conjugation is carried by the block's *location/orientation* in the emergent
+  /// complex (which region hosts which sector), never by the residual's value.
+  [[nodiscard]] std::shared_ptr<MultiCobordism> jointNode(std::uint64_t seed) const;
 
   /// True iff the kept attempt was stationary AND persistent (never a statement about
   /// the singlet or the hole count). Triggers `build()`.
@@ -107,13 +145,26 @@ class ProtonIngredients {
   /// result is comparable to the canonical build's carried level (`≈0` there). It never
   /// steers or gates this build. Triggers `build()`.
   [[nodiscard]] double singletResidual();
-  /// Step B's inputs-only realizability residual `r_U` (the whole matter term of the
-  /// emergent arm's objective). Triggers `build()`.
+  /// The kept node's full matter term `r_U`: after `build()` this is step B's
+  /// inputs-only residual (nothing is pinned downstream there); after `buildJoint()`
+  /// it also contains the two output-block terms. Triggers `build()`.
   [[nodiscard]] double inputResidual();
   /// The kept attempt's final objective `F`. Triggers `build()`.
   [[nodiscard]] double finalObjective();
-  /// Step A's `r_U` — reported exactly as `Proton` reports it. Triggers `build()`.
+  /// Step A's `r_U` — reported exactly as `Proton` reports it. NaN after
+  /// `buildJoint()`: the joint arm has no step A (never a stale zero). Triggers
+  /// `build()`.
   [[nodiscard]] double diquarkResidual();
+  /// The baryon output block's singlet residual (#560) — its target `[1,ω,ω²]` scored
+  /// against the block's OWN emergent sub-complex, read after the fact exactly as the
+  /// drive's `rU` scores it. NaN unless `buildJoint()` ran (the two-step's step B has
+  /// no localized output blocks). Triggers `build()`.
+  [[nodiscard]] double baryonResidual();
+  /// The antibaryon output block's residual — its conjugate target `[1,ω̄,ω̄²]` against
+  /// its own sub-complex (see `jointNode` on why the conjugation lives in the block's
+  /// location, not the residual's value). NaN unless `buildJoint()` ran. Triggers
+  /// `build()`.
+  [[nodiscard]] double antibaryonResidual();
 
  private:
   /// Lazily run `build()` with default parameters on first accessor use.
@@ -122,6 +173,36 @@ class ProtonIngredients {
   /// all-spacelike metric (`ℓ² = +1`; see the class note on why no causal structure is
   /// initialized). Mirrors `Proton::buildMinimalSeed`, which is private there.
   [[nodiscard]] static std::shared_ptr<Spacetime> buildMinimalSeed();
+  /// `Proton::build()`'s exact per-node drive, shared by `build()` and `buildJoint()`:
+  /// INITIALIZATION pass (`grow_boundaries=true`), optional directed cone-out,
+  /// EVOLUTION pass (∂W frozen), optional directed cone-in, then the geometric
+  /// relaxation.
+  void driveNode(MultiCobordism &node, int initSteps, int evolveSteps,
+                 int stage1CandidateMoves, int stage1Patience, double stage2Beta,
+                 int stage2MaxIters) const;
+  /// The persistence verdict shared by `build()` and `buildJoint()`: continued
+  /// evolution (∂W frozen) + relaxation must leave the answer-agnostic summary — the
+  /// emergent hole count, `b_k`, and `F` (within `persistRelTol` relative) — stable.
+  /// Up to `kMaxPersistencePasses` passes may settle a not-quite-stationary complex;
+  /// the LAST pass has to be the stable one.
+  [[nodiscard]] bool settleAndVerifyPersistence(MultiCobordism &node, int evolveSteps,
+                                                int stage1CandidateMoves,
+                                                int stage1Patience, double stage2Beta,
+                                                int stage2MaxIters,
+                                                double persistRelTol) const;
+  /// The emergent hole count at `registerDegree_` (one leg of the answer-agnostic
+  /// persistence summary).
+  [[nodiscard]] int emergentHoleCount(const std::shared_ptr<Spacetime> &whole) const;
+  /// `b_k` at `registerDegree_` (the other combinatorial leg of the summary).
+  [[nodiscard]] int bettiAtRegisterDegree(const std::shared_ptr<Spacetime> &whole) const;
+  /// One output block's residual, read after the fact for `buildJoint()`'s per-block
+  /// observables: the block's own sub-complex (the ambient complex's top cells whose
+  /// vertices all lie in the block's region) scored against the block's target —
+  /// mirroring `MultiCobordism::residualForBoundaryBlock` (private there) at this
+  /// class's single register degree, so the read matches how the drive's `rU` scored
+  /// the block. The full leak `‖target‖²` when the region contains no full cell.
+  [[nodiscard]] double outputBlockResidual(const MultiCobordism &node,
+                                           std::size_t blockIndex) const;
 
   // ---- configuration ----
   /// The canonical arm, composed unchanged: supplies step A's node verbatim and the
@@ -146,6 +227,11 @@ class ProtonIngredients {
   double inputResidual_ = 0.0;
   double finalObjective_ = 0.0;
   double diquarkResidual_ = 0.0;
+  // Joint-arm per-output-block reads (#560); NaN whenever the two-step build() ran
+  // instead (its step B has no localized output blocks), set in the .cpp so the
+  // header stays <limits>-free.
+  double baryonResidual_;
+  double antibaryonResidual_;
 };
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -977,7 +977,15 @@ and may only emerge. Convergence carries no answer-shaped gate: an attempt
 converges iff it is STATIONARY (stage 2 stopped on its stationarity test) and
 PERSISTENT (a continued evolve+relax pass leaves holes, b_k, and F stable).
 Everything physical is a post-hoc observable, including the singlet residual —
-a diagnostic for comparing against the canonical build's carried level.)doc")
+a diagnostic for comparing against the canonical build's carried level.
+
+The class also hosts the JOINT arm (#560, rung 1): the two-step event graph
+collapsed into ONE co-optimized node (joint_node / build_joint) — inputs = the
+Z3-orbit neutral triple, outputs = a baryon + antibaryon block pair — driven and
+judged exactly as build(). Exactly one variable then differs from Proton.build():
+the event graph (joint vs two-step). Microcausality lives in the move history
+(every accepted change is one gated local move), not in the boundary-block
+count, so the joint node is physically admissible (epic #559 decision log).)doc")
       .def(py::init<std::uint64_t, int, double, double, int, bool>(),
            py::arg("seed") = 0, py::arg("register_degree") = 3,
            py::arg("gamma") = 50.0, py::arg("input_weight") = 20.0,
@@ -990,6 +998,18 @@ a diagnostic for comparing against the canonical build's carried level.)doc")
            "Restart across seeds until an attempt is stationary AND persistent (no "
            "color tolerance, no minimum hole count); otherwise keep the lowest-F "
            "attempt. Same drive per node as Proton.build().")
+      .def("build_joint", &ProtonIngredients::buildJoint, py::arg("max_restarts") = 16,
+           py::arg("init_steps") = 180, py::arg("evolve_steps") = 60,
+           py::arg("stage1_candidate_moves") = 8, py::arg("stage1_patience") = 15,
+           py::arg("stage2_beta") = 1.0, py::arg("stage2_max_iters") = 10,
+           py::arg("persist_rel_tol") = 0.05,
+           "The JOINT arm (#560): identical to build() — same per-node drive, same "
+           "stationarity + persistence convergence, same restart policy — except each "
+           "attempt drives ONE joint_node (restart i seeds it at seed + i). Extra "
+           "after-the-fact observables: baryon_residual/antibaryon_residual (per-"
+           "output-block singlet residuals); diquark_residual is NaN (no step A "
+           "exists). Mutually exclusive with build(): whichever runs first claims "
+           "the instance.")
       .def("recombination_node", &ProtonIngredients::recombinationNode,
            py::arg("seed"),
            "Step A verbatim: the composed canonical Proton's recombination_node.")
@@ -997,6 +1017,16 @@ a diagnostic for comparing against the canonical build's carried level.)doc")
            "Step B with nothing pinned: the same ideal diquark {1,w} + third quark "
            "{w*w} inputs on the same single Delta^4 seed as Proton.formation_node, "
            "but with an EMPTY output-target list — the final state emerges.")
+      .def("joint_node", &ProtonIngredients::jointNode, py::arg("seed"),
+           "The JOINT formation node (#560, rung 1), fresh, seeded, NOT run: inputs = "
+           "the Z3-orbit neutral triple {1,-1,0}, {0,1,-1}, {-1,0,1} at the Delta^4 "
+           "seed's v0,v1,v2; outputs = TWO localized blocks (the multi-output r_u "
+           "branch, as the 2->2 recombination) — the baryon {1,w,w*w} at v3 and the "
+           "antibaryon {1,conj(w),conj(w)^2} at v4. NOTE: the antibaryon target is a "
+           "component-permutation of the baryon's (conj(w) = w^2) and the block "
+           "residual is relabeling-invariant, so the two targets score identically as "
+           "multisets — the conjugation is carried by the block's location in the "
+           "emergent complex, never by the residual's value.")
       .def("converged", &ProtonIngredients::converged,
            "True iff the kept attempt was stationary AND persistent — never a "
            "statement about the singlet or the hole count.")
@@ -1018,11 +1048,23 @@ a diagnostic for comparing against the canonical build's carried level.)doc")
            "whole, read after the fact for comparison with the canonical build. It "
            "never steers or gates this build.")
       .def("input_residual", &ProtonIngredients::inputResidual,
-           "Step B's inputs-only r_U — the whole matter term of the emergent arm.")
+           "The kept node's full matter term r_U: after build() the inputs-only "
+           "residual (nothing pinned downstream there); after build_joint() it also "
+           "contains the two output-block terms.")
       .def("final_objective", &ProtonIngredients::finalObjective,
            "The kept attempt's final objective F.")
       .def("diquark_residual", &ProtonIngredients::diquarkResidual,
-           "Step A's r_U — reported exactly as Proton reports it.");
+           "Step A's r_U — reported exactly as Proton reports it. NaN after "
+           "build_joint(): the joint arm has no step A (never a stale zero).")
+      .def("baryon_residual", &ProtonIngredients::baryonResidual,
+           "The baryon output block's singlet residual (#560): its target {1,w,w*w} "
+           "scored against the block's OWN emergent sub-complex, read after the fact "
+           "exactly as the drive's r_u scored it. NaN unless build_joint() ran (the "
+           "two-step's step B has no localized output blocks).")
+      .def("antibaryon_residual", &ProtonIngredients::antibaryonResidual,
+           "The antibaryon output block's residual: its conjugate target against its "
+           "own sub-complex (the conjugation lives in the block's location, not the "
+           "residual's value — see joint_node). NaN unless build_joint() ran.");
 
   // ----- Gated surgical cone-out/cone-in (topology change, #460) -----
   py::class_<SurgicalCone>(m, "SurgicalCone",

--- a/src/cobordism/ProtonIngredients.cpp
+++ b/src/cobordism/ProtonIngredients.cpp
@@ -4,12 +4,14 @@
 #include "cobordism/ProtonIngredients.h"
 
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <utility>
 
 #include "cobordism/MultiCobordism.h"
 #include "mesh/Edge.h"
 #include "mesh/EdgeList.h"
+#include "mesh/Simplex.h"
 #include "mesh/Vertex.h"
 #include "mesh/VertexList.h"
 #include "spacetime/Foliation.h"
@@ -42,7 +44,11 @@ ProtonIngredients::ProtonIngredients(std::uint64_t seed, int registerDegree,
       gamma_(gamma),
       inputResidualWeight_(inputWeight),
       precone_(precone),
-      shouldUseDirectedSurgery_(shouldUseDirectedSurgery) {}
+      shouldUseDirectedSurgery_(shouldUseDirectedSurgery),
+      // The joint-arm per-block reads stay NaN unless buildJoint() runs — the
+      // two-step's step B has no localized output blocks to read.
+      baryonResidual_(std::numeric_limits<double>::quiet_NaN()),
+      antibaryonResidual_(std::numeric_limits<double>::quiet_NaN()) {}
 
 std::shared_ptr<Spacetime> ProtonIngredients::buildMinimalSeed() {
   using namespace ::tessera::spacetime;
@@ -93,40 +99,107 @@ std::shared_ptr<MultiCobordism> ProtonIngredients::formationNode(
   return node;
 }
 
+std::shared_ptr<MultiCobordism> ProtonIngredients::jointNode(
+    std::uint64_t seed) const {
+  // The JOINT node (#560, rung 1): the two-step event graph collapsed into one
+  // co-optimized node. Inputs: the Z₃ ORBIT of the neutral q-q̄ pair — {1,-1,0} and its
+  // two cyclic rotations (the #398 symmetric-input lesson) — at v0,v1,v2. Outputs: TWO
+  // localized blocks (the multi-output rU branch, exactly as the 2→2 recombination) —
+  // the baryon [1,ω,ω²] at v3 ⊔ its component-wise conjugate, the antibaryon
+  // [1,ω̄,ω̄²], at v4. The conjugate is a component-permutation of the singlet
+  // (ω̄ = ω²) and the block residual is relabeling-invariant, so the conjugation is
+  // carried by the block's location in the emergent complex, not the residual's value
+  // (see the header note).
+  const std::vector<std::vector<complexd>> pairTriple = {
+      {complexd(1.0, 0.0), complexd(-1.0, 0.0), complexd(0.0, 0.0)},
+      {complexd(0.0, 0.0), complexd(1.0, 0.0), complexd(-1.0, 0.0)},
+      {complexd(-1.0, 0.0), complexd(0.0, 0.0), complexd(1.0, 0.0)}};
+  const std::vector<complexd> baryon = Proton::singlet();  // {1, ω, ω²}
+  std::vector<complexd> antibaryon;
+  antibaryon.reserve(baryon.size());
+  for (const auto &component : baryon) antibaryon.push_back(std::conj(component));
+  auto host = buildMinimalSeed();
+  // Capture the seed vertex IDS before constructing the node (see
+  // Proton::recombinationNode): precone_ > 0 regrows the complex in the ctor, but the
+  // seed ids persist.
+  std::vector<std::uint64_t> seedVertexIds;
+  for (const auto *vertex : host->getVertexList()->toVector())
+    seedVertexIds.push_back(vertex->getId());
+  auto node = std::make_shared<MultiCobordism>(
+      host, pairTriple, std::vector<std::vector<complexd>>{baryon, antibaryon},
+      std::vector<int>{registerDegree_}, gamma_, seed, precone_);
+  node->setInputResidualWeight(inputResidualWeight_);
+  node->seedInputs({seedVertexIds[0], seedVertexIds[1], seedVertexIds[2]});
+  node->seedOutputs({seedVertexIds[3], seedVertexIds[4]});
+  return node;
+}
+
+void ProtonIngredients::driveNode(MultiCobordism &node, int initSteps,
+                                  int evolveSteps, int stage1CandidateMoves,
+                                  int stage1Patience, double stage2Beta,
+                                  int stage2MaxIters) const {
+  // Proton::build()'s exact drive per node: INITIALIZATION pass (grow_boundaries=true),
+  // optional directed cone-out, EVOLUTION pass (∂W frozen), optional directed cone-in,
+  // then the geometric relaxation. Shared verbatim by build() and buildJoint() — the
+  // joint arm changes the event graph, never the drive.
+  node.runStage1(initSteps, stage1CandidateMoves, stage1Patience,
+                 /*growBoundaries=*/true);
+  if (shouldUseDirectedSurgery_)
+    (void)node.directedConeOut();
+  node.runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
+                 /*growBoundaries=*/false);
+  if (shouldUseDirectedSurgery_)
+    (void)node.directedConeIn();
+  node.runStage2(stage2Beta, stage2MaxIters);
+}
+
+int ProtonIngredients::emergentHoleCount(
+    const std::shared_ptr<Spacetime> &whole) const {
+  return static_cast<int>(
+      MultiCobordism::emergentHoles(*whole, registerDegree_).size());
+}
+
+int ProtonIngredients::bettiAtRegisterDegree(
+    const std::shared_ptr<Spacetime> &whole) const {
+  const auto betti = MultiCobordism::betti(*whole);
+  return registerDegree_ < static_cast<int>(betti.size()) ? betti[registerDegree_]
+                                                          : 0;
+}
+
+bool ProtonIngredients::settleAndVerifyPersistence(
+    MultiCobordism &node, int evolveSteps, int stage1CandidateMoves,
+    int stage1Patience, double stage2Beta, int stage2MaxIters,
+    double persistRelTol) const {
+  // Persistence: continued evolution (∂W frozen) + relaxation must leave the
+  // answer-agnostic summary — the emergent hole count, b_k, and the objective;
+  // deliberately NOT the singlet residual, since no answer-shaped quantity may steer
+  // or gate these builds — stable. Up to kMaxPersistencePasses passes may settle a
+  // not-quite-stationary complex; the LAST pass has to be the stable one.
+  bool persisted = false;
+  for (int pass = 0; pass < kMaxPersistencePasses && !persisted; ++pass) {
+    const auto whole = node.spacetime();
+    const int holesBefore = emergentHoleCount(whole);
+    const int bettiBefore = bettiAtRegisterDegree(whole);
+    const double objectiveBefore = node.objective();
+    node.runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
+                   /*growBoundaries=*/false);
+    node.runStage2(stage2Beta, stage2MaxIters);
+    const auto settled = node.spacetime();
+    const double objectiveAfter = node.objective();
+    persisted = emergentHoleCount(settled) == holesBefore &&
+                bettiAtRegisterDegree(settled) == bettiBefore &&
+                std::abs(objectiveAfter - objectiveBefore) <=
+                    persistRelTol * std::max(std::abs(objectiveBefore), 1.0);
+  }
+  return persisted;
+}
+
 void ProtonIngredients::build(int maxRestarts, int initSteps, int evolveSteps,
                               int stage1CandidateMoves, int stage1Patience,
                               double stage2Beta, int stage2MaxIters,
                               double persistRelTol) {
   if (attempted_) return;
   attempted_ = true;
-
-  // Proton::build()'s exact drive per node: INITIALIZATION pass (grow_boundaries=true),
-  // optional directed cone-out, EVOLUTION pass (∂W frozen), optional directed cone-in,
-  // then the geometric relaxation.
-  const auto runNode = [&](MultiCobordism &node) {
-    node.runStage1(initSteps, stage1CandidateMoves, stage1Patience,
-                   /*growBoundaries=*/true);
-    if (shouldUseDirectedSurgery_)
-      (void)node.directedConeOut();
-    node.runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
-                   /*growBoundaries=*/false);
-    if (shouldUseDirectedSurgery_)
-      (void)node.directedConeIn();
-    node.runStage2(stage2Beta, stage2MaxIters);
-  };
-
-  // The answer-agnostic summary the persistence check compares: the emergent hole
-  // count, b_k, and the objective. Deliberately NOT the singlet residual — no
-  // answer-shaped quantity may steer or gate this build.
-  const auto holeCount = [&](const std::shared_ptr<Spacetime> &whole) {
-    return static_cast<int>(
-        MultiCobordism::emergentHoles(*whole, registerDegree_).size());
-  };
-  const auto bettiAtRegisterDegree = [&](const std::shared_ptr<Spacetime> &whole) {
-    const auto betti = MultiCobordism::betti(*whole);
-    return registerDegree_ < static_cast<int>(betti.size()) ? betti[registerDegree_]
-                                                            : 0;
-  };
 
   double bestObjective = std::numeric_limits<double>::infinity();
 
@@ -136,32 +209,18 @@ void ProtonIngredients::build(int maxRestarts, int initSteps, int evolveSteps,
 
     // ---- Step A — recombination: best-effort; its r_U is reported, not gated. ----
     auto stepA = recombinationNode(seedA);
-    runNode(*stepA);
+    driveNode(*stepA, initSteps, evolveSteps, stage1CandidateMoves, stage1Patience,
+              stage2Beta, stage2MaxIters);
     const double diquarkR = stepA->rU(stepA->spacetime());
 
     // ---- Step B — formation with nothing pinned ----
     auto stepB = formationNode(seedB);
-    runNode(*stepB);
+    driveNode(*stepB, initSteps, evolveSteps, stage1CandidateMoves, stage1Patience,
+              stage2Beta, stage2MaxIters);
 
-    // Persistence: continued evolution (∂W frozen) + relaxation must leave the
-    // answer-agnostic summary stable. Up to kMaxPersistencePasses passes may settle a
-    // not-quite-stationary complex; the LAST pass has to be the stable one.
-    bool persisted = false;
-    for (int pass = 0; pass < kMaxPersistencePasses && !persisted; ++pass) {
-      const auto whole = stepB->spacetime();
-      const int holesBefore = holeCount(whole);
-      const int bettiBefore = bettiAtRegisterDegree(whole);
-      const double objectiveBefore = stepB->objective();
-      stepB->runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
-                       /*growBoundaries=*/false);
-      stepB->runStage2(stage2Beta, stage2MaxIters);
-      const auto settled = stepB->spacetime();
-      const double objectiveAfter = stepB->objective();
-      persisted = holeCount(settled) == holesBefore &&
-                  bettiAtRegisterDegree(settled) == bettiBefore &&
-                  std::abs(objectiveAfter - objectiveBefore) <=
-                      persistRelTol * std::max(std::abs(objectiveBefore), 1.0);
-    }
+    const bool persisted = settleAndVerifyPersistence(
+        *stepB, evolveSteps, stage1CandidateMoves, stage1Patience, stage2Beta,
+        stage2MaxIters, persistRelTol);
     const bool isStationary = stepB->lastStage2Stationary();
     const bool ok = isStationary && persisted;
 
@@ -183,6 +242,94 @@ void ProtonIngredients::build(int maxRestarts, int initSteps, int evolveSteps,
       inputResidual_ = stepB->rU(whole);
       finalObjective_ = finalObjective;
       diquarkResidual_ = diquarkR;
+    }
+    if (ok) return;  // a stationary, persistent structure emerged — stop restarting
+  }
+}
+
+double ProtonIngredients::outputBlockResidual(const MultiCobordism &node,
+                                              std::size_t blockIndex) const {
+  // The after-the-fact per-output-block read (#560): the block's own sub-complex —
+  // the ambient complex's top cells all of whose vertices lie in the block's region —
+  // scored against the block's target. Mirrors MultiCobordism's private
+  // residualForBoundaryBlock at this class's single register degree (uniform-metric
+  // sub-complex via fromCells), so the read matches how the drive's rU scored the
+  // block; with no full cell inside the region, the full leak ‖target‖².
+  const auto &block = node.outputs().at(blockIndex);
+  std::vector<std::vector<std::uint64_t>> cellsInsideRegion;
+  for (const auto &topSimplex : node.spacetime()->getTopSimplices()) {
+    std::vector<std::uint64_t> cellVertexIds;
+    bool cellIsInsideRegion = true;
+    for (const auto *vertex : topSimplex->getVertices()) {
+      if (!block.vertices.count(vertex->getId())) {
+        cellIsInsideRegion = false;
+        break;
+      }
+      cellVertexIds.push_back(vertex->getId());
+    }
+    if (cellIsInsideRegion) cellsInsideRegion.push_back(std::move(cellVertexIds));
+  }
+  if (cellsInsideRegion.empty()) {
+    double targetNormSquared = 0.0;
+    for (const auto &component : block.target)
+      targetNormSquared += std::norm(component);
+    return targetNormSquared;  // the full leak — nothing carries the block yet
+  }
+  const auto blockSubcomplex = Spacetime::fromCells(kDim, cellsInsideRegion, 1.0, 0.0);
+  return MultiCobordism::residualOfTargetStateAgainstHarmonic(
+      blockSubcomplex, registerDegree_, block.target);
+}
+
+void ProtonIngredients::buildJoint(int maxRestarts, int initSteps, int evolveSteps,
+                                   int stage1CandidateMoves, int stage1Patience,
+                                   double stage2Beta, int stage2MaxIters,
+                                   double persistRelTol) {
+  if (attempted_) return;
+  attempted_ = true;
+
+  // The joint arm has no step A — the diquark intermediate is collapsed away — so its
+  // observable is explicitly not-a-number, never a stale zero.
+  diquarkResidual_ = std::numeric_limits<double>::quiet_NaN();
+
+  double bestObjective = std::numeric_limits<double>::infinity();
+
+  for (int attempt = 0; attempt < maxRestarts; ++attempt) {
+    // ONE node per attempt (the collapsed event graph is the experiment), so the
+    // restart enumeration is dense: seed + attempt.
+    const std::uint64_t seed = baseSeed_ + static_cast<std::uint64_t>(attempt);
+
+    auto node = jointNode(seed);
+    driveNode(*node, initSteps, evolveSteps, stage1CandidateMoves, stage1Patience,
+              stage2Beta, stage2MaxIters);
+
+    const bool persisted = settleAndVerifyPersistence(
+        *node, evolveSteps, stage1CandidateMoves, stage1Patience, stage2Beta,
+        stage2MaxIters, persistRelTol);
+    const bool isStationary = node->lastStage2Stationary();
+    const bool ok = isStationary && persisted;
+
+    const auto whole = node->spacetime();
+    const double finalObjective = node->objective();
+
+    // Keep the converged attempt, or the lowest-objective one so far otherwise — the
+    // objective itself is the only ranking, never a target state.
+    if (ok || finalObjective < bestObjective) {
+      bestObjective = finalObjective;
+      converged_ = ok;
+      stationary_ = isStationary;
+      persistent_ = persisted;
+      keptSeed_ = seed;
+      spacetime_ = whole;
+      emergentHoles_ = MultiCobordism::emergentHoles(*whole, registerDegree_);
+      singletResidual_ = MultiCobordism::residualOfTargetStateAgainstHarmonic(
+          whole, registerDegree_, Proton::singlet());  // diagnostic read, after the fact
+      inputResidual_ = node->rU(whole);  // full matter term: inputs + output blocks
+      finalObjective_ = finalObjective;
+      // The per-output-block singlet residuals, read after the fact off each block's
+      // own emergent sub-complex: baryon first, antibaryon second (jointNode's
+      // seeding order).
+      baryonResidual_ = outputBlockResidual(*node, 0);
+      antibaryonResidual_ = outputBlockResidual(*node, 1);
     }
     if (ok) return;  // a stationary, persistent structure emerged — stop restarting
   }
@@ -245,6 +392,16 @@ double ProtonIngredients::finalObjective() {
 double ProtonIngredients::diquarkResidual() {
   ensureBuilt();
   return diquarkResidual_;
+}
+
+double ProtonIngredients::baryonResidual() {
+  ensureBuilt();
+  return baryonResidual_;  // NaN unless buildJoint() ran (see the header note)
+}
+
+double ProtonIngredients::antibaryonResidual() {
+  ensureBuilt();
+  return antibaryonResidual_;  // NaN unless buildJoint() ran (see the header note)
 }
 
 }  // namespace tessera::cobordism

--- a/tests/cobordism/test_proton_ingredients_python.py
+++ b/tests/cobordism/test_proton_ingredients_python.py
@@ -13,6 +13,12 @@ terms scale linearly with the input weight; the canonical node carries a
 weight-independent whole-read singlet term on top), and (3) that the slow build reports a
 coherent, answer-agnostic summary — deliberately asserting nothing about the singlet or
 the hole count, which are observables of the experiment, not requirements.
+
+The JOINT arm (#560) is locked in the same way: `joint_node` collapses the two-step
+event graph into one co-optimized node — the Z₃-orbit neutral triple in, a baryon ⊔
+antibaryon block pair out (the multi-output `r_u` branch, so `r_u` is NOT linear in the
+input weight) — and the bounded slow smoke checks `build_joint` reports the same
+answer-agnostic summary plus the per-output-block residuals.
 """
 import math
 import unittest
@@ -90,6 +96,64 @@ class ProtonIngredientsNodesTest(unittest.TestCase):
         self.assertLess(r_at_weight_2, 2.0 * r_at_weight_1 - 0.1)
 
 
+class ProtonIngredientsJointNodeTest(unittest.TestCase):
+    """The joint node factory (#560): the two-step event graph collapsed into ONE
+    co-optimized node — Z₃-orbit neutral triple in, baryon ⊔ antibaryon blocks out."""
+
+    def test_joint_node_has_three_inputs_and_two_localized_outputs(self):
+        # Inputs at v0,v1,v2 and outputs at v3,v4 of the single Δ⁴ seed: 3 input blocks
+        # and 2 localized output blocks (the multi-output r_u branch, exactly the shape
+        # the 2->2 recombination exercises).
+        node = cob.ProtonIngredients(seed=5).joint_node(5)
+        self.assertEqual(len(node.inputs), 3)
+        self.assertEqual(len(node.outputs), 2)
+
+    def test_joint_node_inputs_are_the_z3_orbit(self):
+        # The #398 symmetric-input lesson: the three pairs are ONE Z₃ orbit — {1,-1,0}
+        # and its two cyclic rotations — not an ad-hoc triple. Each is neutral (Σ = 0).
+        node = cob.ProtonIngredients(seed=5).joint_node(5)
+        orbit = [[1, -1, 0], [0, 1, -1], [-1, 0, 1]]
+        for block, expected in zip(node.inputs, orbit):
+            self.assertEqual([complex(c) for c in block.target],
+                             [complex(c) for c in expected])
+            self.assertAlmostEqual(abs(sum(block.target)), 0.0, places=12)
+
+    def test_joint_node_output_targets_are_conjugates(self):
+        # Baryon [1,w,w^2] at v3, antibaryon = its component-wise conjugate at v4.
+        node = cob.ProtonIngredients(seed=5).joint_node(5)
+        baryon, antibaryon = node.outputs[0].target, node.outputs[1].target
+        self.assertEqual(len(baryon), 3)
+        singlet = cob.Proton.singlet()
+        for got, expected in zip(baryon, singlet):
+            self.assertAlmostEqual(abs(got - expected), 0.0, places=12)
+        for got, expected in zip(antibaryon, baryon):
+            self.assertAlmostEqual(abs(got - expected.conjugate()), 0.0, places=12)
+
+    def test_conjugate_targets_score_identically_as_multisets(self):
+        # The documented subtlety: [1,conj(w),conj(w)^2] is a component-PERMUTATION of
+        # [1,w,w^2] and the block residual is relabeling-invariant, so the two targets
+        # score identically against any one complex — the conjugation is carried by the
+        # block's location in the emergent complex, never by the residual's value.
+        host = cob.ProtonIngredients().formation_node(1).st
+        baryon = cob.Proton.singlet()
+        antibaryon = [c.conjugate() for c in baryon]
+        self.assertAlmostEqual(cob.MultiCobordism.r_state(host, 3, baryon),
+                               cob.MultiCobordism.r_state(host, 3, antibaryon),
+                               places=12)
+
+    def test_joint_r_u_includes_the_output_block_terms(self):
+        # The joint node pins outputs as LOCALIZED BLOCKS, so r_u = weight * (input
+        # terms) + (output-block terms): strictly sublinear in the input weight —
+        # unlike the two-step's step B, whose r_u is purely the weighted input terms.
+        node = cob.ProtonIngredients(seed=5).joint_node(6)
+        node.set_input_residual_weight(1.0)
+        r_at_weight_1 = node.r_u(node.st)
+        node.set_input_residual_weight(2.0)
+        r_at_weight_2 = node.r_u(node.st)
+        self.assertGreater(r_at_weight_1, 0.0)
+        self.assertLess(r_at_weight_2, 2.0 * r_at_weight_1 - 0.1)
+
+
 @pytest.mark.slow
 class ProtonIngredientsBuildTest(unittest.TestCase):
     """Slow: one real emergent-arm attempt. The assertions are deliberately
@@ -129,6 +193,57 @@ class ProtonIngredientsBuildTest(unittest.TestCase):
         self.assertEqual(len(block.getTopSimplices()), len(whole.getTopSimplices()))
         self.assertEqual(len(block.getEdgeList().toVector()),
                          len(whole.getEdgeList().toVector()))
+
+
+@pytest.mark.slow
+class ProtonIngredientsJointBuildTest(unittest.TestCase):
+    """Slow: ONE bounded joint-arm attempt (#560) at smoke budgets. As with the
+    two-step, the assertions are answer-agnostic — hole count, singlet diagnostic, and
+    the per-output-block residuals are REPORTED observables, never requirements."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ingredients = cob.ProtonIngredients(seed=1)
+        cls.ingredients.build_joint(max_restarts=1, init_steps=40, evolve_steps=20,
+                                    stage2_max_iters=10)
+
+    def test_summary_is_coherent(self):
+        # converged ⟺ stationary AND persistent — never a statement about the singlet.
+        converged = self.ingredients.converged()
+        stationary = self.ingredients.stationary()
+        persistent = self.ingredients.persistent()
+        self.assertIsInstance(converged, bool)
+        self.assertEqual(converged, stationary and persistent)
+
+    def test_observables_are_read_and_finite(self):
+        self.assertTrue(math.isfinite(self.ingredients.singlet_residual()))
+        self.assertTrue(math.isfinite(self.ingredients.input_residual()))
+        self.assertTrue(math.isfinite(self.ingredients.final_objective()))
+        self.assertIsInstance(self.ingredients.emergent_holes(), list)
+
+    def test_per_output_block_residuals_are_read(self):
+        # The joint arm's extra observables: one residual per output block, finite and
+        # non-negative (each is a least-squares residual against the block's own
+        # sub-complex — or the full leak while nothing carries the block).
+        baryon_r = self.ingredients.baryon_residual()
+        antibaryon_r = self.ingredients.antibaryon_residual()
+        self.assertTrue(math.isfinite(baryon_r))
+        self.assertTrue(math.isfinite(antibaryon_r))
+        self.assertGreaterEqual(baryon_r, 0.0)
+        self.assertGreaterEqual(antibaryon_r, 0.0)
+
+    def test_diquark_residual_is_nan_without_a_step_a(self):
+        # The joint arm collapses the diquark intermediate away — its observable is
+        # explicitly not-a-number, never a stale zero pretending step A converged.
+        self.assertTrue(math.isnan(self.ingredients.diquark_residual()))
+
+    def test_whole_complex_exists_and_block_is_the_whole(self):
+        whole = self.ingredients.spacetime()
+        self.assertIsNotNone(whole)
+        self.assertTrue(whole.getEdgeList().toVector(),
+                        "emergent complex has no edges")
+        block = self.ingredients.block()
+        self.assertEqual(len(block.getTopSimplices()), len(whole.getTopSimplices()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rung 1 of the fully-emergent-proton design (epic #559): collapse the two-step event graph into ONE co-optimized `MultiCobordism` — the #489 shape through today's canonical engine — keeping the final-state knob. Exactly one variable differs from `Proton::build()`: the event graph (joint vs two-step). Per the epic decision log, microcausality lives in the **move history** (every accepted change is one gated local move), not in the boundary-block count, so the joint node is physically admissible.

## What's here

* **`ProtonIngredients::jointNode(seed)`** — fresh, seeded, NOT-run node: inputs = the **Z₃-orbit neutral triple** `{1,-1,0}`, `{0,1,-1}`, `{-1,0,1}` at the Δ⁴ seed's v0,v1,v2 (seed vertex ids captured before construction, as `recombinationNode` does — precone regrows the complex); outputs = **two localized blocks** via `seedOutputs` (the multi-output `rU` branch): baryon `[1,ω,ω²]` at v3 ⊔ antibaryon `[1,ω̄,ω̄²]` at v4. Header documents the subtlety: the conjugate is a component-permutation of the singlet and the block residual is relabeling-invariant, so the conjugation is carried by the block's *location*, never the residual's value.
* **`ProtonIngredients::buildJoint(...)`** — a separate method (smaller API than a mode flag on `build()`; documented as mutually exclusive — whichever runs first claims the instance): ONE `jointNode` per attempt, the same Grow → (directed probes if enabled) → Evolve → Relax drive and the same stationarity + persistence convergence as the two-step, restarting across seeds (`seed + i`). Observables read after the fact, including the new per-output-block singlet residuals `baryonResidual()` / `antibaryonResidual()` (each block's target scored against its own sub-complex, exactly as the drive's `rU` scored it). `diquarkResidual()` is NaN in the joint arm — no step A exists, never a stale zero.
* `build()`'s per-node drive and persistence verdict extracted into shared private helpers (`driveNode` / `settleAndVerifyPersistence` / `emergentHoleCount` / `bettiAtRegisterDegree`) — two-step behavior unchanged (existing slow two-step build test re-run green).
* Python bindings mirroring the existing `ProtonIngredients` block, with the joint shape documented.
* `Proton.cpp`/`Proton.h` byte-identical; `MultiCobordism` engine untouched.

## Smoke-scale calibration (bounded, as scoped)

Budgets: `max_restarts=1, init_steps=40, evolve_steps=20, stage2_max_iters=10` — the fast-test scale, ONE attempt per point. Γ ∈ {20, 50, 100} × `input_weight` ∈ {5, 20} on 2 seeds. **This is the smoke calibration only** — the machine-precision fixed-seed A/B battery vs the canonical two-step (with the microcausality verdict note and animation labels) is the follow-up run.

`r_U` = the node's full matter term (weighted Z₃-triple inputs + both output blocks); `baryon r`/`antibaryon r` = per-output-block singlet residuals (full leak = 3.0); `singlet diag` = the two-step's whole-complex diagnostic, retained for comparability; holes/b₃ at k=3.

| Γ | w | seed | stat | pers | holes | b₃ | F | r_U | singlet diag | baryon r | antibaryon r | cells | s |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 20 | 5 | 1 | n | Y | 2 | 2 | 39.35 | 3.6e-30 | 1.0 | 1.5e-30 | 1.5e-30 | 80 | 489 |
| 20 | 5 | 2 | n | n | 2 | 2 | 47.88 | 2.6e-30 | 1.0 | 4.8e-31 | 4.8e-31 | 75 | 381 |
| 20 | 20 | 1 | n | Y | 0 | 0 | 2525 | **126 (seed leak)** | 3.0 | **3.0** | **3.0** | 20 | 22 |
| 20 | 20 | 2 | n | n | 2 | 2 | 27.88 | 4.2e-30 | 1.0 | 2.5e-31 | 2.5e-31 | 79 | 322 |
| 50 | 5 | 1 | n | Y | 1 | 1 | 29.71 | 5.2e-30 | 2.0 | 1.8e-31 | 1.8e-31 | 82 | 348 |
| 50 | 5 | 2 | n | n | 1 | 1 | 49.31 | 1.1e-30 | 2.0 | 5.1e-31 | 5.1e-31 | 92 | 412 |
| **50** | **20** | 1 | n | n | 2 | 2 | **11.36** | 1.3e-30 | 1.0 | 2.6e-31 | 2.6e-31 | 44 | 170 |
| **50** | **20** | 2 | n | n | 2 | 2 | 57.65 | 2.7e-29 | 1.0 | 1.9e-31 | 1.9e-31 | 89 | 413 |
| 100 | 5 | 1 | n | Y | 1 | 1 | 3653 | **36 (seed leak)** | 2.0 | **3.0** | **3.0** | 79 | 116 |
| 100 | 5 | 2 | n | n | 0 | 0 | 17.39 | 4.0e-30 | 3.0 | 1.5e-31 | 1.5e-31 | 48 | 130 |
| 100 | 20 | 1 | n | Y | 1 | 1 | 23.30 | 6.0e-30 | 2.0 | 5.2e-32 | 5.2e-32 | 53 | 106 |
| 100 | 20 | 2 | n | n | 1 | 1 | 78.48 | 5.6e-29 | 2.0 | 2.0e-29 | 2.0e-29 | 104 | 484 |

**Reading.** 10 of 12 single-attempt points drive the FULL joint matter term to machine precision (`r_U` ~1e-30–6e-29) with both output blocks carried (block residuals 5e-32–2e-29 vs full leak 3.0) — the collapsed event graph carries baryon ⊔ antibaryon co-optimized, at smoke budgets, without staging. The two no-carry points (Γ=20/w=20 seed 1: stalled at the 20-cell seed scale; Γ=100/w=5 seed 1: grew to 79 cells but stayed at full leak) are each contradicted by the sibling seed at identical knobs — single-attempt seed luck, which `max_restarts > 1` exists to absorb. No point is stage-2 stationary (the 10-iter smoke cap always exhausts — expected; stationarity is a battery-scale question). Note the whole-complex `singlet diag` sits at 1–3 even where both blocks carry at 1e-31: with baryon + antibaryon + neutral inputs all hosted, the whole-read is the wrong observable — precisely why this PR adds the per-block reads.

**Recommended battery knobs: Γ=50, `input_weight`=20** — the canonical `Proton` defaults. Both seeds carry at machine precision there (and it includes the sweep's lowest F, 11.36); staying at the canonical knobs keeps the A/B clean — the event graph remains the ONLY variable separating `buildJoint` from `Proton::build()`. The sweep gives no reason to leave them: carrying is knob-robust everywhere except two seed-luck stalls at the extreme cells.

## Test plan

- [x] Fast joint-node shape tests: 3 input blocks / 2 output blocks; inputs are the Z₃ orbit (each neutral); output targets conjugate component-wise; conjugate targets score identically as multisets (relabeling invariance); joint `r_u` includes both output-block terms (strictly sublinear in `input_weight`)
- [x] Existing `ProtonIngredients` fast tests stay green (empty-outputs engine regression, two-step node shapes)
- [x] `pytest tests/cobordism/test_proton_ingredients_python.py tests/cobordism/test_emergent_proton_animation.py -m "not slow" -n 2` — 14 passed
- [x] One bounded `@pytest.mark.slow` joint-build smoke: coherent summary (`converged ⟺ stationary ∧ persistent`), finite observables, per-output-block residuals ≥ 0, `diquark_residual` NaN, whole complex exists — 5 passed
- [x] Existing slow two-step `ProtonIngredientsBuildTest` re-run after the `build()` helper refactor — 3 passed (behavior-preserving)

## Follow-ups (ticket scope, deliberately not in this PR)

Fixed-seed A/B battery vs canonical `Proton` at real budgets + findings note with the microcausality verdict recorded in the epic decision log; per-hole DK charge spread and baryon-block hole-clustering reads; `emergent_proton.py` animation labels.

Closes #560.
