### PR TITLE
feat(cobordism): campaign hardening — frozen scripts, geometry dumps, attempt analyzer

### DIFF
--- a/examples/cobordism/proton_campaign/README.md
+++ b/examples/cobordism/proton_campaign/README.md
@@ -1,0 +1,88 @@
+# Proton campaign harness (#562)
+
+The inputs-only sweep hunting a fully emergent proton: a `b₃ = 3` basin of the
+two-step `ProtonIngredients` build that carries the color singlet `{1, ω, ω²}`
+with nothing pinned downstream. Sixteen detached single-threaded workers run
+attempts to genuine stationarity (stage-2 `relTol = 1e-9` + persistence passes)
+until the calendar deadline, recording one verdict line per attempt, per-chunk
+progress, animations for the interesting attempts, and — via the keep-policy
+below — a drift-proof geometry dump of each interesting final complex.
+
+These are the **canonical copies** of the campaign scripts. The live campaign
+executes untracked copies in the campaign worktree's `.overnight/` directory;
+this directory freezes those bytes so the exact drive that produced any verdict
+stays recoverable forever. When the two diverge, the running generation defines
+the physics until its workers exit; deploys land at generation boundaries only.
+
+## Files
+
+- `worker.py` — one attempt per base seed: build `ProtonIngredients` nodes,
+  init → evolve → stage-2 to stationarity per node, persistence passes on the
+  formation node, verdict + progress records, GIF + geometry-dump keep-policy.
+- `renderer.py` — per-attempt animation recorder (reuses the emergent-proton
+  panels; frames at real pass/chunk boundaries).
+- `aggregate.py` — sweep statistics over the verdict files.
+- `launch_campaign.sh` — the supervisor: waits for prior-generation workers to
+  drain, launches 16 single-threaded workers against the persisted deadline
+  file. Run it under `systemd-run --user` so the unit (and the workers' cgroup)
+  survives the launching session.
+- `analyze_attempt.py` — out-of-band rebuild + characterization of a recorded
+  attempt: exact replay from its seed, verification against the recorded
+  verdict (and geometry dump when present), then the ready observables.
+
+## Exact replay (the rebuild contract)
+
+Attempts are **bit-for-bit reproducible** from their recorded `base_seed`: a
+fresh single-threaded process running the same scripts against the same
+engine build reproduces the recorded snapshots exactly (verified: replayed
+campaign snapshots match `F` to all digits, plus `gradN2`, `rU`, `holes`,
+`b3`, `cells`, `edges`). The contract requires:
+
+- the campaign worktree's editable engine build (its `.venv-build` python);
+- single-threaded numerics: `OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+  MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1`;
+- the generation's own `worker.py` drive (this directory, for the generation
+  recorded in the provenance manifest).
+
+The geometry dumps exist so that an interesting find survives even a broken
+contract: they record the final complex itself, not a recipe for rebuilding it.
+
+## Provenance manifest
+
+Generation boundaries — a verdict replays only under the scripts of the
+generation that recorded it:
+
+| generation | window (MDT) | replayable | notes |
+|---|---|---|---|
+| pre-campaign | 2026-07-01 evening → 2026-07-02 08:57 | **no** (superseded scripts) | 16 verdicts: 15× b₃=1, 1× b₃=2; killed by the box crash |
+| campaign | launched 2026-07-02 06:44 (workers from 09:21) | **yes** (these bytes) | deadline 2026-08-01 06:44 MDT |
+
+sha256 of the frozen (= running campaign generation) scripts:
+
+```
+3641c06ca525b0cf43aa11cea42b092d709e531683c30fa64b1f63120bb522cf  worker.py   (as launched; before the geometry-dump addition)
+9d75f11d1d79103e50660b1ae362db623ce8c4d7dc6ba015a1c8aaf7e4e8929c  renderer.py
+198c263707aca4eeffffcbd2946378befbe3274824abc1b06a9599899994d13f  aggregate.py
+73474a87d000afddefee589ed39ce0156de00b836764e72afadb3793f0deec55  launch_campaign.sh
+```
+
+The geometry-dump addition to `worker.py` executes only after an attempt
+completes (it reads the final state; the drive and its RNG draws are
+untouched), so it does not open a new replay generation: seeds recorded by the
+as-launched bytes replay identically under the dump-enabled bytes.
+
+## Analyzing an attempt
+
+```bash
+cd <campaign worktree>
+OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
+.venv-build/bin/python <this dir>/analyze_attempt.py \
+    --seed <base_seed> --run-dir .overnight
+```
+
+The analyzer replays the attempt (single-threaded; expect the attempt's
+original wall time), verifies the final state against the recorded verdict
+line and the geometry dump if one exists, runs the ready observables, and
+writes `analysis_seed_<base_seed>.json` into the run directory. Use
+`--skip-replay` to run the dump-only observables (no engine rebuild) on a
+recorded geometry dump.

--- a/examples/cobordism/proton_campaign/README.md
+++ b/examples/cobordism/proton_campaign/README.md
@@ -30,46 +30,48 @@ the physics until its workers exit; deploys land at generation boundaries only.
   attempt: exact replay from its seed, verification against the recorded
   verdict (and geometry dump when present), then the ready observables.
 
-## Exact replay (the rebuild contract)
+## The rebuild contract: dumps, not replays
 
-Attempts are **bit-for-bit reproducible** from their recorded `base_seed`: a
-fresh single-threaded process running the same scripts against the same
-engine build reproduces the recorded snapshots exactly (verified: replayed
-campaign snapshots match `F` to all digits, plus `gradN2`, `rU`, `holes`,
-`b3`, `cells`, `edges`). The contract requires:
+The engine build is **not process-deterministic**: identical fresh single-
+threaded processes running the identical node construction and drive on the
+same seed can produce different complexes (measured: same seed, same calls,
+`F=272.5`/78 cells vs `F=81.0`/43 cells). Occasional bit-exact replays happen
+on stable paths, but they are luck, not a contract. A `base_seed` therefore
+**labels** an attempt; it cannot reproduce one.
 
-- the campaign worktree's editable engine build (its `.venv-build` python);
-- single-threaded numerics: `OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
-  MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1`;
-- the generation's own `worker.py` drive (this directory, for the generation
-  recorded in the provenance manifest).
-
-The geometry dumps exist so that an interesting find survives even a broken
-contract: they record the final complex itself, not a recipe for rebuilding it.
+The **geometry dump is the attempt's only faithful record**: `worker.py`
+writes one per attempt (`geometry/seed_<base>_geometry.json` — top cells in
+intrinsic vertex order, every edge's complex ℓ², per-vertex times), canonically
+ordered so the same state always serializes to the same bytes, written only
+after the attempt completes. `Spacetime.fromCells` rebuilds the exact final
+state from it in seconds; `analyze_attempt.py --replay` remains available as a
+fresh *sample* of a seed's attempt distribution (its verdict comparison is a
+divergence measurement, not a check).
 
 ## Provenance manifest
 
