### PR TITLE
feat(cobordism): pair-loop dual-basis flavor read on the 3-hole register (#561)

### DIFF
--- a/examples/cobordism/pair_loop_flavor.py
+++ b/examples/cobordism/pair_loop_flavor.py
@@ -1,0 +1,408 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Pair-loop dual-basis flavor read on a 3-hole register (#561, part of #410/#559).
+
+The `docs/theory/cobordism/proton-spin/pair_loop_quarks.tex` experiment (its §7
+"genuinely new, cheap experiment"), implemented literally. On a structure with
+three register holes carrying the color singlet `[1, ω, ω²]`:
+
+1. **Joint read.** One correlated multi-hole read — the SINGLE joint carried
+   representative `ψ = EigenstateSynthesis(st, 3).carriedRepresentative(holes,
+   target)` — never three independent per-hole extractions. The per-hole
+   carried weight is the period `w_h = ∮_[h] ψ` over hole `h`'s boundary
+   3-cycle (the five (-1)^j-signed tetrahedral facets of the removed 4-cell).
+2. **Pair loops, no new geometry.** The loop `γ_ij` encircling holes `i, j` is
+   homologous to `[i] + [j]`, so its period is `w_i + w_j` — formed
+   arithmetically from the per-hole weights. Imposing the singlet
+   (`Σ_h w_h = 0`) gives the Poincaré duality `[γ_ij] = -[k]`: each pair loop
+   is minus the complementary hole (`pair_loops` / `complement_hole`).
+3. **Flavor/taste charge.** The per-hole Dirac–Kähler charge read of the
+   retired `dk_joint_spin.per_hole_flavor` was `DiracKahler.charge(lift(3, ψ))
+   = Σ_c W_c |ψ_c|²` — the metric-weighted norm² (the DK charge density `j⁰_c
+   = W_c |ψ_c|²` summed). #509 retired `DiracKahler`, but the same number needs
+   only the surviving `HodgeLaplacian.weights(3)` (the per-3-cell metric
+   volume weights `W_c`, in the same canonical cell order as
+   `EigenstateSynthesis.cellSimplices()`). Localized to a cycle it is the
+   charge that cycle carries: per hole `q_h = Σ_{c ∈ ∂h} W_c |ψ_c|²`, and per
+   pair loop the weighted norm of ψ on the loop's combined cycle support
+   `∂i ⊔ ∂j`. Because distinct holes have disjoint boundary facets this is
+   exactly `q_i + q_j` (additivity is structural, not an approximation — see
+   the criterion-(b) honesty note below). Equivalently: the symmetric metric
+   operator is assembled with `B₄ = W₃^{1/2} ∂₄ W₄^{-1/2}`, so the CLOSED
+   cochain behind a harmonic row ψ̃ is `χ = √W₃ ψ̃` (`∂₄ᵀχ = 0`), and the
+   weighted norm is the plain norm² of that closed representative on the
+   cycle — the charge lives on the topological object.
+
+## Orientation (the RELABEL lesson)
+
+`cyclePeriods`' raw facet signs orient every hole by its sorted vertex tuple —
+a labeling convention, not physics: a vertex relabeling can flip one hole's
+boundary orientation and silently pin `-t_h`. The label-free orientation is the
+induced one: `ChainComplex.endSignCovector(top_cells, holes)` returns the
+per-hole signs `σ_h = ±1` from the complex's own coherent (facet-sharing)
+orientation, under which every closed form's signed periods obey
+`Σ_h σ_h p_h = 0`. Targets are pinned as `σ_h · t_h` and weights read back as
+`w_h = σ_h ∮_h ψ`, so `w` carries the singlet in the induced orientation. The
+one remaining ambiguity is a single GLOBAL sign (the propagation root), which
+is `-1 ∈ U(1)` on the register — gauge, not physics (see the GAUGE gate).
+
+## Pre-registered criteria (pair_loop_quarks.tex §7; falsifiable)
+
+(a) **Multiplicity 2:1** — the three pair-loop charges cluster as {u, u, d}:
+    two alike, one apart. Quantified by `rho` = (spread of the closest pair) /
+    (its separation from the odd one); `rho < RHO_MAX = 0.5` counts as 2:1.
+(b) **The odd-one-out loop is the diquark loop** — the dual of the spectator
+    (step-2) quark hole. HONESTY NOTE: with the additive pair charge, the
+    charge-odd loop is automatically the dual of the charge-odd hole, so on a
+    fixture (no build history) only the odd loop's IDENTITY is reportable.
+    The falsifiable content of (b) is that the charge-odd hole coincides with
+    the quark the build added last (the two step-1 holes are the diquark) —
+    pass `diquark_pair` (the step-1 hole indices) when the specimen's build
+    history is known; the criterion then passes iff the odd loop IS that pair.
+(c) **GAUGE and RELABEL invariance** — see the gates below.
+
+Failure of (b) on a genuine specimen falsifies the dual-flavor framing; either
+outcome is a finding.
+
+## Gates (post-hoc validation, never a loop condition)
+
+* GAUGE — this readout is built from periods and metric-weighted norms only:
+  no embedding, no per-cell frame exists to SO(4)-rotate (that gate is vacuous
+  here by construction). The register's surviving gauge freedom is the global
+  U(1) phase of the target, `t → e^{iθ} t` — which contains the Z₃ cyclic
+  recolor of the singlet (a cyclic shift of `[1, ω, ω²]` is `ω^{±1}` times it)
+  and the global orientation flip (`-1`). Charges must be invariant and loop
+  periods covariant (`w → e^{iθ} w`).
+* RELABEL — random vertex-id permutation, rebuild the complex from the
+  permuted cells and edge lengths, re-read with the permuted holes: charges,
+  `rho`, and the odd-one-out identity must match, and the oriented loop
+  periods must match up to the global orientation sign.
+
+Both gates hold to machine precision: directly-read quantities (charges,
+periods, duality residuals) reproduce to `GATE_TOL = 1e-12` (observed ~1e-16
+on the fixtures); the derived clustering ratio `rho` divides two small charge
+differences, which amplifies eigensolve roundoff (observed ~1e-13), so tests
+give `d_rho` the looser `RHO_GATE_TOL = 1e-9` while the odd-one-out identity
+must match exactly.
+
+Run `python pair_loop_flavor.py` for the per-fixture table over the synthetic
+b₃ = 3..5 fixtures (+ the real converged_b3_3) in
+`tests/fixtures/composite_spin/`. The read takes the structure's first three
+register holes (`MultiCobordism.emergent_holes(st, 3)[:3]`, the #485 fixture
+convention). `read_structure` is the specimen entry point — point it at a
+built proton block (e.g. `Proton.block()` + `Proton.quark_holes()`) with
+`diquark_pair` from the build history once a 3-hole specimen is available.
+"""
+import cmath
+import json
+import math
+import os
+import random
+
+import numpy as np
+
+import tessera as T
+
+cob = T.cobordism
+
+OMEGA = cmath.exp(2j * math.pi / 3)
+#: The color singlet `[1, ω, ω²]` — the carried register state (Σ = 0).
+SINGLET = (1.0 + 0.0j, OMEGA, OMEGA * OMEGA)
+
+#: The three pair loops as (i, j) hole-index pairs; `γ_ij` encircles holes i, j.
+PAIR_LOOPS = ((0, 1), (0, 2), (1, 2))
+
+#: Criterion (a): the closest pair's spread over its separation from the odd
+#: one must stay below this for a 2:1 (u:u:d) verdict.
+RHO_MAX = 0.5
+
+#: Both gates must reproduce every directly-read quantity to this tolerance.
+GATE_TOL = 1e-12
+
+#: Looser gate tolerance for the derived ratio `rho` (a quotient of two small
+#: charge differences — it amplifies eigensolve roundoff by ~1/separation).
+RHO_GATE_TOL = 1e-9
+
+_FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         "..", "..", "tests", "fixtures", "composite_spin")
+
+
+def complement_hole(pair):
+    """The hole index dual to the pair loop `γ_ij`: `[γ_ij] = -[k]`, the third
+    index. The Poincaré-duality bookkeeping of pair_loop_quarks.tex Eq. (dual)."""
+    (i, j) = pair
+    return 3 - i - j
+
+
+def load_fixture(name, fixtures_dir=_FIXTURES):
+    """A composite_spin fixture as (meta, cells, edges): `cells` the 5-vertex
+    top 4-cells, `edges` {(min_id, max_id): complex squared length}."""
+    with open(os.path.join(fixtures_dir, name)) as f:
+        meta = json.load(f)
+    cells = [list(c) for c in meta["cells"]]
+    edges = {}
+    for key, (re, im) in meta["edges"].items():
+        a, b = (int(x) for x in key.split(","))
+        edges[(a, b)] = complex(re, im)
+    return meta, cells, edges
+
+
+def build_spacetime(cells, edges, perm=None):
+    """The live complex from explicit top cells + edge squared lengths,
+    optionally relabeled by `perm` (vertex id -> vertex id). The skeleton is
+    materialized in C++ (`ReggeSolver`), so the degree-3 cell universe exists."""
+    if perm is not None:
+        cells = [[perm[v] for v in c] for c in cells]
+        edges = {tuple(sorted((perm[a], perm[b]))): z
+                 for (a, b), z in edges.items()}
+    st = T.Spacetime.fromCells(4, cells, 1.0, 0.0)
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        e.setSquaredLength(edges[(a, b) if a < b else (b, a)])
+    T.ReggeSolver(st, T.MatterConfiguration())
+    return st
+
+
+def register_holes(st, count=3):
+    """The structure's first `count` register holes (removed top 4-cells), in
+    `MultiCobordism.emergent_holes` order — the #485 fixture convention."""
+    holes = [tuple(h) for h in cob.MultiCobordism.emergent_holes(st, 3)]
+    if len(holes) < count:
+        raise ValueError(f"need >= {count} register holes, found {len(holes)}")
+    return holes[:count]
+
+
+def induced_orientation_signs(st, holes):
+    """The induced-orientation signs `σ_h = ±1` of the holes' boundary cycles
+    relative to the complex's own coherent orientation
+    (`ChainComplex.endSignCovector`): the label-free orientation under which
+    every closed form's signed periods obey `Σ_h σ_h p_h = 0`. Determined up
+    to one global sign (the propagation root) = `-1 ∈ U(1)` on the register."""
+    tops = [[v.getId() for v in s.getVertices()] for s in st.getTopSimplices()]
+    return list(cob.ChainComplex.endSignCovector(tops, [list(h) for h in holes]))
+
+
+def _facet_indices(cell_index, hole):
+    """Hole `h`'s five boundary tetrahedra as (cochain index, (-1)^j sign)
+    pairs. Facet j of the sorted hole drops vertex v_j and carries (-1)^j —
+    the same boundary-operator convention `cyclePeriods` documents, mirrored
+    here so ψ's periods are read in the operator's own indexing. Facets are
+    matched by vertex SET (never by an imposed order); the physical
+    orientation is supplied separately by `induced_orientation_signs`."""
+    hs = sorted(hole)
+    out = []
+    for j in range(len(hs)):
+        facet = frozenset(hs[:j] + hs[j + 1:])
+        out.append((cell_index[facet], (-1) ** j))
+    return out
+
+
+def joint_read(st, holes, target=SINGLET):
+    """The single correlated multi-hole read. Returns a dict:
+
+    * ``sigma`` — induced-orientation signs of the three holes;
+    * ``psi`` — the joint carried representative of `σ·target` over `holes`;
+    * ``r_u`` — `residualForPeriods` of that pin (~0 = the register carries it);
+    * ``w`` — oriented per-hole carried weights `w_h = σ_h ∮_h ψ` (== target);
+    * ``q`` — per-hole DK-style charges `q_h = Σ_{c ∈ ∂h} W_c |ψ_c|²`;
+    * ``loop_w`` — pair-loop periods `w_i + w_j` in `PAIR_LOOPS` order;
+    * ``loop_q`` — pair-loop charges (weighted norm² of ψ on `∂i ⊔ ∂j`);
+    * ``dual_residual`` — `|w_i + w_j + w_k|` per loop (the `[γ_ij] = -[k]`
+      bookkeeping; ~0 whenever the pinned target sums to zero).
+    """
+    if len(holes) != 3 or len(target) != 3:
+        raise ValueError("the pair-loop read is over exactly 3 holes")
+    es = cob.EigenstateSynthesis(st, 3)
+    cell_index = {frozenset(t): i for i, t in enumerate(es.cellSimplices())}
+    weights = np.asarray(cob.HodgeLaplacian(st).weights(3), float)
+    sigma = induced_orientation_signs(st, holes)
+    hole_lists = [list(h) for h in holes]
+    raw_target = [s * t for s, t in zip(sigma, target)]
+    psi = np.asarray(es.carriedRepresentative(hole_lists, raw_target), complex)
+    r_u = es.residualForPeriods(hole_lists, raw_target)
+
+    facets = [_facet_indices(cell_index, h) for h in holes]
+    w = [sigma[h] * sum(sgn * psi[c] for c, sgn in facets[h]) for h in range(3)]
+    q = [float(sum(weights[c] * abs(psi[c]) ** 2 for c, _ in facets[h]))
+         for h in range(3)]
+
+    loop_w, loop_q, dual_residual = [], [], []
+    for (i, j) in PAIR_LOOPS:
+        loop_w.append(w[i] + w[j])
+        support = {c for c, _ in facets[i]} | {c for c, _ in facets[j]}
+        loop_q.append(float(sum(weights[c] * abs(psi[c]) ** 2 for c in support)))
+        dual_residual.append(abs(w[i] + w[j] + w[complement_hole((i, j))]))
+    return dict(sigma=sigma, psi=psi, r_u=r_u, w=w, q=q,
+                loop_w=loop_w, loop_q=loop_q, dual_residual=dual_residual)
+
+
+def odd_one_out(loop_q):
+    """(odd loop index, rho): the loop whose charge sits farthest from the
+    mean of the other two, and `rho` = |spread of the other two| / |that
+    separation| — small `rho` is a clean 2:1 (u:u:d) clustering."""
+    separations = []
+    for k in range(3):
+        others = [loop_q[i] for i in range(3) if i != k]
+        separations.append(abs(loop_q[k] - (others[0] + others[1]) / 2.0))
+    odd = int(np.argmax(separations))
+    others = [loop_q[i] for i in range(3) if i != odd]
+    rho = (abs(others[0] - others[1]) / separations[odd]
+           if separations[odd] > 0 else float("inf"))
+    return odd, rho
+
+
+def evaluate_criteria(read, diquark_pair=None, rho_max=RHO_MAX):
+    """The pre-registered criteria on a finished `joint_read`.
+
+    (a) `multiplicity_2_1`: `rho < rho_max`.
+    (b) `odd_is_diquark_loop`: only decidable with `diquark_pair` (the step-1
+        hole-index pair from the specimen's build history) — True iff the
+        charge-odd loop is exactly that pair; None on fixtures (no history).
+    Duality bookkeeping and the gates are (2)/(c), reported alongside.
+    """
+    odd, rho = odd_one_out(read["loop_q"])
+    verdict = dict(odd_loop=PAIR_LOOPS[odd],
+                   dual_hole=complement_hole(PAIR_LOOPS[odd]),
+                   rho=rho,
+                   multiplicity_2_1=bool(rho < rho_max),
+                   odd_is_diquark_loop=None)
+    if diquark_pair is not None:
+        verdict["odd_is_diquark_loop"] = (
+            tuple(sorted(diquark_pair)) == PAIR_LOOPS[odd])
+    return verdict
+
+
+def read_structure(st, holes=None, target=SINGLET, diquark_pair=None):
+    """The specimen entry point: `joint_read` + `evaluate_criteria` on a live
+    complex (e.g. a built proton block: `st = Proton.block()`, holes from
+    `Proton.quark_holes()`, `diquark_pair` from the build's step-1 history)."""
+    holes = register_holes(st) if holes is None else [tuple(h) for h in holes]
+    read = joint_read(st, holes, target)
+    return read, evaluate_criteria(read, diquark_pair=diquark_pair)
+
+
+# ---------------------------------------------------------------------------
+# The gates — post-hoc validation, never a loop condition.
+# ---------------------------------------------------------------------------
+
+def gauge_gate(st, holes, base, theta=2.0 * math.pi * 0.371, target=SINGLET):
+    """GAUGE: re-read with the target rotated by the global U(1) phase
+    `e^{iθ}`. Returns the residual dict — every entry must be < `GATE_TOL`:
+    charges invariant, loop periods covariant, duality/oddity unchanged."""
+    phase = cmath.exp(1j * theta)
+    gauged = joint_read(st, holes, [phase * t for t in target])
+    odd0, rho0 = odd_one_out(base["loop_q"])
+    odd1, rho1 = odd_one_out(gauged["loop_q"])
+    return {
+        "d_charge": max(abs(a - b) for a, b in zip(gauged["q"], base["q"])),
+        "d_loop_charge": max(abs(a - b)
+                             for a, b in zip(gauged["loop_q"], base["loop_q"])),
+        "d_loop_period": max(abs(a - phase * b)
+                             for a, b in zip(gauged["loop_w"], base["loop_w"])),
+        "d_rho": abs(rho1 - rho0),
+        "d_odd": float(odd1 != odd0),
+    }
+
+
+def relabel_gate(cells, edges, holes, base, seed=3, target=SINGLET):
+    """RELABEL: random vertex-id permutation, rebuild, re-read with the
+    permuted holes. Returns the residual dict — every entry must be
+    < `GATE_TOL`. Oriented loop periods are compared up to the one global
+    orientation sign (the `endSignCovector` propagation root, `-1 ∈ U(1)`)."""
+    all_vertices = sorted({v for c in cells for v in c})
+    shuffled = all_vertices[:]
+    random.Random(seed).shuffle(shuffled)
+    perm = dict(zip(all_vertices, shuffled))
+    st2 = build_spacetime(cells, edges, perm=perm)
+    holes2 = [tuple(perm[v] for v in h) for h in holes]
+    relabeled = joint_read(st2, holes2, target)
+    flip = -1.0 if (abs(relabeled["w"][0] + base["w"][0])
+                    < abs(relabeled["w"][0] - base["w"][0])) else 1.0
+    odd0, rho0 = odd_one_out(base["loop_q"])
+    odd1, rho1 = odd_one_out(relabeled["loop_q"])
+    return {
+        "d_charge": max(abs(a - b) for a, b in zip(relabeled["q"], base["q"])),
+        "d_loop_charge": max(abs(a - b) for a, b in
+                             zip(relabeled["loop_q"], base["loop_q"])),
+        "d_loop_period": max(abs(a - flip * b) for a, b in
+                             zip(relabeled["loop_w"], base["loop_w"])),
+        "d_rho": abs(rho1 - rho0),
+        "d_odd": float(odd1 != odd0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# The fixture battery.
+# ---------------------------------------------------------------------------
+
+def read_fixture(name, fixtures_dir=_FIXTURES, relabel_seed=3):
+    """One full row: joint read + criteria + both gates on a fixture."""
+    meta, cells, edges = load_fixture(name, fixtures_dir)
+    st = build_spacetime(cells, edges)
+    holes = register_holes(st)
+    read = joint_read(st, holes)
+    verdict = evaluate_criteria(read)
+    gauge = gauge_gate(st, holes, read)
+    relabel = relabel_gate(cells, edges, holes, read, seed=relabel_seed)
+    return dict(name=name, b3=meta["b3"], kind=meta.get("kind", "?"),
+                holes=holes, read=read, verdict=verdict,
+                gauge=gauge, relabel=relabel)
+
+
+def main():
+    print("Pair-loop dual-basis flavor read (#561) — pair_loop_quarks.tex §7")
+    print(f"target singlet [1, ω, ω²]; loops {PAIR_LOOPS} dual to holes "
+          f"{[complement_hole(p) for p in PAIR_LOOPS]}; rho_max={RHO_MAX}, "
+          f"gate tol={GATE_TOL:.0e}\n")
+    names = ["synthetic_b3_3.json", "synthetic_b3_4.json",
+             "synthetic_b3_5.json", "converged_b3_3.json"]
+    rows = [read_fixture(n) for n in names]
+
+    head = (f"{'fixture':<22} {'b3':>2} {'r_U':>8} "
+            f"{'q(γ01)':>9} {'q(γ02)':>9} {'q(γ12)':>9} "
+            f"{'odd':>5} {'dual':>4} {'rho':>6} {'2:1':>4} "
+            f"{'dual_res':>9} {'gauge':>8} {'relabel':>8}")
+    print(head)
+    print("-" * len(head))
+    for r in rows:
+        v, rd = r["verdict"], r["read"]
+        gate_g = max(r["gauge"].values())
+        gate_r = max(r["relabel"].values())
+        print(f"{r['name']:<22} {r['b3']:>2} {rd['r_u']:>8.1e} "
+              f"{rd['loop_q'][0]:>9.5f} {rd['loop_q'][1]:>9.5f} "
+              f"{rd['loop_q'][2]:>9.5f} "
+              f"{'γ' + str(v['odd_loop']):>5} {v['dual_hole']:>4} "
+              f"{v['rho']:>6.3f} {str(v['multiplicity_2_1']):>4} "
+              f"{max(rd['dual_residual']):>9.1e} {gate_g:>8.1e} {gate_r:>8.1e}")
+
+    print("\nper-hole detail (oriented weights w_h == the pinned singlet; "
+          "charges q_h):")
+    for r in rows:
+        rd = r["read"]
+        w_str = ", ".join(f"{w:.3f}" for w in rd["w"])
+        q_str = ", ".join(f"{q:.5f}" for q in rd["q"])
+        print(f"  {r['name']:<22} σ={rd['sigma']}  w=[{w_str}]  q=[{q_str}]")
+
+    print("\nfindings:")
+    print("  * duality bookkeeping [γ_ij] = -[k]: |w_i + w_j + w_k| ~ 1e-16 "
+          "on every fixture (exact under the pinned singlet).")
+    print("  * GAUGE and RELABEL hold to machine precision — the read is a "
+          "label-free, gauge-clean observable (criterion c).")
+    synth = [r for r in rows if r["kind"] == "synthetic"]
+    conv = [r for r in rows if r["kind"] != "synthetic"]
+    ok = sum(r["verdict"]["multiplicity_2_1"] for r in synth)
+    rhos = ", ".join(f"{r['verdict']['rho']:.3f}" for r in synth)
+    print(f"  * multiplicity 2:1 (criterion a): {ok}/{len(synth)} synthetic "
+          f"fixtures cluster u:u:d (rho {rhos}).")
+    for r in conv:
+        print(f"  * {r['name']}: rho={r['verdict']['rho']:.3f} — the relaxed "
+              "geometry is near-degenerate across the three loops; the "
+              "clustering verdict needs a genuine built specimen.")
+    print("  * criterion (b) (odd loop == the diquark loop) needs the build's "
+          "step-1 pair: fixtures carry no build history, so it is reported as "
+          "the odd loop's identity only. Run `read_structure(st, holes, "
+          "diquark_pair=...)` on the first 3-hole specimen.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cobordism/test_pair_loop_flavor.py
+++ b/tests/cobordism/test_pair_loop_flavor.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Pair-loop dual-basis flavor read (#561) — duality bookkeeping, gates, determinism.
+
+Covers `examples/cobordism/pair_loop_flavor.py` on the controlled
+`tests/fixtures/composite_spin` fixtures:
+
+  * the Poincaré-duality bookkeeping — pair-loop index ↔ complementary hole,
+    `w_i + w_j = -w_k` under the pinned singlet, and the label-free
+    closed-form relation `Σ_h σ_h p_h = 0` behind the induced-orientation
+    signs (`ChainComplex.endSignCovector`);
+  * the DK-style charge — positive, and structurally additive over a pair
+    loop's disjoint cycle support;
+  * the GAUGE gate (global U(1) target phase: charges invariant, loop periods
+    covariant) and the RELABEL gate (random vertex-id permutation, rebuild,
+    re-read: everything must match, loop periods up to the one global
+    orientation sign) on a fixture;
+  * determinism — two independent rebuild+read passes agree exactly.
+
+Everything here runs on the smallest fixture (74 top cells; a read is ~0.3 s),
+so no `slow` marks are needed; the full fixture battery lives in the example's
+`__main__`.
+"""
+import cmath
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class PairLoopFlavorBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.plf = _load("pair_loop_flavor")
+        cls.meta, cls.cells, cls.edges = cls.plf.load_fixture("synthetic_b3_3.json")
+        cls.st = cls.plf.build_spacetime(cls.cells, cls.edges)
+        cls.holes = cls.plf.register_holes(cls.st)
+        cls.read = cls.plf.joint_read(cls.st, cls.holes)
+
+
+class TestDualityBookkeeping(PairLoopFlavorBase):
+    def test_pair_loop_index_maps_to_complementary_hole(self):
+        # [γ_ij] = -[k]: the loop over (i, j) is dual to the third hole.
+        plf = self.plf
+        self.assertEqual(plf.PAIR_LOOPS, ((0, 1), (0, 2), (1, 2)))
+        self.assertEqual([plf.complement_hole(p) for p in plf.PAIR_LOOPS],
+                         [2, 1, 0])
+        for pair in plf.PAIR_LOOPS:
+            k = plf.complement_hole(pair)
+            self.assertEqual(set(pair) | {k}, {0, 1, 2})
+            self.assertNotIn(k, pair)
+
+    def test_oriented_weights_pin_the_singlet(self):
+        # The joint carried representative's oriented per-hole periods are the
+        # pinned singlet exactly (the leak construction), and the pin carries.
+        for w, t in zip(self.read["w"], self.plf.SINGLET):
+            self.assertLess(abs(w - t), 1e-12)
+        self.assertLess(self.read["r_u"], 1e-20)
+
+    def test_pair_loop_period_is_minus_the_complementary_weight(self):
+        # w_i + w_j = -w_k, loop by loop, and the recorded duality residual.
+        read, plf = self.read, self.plf
+        for loop_idx, pair in enumerate(plf.PAIR_LOOPS):
+            k = plf.complement_hole(pair)
+            self.assertLess(abs(read["loop_w"][loop_idx] + read["w"][k]), 1e-12)
+            self.assertLess(read["dual_residual"][loop_idx], 1e-12)
+
+    def test_induced_signs_give_the_closed_form_relation(self):
+        # The label-free content of endSignCovector: a CLOSED 3-cochain's
+        # signed periods over all of the structure's hole cycles sum to zero
+        # (Σ_h σ_h p_h = 0 — the holes' induced boundaries cancel against the
+        # present top cells' coherent boundary). The symmetric metric operator
+        # is assembled with B₄ = W₃^{1/2} ∂₄ W₄^{-1/2}, so a kernel row ψ̃ of
+        # harmonicMatrix(3) satisfies ∂₄ᵀ(√W₃ ψ̃) = 0: the closed cochain is
+        # χ = √W₃ ψ̃ (ψ̃ itself is not closed, and its raw signed periods do
+        # NOT cancel — the register's period pin is a convention, not Stokes).
+        all_holes = [list(h) for h in cob.MultiCobordism.emergent_holes(self.st, 3)]
+        sigma = self.plf.induced_orientation_signs(self.st, all_holes)
+        es = cob.EigenstateSynthesis(self.st, 3)
+        cell_index = {frozenset(t): i for i, t in enumerate(es.cellSimplices())}
+        hl = cob.HodgeLaplacian(self.st)
+        sqrt_w = np.sqrt(np.asarray(hl.weights(3), float))
+        harmonics = np.asarray(hl.harmonicMatrix(3), complex)
+        harmonics = harmonics.reshape(-1, len(sqrt_w))
+        self.assertGreater(harmonics.shape[0], 0)
+
+        def period(vec, hole):
+            pairs = self.plf._facet_indices(cell_index, hole)
+            return sum(sign * vec[c] for c, sign in pairs)
+
+        for row in harmonics:
+            chi = sqrt_w * row
+            signed_sum = sum(s * period(chi, h)
+                             for s, h in zip(sigma, all_holes))
+            self.assertLess(abs(signed_sum), 1e-12)
+
+    def test_charges_positive_and_additive_over_the_pair_support(self):
+        # q_h > 0 (a weighted norm²), and the pair-loop charge over the
+        # disjoint union of the two boundary cycles is exactly q_i + q_j.
+        read, plf = self.read, self.plf
+        for q in read["q"]:
+            self.assertGreater(q, 0.0)
+        for loop_idx, (i, j) in enumerate(plf.PAIR_LOOPS):
+            self.assertAlmostEqual(read["loop_q"][loop_idx],
+                                   read["q"][i] + read["q"][j], places=15)
+
+
+class TestCriteria(PairLoopFlavorBase):
+    def test_odd_one_out_on_a_clean_triple(self):
+        odd, rho = self.plf.odd_one_out([1.0, 1.01, 2.0])
+        self.assertEqual(odd, 2)
+        self.assertLess(rho, 0.02)
+
+    def test_evaluate_criteria_verdict_shape(self):
+        verdict = self.plf.evaluate_criteria(self.read)
+        self.assertIn(verdict["odd_loop"], self.plf.PAIR_LOOPS)
+        self.assertEqual(verdict["dual_hole"],
+                         self.plf.complement_hole(verdict["odd_loop"]))
+        self.assertIsInstance(verdict["multiplicity_2_1"], bool)
+        # fixtures carry no build history: criterion (b) must stay undecided
+        self.assertIsNone(verdict["odd_is_diquark_loop"])
+
+    def test_criterion_b_decides_with_build_history(self):
+        # With a supplied step-1 diquark pair the criterion becomes decidable:
+        # True iff the charge-odd loop is exactly that pair.
+        odd_pair = self.plf.evaluate_criteria(self.read)["odd_loop"]
+        other = next(p for p in self.plf.PAIR_LOOPS if p != odd_pair)
+        hit = self.plf.evaluate_criteria(self.read, diquark_pair=odd_pair)
+        miss = self.plf.evaluate_criteria(self.read, diquark_pair=other)
+        self.assertTrue(hit["odd_is_diquark_loop"])
+        self.assertFalse(miss["odd_is_diquark_loop"])
+
+
+class TestGates(PairLoopFlavorBase):
+    def _assert_gate(self, residuals):
+        for key, value in residuals.items():
+            tol = (self.plf.RHO_GATE_TOL if key == "d_rho"
+                   else self.plf.GATE_TOL)
+            self.assertLess(value, tol, f"{key} = {value:.3e} exceeds {tol:.0e}")
+
+    def test_gauge_gate(self):
+        self._assert_gate(self.plf.gauge_gate(self.st, self.holes, self.read))
+
+    def test_gauge_gate_covers_the_cyclic_recolor(self):
+        # A cyclic recolor of the singlet assignment IS a global U(1) phase:
+        # shifting [1, ω, ω²] by one slot equals ω² · [1, ω, ω²], so the
+        # charges must be blind to which hole carries which color.
+        t = list(self.plf.SINGLET)
+        shifted = [t[2], t[0], t[1]]
+        expected = [t[i] * (self.plf.OMEGA ** 2) for i in range(3)]
+        for a, b in zip(shifted, expected):
+            self.assertLess(abs(a - b), 1e-15)
+        recolored = self.plf.joint_read(self.st, self.holes, shifted)
+        for a, b in zip(recolored["q"], self.read["q"]):
+            self.assertLess(abs(a - b), self.plf.GATE_TOL)
+
+    def test_relabel_gate_two_permutations(self):
+        for seed in (3, 11):
+            with self.subTest(seed=seed):
+                self._assert_gate(self.plf.relabel_gate(
+                    self.cells, self.edges, self.holes, self.read, seed=seed))
+
+    def test_determinism(self):
+        st2 = self.plf.build_spacetime(self.cells, self.edges)
+        again = self.plf.joint_read(st2, self.plf.register_holes(st2))
+        self.assertEqual(again["sigma"], self.read["sigma"])
+        for key in ("w", "q", "loop_w", "loop_q", "dual_residual"):
+            for a, b in zip(again[key], self.read[key]):
+                self.assertLess(abs(a - b), 1e-15)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #561. Part of #559 (P1).

## Summary

The `pair_loop_quarks.tex` §7 experiment, implemented literally in the examples lane (`examples/cobordism/pair_loop_flavor.py`) — the diquark as a *read*, not a target:

1. **Joint read** — the per-hole carried weights `w_h = ∮_[h] ψ` come from the SINGLE joint carried representative `EigenstateSynthesis(st, 3).carriedRepresentative(holes, [1, ω, ω²])` (the correlated multi-hole read; never three independent extractions).
2. **Pair loops, no new geometry** — the three dual-basis pair-loop periods are formed arithmetically, `∮_{γ_ij} ψ = w_i + w_j`, with the Poincaré duality `[γ_ij] = −[k]` as bookkeeping (`complement_hole`).
3. **DK taste on each combination** — #509 retired `DiracKahler`, but its charge was `⟨Φ,Φ⟩_W = Σ_c W_c|Φ_c|²`, a metric-weighted norm²; the identical number needs only the surviving `HodgeLaplacian.weights(3)` (same canonical cell order as `cellSimplices()`). Per pair loop: the weighted norm² of ψ on the loop's combined cycle support `∂i ⊔ ∂j` (disjoint boundaries ⇒ structurally `q_i + q_j`). Equivalently the plain norm² of the *closed* cochain `χ = √W₃·ψ̃` on the cycle (`B₄ = W₃^{1/2}∂₄W₄^{-1/2}` ⇒ `∂₄ᵀχ = 0`) — the charge lives on the topological object.

**The correctness core found on the way:** `cyclePeriods`' raw facet signs orient every hole by its *sorted vertex tuple* — a labeling convention. A random relabeling flips hole orientations and silently pins `−t_h`: charges moved ~1e−3 and the odd-one-out **flipped** on `synthetic_b3_5`. The fix is the label-free induced orientation `ChainComplex.endSignCovector` (per the register sign convention): pin `σ_h·t_h`, read back `w_h = σ_h ∮_h ψ`. The one global-sign ambiguity is `−1 ∈ U(1)` on the register — gauge, not physics. With σ in place both gates hold at machine precision.

## Fixture table (`python examples/cobordism/pair_loop_flavor.py`)

```
fixture                b3      r_U    q(γ01)    q(γ02)    q(γ12)   odd dual    rho  2:1  dual_res    gauge  relabel
-------------------------------------------------------------------------------------------------------------------
synthetic_b3_3.json     3  2.0e-27   0.06054   0.05971   0.06063 γ(0, 2)    1  0.103 True   2.5e-16  8.2e-16  1.1e-13
synthetic_b3_4.json     4  2.8e-27   0.05726   0.05971   0.06074 γ(0, 1)    2  0.348 True   3.5e-16  3.9e-15  2.0e-14
synthetic_b3_5.json     5  2.7e-27   0.05542   0.05722   0.05772 γ(0, 1)    2  0.248 True   4.6e-16  2.6e-15  2.5e-14
converged_b3_3.json     3  3.1e-27   0.05153   0.05165   0.05177 γ(0, 1)    2  0.665 False   5.0e-16  2.5e-14  6.4e-14
```

(`odd` = charge-odd loop, `dual` = its complementary hole, `rho` = cluster spread / odd separation with `rho < 0.5` ⇒ 2:1, `dual_res` = max `|w_i+w_j+w_k|`, `gauge`/`relabel` = max gate residual; gate tol 1e−12 on read quantities, 1e−9 on the derived `rho`.)

## Pre-registered criteria

- **(a) multiplicity 2:1** — 3/3 synthetic b₃=3..5 fixtures cluster u:u:d (rho 0.103 / 0.348 / 0.248). The real `converged_b3_3` is near-degenerate (rho 0.665, charges within 0.5%): relaxed geometry symmetrizes the three loops — an honest instrument reading, not a pass.
- **(b) odd-one-out == the diquark loop** — with the additive pair charge the charge-odd loop is *automatically* the dual of the charge-odd hole, so (b)'s falsifiable content is that the charge-odd hole coincides with the build's step-2 spectator quark. Fixtures carry no build history ⇒ reported as identity only (`odd_is_diquark_loop = None`); `read_structure(st, holes, diquark_pair=...)` is the specimen entry point.
- **(c) GAUGE + RELABEL** — GAUGE: this readout uses periods and metric-weighted norms only (no embedding exists to SO(4)-rotate — that half is vacuous by construction); the register's surviving gauge freedom, the global U(1) target phase, *contains* the Z₃ cyclic recolor of the singlet (a cyclic shift of `[1, ω, ω²]` is `ω^{±1}` times it) and the orientation flip. Charges invariant to ~1e−17, loop periods covariant to ~3e−16. RELABEL: random vertex-id permutation → rebuild → re-read with permuted holes; charges ~1e−16, oriented loop periods match up to the global sign to ~5e−16, odd-one-out and rho exactly stable (3 permutation seeds probed, 2 in the tests).

## Draft status — the specimen half

Kept as **draft**: the specimen read (criterion (b) proper) is blocked on the first 3-hole specimen with known step-1 build history (#560's joint node, or the campaign's first b₃=3 basin — #562). Fixtures suffice for validating the machinery per the ticket; `read_structure` is ready to point at `Proton.block()` / `quark_holes()` + `diquark_pair` when the specimen lands.

## Test plan

- [x] `tests/cobordism/test_pair_loop_flavor.py` — 12 tests, <1 s (no `slow` marks needed):
  - duality bookkeeping: pair-loop index ↔ complementary hole, oriented weights pin the singlet exactly (leak construction), `w_i + w_j = −w_k` per loop, and the label-free closed-form relation `Σ_h σ_h p_h = 0` over ALL hole cycles for `χ = √W₃·ψ̃` (5e−15; the raw rows fail it at 3.6e−3 — the regression the σ fix guards);
  - charges positive + structurally additive over the disjoint pair support;
  - GAUGE gate incl. the explicit cyclic-recolor identity; RELABEL gate on two permutation seeds; determinism (two rebuild+read passes byte-agree);
  - criteria surface: odd-one-out on a clean triple, verdict shape, and (b) deciding True/False once `diquark_pair` is supplied.
- [x] Neighboring fast cobordism suites green (see PR checks / report).
- [x] Example runs end-to-end on the b₃=3..5 synthetic fixtures + `converged_b3_3` (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
