### PR TITLE
feat(cobordism): mass/radius battery on the relaxed emergent 4D interior

### DIFF
--- a/examples/cobordism/emergent_mass_radius.py
+++ b/examples/cobordism/emergent_mass_radius.py
@@ -1,0 +1,490 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Mass and radius read the right way off a converged emergent 4D interior (#566).
+
+This ports the #451 geometric-proton methodology (see
+``docs/design/451-proton-geometry-0a1a5aa.md``) from its 3D event to the genuinely
+4D emergent builds: the canonical ``tessera.cobordism.Proton().block()`` and the
+emergent arm ``tessera.cobordism.ProtonIngredients().block()`` (or any other
+converged 4D ``Spacetime``). Everything here is a *post-hoc observable reader* —
+nothing shapes the lattice.
+
+The load-bearing methodology rules, ported from #451:
+
+  * **Hinges.** On a d = 4 complex the Regge hinges are the (d-2) = 2-simplices —
+    TRIANGLES (#451 was 3D, where hinges were edges). Curvature is the complex
+    Lorentzian deficit angle at each triangle.
+  * **Closed fans only.** A hinge carries an honest curvature ONLY if its coface
+    fan is closed — every tetrahedron around the triangle shared by exactly two
+    4-cells. Open-fan hinges (the ∂W input boundary, the register-hole walls) give
+    boundary artefacts near 2π, not curvature: they are EXCLUDED, and the census
+    (interior vs boundary counts) is reported with every reading. The fan test is
+    combinatorial over the CURRENT top cells, so orphan sub-simplices stranded by
+    Pachner moves never pollute the selection.
+  * **Skeleton in C++.** ``dualVolume()`` / ``lorentzianDeficitAngle()`` walk a
+    hinge up through its cofaces, so the facet/coface lattice must exist and be
+    built in C++: the ``ReggeSolver(st, MatterConfiguration())`` ctor materializes
+    tops → tetrahedra → triangle hinges, and ``ChainComplex.fromSpacetime(st)``
+    (a C++ BFS seeded from the current tops) completes the lattice down to edges
+    and vertices for the dual volumes. Never drive ``materializeFacets`` from
+    Python — the #451 lesson: a Python-driven materialization corrupted the coface
+    lists and ``dualVolume()`` saw half its cofaces.
+  * **Signature-aware readings.** Dual volumes are the circumcentric
+    ``Simplex.dualVolume`` (signed); the deficit is the complex
+    ``Simplex.lorentzianDeficitAngle``. Masses use Re ε; the imaginary part is
+    real physics (boost content), so its magnitude is always reported alongside —
+    never silently dropped.
+  * **Dimension-correct radius.** The dual radius is r = V_dual^(1/4) on a
+    4-complex (V_dual = the summed circumcentric dual 4-volume of the strictly
+    interior vertices). #451 used V_dual^(1/3) because its complex was 3D; the
+    root tracks the top dimension, nothing else. The primal cross-check is
+    r = V_primal^(1/4) over the top 4-cells.
+  * **r·m is definition-sensitive.** The #451 lesson: across reasonable mass
+    definitions (intensive shell-mean vs the two extensive sums) r·m spans orders
+    of magnitude, so the FULL table with its spread is stated up front and any
+    agreement with the physical m_p·r_p/ħc ≈ 4.0 is an order-of-magnitude claim
+    only — never one number presented as THE mass.
+
+What is measured (per converged spacetime):
+  1. interior closed-fan hinge selection + census (interior / boundary / total);
+  2. mass, intensive AND extensive: m_shell = the #352/#451 shell-mean Re-deficit,
+     m_sum = Σ Re ε, m_action = Σ |★h|·Re ε;
+  3. radius: r_dual = V_dual^(1/4) with the r_primal = V_primal^(1/4) cross-check;
+  4. localization: participation ratio of |Re ε·★h| against the equal-volume
+     uniform (round-sphere) reference, the BFS shell profile of curvature relative
+     to the register holes' vertices, and the mean deficit sign;
+  5. the r·m table across ALL mass × radius combinations, spread first.
+
+Importable (the tests reuse these): ``build_skeleton``, ``interior_hinges``,
+``masses``, ``radii``, ``localization``, ``rm_table``, ``measure``, ``report``.
+
+Run (bounded budgets — the fast-test pattern, one attempt per arm):
+
+    python emergent_mass_radius.py                 # canonical Proton
+    python emergent_mass_radius.py --arm both      # + the ProtonIngredients arm
+    python emergent_mass_radius.py --seed 3
+"""
+import argparse
+import itertools
+import math
+from collections import Counter, defaultdict
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+# Physical anchor: m_p·r_p/ħc = 938 MeV · 0.84 fm / 197 MeV·fm ≈ 4.0 (dimensionless).
+PHYSICAL_RM = 938.0 * 0.84 / 197.0
+
+# |Im ε| above this counts as genuinely complex (boost content at the hinge).
+IM_TOL = 1e-12
+
+
+def build_skeleton(st):
+    """Materialize the full facet/coface lattice of ``st`` in C++ and return the
+    keep-alive handles ``(solver, chain_complex)``.
+
+    ``ReggeSolver(st, MatterConfiguration())`` is the blessed Regge path: its ctor
+    builds tops → tetrahedra → triangle hinges, which is everything the deficit
+    angles need. ``ChainComplex.fromSpacetime(st)`` then completes the lattice
+    down to edges and vertices — a C++ BFS seeded from the CURRENT top cells only
+    (orphan-safe) — which the vertex ``dualVolume()`` recursion needs for V_dual.
+    Both are C++ constructors; no materialization is ever driven from Python
+    (the #451 corruption lesson).
+    """
+    solver = tessera.ReggeSolver(st, tessera.MatterConfiguration())
+    chain_complex = cob.ChainComplex.fromSpacetime(st)
+    return solver, chain_complex
+
+
+def _top_vertex_ids(st):
+    """Sorted vertex-id tuples of the current top cells (4-simplices). Fails
+    loudly if the complex is not genuinely 4D — this reader is 4D-specific (the
+    hinge dimension and the radius root both track d = 4)."""
+    tops = [tuple(sorted(v.getId() for v in t.getVertices()))
+            for t in st.getTopSimplices()]
+    if not tops:
+        raise ValueError("spacetime has no top cells")
+    sizes = {len(t) for t in tops}
+    if sizes != {5}:
+        raise ValueError(
+            f"top cells have vertex counts {sorted(sizes)}; this reader is for "
+            "4-complexes (5-vertex top cells) — on a d-complex the hinges are the "
+            "(d-2)-simplices and the radius root is 1/d, so use the reader that "
+            "matches your dimension")
+    return sorted(tops)
+
+
+def _bfs_shells(tops, seed_vertex_ids):
+    """BFS shell distance from ``seed_vertex_ids`` over the 1-skeleton of the
+    CURRENT top cells (combinatorial, orphan-immune). Returns {vertex_id: shell};
+    unreachable vertices are absent. Empty seeds give an empty map (every hinge
+    then reports shell None and the shell profile is skipped)."""
+    adjacency = defaultdict(set)
+    for top in tops:
+        for a, b in itertools.combinations(top, 2):
+            adjacency[a].add(b)
+            adjacency[b].add(a)
+    dist = {v: 0 for v in sorted(set(seed_vertex_ids)) if v in adjacency}
+    frontier = sorted(dist)
+    while frontier:
+        nxt = []
+        for u in frontier:
+            for v in sorted(adjacency[u]):
+                if v not in dist:
+                    dist[v] = dist[u] + 1
+                    nxt.append(v)
+        frontier = nxt
+    return dist
+
+
+def interior_hinges(st, holes=()):
+    """Select the interior (closed-coface-fan) triangle hinges of the 4-complex
+    and read their curvature. Returns ``(hinges, census)``.
+
+    A triangle hinge is INTERIOR iff every tetrahedron of its coface fan is shared
+    by exactly two top 4-cells; hinges with any once-shared (boundary) tetrahedron
+    are boundary artefacts — their "deficit" is a near-2π opening-angle remnant,
+    not curvature — and are excluded. Both the fan and the tetrahedron counts are
+    derived combinatorially from the CURRENT top cells (never from raw coface
+    lists), so orphan simplices stranded by Pachner moves cannot leak in; the
+    readings themselves are then taken off the canonical registered triangle
+    Simplex objects (skeleton required — call ``build_skeleton`` first).
+
+    Each hinge dict carries: ``vids`` (the 3 vertex ids), ``re``/``im`` (the
+    complex Lorentzian deficit), ``dv`` (the signed circumcentric dual content
+    |★h|), and ``shell`` (BFS distance from the register holes' vertices, None
+    when ``holes`` is empty).
+
+    ``census`` reports the interior/boundary/total hinge counts, the boundary
+    tetrahedron count, and the sizes of the complex.
+    """
+    tops = _top_vertex_ids(st)
+
+    # Tetrahedron -> number of top cells sharing it, and triangle -> its fan.
+    tet_count = Counter()
+    tri_fans = defaultdict(set)
+    for top in tops:
+        for tet in itertools.combinations(top, 4):
+            tet_count[tet] += 1
+        for tri in itertools.combinations(top, 3):
+            rest = [v for v in top if v not in tri]
+            for extra in rest:
+                tri_fans[tri].add(tuple(sorted(tri + (extra,))))
+
+    # Canonical registered triangle Simplex objects, keyed by vertex set.
+    tri_by_key = {}
+    for s in st.getSimplices():
+        if len(s.getVertices()) == 3 and s.hasTopCoface():
+            tri_by_key[tuple(sorted(v.getId() for v in s.getVertices()))] = s
+
+    hole_vertex_ids = sorted(set(v for hole in holes for v in hole))
+    shell_of = _bfs_shells(tops, hole_vertex_ids)
+
+    hinges = []
+    n_boundary = 0
+    for tri in sorted(tri_fans):
+        closed = all(tet_count[tet] == 2 for tet in tri_fans[tri])
+        if not closed:
+            n_boundary += 1
+            continue
+        simplex = tri_by_key.get(tri)
+        if simplex is None:
+            raise RuntimeError(
+                f"interior hinge {tri} has no registered triangle Simplex — "
+                "the C++ skeleton was not built; call build_skeleton(st) first")
+        deficit = simplex.lorentzianDeficitAngle()
+        shell = (min(shell_of[v] for v in tri if v in shell_of)
+                 if any(v in shell_of for v in tri) else None)
+        hinges.append(dict(vids=list(tri), re=deficit.real, im=deficit.imag,
+                           dv=simplex.dualVolume(), shell=shell))
+
+    boundary_tets = sorted(t for t, c in tet_count.items() if c == 1)
+    census = dict(
+        n_tops=len(tops),
+        n_tets=len(tet_count),
+        n_hinges_total=len(tri_fans),
+        n_hinges_interior=len(hinges),
+        n_hinges_boundary=n_boundary,
+        n_boundary_tets=len(boundary_tets),
+        boundary_tets=boundary_tets,
+        n_hole_vertices=len(hole_vertex_ids),
+    )
+    return hinges, census
+
+
+def masses(hinges):
+    """The three #451 mass readings over the interior hinges — one intensive,
+    two extensive (the r·m validator is sensitive to which is called "the mass",
+    so all three are always carried together):
+
+      * ``m_shell`` (intensive): the #352/#451 shell mass — the sum over BFS
+        shells (from the register holes) of the MEAN Re-deficit in that shell.
+        With no holes every hinge sits in one unlabeled bin and m_shell reduces
+        to the plain mean Re-deficit.
+      * ``m_sum`` (extensive): Σ Re ε — the raw integrated curvature.
+      * ``m_action`` (extensive, dual-weighted): Σ |★h|·Re ε — the dual-volume-
+        weighted Regge curvature.
+
+    Also returns ``shell_means`` (the per-shell means) and the imaginary-part
+    accounting: ``max_abs_im`` and ``n_im_nonzero`` (|Im ε| > IM_TOL) — the
+    deficit is complex Lorentzian, and whether Im is zero is always reported.
+    """
+    if not hinges:
+        nan = float("nan")
+        return dict(m_shell=nan, m_sum=nan, m_action=nan, shell_means={},
+                    max_abs_im=nan, n_im_nonzero=0)
+    bins = defaultdict(list)
+    for h in hinges:
+        bins[h["shell"]].append(h["re"])
+    shell_means = {shell: float(np.mean(values))
+                   for shell, values in sorted(bins.items(),
+                                               key=lambda kv: (kv[0] is None, kv[0]))}
+    return dict(
+        m_shell=float(sum(shell_means.values())),
+        m_sum=float(sum(h["re"] for h in hinges)),
+        m_action=float(sum(h["re"] * abs(h["dv"]) for h in hinges)),
+        shell_means=shell_means,
+        max_abs_im=float(max(abs(h["im"]) for h in hinges)),
+        n_im_nonzero=sum(1 for h in hinges if abs(h["im"]) > IM_TOL),
+    )
+
+
+def radii(st, census):
+    """The emergent size of the interior, dual and primal:
+
+      * ``r_dual`` = V_dual^(1/4): V_dual = Σ |★v| over the strictly INTERIOR
+        vertices (vertices on no boundary tetrahedron) — the signature-aware
+        circumcentric dual 4-volume. The fourth root is the dimension-correct
+        volume→length map on a 4-complex (#451 took the cube root of a dual
+        3-volume on its 3D event; same rule, different d).
+      * ``r_primal`` = V_primal^(1/4): V_primal = Σ |V₄| over ALL top 4-cells —
+        the primal-side cross-check of the same 4-volume (dual/primal agreement
+        is the skeleton-sanity signal; on a closed uniform complex they are
+        equal to machine precision).
+      * ``rms_dual_cell``: sqrt(mean |★h|) over the interior hinges — an RMS
+        dual-cell length scale (|★h| is a 2-volume in 4D), reported as the
+        auxiliary scale reading, not used in the r·m table.
+    """
+    boundary_vertex_ids = set(v for tet in census["boundary_tets"] for v in tet)
+    v_dual = 0.0
+    n_interior_vertices = 0
+    vertex_simplices = [s for s in st.getSimplices() if len(s.getVertices()) == 1]
+    for s in sorted(vertex_simplices, key=lambda s: s.getVertices()[0].getId()):
+        if not s.hasTopCoface():
+            continue  # orphan 0-simplex stranded by a move
+        vid = s.getVertices()[0].getId()
+        if vid in boundary_vertex_ids:
+            continue
+        v_dual += abs(s.dualVolume())
+        n_interior_vertices += 1
+    v_primal = sum(abs(t.volume()) for t in st.getTopSimplices())
+    return dict(
+        Vdual=float(v_dual),
+        Vprimal=float(v_primal),
+        n_interior_vertices=n_interior_vertices,
+        r_dual=float(v_dual) ** 0.25 if v_dual > 0 else float("nan"),
+        r_primal=float(v_primal) ** 0.25 if v_primal > 0 else float("nan"),
+    )
+
+
+def localization(hinges):
+    """Is the curvature a localized lump or spread out?
+
+      * ``PR``: participation ratio of the weight w = |Re ε·★h| over the interior
+        hinges, in (0, 1]. The equal-volume UNIFORM reference (a round sphere
+        spreads its curvature evenly over every hinge) has PR = 1.0;
+        ``concentration`` = 1/PR is how many times more concentrated the lump is.
+      * ``mean_re`` / ``std_re`` / ``std_over_mean``: the deficit statistics;
+        mean_re > 0 is the positive-curvature (bound-state, sphere-like) sign.
+      * ``shell_profile``: per BFS shell (from the register holes' vertices) the
+        hinge count, mean Re ε, and share of the total weight; plus
+        ``rms_shell_radius`` (the weight-weighted RMS shell distance — the lump
+        size in shells) and ``frac_within_shell1`` (the weight fraction within
+        one shell of the holes). Empty when no holes were given.
+    """
+    if not hinges:
+        nan = float("nan")
+        return dict(PR=nan, concentration=nan, mean_re=nan, std_re=nan,
+                    std_over_mean=nan, shell_profile={}, rms_shell_radius=nan,
+                    frac_within_shell1=nan)
+    re = np.array([h["re"] for h in hinges])
+    weight = np.abs(re * np.array([abs(h["dv"]) for h in hinges]))
+    total_weight = float(weight.sum())
+    pr = (float(total_weight ** 2 / (len(weight) * float((weight ** 2).sum())))
+          if total_weight > 0 else float("nan"))
+
+    shells = [h["shell"] for h in hinges]
+    profile = {}
+    rms_shell = float("nan")
+    frac_near = float("nan")
+    if all(s is not None for s in shells) and total_weight > 0:
+        shell_arr = np.array(shells, dtype=float)
+        for shell in sorted(set(shells)):
+            mask = shell_arr == shell
+            profile[shell] = dict(
+                n=int(mask.sum()),
+                mean_re=float(re[mask].mean()),
+                weight_share=float(weight[mask].sum() / total_weight),
+            )
+        rms_shell = float(np.sqrt(float((weight * shell_arr ** 2).sum())
+                                  / total_weight))
+        frac_near = float(weight[shell_arr <= 1].sum() / total_weight)
+
+    mean_re = float(re.mean())
+    return dict(
+        PR=pr,
+        concentration=(1.0 / pr) if pr and pr > 0 else float("nan"),
+        mean_re=mean_re,
+        std_re=float(re.std()),
+        std_over_mean=(float(re.std() / abs(mean_re)) if mean_re != 0.0
+                       else float("inf")),
+        shell_profile=profile,
+        rms_shell_radius=rms_shell,
+        frac_within_shell1=frac_near,
+    )
+
+
+def rm_table(mass, rad):
+    """Every r·m combination — 3 mass definitions × 2 radius definitions — with
+    the definitional spread stated FIRST (#451's lesson: r·m is too definition-
+    sensitive to quote as one number; the claim is order-of-magnitude only)."""
+    combos = {}
+    for m_name in ("m_shell", "m_sum", "m_action"):
+        for r_name in ("r_dual", "r_primal"):
+            combos[f"{r_name} x {m_name}"] = rad[r_name] * mass[m_name]
+    finite = [v for v in combos.values() if math.isfinite(v)]
+    spread = ((min(finite), max(finite)) if finite
+              else (float("nan"), float("nan")))
+    return dict(spread_min=spread[0], spread_max=spread[1], combos=combos,
+                physical=PHYSICAL_RM)
+
+
+def measure(st, holes=(), label=""):
+    """Read every geometric observable off one converged 4D spacetime: build the
+    C++ skeleton, select the interior hinges, and return the readings dict.
+    ``holes`` are the register holes' vertex-id tuples (e.g. ``Proton.quark_holes()``
+    / ``ProtonIngredients.emergent_holes()``) — the BFS shell seeds."""
+    skeleton = build_skeleton(st)
+    hinges, census = interior_hinges(st, holes)
+    mass = masses(hinges)
+    rad = radii(st, census)
+    loc = localization(hinges)
+    table = rm_table(mass, rad)
+    del skeleton
+    return dict(label=label, census=census, mass=mass, radius=rad,
+                localization=loc, rm=table, n_holes=len(holes), hinges=hinges)
+
+
+def report(o):
+    """Print one measurement dict in the #451 layout: census first, then the r·m
+    spread up front, then the per-definition table, then localization."""
+    c, mass, rad, loc, rm = (o["census"], o["mass"], o["radius"],
+                             o["localization"], o["rm"])
+    print(f"=== {o['label'] or 'converged spacetime'} ===")
+    print(f"-- census: {c['n_hinges_interior']} interior (closed-fan) hinges of "
+          f"{c['n_hinges_total']} triangles "
+          f"({c['n_hinges_boundary']} boundary artefacts excluded); "
+          f"{c['n_tops']} top 4-cells, {c['n_boundary_tets']} boundary tetrahedra, "
+          f"{o['n_holes']} register holes ({c['n_hole_vertices']} hole vertices)")
+    if c["n_hinges_interior"] == 0:
+        print("   no interior hinges — every triangle touches the boundary; "
+              "the geometric readings below are NaN by construction\n")
+    print(f"-- r·m (physical anchor ~ {rm['physical']:.1f}; ORDER-OF-MAGNITUDE "
+          f"claim only):")
+    print(f"   definitional spread: {rm['spread_min']:.3g} .. {rm['spread_max']:.3g} "
+          f"across {len(rm['combos'])} mass x radius definitions")
+    for name, value in rm["combos"].items():
+        print(f"     {name:24s} = {value:10.4g}")
+    print(f"-- mass: m_shell (intensive) = {mass['m_shell']:.4g}   "
+          f"m_sum = {mass['m_sum']:.4g}   m_action = {mass['m_action']:.4g}")
+    if mass["n_im_nonzero"] == 0:
+        im_note = "ZERO (all-spacelike fans)"
+    else:
+        im_note = (f"NONZERO on {mass['n_im_nonzero']} hinges (boost content); "
+                   "masses use Re ε only")
+    print(f"   Im(deficit): max |Im ε| = {mass['max_abs_im']:.3g} over the interior "
+          f"hinges — {im_note}")
+    print(f"-- radius: r_dual = V_dual^(1/4) = {rad['r_dual']:.4g} "
+          f"(V_dual = {rad['Vdual']:.4g} over {rad['n_interior_vertices']} interior "
+          f"vertices)   cross-check r_primal = {rad['r_primal']:.4g} "
+          f"(V_primal = {rad['Vprimal']:.4g})")
+    print(f"-- localization: PR = {loc['PR']:.3f} (uniform reference 1.0) -> "
+          f"{loc['concentration']:.2f}x more concentrated;   "
+          f"mean Re ε = {loc['mean_re']:+.4g} "
+          f"({'positive-curvature lump' if loc['mean_re'] > 0 else 'NET NEGATIVE — not the bound-state sign'});   "
+          f"std/|mean| = {loc['std_over_mean']:.2f}")
+    if loc["shell_profile"]:
+        cells = "  ".join(
+            f"shell {shell}: n={p['n']}, mean Re ε={p['mean_re']:+.3g}, "
+            f"w={p['weight_share']:.0%}"
+            for shell, p in loc["shell_profile"].items())
+        print(f"   shell profile (BFS from the hole vertices): {cells}")
+        print(f"   weighted RMS shell radius = {loc['rms_shell_radius']:.3f} shells; "
+              f"|curvature| within shell<=1 = {loc['frac_within_shell1']:.0%}")
+    else:
+        print("   shell profile: skipped (no register holes to seed the BFS)")
+    print()
+
+
+def _measure_arm(builder, label, seed, max_restarts):
+    """Build one arm with the bounded fast-test budget and measure its block()."""
+    print(f"building {label} (seed={seed}, max_restarts={max_restarts}, "
+          f"defaults otherwise) ...")
+    arm = builder(seed=seed)
+    arm.build(max_restarts=max_restarts)
+    holes = (arm.quark_holes() if hasattr(arm, "quark_holes")
+             else arm.emergent_holes())
+    o = measure(arm.block(), holes, label)
+    o["converged"] = arm.converged()
+    return o
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--arm", choices=("canonical", "ingredients", "both"),
+                        default="canonical",
+                        help="which build to read: the canonical Proton, the "
+                             "emergent-arm ProtonIngredients, or both (the "
+                             "geometry A/B comparison)")
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--max-restarts", type=int, default=1,
+                        help="bounded validation budget (the fast-test pattern)")
+    args = parser.parse_args()
+
+    results = []
+    if args.arm in ("canonical", "both"):
+        results.append(_measure_arm(cob.Proton, "canonical Proton().block()",
+                                    args.seed, args.max_restarts))
+    if args.arm in ("ingredients", "both"):
+        results.append(_measure_arm(cob.ProtonIngredients,
+                                    "emergent-arm ProtonIngredients().block()",
+                                    args.seed, args.max_restarts))
+    print()
+    for o in results:
+        report(o)
+
+    if len(results) == 2:
+        a, b = results
+        print("-- emergent-arm vs canonical (same seed, same budget) --")
+        for key, path in (("interior hinges", ("census", "n_hinges_interior")),
+                          ("r_dual", ("radius", "r_dual")),
+                          ("m_shell", ("mass", "m_shell")),
+                          ("PR", ("localization", "PR")),
+                          ("mean Re ε", ("localization", "mean_re"))):
+            va = a[path[0]][path[1]]
+            vb = b[path[0]][path[1]]
+            print(f"   {key:16s} canonical {va:10.4g}   emergent {vb:10.4g}")
+        print()
+
+    print("VERDICT (the #451 discipline): the robust evidence is the census-clean "
+          "interior selection,\n  the localization (participation ratio vs the "
+          "uniform reference) and the sign of the mean\n  deficit — r·m is "
+          "definition-sensitive, so its table is an order-of-magnitude reading, "
+          "never\n  a sharp validator.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/emergent_mass_radius.py
+++ b/examples/cobordism/emergent_mass_radius.py
@@ -367,13 +367,12 @@ def measure(st, holes=(), label=""):
     C++ skeleton, select the interior hinges, and return the readings dict.
     ``holes`` are the register holes' vertex-id tuples (e.g. ``Proton.quark_holes()``
     / ``ProtonIngredients.emergent_holes()``) — the BFS shell seeds."""
-    skeleton = build_skeleton(st)
+    build_skeleton(st)  # registers the lattice onto st itself; idempotent
     hinges, census = interior_hinges(st, holes)
     mass = masses(hinges)
     rad = radii(st, census)
     loc = localization(hinges)
     table = rm_table(mass, rad)
-    del skeleton
     return dict(label=label, census=census, mass=mass, radius=rad,
                 localization=loc, rm=table, n_holes=len(holes), hinges=hinges)
 

--- a/tests/cobordism/test_emergent_mass_radius.py
+++ b/tests/cobordism/test_emergent_mass_radius.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Mass/radius reader on converged emergent 4D interiors (#566).
+
+Three layers, mirroring the #451 methodology the example ports to 4D:
+
+  * closed-fan hinge selection proved on hand-checkable complexes — the boundary
+    of Δ⁵ (the minimal closed S⁴: every one of its 20 triangles has a closed
+    3-pentatope fan) and the star of one vertex in it (a solid 4-ball where
+    exactly the 10 triangles containing the apex are interior);
+  * the C++-skeleton rule — after ``build_skeleton`` the readings are finite and
+    nonzero, dual and primal 4-volumes agree to machine precision (the guard that
+    ``dualVolume`` sees ALL its cofaces), and the deficit matches the closed form
+    2π − 3·arccos(¼) with Im = 0; without the skeleton the reader fails loudly;
+  * determinism — independent same-parameter builds read bit-identically, and
+    re-reading one complex is bit-identical;
+
+plus the bounded canonical ``Proton`` build validation (@slow, the fast-test
+budget: seed=1, max_restarts=1, defaults otherwise).
+"""
+import importlib.util
+import itertools
+import math
+import os
+import sys
+import unittest
+
+import pytest
+
+import tessera
+
+cob = tessera.cobordism
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+emr = _load("emergent_mass_radius")
+
+# Regular 4-simplex dihedral angle at a triangle hinge is arccos(1/4); three
+# pentatopes close each fan of dDelta^5, so every deficit is 2pi - 3 arccos(1/4).
+S4_DEFICIT = 2.0 * math.pi - 3.0 * math.acos(0.25)
+# Volume of the regular unit-side 4-simplex is sqrt(5)/96; dDelta^5 has 6 of them.
+S4_VOLUME = 6.0 * math.sqrt(5.0) / 96.0
+
+
+def _boundary_delta5():
+    """The closed S^4 = dDelta^5 (6 pentatopes on {0..5}), uniform l^2 = 1."""
+    cells = [list(c) for c in itertools.combinations(range(6), 5)]
+    return tessera.Spacetime.fromCells(4, cells, 1.0, 0.0)
+
+
+def _star_of_apex():
+    """The star of vertex 5 in dDelta^5: the 5 pentatopes containing vertex 5 —
+    a solid 4-ball whose boundary is the dropped cell's dDelta^4. Hand count:
+    the 10 triangles containing the apex 5 have closed fans (each fan
+    tetrahedron contains 5, so both its pentatopes survive the drop); the 10
+    triangles inside {0..4} touch a once-shared tetrahedron and are boundary."""
+    cells = [list(c) for c in itertools.combinations(range(6), 5) if 5 in c]
+    return tessera.Spacetime.fromCells(4, cells, 1.0, 0.0)
+
+
+class ClosedFanSelectionTest(unittest.TestCase):
+    """Interior selection + census on hand-checkable 4-complexes."""
+
+    def test_closed_s4_all_hinges_interior(self):
+        st = _boundary_delta5()
+        emr.build_skeleton(st)
+        hinges, census = emr.interior_hinges(st)
+        self.assertEqual(census["n_hinges_total"], 20)
+        self.assertEqual(census["n_hinges_interior"], 20)
+        self.assertEqual(census["n_hinges_boundary"], 0)
+        self.assertEqual(census["n_tops"], 6)
+        self.assertEqual(census["n_tets"], 15)
+        self.assertEqual(census["n_boundary_tets"], 0)
+        self.assertEqual(len(hinges), 20)
+
+    def test_star_of_apex_census_matches_hand_count(self):
+        st = _star_of_apex()
+        emr.build_skeleton(st)
+        hinges, census = emr.interior_hinges(st)
+        self.assertEqual(census["n_hinges_total"], 20)
+        self.assertEqual(census["n_hinges_interior"], 10)
+        self.assertEqual(census["n_hinges_boundary"], 10)
+        self.assertEqual(census["n_boundary_tets"], 5)
+        # exactly the triangles containing the apex vertex 5 are interior
+        for h in hinges:
+            self.assertIn(5, h["vids"])
+        # the boundary tetrahedra are getBoundary()'s (independent C++ count)
+        self.assertEqual({tuple(sorted(t)) for t in st.getBoundary()},
+                         set(census["boundary_tets"]))
+
+    def test_single_pentatope_has_no_interior_hinge(self):
+        st = tessera.Spacetime.fromCells(4, [list(range(5))], 1.0, 0.0)
+        emr.build_skeleton(st)
+        hinges, census = emr.interior_hinges(st)
+        self.assertEqual(census["n_hinges_total"], 10)
+        self.assertEqual(census["n_hinges_interior"], 0)
+        self.assertEqual(census["n_hinges_boundary"], 10)
+        self.assertEqual(hinges, [])
+
+    def test_non_4d_complex_fails_loudly(self):
+        # dDelta^4 is a 3-complex — hinges would be edges there, not triangles.
+        cells = [list(c) for c in itertools.combinations(range(5), 4)]
+        st = tessera.Spacetime.fromCells(3, cells, 1.0, 0.0)
+        with self.assertRaises(ValueError):
+            emr.interior_hinges(st)
+
+
+class SkeletonRuleTest(unittest.TestCase):
+    """The C++-built skeleton rule: readings finite/nonzero, dual == primal."""
+
+    def test_readings_on_closed_s4(self):
+        st = _boundary_delta5()
+        o = emr.measure(st, label="dDelta^5")
+        census, mass, rad, loc = (o["census"], o["mass"], o["radius"],
+                                  o["localization"])
+        self.assertEqual(census["n_hinges_interior"], 20)
+        # every deficit is the closed form, purely real
+        self.assertAlmostEqual(mass["m_sum"], 20 * S4_DEFICIT, places=10)
+        self.assertEqual(mass["n_im_nonzero"], 0)
+        self.assertLess(mass["max_abs_im"], 1e-12)
+        # m_shell with no holes reduces to the plain mean deficit
+        self.assertAlmostEqual(mass["m_shell"], S4_DEFICIT, places=10)
+        self.assertGreater(mass["m_action"], 0.0)
+        # dual 4-volume == primal 4-volume == 6*sqrt(5)/96 to machine precision:
+        # the "dualVolume sees ALL its cofaces" guard (a corrupt skeleton halves it)
+        self.assertAlmostEqual(rad["Vdual"], rad["Vprimal"], places=12)
+        self.assertAlmostEqual(rad["Vprimal"], S4_VOLUME, places=12)
+        self.assertEqual(rad["n_interior_vertices"], 6)
+        # the dimension-correct FOURTH root on a 4-complex (#451 used the cube
+        # root on its 3D event)
+        self.assertAlmostEqual(rad["r_dual"], rad["Vdual"] ** 0.25, places=15)
+        self.assertGreater(rad["r_dual"], 0.0)
+        # a perfectly uniform complex IS the round reference: PR = 1 exactly
+        self.assertAlmostEqual(loc["PR"], 1.0, places=12)
+        self.assertGreater(loc["mean_re"], 0.0)  # positive curvature
+        # the r.m table: 6 finite combos and an honest spread
+        self.assertEqual(len(o["rm"]["combos"]), 6)
+        self.assertTrue(all(math.isfinite(v) for v in o["rm"]["combos"].values()))
+        self.assertLessEqual(o["rm"]["spread_min"], o["rm"]["spread_max"])
+
+    def test_hole_seeded_shells_on_star_fixture(self):
+        # Treat the dropped pentatope {0..4} as the register hole: its vertices
+        # seed the BFS, every interior hinge touches shell 0, and the whole
+        # curvature weight sits within shell <= 1.
+        st = _star_of_apex()
+        o = emr.measure(st, holes=[(0, 1, 2, 3, 4)], label="star")
+        self.assertEqual(o["census"]["n_hole_vertices"], 5)
+        self.assertEqual(sorted(o["localization"]["shell_profile"]), [0])
+        self.assertAlmostEqual(o["localization"]["frac_within_shell1"], 1.0,
+                               places=12)
+        self.assertAlmostEqual(o["mass"]["m_shell"], S4_DEFICIT, places=10)
+
+    def test_reader_fails_loudly_without_skeleton(self):
+        # fromCells registers only the top cells; without the C++ skeleton the
+        # canonical triangle Simplex objects don't exist and the reader must
+        # refuse rather than silently reading nothing.
+        st = _boundary_delta5()
+        with self.assertRaises(RuntimeError):
+            emr.interior_hinges(st)
+
+
+class DeterminismTest(unittest.TestCase):
+    """Same parameters => identical numbers, and re-reads are bit-identical."""
+
+    @staticmethod
+    def _flat(o):
+        """Every numeric leaf of a measurement dict, in a stable order — down to
+        the per-hinge deficits, so equality is bit-for-bit (NaN normalized to a
+        sentinel so an absent reading equals an absent reading)."""
+        def norm(v):
+            return "nan" if isinstance(v, float) and math.isnan(v) else v
+
+        flat = []
+        for section in ("census", "mass", "radius", "localization", "rm"):
+            for key, value in sorted(o[section].items()):
+                if isinstance(value, (int, float)):
+                    flat.append((section, key, norm(value)))
+        flat.extend(("combo", k, v) for k, v in sorted(o["rm"]["combos"].items()))
+        flat.extend(("shell_mean", k, v)
+                    for k, v in sorted(o["mass"]["shell_means"].items(),
+                                       key=lambda kv: (kv[0] is None, kv[0])))
+        flat.extend(("shell_profile", k, tuple(sorted(p.items())))
+                    for k, p in sorted(o["localization"]["shell_profile"].items()))
+        for h in o["hinges"]:
+            flat.append(("hinge", tuple(h["vids"]),
+                         (h["re"], h["im"], h["dv"], h["shell"])))
+        return flat
+
+    def test_independent_builds_read_identically(self):
+        a = emr.measure(_boundary_delta5())
+        b = emr.measure(_boundary_delta5())
+        self.assertEqual(self._flat(a), self._flat(b))
+
+    def test_rereading_one_complex_is_identical(self):
+        st = _star_of_apex()
+        holes = [(0, 1, 2, 3, 4)]
+        a = emr.measure(st, holes)
+        b = emr.measure(st, holes)
+        self.assertEqual(self._flat(a), self._flat(b))
+
+
+@pytest.mark.slow
+class ProtonMassRadiusValidationTest(unittest.TestCase):
+    """The bounded canonical build (the fast-test budget): one real emergent
+    proton, read end-to-end. The numeric values are REPORTED findings (printed
+    for the record); the assertions pin structure, finiteness, and reader
+    determinism — never a particular mass."""
+
+    SEED = 1
+    MAX_RESTARTS = 1
+
+    @classmethod
+    def setUpClass(cls):
+        cls.proton = cob.Proton(seed=cls.SEED)
+        cls.proton.build(max_restarts=cls.MAX_RESTARTS)
+        cls.holes = cls.proton.quark_holes()
+        cls.reading = emr.measure(cls.proton.block(), cls.holes,
+                                  "canonical Proton().block()")
+
+    def test_census_is_consistent_and_reported(self):
+        census = self.reading["census"]
+        self.assertEqual(census["n_hinges_interior"] + census["n_hinges_boundary"],
+                         census["n_hinges_total"])
+        self.assertGreater(census["n_hinges_total"], 0)
+        self.assertGreater(census["n_tops"], 0)
+        emr.report(self.reading)  # the readings table, for the record
+
+    def test_relaxed_interior_readings_are_finite(self):
+        # The emergent block must expose a relaxed interior at all — the whole
+        # point of the reader — and every reading off it must be finite.
+        census, mass, rad = (self.reading["census"], self.reading["mass"],
+                             self.reading["radius"])
+        self.assertGreater(census["n_hinges_interior"], 0,
+                           "no closed-fan hinge — nothing interior to read")
+        for name in ("m_shell", "m_sum", "m_action"):
+            self.assertTrue(math.isfinite(mass[name]), name)
+        self.assertTrue(math.isfinite(mass["max_abs_im"]))
+        self.assertGreater(rad["Vprimal"], 0.0)
+        self.assertTrue(math.isfinite(rad["r_primal"]))
+        pr = self.reading["localization"]["PR"]
+        self.assertTrue(math.isfinite(pr))
+        self.assertGreater(pr, 0.0)
+        self.assertLessEqual(pr, 1.0 + 1e-12)
+
+    def test_rm_table_covers_all_definitions(self):
+        rm = self.reading["rm"]
+        self.assertEqual(
+            sorted(rm["combos"]),
+            sorted(f"{r} x {m}" for m in ("m_shell", "m_sum", "m_action")
+                   for r in ("r_dual", "r_primal")))
+        self.assertLessEqual(rm["spread_min"], rm["spread_max"])
+
+    def test_reader_is_deterministic_on_the_built_block(self):
+        # Same complex, same holes => bit-identical numbers. (The BUILD itself is
+        # documented FP-thread-variable — test_proton_cpp_python.py — so reader
+        # determinism, not build determinism, is the assertable contract.)
+        again = emr.measure(self.proton.block(), self.holes,
+                            "canonical Proton().block()")
+        self.assertEqual(DeterminismTest._flat(self.reading),
+                         DeterminismTest._flat(again))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #566.

The #451 geometric-proton methodology (`docs/design/451-proton-geometry-0a1a5aa.md`), ported from its 3D event to the genuinely 4D emergent builds — a post-hoc observable reader over any converged 4D `Spacetime` (canonical `Proton().block()` or the emergent-arm `ProtonIngredients().block()`).

## What the reader does (`examples/cobordism/emergent_mass_radius.py`)

- **Interior selection + census.** On d = 4 the Regge hinges are the (d−2) = 2-simplices — **triangles** (#451 was 3D, hinges were edges). A hinge is interior iff its coface fan is **closed** (every tetrahedron around it shared by exactly two 4-cells); open-fan hinges are boundary artefacts near 2π and are excluded. The fan test is combinatorial over the *current* top cells, so Pachner-orphaned simplices cannot leak in. Interior/boundary/total counts are reported with every reading.
- **Skeleton built in C++.** `ReggeSolver(st, MatterConfiguration())` materializes tops → tets → triangle hinges; `ChainComplex.fromSpacetime(st)` (C++ BFS from the current tops) completes edges + vertices for the vertex dual volumes. `materializeFacets` is never driven from Python (the #451 corruption lesson).
- **Mass, intensive AND extensive:** `m_shell` (the #352/#451 shell-mean Re-deficit), `m_sum = Σ Re ε`, `m_action = Σ |★h|·Re ε`. The deficit is the complex `lorentzianDeficitAngle`; whether Im is zero is always reported (`max |Im ε|`, count above 1e-12).
- **Radius:** `r_dual = V_dual^(1/4)` over strictly-interior vertices (signature-aware circumcentric `dualVolume`), with the `r_primal = V_primal^(1/4)` cross-check. The **fourth** root is the dimension-correct volume→length map on a 4-complex — #451 used the cube root on its 3-complex.
- **Localization:** participation ratio of |Re ε·★h| vs the equal-volume uniform reference (PR = 1.0), BFS shell profile of curvature relative to the register holes' vertices, mean deficit sign.
- **The r·m table** across all 3 mass × 2 radius definitions, with the definitional spread stated first — the #451 lesson: order-of-magnitude claim only, never one number as THE mass.

## Validation readings (bounded builds: seed 1, `max_restarts=1`, defaults otherwise)

**Canonical `Proton().block()`** (from the @slow test, `ProtonMassRadiusValidationTest`):

- census: **487 interior** (closed-fan) hinges of 673 triangles (186 boundary artefacts excluded); 249 top 4-cells, 93 boundary tetrahedra, **3 register holes** (14 hole vertices)
- masses: `m_shell` (intensive) = **4.702**, `m_sum` = 475.5, `m_action` = 15.27; **Im(deficit) = 0 exactly** over all interior hinges — the relaxed interior stayed all-spacelike
- radii: `r_dual` = V_dual^(1/4) = **0.9425** (V_dual = 0.789 over 21 interior vertices), cross-check `r_primal` = 1.456 (V_primal = 4.5)
- localization: **PR = 0.406** (uniform reference 1.0) → 2.46× more concentrated; **mean Re ε = +0.976** (positive-curvature lump); shell profile: 60% of the curvature weight at shell 0, 40% at shell 1, **100% within one shell of the register holes**; weighted RMS shell radius 0.64
- r·m table (physical anchor m_p·r_p/ħc ≈ 4.0; definitional spread **4.43 .. 693**):

  | | × m_shell | × m_sum | × m_action |
  |---|---|---|---|
  | **r_dual** | **4.43** | 448 | 14.4 |
  | **r_primal** | 6.85 | 693 | 22.2 |

  The intensive shell mass with the dual radius lands at the anchor; per the #451 discipline this stays an order-of-magnitude observation (the spread spans two decades), but the geometric picture — a localized, strictly positive-curvature, all-spacelike lump centered on the three quark holes — is definition-independent.

**Emergent arm `ProtonIngredients().block()`**: _pending — filled from the bounded run below._

## Test plan

- [x] `tests/cobordism/test_emergent_mass_radius.py -m "not slow"` — closed-fan selection on hand-checkable complexes (∂Δ⁵ = the minimal closed S⁴, all 20 triangle fans closed; the star-of-apex 4-ball, exactly the 10 apex triangles interior — hand-counted; single Δ⁴, zero interior), C++-skeleton rule (V_dual == V_primal == 6√5/96 to machine precision, deficit == 2π − 3·arccos(¼) with Im = 0, PR == 1.0 on the uniform complex), fail-loudly without the skeleton, and determinism (independent same-parameter builds and re-reads bit-identical down to per-hinge deficits). **9 passed.**
- [x] `ProtonMassRadiusValidationTest` (@slow) — the bounded canonical `Proton` build (seed 1, max_restarts=1): census consistency, finite interior readings, full r·m table, reader determinism on the built block. **4 passed (26:54 on a heavily loaded box).** Note: the assertable determinism contract is *reader* determinism (bit-identical re-reads of the built block, down to per-hinge deficits) — the build itself is documented FP-thread-variable (`test_proton_cpp_python.py`).
- [x] `pytest tests/cobordism -m "not slow" -n 2` — 371 passed, 1 skipped; 17 failures all in `test_ru_gradient_gpu_python.py`, the known consumer-GPU r_U-gradient failures, pre-existing (this branch is additive-only — two new files); main has since merged #572 which addresses that path, and this branch is rebased onto it.