-Generation boundaries — a verdict replays only under the scripts of the
-generation that recorded it:
+Generation boundaries — which scripts *drove* which verdicts (the drive
+defines the physics of the recorded statistics; it cannot reproduce
+individual attempts, see above):
 
-| generation | window (MDT) | replayable | notes |
-|---|---|---|---|
-| pre-campaign | 2026-07-01 evening → 2026-07-02 08:57 | **no** (superseded scripts) | 16 verdicts: 15× b₃=1, 1× b₃=2; killed by the box crash |
-| campaign | launched 2026-07-02 06:44 (workers from 09:21) | **yes** (these bytes) | deadline 2026-08-01 06:44 MDT |
+| generation | window (MDT) | notes |
+|---|---|---|
+| pre-campaign | 2026-07-01 evening → 2026-07-02 08:57 | 16 verdicts: 15× b₃=1, 1× b₃=2; superseded scripts; killed by the box crash |
+| campaign | launched 2026-07-02 06:44 (workers from 09:21) | two-step drive, dump-less at launch; deadline 2026-08-01 06:44 MDT |
 
-sha256 of the frozen (= running campaign generation) scripts:
+sha256 of the campaign generation's scripts as launched:
 
 ```
-3641c06ca525b0cf43aa11cea42b092d709e531683c30fa64b1f63120bb522cf  worker.py   (as launched; before the geometry-dump addition)
+3641c06ca525b0cf43aa11cea42b092d709e531683c30fa64b1f63120bb522cf  worker.py   (as launched; before dumps-per-attempt)
 9d75f11d1d79103e50660b1ae362db623ce8c4d7dc6ba015a1c8aaf7e4e8929c  renderer.py
 198c263707aca4eeffffcbd2946378befbe3274824abc1b06a9599899994d13f  aggregate.py
 73474a87d000afddefee589ed39ce0156de00b836764e72afadb3793f0deec55  launch_campaign.sh
 ```
 
-The geometry-dump addition to `worker.py` executes only after an attempt
+The dumps-per-attempt addition to `worker.py` executes only after an attempt
 completes (it reads the final state; the drive and its RNG draws are
-untouched), so it does not open a new replay generation: seeds recorded by the
-as-launched bytes replay identically under the dump-enabled bytes.
+untouched), so deploying it mid-generation changes no attempt physics — it
+only starts recording what was previously lost.
 
 ## Analyzing an attempt
 
@@ -80,9 +82,10 @@ OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
     --seed <base_seed> --run-dir .overnight
 ```
 
-The analyzer replays the attempt (single-threaded; expect the attempt's
-original wall time), verifies the final state against the recorded verdict
-line and the geometry dump if one exists, runs the ready observables, and
-writes `analysis_seed_<base_seed>.json` into the run directory. Use
-`--skip-replay` to run the dump-only observables (no engine rebuild) on a
-recorded geometry dump.
+The analyzer rebuilds the attempt's final state from its geometry dump
+(seconds), verifies it against the dump's recorded metadata, runs the ready
+observables (color, geometry/curvature in both deficit channels, spectral
+dimension, deficit-angle Wilson loops), and writes
+`analysis_seed_<base_seed>.json` into the run directory. `--replay` re-runs
+the attempt with the frozen drive instead — a fresh sample of the seed's
+attempt distribution whose verdict comparison measures divergence.

--- a/examples/cobordism/proton_campaign/aggregate.py
+++ b/examples/cobordism/proton_campaign/aggregate.py
@@ -1,0 +1,59 @@
+# Throwaway overnight sweep aggregator (#555): summarize the workers' JSONL records.
+import glob
+import json
+import statistics
+import sys
+from collections import Counter
+
+
+def main():
+    paths = sys.argv[1:] or glob.glob(
+        "/home/andrew/feat-proton-ingredients/.overnight/worker_*.jsonl")
+    paths = [p for p in paths if ".progress." not in p]   # verdicts only, not the trend stream
+    records = []
+    for path in sorted(paths):
+        with open(path) as f:
+            records += [json.loads(line) for line in f if line.strip()]
+    ok = [r for r in records if "error" not in r]
+    errors = [r for r in records if "error" in r]
+    print(f"attempts: {len(records)}  (clean {len(ok)}, errors {len(errors)})")
+    if errors:
+        print(f"  first error: {errors[0]['error']!r} (worker {errors[0]['worker']})")
+    if not ok:
+        return
+    converged = [r for r in ok if r["converged"]]
+    stationary = [r for r in ok if r["stationary"]]
+    persistent = [r for r in ok if r["persistent"]]
+    print(f"converged (stationary AND persistent): {len(converged)}")
+    for r in converged[:20]:
+        print(f"  seed {r['base_seed']}: holes={r['holes']} betti={r['betti']} "
+              f"singlet={r['singlet']:.4g} F={r['F']:.4g} edges={r['edges']}")
+    print(f"stationary: {len(stationary)}/{len(ok)}   persistent: "
+          f"{len(persistent)}/{len(ok)}")
+    print(f"holes histogram: {dict(sorted(Counter(r['holes'] for r in ok).items()))}")
+    print(f"b3 histogram:    "
+          f"{dict(sorted(Counter(r['betti'][3] for r in ok if len(r['betti']) > 3).items()))}")
+    singlets = [r["singlet"] for r in ok]
+    print(f"singlet diagnostic: min={min(singlets):.4g}  "
+          f"median={statistics.median(singlets):.4g}  max={max(singlets):.4g}")
+    fs = [r["F"] for r in ok]
+    print(f"final F: min={min(fs):.4g}  median={statistics.median(fs):.4g}  "
+          f"max={max(fs):.4g}")
+    print(f"cells: median={statistics.median(r['cells'] for r in ok):.0f}  "
+          f"max={max(r['cells'] for r in ok)}   edges: "
+          f"median={statistics.median(r['edges'] for r in ok):.0f}  "
+          f"max={max(r['edges'] for r in ok)}")
+    causal = [r for r in ok if r["im_max"] > 0 or r["re_min"] < 0]
+    print(f"attempts with ANY causal content (Im≠0 or Re<0): {len(causal)}")
+    best = min(ok, key=lambda r: r["singlet"])
+    print(f"lowest singlet diagnostic: seed {best['base_seed']} -> "
+          f"singlet={best['singlet']:.4g} holes={best['holes']} betti={best['betti']} "
+          f"F={best['F']:.4g} stationary={best['stationary']} "
+          f"persistent={best['persistent']}")
+    elapsed = [r["elapsed_s"] for r in ok]
+    print(f"attempt time: median={statistics.median(elapsed):.0f}s  "
+          f"max={max(elapsed):.0f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/proton_campaign/analyze_attempt.py
+++ b/examples/cobordism/proton_campaign/analyze_attempt.py
@@ -1,0 +1,309 @@
+# Out-of-band rebuild + characterization of a recorded campaign attempt (#578).
+#
+# THE rebuild path is the geometry dump — Spacetime.fromCells on the recorded final
+# complex (seconds, exact by construction):
+#
+#   --from-dump P   rebuild from a geometry dump; verified against the dump's own
+#                   recorded metadata (Betti/holes/singlet);
+#   --seed N        uses the seed's dump when one exists. Passing --replay instead
+#                   re-RUNS the attempt with the frozen drive — but the engine build
+#                   is NOT process-deterministic (identical fresh processes diverge on
+#                   the same seed), so a replay is a fresh sample from the seed's
+#                   attempt distribution, not a reconstruction; the verdict comparison
+#                   it reports is a divergence measurement, not a check that must pass.
+#
+# The rebuilt state is characterized with the READY observables — color (Betti,
+# emergent holes, singlet residual, per-register unit carry), geometry (Regge
+# stationarity, Lorentzian deficit-angle curvature in BOTH channels, dual volumes,
+# edge-length ranges), spectral dimension on the 1-skeleton, and the deficit-angle
+# Wilson-loop measurements — landing in one analysis JSON. The open physics readouts
+# (#478 charge, #479 flavor, #480 mass/radius, #481 joint) plug in here later.
+#
+# Run in the campaign worktree's venv, single-threaded:
+#
+#   OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
+#   .venv-build/bin/python analyze_attempt.py --seed <base_seed> --run-dir .overnight
+import argparse
+import glob
+import itertools
+import json
+import os
+import sys
+
+import tessera
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import worker  # the frozen drive — replay MUST use the recording generation's bytes
+
+cob = tessera.cobordism
+
+# Verdict fields compared when --replay re-runs an attempt. The engine build is not
+# process-deterministic, so agreement is a divergence MEASUREMENT (how far a fresh
+# sample of the same seed lands from the recorded one), not a check that must pass.
+# Wall-time/host fields (elapsed_s, rss_mb) and artifact paths are excluded.
+REPLAY_KEYS = ("converged", "stationary", "persistent", "stage2_iters_total",
+               "holes", "max_holes", "max_b3", "betti", "singlet", "input_ru",
+               "F", "cells", "edges", "re_min", "re_max", "im_max", "diquark_ru")
+
+
+def find_verdict(run_dir, seed):
+    """The recorded verdict line for a base seed, or None (in-flight/unknown)."""
+    for path in sorted(glob.glob(os.path.join(run_dir, "worker_*.jsonl"))):
+        if ".progress." in path:
+            continue
+        with open(path) as fh:
+            for line in fh:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if record.get("base_seed") == seed:
+                    return record
+    return None
+
+
+def dump_path_for(run_dir, seed):
+    path = os.path.join(run_dir, "geometry", f"seed_{seed}_geometry.json")
+    return path if os.path.exists(path) else None
+
+
+def replay(seed):
+    """Re-run the attempt the way the worker did (no recorder, no dumps): same node
+    construction, same drive, same verdict fields — a fresh SAMPLE of this seed's
+    attempt distribution, not a reconstruction (the build is not process-
+    deterministic). Returns (result_record, final_formation_spacetime, state)."""
+    ingredients = cob.ProtonIngredients(seed=seed)
+    nodes = [(ingredients.recombination_node(seed), worker.STEP_A_LABEL),
+             (ingredients.formation_node(seed + 1), worker.STEP_B_LABEL)]
+    state = worker.AttemptState()
+    result = worker.run_attempt_on_nodes(seed, lambda record: None, None, state,
+                                         nodes)
+    return result, nodes[1][0].st, state
+
+
+def rebuild_from_dump(dump):
+    """A Spacetime carrying the dumped final state: fromCells on the top cells,
+    then the recorded per-vertex times and per-edge complex squared lengths."""
+    st = tessera.spacetime.Spacetime.fromCells(dump["dimensions"], dump["cells"])
+    vertices = st.getVertexList()
+    for vid, t in dump["vertex_times"]:
+        vertices.get(int(vid)).setTime(float(t))
+    by_pair = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        by_pair[(min(a, b), max(a, b))] = e
+    for u, v, re_l2, im_l2 in dump["edges"]:
+        key = (min(int(u), int(v)), max(int(u), int(v)))
+        by_pair[key].setSquaredLength(complex(re_l2, im_l2))
+    st.materializeFacets()
+    return st
+
+
+def compare(expected, actual, keys):
+    """{key: (expected, actual)} for every key that differs (exact equality —
+    the replay contract is bit-for-bit, so no tolerances)."""
+    mismatches = {}
+    for k in keys:
+        if k in expected and expected[k] != actual.get(k):
+            mismatches[k] = (expected[k], actual.get(k))
+    return mismatches
+
+
+def verify_state_against_dump(st, dump):
+    """The rebuilt/replayed state carries exactly the dumped complex: same top
+    cells (as vertex sets), same edge squared lengths, same register content."""
+    mismatches = {}
+    cells = sorted(sorted(int(v.getId()) for v in c.getVertices())
+                   for c in st.getTopSimplices())
+    dumped = sorted(sorted(int(v) for v in c) for c in dump["cells"])
+    if cells != dumped:
+        mismatches["cells"] = (len(dumped), len(cells))
+    lengths = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        l2 = e.getSquaredLength()
+        lengths[(min(a, b), max(a, b))] = (l2.real, l2.imag)
+    dumped_lengths = {(min(int(u), int(v)), max(int(u), int(v))): (re, im)
+                      for u, v, re, im in dump["edges"]}
+    if lengths != dumped_lengths:
+        wrong = sum(1 for k, val in dumped_lengths.items()
+                    if lengths.get(k) != val)
+        mismatches["edge_lengths"] = (len(dumped_lengths), wrong)
+    for key, value in (("betti", list(cob.MultiCobordism.betti(st))),
+                       ("holes", len(cob.MultiCobordism.emergent_holes(
+                           st, worker.REGISTER_DEGREE))),
+                       ("singlet", float(cob.MultiCobordism.r_state(
+                           st, worker.REGISTER_DEGREE, cob.Proton.singlet())))):
+        if key in dump and dump[key] != value:
+            mismatches[key] = (dump[key], value)
+    return mismatches
+
+
+def characterize(st, degree=worker.REGISTER_DEGREE):
+    """The ready observables on a rebuilt state. Each block is best-effort — a
+    block that raises reports its error instead of killing the analysis."""
+    out = {}
+
+    def block(name, fn):
+        try:
+            out[name] = fn()
+        except Exception as error:
+            out[name] = {"error": repr(error)}
+
+    def color():
+        holes = [list(h) for h in cob.MultiCobordism.emergent_holes(st, degree)]
+        es = cob.EigenstateSynthesis(st, degree)
+        return {
+            "betti": list(cob.MultiCobordism.betti(st)),
+            "holes": holes,
+            "singlet_residual": float(cob.MultiCobordism.r_state(
+                st, degree, cob.Proton.singlet())),
+            # a live register carries a unit period on its own cycle
+            "per_register_unit_carry": [
+                float(es.residualForPeriods([h], [1.0])) for h in holes],
+        }
+
+    def geometry():
+        squared = [e.getSquaredLength() for e in st.getEdgeList().toVector()]
+        deficits, dual = [], []
+        for s in st.getSimplices():
+            if len(s.getVertices()) != 3:      # hinges = (d-2)=2-simplices
+                continue
+            try:
+                deficits.append(complex(s.lorentzianDeficitAngle()))
+                dual.append(abs(float(s.dualVolume())))
+            except Exception:                  # boundary/degenerate hinge
+                pass
+        # BOTH channels of the complex Lorentzian deficit, symmetric statistics:
+        # Re ε = the spatial (rotation) angle-defect, Im ε = the temporal (boost)
+        # content — never Re-only.
+        re_parts = [d.real for d in deficits]
+        im_parts = [d.imag for d in deficits]
+
+        def stats(parts):
+            if not parts:
+                return {"min": None, "mean": None, "max": None}
+            return {"min": min(parts), "mean": sum(parts) / len(parts),
+                    "max": max(parts)}
+
+        return {
+            "cells": len(st.getTopSimplices()),
+            "edges": len(squared),
+            "re_l2_min": min(l.real for l in squared),
+            "re_l2_max": max(l.real for l in squared),
+            "im_l2_max": max(abs(l.imag) for l in squared),
+            "regge_grad_norm2": float(
+                cob.MultiCobordism.regge_action_gradient(st)),
+            "hinges": len(deficits),
+            "deficit_spatial_re": stats(re_parts),
+            "deficit_temporal_im": stats(im_parts),
+            "dual_volume_total": sum(dual),
+        }
+
+    def spectral():
+        sigmas = [0.5 * 2 ** i for i in range(8)]           # 0.5 .. 64
+        top_k = len(next(iter(st.getTopSimplices())).getVertices()) - 1
+        ds = st.getSpectralDimensionOnSkeleton(
+            sigmas, 64, tessera.AllSimplexFilter(), top_k, 1)
+        return {"sigmas": sigmas, "spectral_dimension": list(ds)}
+
+    def wilson():
+        # The deficit-angle (spin-connection) mode — the #477 register-spin readout.
+        loop = tessera.WilsonLoop(st)
+        loop.measureAllHinges(tessera.WilsonMode.DEFICIT_ANGLE)
+        averages = loop.getAverageBySize()
+        try:
+            averages = {str(k): float(v) for k, v in dict(averages).items()}
+        except (TypeError, ValueError):
+            averages = [float(v) for v in averages]
+        return {"deficit_angle_average_by_size": averages}
+
+    block("color", color)
+    block("geometry", geometry)
+    block("spectral", spectral)
+    block("wilson", wilson)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Rebuild a recorded campaign attempt and run the ready "
+                    "observables on it.")
+    ap.add_argument("--seed", type=int,
+                    help="base seed of the recorded attempt (rebuilds from its dump)")
+    ap.add_argument("--from-dump", dest="from_dump",
+                    help="geometry dump to rebuild from")
+    ap.add_argument("--replay", action="store_true",
+                    help="with --seed: re-RUN the attempt with the frozen drive "
+                         "instead of loading the dump — a fresh sample of the seed's "
+                         "attempt distribution (the build is not process-"
+                         "deterministic); the verdict comparison is a divergence "
+                         "measurement")
+    ap.add_argument("--run-dir", default=".overnight", dest="run_dir")
+    ap.add_argument("--out", help="analysis JSON path (default: "
+                                  "<run-dir>/analysis_seed_<seed>.json)")
+    args = ap.parse_args()
+    if args.seed is None and not args.from_dump:
+        ap.error("one of --seed / --from-dump is required")
+
+    analysis = {"seed": args.seed}
+    dump = None
+    dump_path = args.from_dump or (args.seed is not None
+                                   and dump_path_for(args.run_dir, args.seed))
+    if dump_path:
+        with open(dump_path) as fh:
+            dump = json.load(fh)
+        analysis["dump"] = dump_path
+        analysis.setdefault("seed", dump.get("base_seed"))
+
+    verdict = (find_verdict(args.run_dir, analysis["seed"])
+               if analysis["seed"] is not None else None)
+    if verdict:
+        analysis["verdict"] = {k: verdict[k] for k in
+                               (*REPLAY_KEYS, "worker", "elapsed_s")
+                               if k in verdict}
+
+    if args.replay and args.seed is not None:
+        print(f"re-running seed {args.seed} with the frozen drive — a fresh sample "
+              f"of this seed's attempt distribution, NOT a reconstruction "
+              f"(expect roughly the attempt's original wall time) ...", flush=True)
+        result, st, _state = replay(args.seed)
+        analysis["rebuild"] = "replay (fresh sample — not a reconstruction)"
+        if verdict:
+            divergence = compare(verdict, result, REPLAY_KEYS)
+            analysis["replay_equals_verdict"] = not divergence
+            if divergence:
+                analysis["replay_divergence"] = {
+                    k: {"recorded": a, "replayed": b}
+                    for k, (a, b) in divergence.items()}
+    else:
+        if not dump:
+            raise SystemExit(
+                f"no geometry dump for seed {analysis['seed']} (dumps are written "
+                f"per attempt going forward; older attempts kept them only under "
+                f"the GIF keep-policy) — use --replay for a fresh sample instead")
+        st = rebuild_from_dump(dump)
+        analysis["rebuild"] = "dump"
+        state_mismatches = verify_state_against_dump(st, dump)
+        analysis["rebuild_matches_dump"] = not state_mismatches
+        if state_mismatches:
+            analysis["dump_mismatches"] = state_mismatches
+
+    analysis["observables"] = characterize(st)
+
+    out = args.out or os.path.join(
+        args.run_dir, f"analysis_seed_{analysis['seed']}.json")
+    tmp = out + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(analysis, fh, indent=2)
+    os.replace(tmp, out)
+    print(f"analysis -> {out}")
+    verified = analysis.get("rebuild_matches_dump",
+                            analysis.get("replay_equals_verdict"))
+    color = analysis["observables"].get("color", {})
+    print(f"verified={verified}  betti={color.get('betti')}  "
+          f"singlet_residual={color.get('singlet_residual')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/proton_campaign/launch_campaign.sh
+++ b/examples/cobordism/proton_campaign/launch_campaign.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Throwaway campaign supervisor (#555): wait for any prior-generation workers to finish
+# their in-flight attempts (never oversubscribe the 16-CPU cap), then launch 16
+# animated sweep workers against the calendar-pinned deadline. Safe to re-run after a
+# reboot: the deadline file persists and the workers skip already-recorded seeds.
+set -u
+cd /home/andrew/feat-proton-ingredients
+RUN=.overnight
+END_FILE=$RUN/campaign_deadline
+if [ ! -f "$END_FILE" ]; then
+  echo $(( $(date +%s) + 30 * 24 * 3600 )) > "$END_FILE"
+fi
+DEADLINE=$(cat "$END_FILE")
+echo "$(date): campaign deadline $(date -d @"$DEADLINE")"
+
+while :; do
+  ALIVE=$(ps -eo args | grep -c "[w]orker.py --worker")
+  [ "$ALIVE" -eq 0 ] && break
+  echo "$(date): waiting for $ALIVE prior workers to finish their in-flight attempts"
+  sleep 300
+done
+
+# Workers are plain children and this script WAITS on them: run under
+# `systemd-run --user` the service's main process is this script, so the unit —
+# and with it the workers' cgroup — stays alive for the whole campaign. (Detached
+# setsid children die with the harness session; a long campaign must live in its
+# own unit.)
+rm -f $RUN/*.jsonl.done
+for i in $(seq 0 15); do
+  OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 BLIS_NUM_THREADS=1 \
+  .venv-build/bin/python $RUN/worker.py --worker $i \
+    --deadline "$DEADLINE" --out $RUN/worker_$i.jsonl \
+    --seed-base $(( 1000000 * (i + 1) + 1000 )) --animate \
+    > $RUN/worker_$i.log 2>&1 &
+done
+sleep 5
+ps -eo pid,args | grep "[w]orker.py --worker" | awk '{print $1}' > $RUN/worker.pids
+echo "$(date): campaign launched: $(wc -l < $RUN/worker.pids) workers, deadline $(date -d @"$DEADLINE")"
+wait
+echo "$(date): campaign ended (all workers exited)"

--- a/examples/cobordism/proton_campaign/renderer.py
+++ b/examples/cobordism/proton_campaign/renderer.py
@@ -1,0 +1,72 @@
+# Throwaway sweep renderer (#555): record an attempt as an animation in the style of
+# the animation scripts. Reuses emergent_proton.EmergentProtonAnimator's 2x4 panels
+# verbatim (metrics F/‖∇S‖²/r_U; register+Betti; primal A/B; dual spatial/temporal
+# curvature) — but frames are driven EXTERNALLY at the worker's real pass/chunk
+# boundaries, so the animation shows the exact recorded attempt, not a re-run.
+import os
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+sys.path.insert(0, "/home/andrew/feat-proton-ingredients/examples/cobordism")
+import emergent_proton as ep  # noqa: E402  (brings multicobordism_animation with it)
+
+
+class AttemptRecorder:
+    """PNG frames at the worker's phase/chunk boundaries; GIF assembly for keepers."""
+
+    def __init__(self, nodes, frame_dir, max_frames=400, dpi=70):
+        self.animator = ep.EmergentProtonAnimator(nodes)
+        self.animator._frames = 10 ** 9     # never trip the "final frame" verdict path
+        self.animator._setup(plt)
+        self.frame_dir = frame_dir
+        os.makedirs(frame_dir, exist_ok=True)
+        for stale in os.listdir(frame_dir):  # a crashed prior attempt's leftovers
+            os.remove(os.path.join(frame_dir, stale))
+        self.count = 0
+        self.max_frames = max_frames
+        self.dpi = dpi
+
+    def frame(self, node_index, phase, subtitle=""):
+        """One frame: record the node's metrics into the shared history, redraw the
+        inherited panels, save a PNG. Never raises — rendering must not kill physics."""
+        if self.count >= self.max_frames:
+            return
+        try:
+            self.animator._active = node_index
+            node = self.animator.nodes[node_index][0]
+            self.animator._record(node, node_index, phase)
+            self.animator._redraw()
+            label = self.animator.nodes[node_index][1]
+            self.animator.fig.suptitle(
+                f"ProtonIngredients sweep — {label} · {phase}{subtitle}")
+            self.animator.fig.savefig(
+                os.path.join(self.frame_dir, f"f{self.count:05d}.png"), dpi=self.dpi)
+            self.count += 1
+        except Exception:
+            pass
+
+    def finish(self, gif_path=None):
+        """Close the figure; assemble the GIF when a path is given. Frames are always
+        deleted afterwards (keep decisions are the caller's, via gif_path)."""
+        try:
+            plt.close(self.animator.fig)
+        except Exception:
+            pass
+        try:
+            if gif_path and self.count:
+                from PIL import Image
+                os.makedirs(os.path.dirname(os.path.abspath(gif_path)), exist_ok=True)
+                paths = sorted(
+                    os.path.join(self.frame_dir, f) for f in os.listdir(self.frame_dir))
+                frames = [Image.open(p) for p in paths]
+                frames[0].save(gif_path, save_all=True, append_images=frames[1:],
+                               duration=200, loop=0)
+        except Exception:
+            gif_path = None
+        for f in os.listdir(self.frame_dir):
+            os.remove(os.path.join(self.frame_dir, f))
+        return gif_path

--- a/examples/cobordism/proton_campaign/worker.py
+++ b/examples/cobordism/proton_campaign/worker.py
@@ -13,9 +13,17 @@
 #
 # Keep-policy for animations (disk-bounded): keep the GIF when the attempt ever showed
 # b3 >= 2 or >= 3 holes, or ended with >= 2 holes; any b3 >= 3 sighting is kept
-# unconditionally. Every attempt remains exactly reproducible from its recorded base
-# seed regardless (single-threaded determinism), so a discarded 1-hole GIF loses
-# nothing.
+# unconditionally.
+#
+# EVERY attempt also writes a GEOMETRY DUMP (geometry/seed_<base>_geometry.json): the
+# final complex itself — top cells in intrinsic vertex order, every edge's complex
+# squared length, per-vertex times — enough for Spacetime.fromCells to rebuild the
+# state without re-running anything. The dump is the attempt's ONLY faithful record:
+# the engine build is NOT process-deterministic (identical fresh processes diverge on
+# the same seed — measured, not hypothetical), so a base seed labels an attempt, it
+# does not reproduce it. Dumps are KB-scale (no disk cap), canonically ordered (same
+# state -> same bytes), and written only AFTER the attempt completes — the drive and
+# its RNG draws are untouched.
 import argparse
 import json
 import os
@@ -37,6 +45,7 @@ PERSIST_REL_TOL = 1e-9
 REGISTER_DEGREE = 3
 PROGRESS_BYTE_CAP = 50 * 1024 * 1024        # per worker
 GIF_BYTE_CAP = 5 * 1024 * 1024 * 1024       # global, across all workers
+GEOMETRY_SCHEMA = 1                         # bump on any dump-format change
 
 STEP_A_LABEL = "Step A — recombination (→ diquark {1, ω})"
 STEP_B_LABEL = "Step B — formation (nothing pinned — final state emerges)"
@@ -64,6 +73,41 @@ def gif_dir_full(gif_dir):
     total = sum(os.path.getsize(os.path.join(gif_dir, f))
                 for f in os.listdir(gif_dir) if f.endswith(".gif"))
     return total > GIF_BYTE_CAP
+
+
+def dump_geometry(st, path, meta):
+    """The attempt's faithful record: top cells in intrinsic vertex order, every
+    edge's complex squared length, and per-vertex times — enough for
+    Spacetime.fromCells to rebuild the exact state without re-running anything
+    (the build is not process-deterministic, so nothing else can). Reads state
+    only; canonically ordered so the same state always serializes to the same
+    bytes (each cell/edge keeps its intrinsic internal order — never sorted, per
+    the orientation convention — while the LISTS are sorted by vertex-set key);
+    atomic write."""
+    top = st.getTopSimplices()
+    cells = sorted(([int(v.getId()) for v in c.getVertices()] for c in top),
+                   key=sorted)
+    times = {}
+    for c in top:
+        for v in c.getVertices():
+            times[int(v.getId())] = float(v.getTime())
+    edges = sorted(([int(e.getSource().getId()), int(e.getTarget().getId()),
+                     e.getSquaredLength().real, e.getSquaredLength().imag]
+                    for e in st.getEdgeList().toVector()),
+                   key=lambda r: (min(r[0], r[1]), max(r[0], r[1])))
+    record = dict(meta)
+    record.update({
+        "schema": GEOMETRY_SCHEMA,
+        "dimensions": (len(cells[0]) - 1) if cells else 0,
+        "cells": cells,
+        "edges": edges,
+        "vertex_times": sorted(times.items()),
+    })
+    tmp = path + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(record, fh)
+    os.replace(tmp, path)
+    return path
 
 
 class AttemptState:
@@ -178,9 +222,9 @@ def run_attempt_on_nodes(base, progress, recorder, state, nodes):
     }
 
 
-def run_one(base, progress, args, frame_dir, gif_dir):
-    """Build the attempt's nodes, run it (recorded when --animate), apply the GIF
-    keep-policy, return the result record fields."""
+def run_one(base, progress, args, frame_dir, gif_dir, geom_dir):
+    """Build the attempt's nodes, run it (recorded when --animate), apply the
+    keep-policy (GIF + geometry dump), return the result record fields."""
     ingredients = cob.ProtonIngredients(seed=base)
     nodes = [(ingredients.recombination_node(base), STEP_A_LABEL),
              (ingredients.formation_node(base + 1), STEP_B_LABEL)]
@@ -198,8 +242,8 @@ def run_one(base, progress, args, frame_dir, gif_dir):
         if recorder:
             recorder.finish(None)
         raise
+    keep = (state.max_b3 >= 2 or result["holes"] >= 2 or state.max_holes >= 3)
     if recorder:
-        keep = (state.max_b3 >= 2 or result["holes"] >= 2 or state.max_holes >= 3)
         gif_path = None
         if keep and not gif_dir_full(gif_dir):
             tag = "CONVERGED" if result["converged"] else "unconverged"
@@ -207,6 +251,22 @@ def run_one(base, progress, args, frame_dir, gif_dir):
                 gif_dir,
                 f"seed_{base}_b3max{state.max_b3}_holes{result['holes']}_{tag}.gif")
         result["gif"] = recorder.finish(gif_path)
+    # EVERY attempt gets a geometry dump — the only faithful record (the build is
+    # not process-deterministic; the seed labels the attempt, it can't reproduce it).
+    try:
+        st = nodes[1][0].st
+        meta = {"base_seed": base, "max_b3": state.max_b3,
+                "max_holes": state.max_holes}
+        meta.update({k: result[k] for k in
+                     ("converged", "stationary", "persistent", "holes",
+                      "betti", "singlet", "F")})
+        meta["hole_cells"] = [list(h) for h in
+                              cob.MultiCobordism.emergent_holes(
+                                  st, REGISTER_DEGREE)]
+        result["geometry"] = dump_geometry(
+            st, os.path.join(geom_dir, f"seed_{base}_geometry.json"), meta)
+    except Exception as error:       # best-effort, like the recorder
+        result["geometry_error"] = repr(error)
     return result
 
 
@@ -222,8 +282,10 @@ def main():
 
     run_dir = os.path.dirname(os.path.abspath(args.out))
     gif_dir = os.path.join(run_dir, "animations")
+    geom_dir = os.path.join(run_dir, "geometry")
     frame_dir = os.path.join(run_dir, f"tmp_frames_w{args.worker}")
     os.makedirs(gif_dir, exist_ok=True)
+    os.makedirs(geom_dir, exist_ok=True)
 
     progress_path = args.out.replace(".jsonl", ".progress.jsonl")
     base = args.seed_base
@@ -260,7 +322,8 @@ def main():
             started = time.time()
             record = {"worker": args.worker, "base_seed": base}
             try:
-                record.update(run_one(base, progress, args, frame_dir, gif_dir))
+                record.update(run_one(base, progress, args, frame_dir, gif_dir,
+                                      geom_dir))
             except Exception as error:   # record and move on — the sweep must survive
                 record["error"] = repr(error)
             record["elapsed_s"] = round(time.time() - started, 1)

--- a/examples/cobordism/proton_campaign/worker.py
+++ b/examples/cobordism/proton_campaign/worker.py
@@ -1,0 +1,276 @@
+# Throwaway sweep worker (#555): one emergent-arm attempt per base seed, driven
+# stage-by-stage (mirroring ProtonIngredients.build with max_restarts=1) so the
+# unbounded stage-2 descent streams a progress line every chunk, and — for the
+# interesting attempts — records an animation in the style of the animation scripts
+# (renderer.py reuses emergent_proton's panels; frames land at the real pass/chunk
+# boundaries, so the GIF shows the exact recorded attempt).
+#
+# Machine-precision semantics: stage 2 is chunked, and a chunk that stops early on
+# runStage2's built-in relTol=1e-9 stationarity test IS the stationarity verdict.
+# Persistence: up to 3 continued evolve+relax passes; the last must leave holes, b_k,
+# and F stable to 1e-9 relative. Nothing here steers toward any target — the register
+# count is observed, never optimized for.
+#
+# Keep-policy for animations (disk-bounded): keep the GIF when the attempt ever showed
+# b3 >= 2 or >= 3 holes, or ended with >= 2 holes; any b3 >= 3 sighting is kept
+# unconditionally. Every attempt remains exactly reproducible from its recorded base
+# seed regardless (single-threaded determinism), so a discarded 1-hole GIF loses
+# nothing.
+import argparse
+import json
+import os
+import resource
+import time
+
+import tessera
+
+cob = tessera.cobordism
+
+INIT_STEPS = 180
+EVOLVE_STEPS = 60
+CANDIDATES = 8
+PATIENCE = 15
+STAGE2_BETA = 1.0
+STAGE2_CHUNK = 25            # progress granularity; the stationarity test is the exit
+PERSIST_PASSES = 3
+PERSIST_REL_TOL = 1e-9
+REGISTER_DEGREE = 3
+PROGRESS_BYTE_CAP = 50 * 1024 * 1024        # per worker
+GIF_BYTE_CAP = 5 * 1024 * 1024 * 1024       # global, across all workers
+
+STEP_A_LABEL = "Step A — recombination (→ diquark {1, ω})"
+STEP_B_LABEL = "Step B — formation (nothing pinned — final state emerges)"
+
+
+def snapshot(node):
+    st = node.st
+    betti = cob.MultiCobordism.betti(st)
+    squared = [e.getSquaredLength() for e in st.getEdgeList().toVector()]
+    return {
+        "F": float(node.objective()),
+        "gradN2": float(cob.MultiCobordism.regge_action_gradient(st)),
+        "rU": float(node.r_u(st)),
+        "holes": len(cob.MultiCobordism.emergent_holes(st, REGISTER_DEGREE)),
+        "b3": int(betti[REGISTER_DEGREE]) if len(betti) > REGISTER_DEGREE else 0,
+        "cells": len(st.getTopSimplices()),
+        "edges": len(squared),
+        "re_min": round(min(l.real for l in squared), 6),
+        "re_max": round(max(l.real for l in squared), 6),
+        "im_max": max(abs(l.imag) for l in squared),
+    }
+
+
+def gif_dir_full(gif_dir):
+    total = sum(os.path.getsize(os.path.join(gif_dir, f))
+                for f in os.listdir(gif_dir) if f.endswith(".gif"))
+    return total > GIF_BYTE_CAP
+
+
+class AttemptState:
+    """Running extremes the keep-policy and the final record read."""
+
+    def __init__(self):
+        self.max_b3 = 0
+        self.max_holes = 0
+
+    def see(self, snap):
+        self.max_b3 = max(self.max_b3, snap["b3"])
+        self.max_holes = max(self.max_holes, snap["holes"])
+
+
+def run_attempt_on_nodes(base, progress, recorder, state, nodes):
+    """The attempt physics on already-built nodes: init → evolve → stage-2 to genuine
+    stationarity per node, then the persistence loop on step B. Identical drive with
+    and without a recorder — frames are taken between engine calls, never instead."""
+    step_a, step_b = nodes[0][0], nodes[1][0]
+
+    def frame(node_index, phase, subtitle=""):
+        if recorder:
+            recorder.frame(node_index, phase, subtitle)
+
+    def stage2_to_stationarity(node, node_index, node_tag):
+        iters_done = 0
+        previous_f = float(node.objective())
+        while True:
+            t0 = time.time()
+            node.run_stage2(beta=STAGE2_BETA, max_iters=STAGE2_CHUNK)
+            iters_done += STAGE2_CHUNK
+            stationary = bool(node.last_stage2_stationary)
+            snap = snapshot(node)
+            state.see(snap)
+            progress(dict(base_seed=base, node=node_tag, phase="stage2",
+                          iters=iters_done, dF=previous_f - snap["F"],
+                          stationary=stationary,
+                          chunk_s=round(time.time() - t0, 1), **snap))
+            frame(node_index, "stage2", f" · iter {iters_done}")
+            previous_f = snap["F"]
+            if stationary:
+                return iters_done
+
+    def run_node(node, node_index, node_tag):
+        t0 = time.time()
+        node.run_stage1(max_steps=INIT_STEPS, n_candidate_moves=CANDIDATES,
+                        patience=PATIENCE, grow_boundaries=True)
+        snap = snapshot(node)
+        state.see(snap)
+        progress(dict(base_seed=base, node=node_tag, phase="init",
+                      pass_s=round(time.time() - t0, 1), **snap))
+        frame(node_index, "init")
+        t0 = time.time()
+        node.run_stage1(max_steps=EVOLVE_STEPS, n_candidate_moves=CANDIDATES,
+                        patience=PATIENCE, grow_boundaries=False)
+        snap = snapshot(node)
+        state.see(snap)
+        progress(dict(base_seed=base, node=node_tag, phase="evolve",
+                      pass_s=round(time.time() - t0, 1), **snap))
+        frame(node_index, "evolve")
+        return stage2_to_stationarity(node, node_index, node_tag)
+
+    progress({"base_seed": base, "phase": "attempt_start"})
+    frame(0, "seed")
+    frame(1, "seed")
+    run_node(step_a, 0, "A")
+    diquark_ru = float(step_a.r_u(step_a.st))
+    stage2_iters = run_node(step_b, 1, "B")
+
+    persistent = False
+    for persist_pass in range(1, PERSIST_PASSES + 1):
+        before = snapshot(step_b)
+        step_b.run_stage1(max_steps=EVOLVE_STEPS, n_candidate_moves=CANDIDATES,
+                          patience=PATIENCE, grow_boundaries=False)
+        stage2_iters += stage2_to_stationarity(step_b, 1, "B")
+        after = snapshot(step_b)
+        state.see(after)
+        stable_f = abs(after["F"] - before["F"]) <= PERSIST_REL_TOL * max(
+            abs(before["F"]), 1.0)
+        persistent = (after["holes"] == before["holes"]
+                      and after["b3"] == before["b3"] and stable_f)
+        progress(dict(base_seed=base, node="B", phase="persistence",
+                      persist_pass=persist_pass, persistent=persistent,
+                      dF=before["F"] - after["F"], **after))
+        frame(1, "persistence", f" · pass {persist_pass}")
+        if persistent:
+            break
+
+    stationary = bool(step_b.last_stage2_stationary)
+    st = step_b.st
+    squared = [e.getSquaredLength() for e in st.getEdgeList().toVector()]
+    final = snapshot(step_b)
+    return {
+        "converged": stationary and persistent,
+        "stationary": stationary,
+        "persistent": persistent,
+        "stage2_iters_total": stage2_iters,
+        "holes": final["holes"],
+        "max_holes": state.max_holes,
+        "max_b3": state.max_b3,
+        "betti": list(cob.MultiCobordism.betti(st)),
+        "singlet": float(cob.MultiCobordism.r_state(st, REGISTER_DEGREE,
+                                                    cob.Proton.singlet())),
+        "input_ru": final["rU"],
+        "F": final["F"],
+        "cells": final["cells"],
+        "edges": final["edges"],
+        "re_min": min(l.real for l in squared),
+        "re_max": max(l.real for l in squared),
+        "im_max": max(abs(l.imag) for l in squared),
+        "diquark_ru": diquark_ru,
+    }
+
+
+def run_one(base, progress, args, frame_dir, gif_dir):
+    """Build the attempt's nodes, run it (recorded when --animate), apply the GIF
+    keep-policy, return the result record fields."""
+    ingredients = cob.ProtonIngredients(seed=base)
+    nodes = [(ingredients.recombination_node(base), STEP_A_LABEL),
+             (ingredients.formation_node(base + 1), STEP_B_LABEL)]
+    state = AttemptState()
+    recorder = None
+    if args.animate:
+        try:
+            import renderer
+            recorder = renderer.AttemptRecorder(nodes, frame_dir)
+        except Exception:
+            recorder = None      # rendering is best-effort; physics always runs
+    try:
+        result = run_attempt_on_nodes(base, progress, recorder, state, nodes)
+    except Exception:
+        if recorder:
+            recorder.finish(None)
+        raise
+    if recorder:
+        keep = (state.max_b3 >= 2 or result["holes"] >= 2 or state.max_holes >= 3)
+        gif_path = None
+        if keep and not gif_dir_full(gif_dir):
+            tag = "CONVERGED" if result["converged"] else "unconverged"
+            gif_path = os.path.join(
+                gif_dir,
+                f"seed_{base}_b3max{state.max_b3}_holes{result['holes']}_{tag}.gif")
+        result["gif"] = recorder.finish(gif_path)
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--worker", type=int, required=True)
+    ap.add_argument("--deadline", type=float, required=True)   # epoch; gates NEW attempts
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--seed-base", type=int, required=True)
+    ap.add_argument("--animate", action="store_true",
+                    help="record per-attempt frames; GIFs kept by the keep-policy")
+    args = ap.parse_args()
+
+    run_dir = os.path.dirname(os.path.abspath(args.out))
+    gif_dir = os.path.join(run_dir, "animations")
+    frame_dir = os.path.join(run_dir, f"tmp_frames_w{args.worker}")
+    os.makedirs(gif_dir, exist_ok=True)
+
+    progress_path = args.out.replace(".jsonl", ".progress.jsonl")
+    base = args.seed_base
+    # Restart-safe: after a reboot/relaunch, skip every base seed already recorded so
+    # the campaign never re-runs (and double-counts) an attempt.
+    recorded = set()
+    if os.path.exists(args.out):
+        with open(args.out) as previous:
+            for line in previous:
+                try:
+                    recorded.add(json.loads(line).get("base_seed"))
+                except Exception:
+                    pass
+    with open(args.out, "a", buffering=1) as out, \
+            open(progress_path, "a", buffering=1) as prog:
+        capped = False
+
+        def progress(record):
+            nonlocal capped
+            if capped:
+                return
+            if prog.tell() > PROGRESS_BYTE_CAP:
+                prog.write(json.dumps({"worker": args.worker,
+                                       "progress_capped": True}) + "\n")
+                capped = True
+                return
+            record["worker"] = args.worker
+            record["t"] = round(time.time())
+            prog.write(json.dumps(record) + "\n")
+
+        while time.time() < args.deadline:
+            while base in recorded:
+                base += 2
+            started = time.time()
+            record = {"worker": args.worker, "base_seed": base}
+            try:
+                record.update(run_one(base, progress, args, frame_dir, gif_dir))
+            except Exception as error:   # record and move on — the sweep must survive
+                record["error"] = repr(error)
+            record["elapsed_s"] = round(time.time() - started, 1)
+            record["rss_mb"] = round(
+                resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+            out.write(json.dumps(record) + "\n")
+            base += 2
+    with open(args.out + ".done", "w") as marker:
+        marker.write("done\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Hardens the #562 campaign so any find — above all a b₃≥3 basin — can be rebuilt out of band and characterized immediately. Per #578, reworked after a key finding: **the engine build is not process-deterministic** (identical fresh single-threaded processes diverge on the same seed — measured: F=272.5/78 cells vs F=81.0/43 cells), so replay-from-seed is *not* a rebuild path and the original "bit-for-bit reproducible" claim was wrong (an earlier bit-exact replay was a stable-path coincidence).

- **Frozen campaign scripts** (`examples/cobordism/proton_campaign/`) with a sha256 provenance manifest — the drive defines the physics of the recorded statistics per generation.
- **Per-attempt geometry dumps** — every attempt writes `geometry/seed_<base>_geometry.json` (top cells in intrinsic vertex order, complex edge ℓ², vertex times), canonically ordered (same state → same bytes), written post-attempt (zero effect on the drive/RNG). The dump is the attempt's only faithful record.
- **`analyze_attempt.py`** — rebuilds the exact final state from a dump via `Spacetime.fromCells` (seconds), verifies against the dump metadata, runs the ready observables: color (Betti/holes/singlet + per-register unit carry), geometry (Regge stationarity, Lorentzian deficit curvature in **both** channels Re ε and Im ε, dual volumes), spectral dimension, deficit-angle Wilson loops (#477 mode). `--replay` re-runs the drive as a fresh sample; its verdict comparison is a divergence measurement.

## Test plan
- [x] Frozen copies byte-identical to the running scripts (sha256).
- [x] Round-trip: state → dump → `fromCells` → dump is **byte-identical**; source and rebuilt states both verify against the dump.
- [x] Observables: color identical on original vs rebuilt; geometry agrees (aggregate FP sums to 1e-9 rel — container-order ULPs); spectral + wilson blocks run clean.
- [x] Nondeterminism documented where it matters (worker header, README, analyzer docstrings).
- [ ] Deploy dump-enabled `worker.py` to `.overnight/` (running workers unaffected; arms restarts/next generation).

Closes #578.
