### PR TITLE
fix(mesh,cobordism): propagate imaginary parts — mixed-hinge Lorentzian angles, complex-exact rollbacks, classifier unification

### DIFF
--- a/examples/cobordism/multicobordism_animation.py
+++ b/examples/cobordism/multicobordism_animation.py
@@ -411,10 +411,15 @@ class ProtonAnimator:
             key = tuple(sorted(v.getId() for v in vs))
             try:
                 deficit = complex(s.lorentzianDeficitAngle())
-                weight = abs(float(s.dualVolume()))   # positive dual-measure weight
+                # complex-tolerant positive dual-measure weight (dualVolume
+                # is real today; abs(complex(...)) survives it going complex)
+                weight = abs(complex(s.dualVolume()))
                 hinge_re[key] = deficit.real * weight
                 hinge_im[key] = deficit.imag * weight
-            except Exception:                    # boundary/degenerate hinge → no curvature
+            except RuntimeError:                 # boundary/degenerate hinge → no curvature
+                # Only the geometric failure is swallowed; a type/contract
+                # failure (TypeError, ValueError from the #581 resident-Im
+                # guard) must propagate, never render as zero curvature.
                 hinge_re[key] = hinge_im[key] = 0.0
         curv = {}
         for c in st.getTopSimplices():
@@ -479,8 +484,13 @@ class ProtonAnimator:
             if mag.max() <= 1e-9:                         # channel is identically zero
                 # The temporal (Im) channel is ≡0 whenever the geometry is all-spacelike
                 # (no timelike hinges → no boost content), so the panel would read as blank;
-                # say why instead of showing an empty box.
-                ax.text(0.5, 0.5, "≡ 0\n(all-spacelike: no timelike hinges)",
+                # say why instead of showing an empty box. Only the Im channel gets the
+                # all-spacelike explanation — and only because compute failures now
+                # PROPAGATE out of _cell_curvature (a type failure can no longer zero the
+                # channel and masquerade as all-spacelike, #581).
+                label = ("≡ 0\n(all-spacelike: no timelike hinges)"
+                         if channel == 1 else "≡ 0")
+                ax.text(0.5, 0.5, label,
                         transform=ax.transAxes, ha="center", va="center", fontsize=9,
                         color="0.45")
         ax.set_aspect("equal")

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -690,11 +690,13 @@ class EigenstateSynthesis {
 
     // One removeInteriorCell() record, for exact restore. The removed top cell's
     // sorted vertex tuple (its vertices are kept — only the top simplex and its
-    // orphaned edges are deleted), plus each orphaned edge as (u, v, squaredLength,
-    // phase) so restoreLastRemoval re-creates them bit-exactly.
+    // orphaned edges are deleted), plus each orphaned edge as (u, v, complex
+    // squaredLength, phase) so restoreLastRemoval re-creates them bit-exactly —
+    // the FULL complex ℓ², never its real part alone (#581).
     struct Removal {
       std::vector<std::uint64_t> cell{};
-      std::vector<std::tuple<std::uint64_t, std::uint64_t, double, double>>
+      std::vector<std::tuple<std::uint64_t, std::uint64_t,
+                             std::complex<double>, double>>
           removedEdges{};
     };
     std::vector<Removal> removals_{};

--- a/include/cobordism/EigenstateSynthesis.h
+++ b/include/cobordism/EigenstateSynthesis.h
@@ -650,6 +650,13 @@ class EigenstateSynthesis {
         bool electricOnly = true) const;
 
   private:
+    // The analytic r_U / r_psi gradient cores project the metric Hodge
+    // operator with laplacian(k).real() — lossless for k >= 1 (the metric L_k
+    // there is real symmetric) but silently the WRONG operator at k = 0,
+    // where L_0 consumes the full complex l^2 (#580/#581). Fail loudly until
+    // a complex k = 0 core exists. `who` names the calling core.
+    void requireGradientDegree(const char *who) const;
+
     std::shared_ptr<Spacetime> st_;
     int k_{0};  // the Hodge degree of L_k that apply()/residual() score against
     // The Hodge Laplacian operator over the same complex. laplacian(k_)

--- a/include/cobordism/SurgicalCone.h
+++ b/include/cobordism/SurgicalCone.h
@@ -4,6 +4,7 @@
 #ifndef TESSERA_COBORDISM_SURGICALCONE_H
 #define TESSERA_COBORDISM_SURGICALCONE_H
 
+#include <complex>
 #include <cstdint>
 #include <string>
 #include <tuple>
@@ -110,8 +111,13 @@ class SurgicalCone {
     /// The d+1 vertex ids of the removed (cone-out) / added (cone-in) top cell.
     std::vector<std::uint64_t> cell;
     /// Edges touched: removed orphans (cone-out, to re-create) / freshly
-    /// inserted edges (cone-in, to drop), each (u, v, l2_real, phase).
-    std::vector<std::tuple<std::uint64_t, std::uint64_t, double, double>> edges;
+    /// inserted edges (cone-in, to drop), each (u, v, l2, phase). The full
+    /// COMPLEX l2 is recorded so the restore is bit-exact on analytically
+    /// continued (Im l2 != 0) geometry too — a Re-only record silently
+    /// projected every rejected probe onto the real axis (#581).
+    std::vector<
+        std::tuple<std::uint64_t, std::uint64_t, std::complex<double>, double>>
+        edges;
     /// Vertices touched: isolated vertices removed (cone-out, to re-create) /
     /// the single fresh vertex (cone-in, to drop), each (id, coords). An empty
     /// coords vector marks a coordinate-free vertex.

--- a/include/mesh/Edge.h
+++ b/include/mesh/Edge.h
@@ -170,15 +170,27 @@ class Edge {
     /// sync as \f$\sqrt{l^2}\f$. Prefer this when the geometry is specified by a squared
     /// value (CDT, Van Raamsdonk, the backreaction scan) so \f$l^2\f$ is stored exactly
     /// and the action never sees a round-trip.
+    ///
+    /// **Ordinary-Lorentzian convention (#580/#581):** a *resident* \f$l^2\f$ is real
+    /// and signed (spacelike > 0, timelike < 0, null 0). Storage accepts a general
+    /// complex value (rollback records and saddle bookkeeping round-trip it exactly),
+    /// but the geometry stack does NOT support it: the non-Wick geometry entry points
+    /// (`Simplex::gramMatrix` and the Cayley–Menger builders, hence volumes, Lorentzian
+    /// angles and the dual Regge action) throw `std::domain_error` on
+    /// \f$|\mathrm{Im}\,l^2| > \f$ `Simplex::kResidentImTolerance` instead of silently
+    /// projecting to Re. Genuine Picard–Lefschetz (resident-complex) geometry is
+    /// deferred (#580).
     void setSquaredLength(std::complex<double> l2) noexcept {
       squaredLength_ = l2;
       length_ = std::sqrt(l2);
     }
 
     /// Set the (complex) edge length; the squared length is kept in sync as `l*l`. Use
-    /// when the geometry is specified by a length directly — the off-axis
-    /// (Picard–Lefschetz) saddle the Regge solver explores. Real for spacelike,
-    /// imaginary for timelike, general complex for the saddle.
+    /// when the geometry is specified by a length directly. Real for spacelike,
+    /// imaginary for timelike — under the ordinary-Lorentzian convention (see
+    /// `setSquaredLength`) those are the two supported resident cases; a general
+    /// complex length (the off-axis Picard–Lefschetz saddle) is stored exactly but
+    /// rejected fail-loudly by the non-Wick geometry stack (#580/#581).
     void setLength(std::complex<double> l) noexcept {
       length_ = l;
       squaredLength_ = l * l;

--- a/include/mesh/EdgeList.h
+++ b/include/mesh/EdgeList.h
@@ -44,7 +44,6 @@ class EdgeList {
                                     double squaredLength);
     EdgePtr get(const std::uint64_t &fingerprint);
     void remove(const EdgePtr &edge) noexcept;
-    void replace(const EdgePtr &toRemove, const EdgePtr &toAdd) noexcept;
 
     /// Re-key an edge's fingerprint in the lookup map without moving the object.
     void rekeyEdge(std::uint64_t oldFp, std::uint64_t newFp);

--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -280,15 +280,33 @@ class Simplex {
     [[nodiscard]] double deficitAngle() const;
 
     /// Lorentzian (Sorkin) dihedral angle at ``hinge`` within this top simplex,
-    /// as a complex number. Built from the **signed** (non-Wick) Cayley-Menger
-    /// cofactor ratio r, UN-clamped: for an ordinary (spacelike-normal-plane)
-    /// wedge |r| <= 1 and this returns the real Euclidean angle; for a timelike
-    /// normal plane |r| > 1 (the boost regime) ``std::acos`` returns a complex
-    /// value whose imaginary part is the rapidity (boost) and whose real part
-    /// (0 or pi) carries the light-cone-crossing structure (Sorkin's N pi/2).
-    /// Unlike ``dihedralAngle`` (which Wick-rotates and clamps), this keeps the
-    /// boost. Refs: Regge (1961); Sorkin, Lorentzian angles & trigonometry;
-    /// Asante-Dittrich-Padua-Arguelles, arXiv:2104.00485 Eq. (10).
+    /// as a complex number, from the **signed** (non-Wick) Cayley-Menger
+    /// cofactors — all three of the Sorkin/Asante-Dittrich m ∈ {0, 1, 2}
+    /// regimes (#581). With ``P = C_ii*C_jj`` and ``D = sqrt(|P|)``:
+    ///
+    /// * **P >= 0, |r| <= 1** (``r = -C_ij/(±D)`` with the ``(-1)^d``
+    ///   diagonal-sign fix): the wedge stays on one side of the light cone and
+    ///   the angle is the real Euclidean one (m = 0).
+    /// * **P >= 0, |r| > 1** (the boost regime, m even): ``std::acos`` returns
+    ///   a complex value whose imaginary part is the rapidity and whose real
+    ///   part (0 or pi) counts the crossed light-cone quadrants.
+    /// * **P < 0** (the m = 1 **light-cone crossing**: one facet direction
+    ///   spacelike, one timelike): the true denominator
+    ///   ``sqrt(C_ii)*sqrt(C_jj)`` (principal branches) is purely imaginary,
+    ///   so the angle is ``pi/2 - i*asinh(C_ij/D)`` — exactly a quarter turn
+    ///   plus a signed boost. Around a flat one-ray-per-quadrant Minkowski
+    ///   vertex star the four boosts telescope to zero (closure pins the
+    ///   sign); generic in CDT (every base-tet triangle of a (4,1) cell).
+    ///
+    /// Unlike ``dihedralAngle`` with ``wickRotate=true`` (the Euclidean/CDT
+    /// path, which takes |l^2| and clamps), this keeps the boost content. Note
+    /// the same-sign (m = 0 / boost) regimes' imaginary sign is the principal
+    /// branch: the wedge's boost *orientation* is not determined by edge
+    /// lengths alone (a PT reflection flips it at identical l^2), so only
+    /// crossing wedges carry an intrinsically signed boost.
+    /// Refs: Regge (1961); Sorkin, Lorentzian angles & trigonometry
+    /// (arXiv:1908.10022); Asante-Dittrich-Padua-Arguelles, arXiv:2104.00485
+    /// Eq. (10).
     [[nodiscard]] std::complex<double>
     lorentzianDihedralAngle(SimplexPtr hinge) const;
 
@@ -306,10 +324,13 @@ class Simplex {
     /// \f$ r = -C_{ij}/\pm\sqrt{|C_{ii}C_{jj}|} \f$ a ratio of cofactors of the
     /// (signed) Cayley-Menger matrix \f$ B \f$ (linear in \f$ \ell^2 \f$). Since
     /// \f$ C = \det(B)\,(B^{-1})^\top \f$ the cofactor derivatives are closed
-    /// form; the boost branch uses \f$ d\theta/dr = -1/\sin\theta \f$ so it
-    /// matches ``std::acos`` exactly. Keyed by sorted vertex-id edge; only the
-    /// edges of the top cells touching the hinge appear. Complex (the boost part
-    /// is carried, not truncated).
+    /// form; the same-sign boost branch uses \f$ d\theta/dr = -1/\sin\theta \f$
+    /// so it matches ``std::acos`` exactly, and the m = 1 light-cone-crossing
+    /// branch (\f$ C_{ii}C_{jj} < 0 \f$, #581) differentiates
+    /// \f$ \theta = \pi/2 - i\,\mathrm{asinh}(y) \f$, \f$ y = C_{ij}/D \f$, via
+    /// \f$ d\theta/dy = -i/\sqrt{1+y^2} \f$ (never singular). Keyed by sorted
+    /// vertex-id edge; only the edges of the top cells touching the hinge
+    /// appear. Complex (the boost part is carried, not truncated).
     [[nodiscard]] std::map<std::pair<std::uint64_t, std::uint64_t>,
                            std::complex<double>>
     lorentzianDeficitAngleGradient() const;
@@ -321,8 +342,12 @@ class Simplex {
     /// cofactor second derivative
     /// \f$ \partial^2 C_{pq} = \partial(\det B\,T) \f$ (T the gradient's
     /// bracket), \f$ d\theta/dr = -1/\sin\theta \f$ and
-    /// \f$ d^2\theta/dr^2 = -r/\sin^3\theta \f$. Keyed by the (sorted) edge pair;
-    /// symmetric. Complex (the boost part is carried, not truncated).
+    /// \f$ d^2\theta/dr^2 = -r/\sin^3\theta \f$ on same-sign wedges; on the
+    /// m = 1 crossing (\f$ C_{ii}C_{jj} < 0 \f$, #581)
+    /// \f$ d\theta/dy = -i/\sqrt{1+y^2} \f$ and
+    /// \f$ d^2\theta/dy^2 = +i\,y/(1+y^2)^{3/2} \f$ with \f$ y = C_{ij}/D \f$.
+    /// Keyed by the (sorted) edge pair; symmetric. Complex (the boost part is
+    /// carried, not truncated).
     [[nodiscard]] std::map<std::pair<std::pair<std::uint64_t, std::uint64_t>,
                                      std::pair<std::uint64_t, std::uint64_t>>,
                            std::complex<double>>

--- a/include/mesh/Simplex.h
+++ b/include/mesh/Simplex.h
@@ -248,6 +248,21 @@ class Simplex {
     std::uint64_t hash() const noexcept;
 
     // ==================== Geometry ====================
+    //
+    // Ordinary-Lorentzian convention (#580/#581): the geometry stack consumes
+    // REAL, SIGNED resident squared lengths (spacelike l^2 > 0, timelike
+    // l^2 < 0, null 0). A resident Im l^2 != 0 (an analytically continued /
+    // Picard-Lefschetz saddle length) is UNSUPPORTED here: the non-Wick
+    // entry points below (gramMatrix / cayleyMengerMatrix /
+    // cayleyMengerCanonical, hence volume, dihedral and deficit angles, dual
+    // volumes and the dual Regge action) throw std::domain_error rather than
+    // silently projecting it away. The Wick-rotated (|l^2|) paths remain
+    // Im-tolerant by construction.
+
+    /// Tolerance above which a resident |Im l^2| is treated as a genuine
+    /// analytic continuation (and rejected by the non-Wick geometry): float
+    /// noise stays below it.
+    static constexpr double kResidentImTolerance = 1e-12;
 
     /// Gram matrix of this simplex from its edge lengths.
     /// Returns a flat (d x d) row-major matrix where d = size() - 1.
@@ -260,6 +275,9 @@ class Simplex {
     /// ``wickRotate=true`` for the Euclidean/CDT convention that takes |l^2|
     /// on every edge (det(G) > 0 for a valid cell). For a purely spacelike
     /// (all l^2 > 0) simplex the two agree, so the toggle is a no-op there.
+    /// Non-Wick calls throw ``std::domain_error`` on a resident
+    /// ``|Im l^2| > kResidentImTolerance`` (the ordinary-Lorentzian
+    /// convention above).
     [[nodiscard]] std::vector<double> gramMatrix(bool wickRotate = false) const;
 
     /// Cayley-Menger bordered matrix of this simplex: a flat (d+2) x (d+2)
@@ -356,6 +374,13 @@ class Simplex {
     /// Area of this simplex interpreted as a triangular hinge (3 vertices).
     /// Uses Heron's formula on the three edge squared lengths; ``wickRotate``
     /// selects signed (default) vs. |l^2| (see ``gramMatrix``).
+    ///
+    /// **Lorentzian note (#581):** on the signed (non-Wick) default a
+    /// triangle whose Heron radicand is non-positive — every timelike
+    /// (negative-content) triangle, e.g. the mixed-causal hinge of a CDT
+    /// (4,1) cell — returns **0**, not an imaginary area: this method reports
+    /// only real spacelike content. Use ``volume()`` for the signed
+    /// (signature-recording) content of a Lorentzian cell.
     [[nodiscard]] double area(bool wickRotate = false) const;
 
     /// Signed d-content (volume) of this simplex on the honest,
@@ -470,6 +495,14 @@ class Simplex {
     /// Cofactor matrix of a square matrix (flat row-major, size n x n).
     [[nodiscard]] static std::vector<double> cofactorMatrix(
         const std::vector<double> &M, int n);
+
+    /// The fail-loud non-Wick squared-length read (#581): returns
+    /// ``Re(l^2)`` after asserting the edge honors the ordinary-Lorentzian
+    /// convention, throwing ``std::domain_error`` (naming the edge's vertex
+    /// ids) when ``|Im l^2| > kResidentImTolerance``. The single guard the
+    /// non-Wick geometry entry points (``gramMatrix`` /
+    /// ``cayleyMengerMatrix`` / ``cayleyMengerCanonical``) share.
+    [[nodiscard]] static double realSquaredLengthChecked(const EdgePtr &e);
 
     // ==================== Computational & Utility Methods ====================
     template<typename T> T binomial(unsigned n, unsigned k) const;

--- a/include/simulations/ReggeSolver.h
+++ b/include/simulations/ReggeSolver.h
@@ -147,7 +147,13 @@ class ReggeSolver {
     [[nodiscard]] double gradientNorm2OverEdges(
         const std::vector<std::pair<std::uint64_t, std::uint64_t>> &edges) const;
 
-    /// Point-particle matter action: \f$S_{\text{matter}} = -M \sum_{e \in W} \sqrt{-\ell^2_e}\f$.
+    /// Point-particle matter action:
+    /// \f$S_{\text{matter}} = -M \sum_{e \in W,\ e\ \text{timelike}} \sqrt{-\mathrm{Re}\,\ell^2_e}\f$.
+    /// Causal character is the canonical ``Edge::isTimelike()`` (null edges
+    /// contribute 0); under the ordinary-Lorentzian convention (resident
+    /// \f$\ell^2\f$ real and signed — see ``Edge::setSquaredLength``, #581)
+    /// the Re basis is exact: \f$\sqrt{-\mathrm{Re}\,\ell^2} = \sqrt{-\ell^2}\f$.
+    /// Real return by construction.
     [[nodiscard]] double matterAction() const;
 
     /// Total action: \f$S = S_{\text{grav}} + S_{\text{matter}}\f$.

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -234,11 +234,14 @@ class Spacetime {
     /// @return Shared pointer to the created vertex
     [[nodiscard]] VertexPtr createVertex(std::uint64_t id, const std::vector<double> &coords) const noexcept;
 
-    /// Creates an edge \f$ e = (v_s, v_t) \f$ with squared length computed from the metric.
-    /// The squared length is \f$ \ell^2 = g_{\mu\nu}(x^t - x^s)^\mu(x^t - x^s)^\nu \f$.
+    /// Creates an edge \f$ e = (v_s, v_t) \f$ as a NULL edge: \f$ \ell^2 = 0 \f$,
+    /// explicitly — no metric evaluation happens (#581; the doc previously
+    /// claimed a metric-computed length). Callers that want a geometric length
+    /// use the explicit-\f$\ell^2\f$ overload or set it afterwards
+    /// (``Edge::setSquaredLength``).
     /// @param src The source vertex \f$ v_s \f$
     /// @param tgt The target vertex \f$ v_t \f$
-    /// @return Shared pointer to the created edge
+    /// @return Shared pointer to the created (null) edge
     [[nodiscard]] EdgePtr createEdge(const VertexPtr &src, const VertexPtr &tgt) const noexcept;
 
     /// Creates an edge \f$ e = (v_s, v_t) \f$ with explicit squared length.

--- a/include/spacetime/pachner/RemoveMove.h
+++ b/include/spacetime/pachner/RemoveMove.h
@@ -4,6 +4,7 @@
 #ifndef TESSERA_PACHNER_REMOVEMOVE_H
 #define TESSERA_PACHNER_REMOVEMOVE_H
 
+#include <complex>
 #include <memory>
 #include <random>
 #include <vector>
@@ -91,13 +92,17 @@ private:
 
   // Captured by apply() — for rollback
   bool applied_ = false;
-  // Edge data captured before deletion: (sourcePtr, targetPtr,
-  // squaredLength).  EdgePtr alone is not enough because EdgeList::
-  // remove invalidates the slot.
+  // Edge data captured before deletion: (sourcePtr, targetPtr, the full
+  // COMPLEX squaredLength, and the U(1) phase) so rollback restores the
+  // edge bit-exactly — a Re-only record silently projected analytically
+  // continued geometry onto the real axis and dropped the connection
+  // phase on every rejected move (#581).  EdgePtr alone is not enough
+  // because EdgeList::remove invalidates the slot.
   struct EdgeRecord {
     VertexPtr source;
     VertexPtr target;
-    double squaredLength;
+    std::complex<double> squaredLength;
+    double phase;
   };
   std::vector<EdgeRecord> deletedEdges_;
   // Vertex tuples of the 2 replacement simplices we actually created in

--- a/src/Poset.cpp
+++ b/src/Poset.cpp
@@ -171,10 +171,11 @@ Poset Poset::fromSpacetime(Spacetime const& st) {
     const int n_dense = static_cast<int>(id_in_order.size());
 
     // Collect strict-precedes pairs (earliest → latest) from timelike
-    // edges. We test "timelike" as squaredLength < 0 (the metric-aware
-    // signal — see include/mesh/Edge.h §EdgeDisposition) AND require a
-    // strict time ordering between endpoints, since a zero-time-diff
-    // negative-squared-length edge would be a metric inconsistency we
+    // edges. "Timelike" is the canonical Edge::isTimelike() classifier
+    // (see include/mesh/Edge.h §EdgeDisposition; the superseded
+    // sign-of-Re-squaredLength test is NOT used, #581) AND we require a
+    // strict time ordering between endpoints, since a timelike edge
+    // with zero time difference would be a metric inconsistency we
     // don't want to silently propagate as a partial-order relation.
     auto const& elist = st.getEdgeList();
     std::vector<std::pair<int, int>> strict_pairs;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -651,6 +652,10 @@ bool writeGraphML(const Spacetime &st, const std::string &path) {
          "attr.type=\"int\"/>\n"
       << "  <key id=\"sq_length\" for=\"edge\" attr.name=\"squared_length\" "
          "attr.type=\"double\"/>\n"
+      << "  <key id=\"sq_length_im\" for=\"edge\" "
+         "attr.name=\"squared_length_im\" attr.type=\"double\"/>\n"
+      << "  <key id=\"phase\" for=\"edge\" attr.name=\"phase\" "
+         "attr.type=\"double\"/>\n"
       << "  <key id=\"timelike\" for=\"edge\" attr.name=\"timelike\" "
          "attr.type=\"boolean\"/>\n"
       << "  <graph id=\"spacetime\" edgedefault=\"undirected\">\n";
@@ -664,13 +669,18 @@ bool writeGraphML(const Spacetime &st, const std::string &path) {
 
     for (std::size_t i = 0; i < edges.size(); ++i) {
         auto *e = edges[i];
-        double sq = e->getSquaredLength().real();
+        // Full complex l^2 + U(1) phase; causal character from the canonical
+        // Edge::isTimelike(), not the superseded sign-of-Re test (#581). The
+        // Re key keeps its name for compatibility with existing consumers.
+        const std::complex<double> sq = e->getSquaredLength();
         f << "    <edge id=\"e" << i << "\" source=\""
           << e->getSource()->getId() << "\" target=\""
           << e->getTarget()->getId() << "\">\n"
-          << "      <data key=\"sq_length\">" << sq << "</data>\n"
+          << "      <data key=\"sq_length\">" << sq.real() << "</data>\n"
+          << "      <data key=\"sq_length_im\">" << sq.imag() << "</data>\n"
+          << "      <data key=\"phase\">" << e->getPhase() << "</data>\n"
           << "      <data key=\"timelike\">"
-          << (sq < 0 ? "true" : "false") << "</data>\n"
+          << (e->isTimelike() ? "true" : "false") << "</data>\n"
           << "    </edge>\n";
     }
 
@@ -698,11 +708,15 @@ bool writeDot(const Spacetime &st, const std::string &path) {
           << ", degree=" << v->degree() << "];\n";
 
     for (auto *e : edges) {
-        double sq = e->getSquaredLength().real();
-        bool tl = sq < 0;
+        // Canonical Edge::isTimelike() classification + the full complex l^2
+        // and phase; squared_length stays Re for compatibility (#581).
+        const std::complex<double> sq = e->getSquaredLength();
+        const bool tl = e->isTimelike();
         f << "  " << e->getSource()->getId()
           << " -- " << e->getTarget()->getId()
-          << " [squared_length=" << sq
+          << " [squared_length=" << sq.real()
+          << ", squared_length_im=" << sq.imag()
+          << ", phase=" << e->getPhase()
           << ", timelike=" << (tl ? "true" : "false")
           << ", color=" << (tl ? "blue" : "red") << "];\n";
     }

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -375,8 +375,9 @@ the live edge weights/phases on every call, so residual() tracks setWeights /
 setPhases in place. psi is indexed in the same sorted-vertex-id order as
 HodgeLaplacian (k=0).
 
-Parameters: the per-edge squared-length magnitudes {w_ij} (Edge.setSquaredLength)
-and U(1) phases {theta_ij} (Edge.setPhase), in a stable edge order fixed at
+Parameters: the per-edge SIGNED real squared lengths {w_ij} = Re l^2
+(Edge.setSquaredLength; weights() reads Re, not a magnitude — #581) and U(1)
+phases {theta_ij} (Edge.setPhase), in a stable edge order fixed at
 construction (the weight-carrying edges: both endpoints present, no self-loops).
 
 Fixed-boundary interior fill (§5.0): the tunable edges split into a boundary set
@@ -418,11 +419,15 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "L psi against the current edge weights/phases (no normalization), for "
            "direct L psi || psi cross-checks. Raises if len(psi) != order().")
       .def("weights", &EigenstateSynthesis::weights,
-           "Edge magnitudes {w_ij} (squaredLength) in the stable edge order.")
+           "The SIGNED real parts {Re l^2_ij} of the edge squared lengths, in "
+           "the stable edge order — not magnitudes (a timelike edge reads "
+           "negative), and any resident Im l^2 is not reported (#581).")
       .def("phases", &EigenstateSynthesis::phases,
            "Edge phases {theta_ij} (radians) in the stable edge order.")
       .def("setWeights", &EigenstateSynthesis::setWeights, py::arg("w"),
-           "Write the edge magnitudes in place. Raises if len(w) != numEdges().")
+           "Write the edge squared lengths in place as REAL signed values "
+           "(l^2 = w + 0i, zeroing any resident Im — the ordinary-Lorentzian "
+           "convention, #581). Raises if len(w) != numEdges().")
       .def("setPhases", &EigenstateSynthesis::setPhases, py::arg("theta"),
            "Write the edge phases in place. Raises if len(theta) != numEdges().")
       // ----- Fixed-boundary interior fill (§5.0, #147) -----
@@ -436,13 +441,15 @@ reached. On a 1-complex there is no boundary — every edge is interior.)doc")
            "Number of interior vertices (on no boundary face) — the coned-in "
            "apexes; the interior complexity the synthesis grows / reports.")
       .def("interiorWeights", &EigenstateSynthesis::interiorWeights,
-           "Interior edge magnitudes {w_ij} in interior-edge order.")
+           "Interior edge SIGNED real squared lengths {Re l^2_ij} in "
+           "interior-edge order (Re, not magnitudes — #581).")
       .def("interiorPhases", &EigenstateSynthesis::interiorPhases,
            "Interior edge phases {theta_ij} (radians) in interior-edge order.")
       .def("setInteriorWeights", &EigenstateSynthesis::setInteriorWeights,
            py::arg("w"),
-           "Write the interior edge magnitudes in place; the boundary edges are "
-           "left untouched. Raises if len(w) != numInteriorEdges().")
+           "Write the interior edge squared lengths in place as REAL signed "
+           "values (l^2 = w + 0i, zeroing any resident Im — #581); the boundary "
+           "edges are left untouched. Raises if len(w) != numInteriorEdges().")
       .def("setInteriorPhases", &EigenstateSynthesis::setInteriorPhases,
            py::arg("theta"),
            "Write the interior edge phases in place; the boundary edges are left "

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -392,14 +392,17 @@ bool EigenstateSynthesis::attachInteriorVertex(
     }
   }
 
-  // Snapshot the pinned boundary (id-pair -> (w, theta)) for the bit-exact check.
-  std::map<std::pair<std::uint64_t, std::uint64_t>, std::pair<double, double>>
+  // Snapshot the pinned boundary (id-pair -> (complex w, theta)) for the
+  // bit-exact check. The FULL complex l2 is compared, not (Re, phase) — the
+  // dW invariant must catch Im-only corruption too (#581).
+  std::map<std::pair<std::uint64_t, std::uint64_t>,
+           std::pair<std::complex<double>, double>>
       boundaryBefore;
   for (const auto i : boundaryEdgeIdx_) {
     const std::uint64_t a = edges_[i]->getSource()->getId();
     const std::uint64_t b = edges_[i]->getTarget()->getId();
     boundaryBefore[{std::min(a, b), std::max(a, b)}] = {
-        edges_[i]->getSquaredLength().real(), edges_[i]->getPhase()};
+        edges_[i]->getSquaredLength(), edges_[i]->getPhase()};
   }
 
   // Fresh interior vertex with the largest id (sorts last; preserves the
@@ -459,7 +462,7 @@ bool EigenstateSynthesis::attachInteriorVertex(
       const auto it =
           boundaryBefore.find({std::min(a, b), std::max(a, b)});
       if (it == boundaryBefore.end() ||
-          it->second.first != edges_[i]->getSquaredLength().real() ||
+          it->second.first != edges_[i]->getSquaredLength() ||
           it->second.second != edges_[i]->getPhase()) {
         valid = false;
         break;
@@ -598,20 +601,21 @@ bool EigenstateSynthesis::removeInteriorCell(
       if (covered(u, v)) continue;  // edge survives in another top cell
       const auto it = edgeByPair.find({u, v});
       if (it == edgeByPair.end()) continue;  // already absent
-      rem.removedEdges.emplace_back(
-          u, v, it->second->getSquaredLength().real(),
-          it->second->getPhase());
+      rem.removedEdges.emplace_back(u, v, it->second->getSquaredLength(),
+                                    it->second->getPhase());
       toRemove.push_back(it->second);
     }
 
-  // Snapshot ∂W (id-pair -> (w, theta)) for the bit-exact check.
-  std::map<std::pair<std::uint64_t, std::uint64_t>, std::pair<double, double>>
+  // Snapshot ∂W (id-pair -> (complex w, theta)) for the bit-exact check. Full
+  // complex l2, not (Re, phase): the dW invariant covers Im corruption (#581).
+  std::map<std::pair<std::uint64_t, std::uint64_t>,
+           std::pair<std::complex<double>, double>>
       boundaryBefore;
   for (const auto i : boundaryEdgeIdx_) {
     const std::uint64_t a = edges_[i]->getSource()->getId();
     const std::uint64_t b = edges_[i]->getTarget()->getId();
     boundaryBefore[{std::min(a, b), std::max(a, b)}] = {
-        edges_[i]->getSquaredLength().real(), edges_[i]->getPhase()};
+        edges_[i]->getSquaredLength(), edges_[i]->getPhase()};
   }
 
   // Mutate: drop the top cell, then its orphaned edges.
@@ -627,14 +631,15 @@ bool EigenstateSynthesis::removeInteriorCell(
   // present with the same weight/phase (newly EXPOSED boundary edges are allowed
   // — the opened hole — so this is a subset check, not equality).
   bool valid = true;
-  std::map<std::pair<std::uint64_t, std::uint64_t>, std::pair<double, double>>
+  std::map<std::pair<std::uint64_t, std::uint64_t>,
+           std::pair<std::complex<double>, double>>
       liveWeights;
   for (const auto e : edges_) {
     const std::uint64_t a = e->getSource()->getId();
     const std::uint64_t b = e->getTarget()->getId();
     const std::pair<std::uint64_t, std::uint64_t> key{std::min(a, b),
                                                       std::max(a, b)};
-    liveWeights[key] = {e->getSquaredLength().real(), e->getPhase()};
+    liveWeights[key] = {e->getSquaredLength(), e->getPhase()};
   }
   for (const auto &[key, wp] : boundaryBefore) {
     const auto it = liveWeights.find(key);
@@ -684,7 +689,7 @@ bool EigenstateSynthesis::applyRestore(const Removal &rem) {
   for (const auto &[u, v, w, theta] : rem.removedEdges) {
     const auto it = edgeByPair.find({std::min(u, v), std::max(u, v)});
     if (it != edgeByPair.end()) {
-      it->second->setSquaredLength(std::complex<double>{w, 0.0});
+      it->second->setSquaredLength(w);  // the recorded complex l2, bit-exact
       it->second->setPhase(theta);
     }
   }

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -1366,9 +1366,21 @@ double EigenstateSynthesis::periodGapForPeriods(
       targetPeriods);
 }
 
+void EigenstateSynthesis::requireGradientDegree(const char *who) const {
+  if (k_ == 0)
+    throw std::runtime_error(
+        std::string("EigenstateSynthesis::") + who +
+        ": the analytic gradient cores read laplacian(k).real(), which is "
+        "lossless for k >= 1 but the WRONG operator at k = 0 (L_0 consumes "
+        "the full complex l^2, so .real() silently truncates it — see #580). "
+        "The complex k = 0 gradient core is not implemented; construct the "
+        "synthesis at k >= 1 or use finite differences of residual().");
+}
+
 std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
     const std::vector<EdgeLoop> &loops,
     const std::vector<cd> &targetPeriods) const {
+  requireGradientDegree("periodGradientOverLoops");
   using Eigen::Index;
   using Eigen::MatrixXd;
   using Eigen::VectorXcd;
@@ -1568,6 +1580,7 @@ std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
 std::vector<double> EigenstateSynthesis::periodGradientGeneral(
     const std::vector<std::vector<std::uint64_t>> &holes,
     const std::vector<cd> &targetPeriods) const {
+  requireGradientDegree("periodGradientGeneral");
   // Arbitrary-degree exact d r_U / d l^2 over the removed-(k+1)-cell holes. M = L_k,
   // the per-edge dL_k/dl^2 (HodgeLaplacian::laplacianGradient, on Simplex::volumeGradient)
   // through first-order eigenvector perturbation, period covector + leak from each
@@ -1721,6 +1734,7 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradient(
 std::vector<double> EigenstateSynthesis::periodGapForLoopsGradient(
     const std::vector<EdgeLoop> &loops,
     const std::vector<cd> &targetPeriods) const {
+  requireGradientDegree("periodGapForLoopsGradient");
   // The hard-pin sibling of periodGradientOverLoops (r_U): same first-order
   // eigenvector-perturbation setup (M = L1, harmonic split Un/Unn, the per-edge
   // low-rank dM, dUn), but the score is the period GAP r_psi = ||A c - t||^2 with
@@ -1925,6 +1939,7 @@ std::vector<double> EigenstateSynthesis::residualForLoopsGradient(
 std::vector<double> EigenstateSynthesis::residualForPeriodsGradientGpu(
     const std::vector<std::vector<std::uint64_t>> &holes,
     const std::vector<cd> &targetPeriods) const {
+  requireGradientDegree("residualForPeriodsGradientGpu");
 #ifndef TESSERA_CUDA
   (void)holes;
   (void)targetPeriods;

--- a/src/cobordism/SurgicalCone.cpp
+++ b/src/cobordism/SurgicalCone.cpp
@@ -132,7 +132,8 @@ std::pair<bool, std::string> SurgicalCone::coneOut(
   if (otherTop.empty()) return {false, "refusing to remove the last top cell"};
 
   // An edge {u,v} of the cell is orphaned iff no surviving top cell covers both
-  // endpoints. Capture (u, v, l2, phase) for each orphan so rollback restores it.
+  // endpoints. Capture (u, v, complex l2, phase) for each orphan so rollback
+  // restores it bit-exactly (#581: the full complex value, never Re alone).
   const auto covered = [&](std::uint64_t u, std::uint64_t v) {
     for (const auto &c : otherTop) {
       const bool hu = std::find(c.begin(), c.end(), u) != c.end();
@@ -152,7 +153,7 @@ std::pair<bool, std::string> SurgicalCone::coneOut(
       if (covered(u, v)) continue;
       const auto it = eidx.find({std::min(u, v), std::max(u, v)});
       if (it == eidx.end()) continue;  // already absent
-      m.edges.emplace_back(u, v, it->second->getSquaredLength().real(),
+      m.edges.emplace_back(u, v, it->second->getSquaredLength(),
                            it->second->getPhase());
       toRemove.push_back(it->second);
     }
@@ -230,7 +231,7 @@ std::pair<bool, std::string> SurgicalCone::coneIn(
   for (const auto &e : r.newEdges)
     if (e != nullptr && e->getSource() != nullptr && e->getTarget() != nullptr)
       m.edges.emplace_back(e->getSource()->getId(), e->getTarget()->getId(),
-                           e->getSquaredLength().real(), e->getPhase());
+                           e->getSquaredLength(), e->getPhase());
 
   const auto verdict = validate();
   if (!verdict.first) {
@@ -264,7 +265,7 @@ void SurgicalCone::undoConeOut(const Move &m) {
   for (const auto &[u, v, w, theta] : m.edges) {
     const auto it = eidx.find({std::min(u, v), std::max(u, v)});
     if (it != eidx.end()) {
-      it->second->setSquaredLength(std::complex<double>{w, 0.0});
+      it->second->setSquaredLength(w);  // the recorded complex l2, bit-exact
       it->second->setPhase(theta);
     }
   }

--- a/src/cuda/regge_cuda.cu
+++ b/src/cuda/regge_cuda.cu
@@ -86,6 +86,10 @@ __device__ double cofactor_ij(const double *M, int n, int i, int j) {
 
 // Compute dihedral angle from a Cayley-Menger bordered matrix B of size n×n,
 // at the hinge opposite local vertices va, vb (0-indexed simplex vertices).
+// Mirrors the CPU Simplex::dihedralAngle Euclidean path exactly (#581): the
+// same (-1)^d diagonal-sign fix (C_ii < 0 in odd dimension would otherwise
+// collapse the angle to its supplement) applied BEFORE the clamp, so the
+// clamped ratio is the same sign-fixed ratio the CPU clamps.
 __device__ double dihedral_from_cm(const double *B, int n, int va, int vb) {
     int bi = va + 1; // shift for border row/col
     int bj = vb + 1;
@@ -94,6 +98,7 @@ __device__ double dihedral_from_cm(const double *B, int n, int va, int vb) {
     double Cjj = cofactor_ij(B, n, bj, bj);
     double denom = sqrt(fabs(Cii * Cjj));
     if (denom < 1e-15) return 0.0;
+    if (Cii < 0.0) denom = -denom;  // (-1)^d diagonal-sign fix (CPU parity)
     double cosTheta = -Cij / denom;
     cosTheta = fmax(-1.0, fmin(1.0, cosTheta));
     return acos(cosTheta);

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -391,10 +391,12 @@ Python-driven materialization corrupted dualVolume(). Reference fixes it
            "content).")
       .def("lorentzianDihedralAngle", &Simplex::lorentzianDihedralAngle,
            py::arg("hinge"),
-           "Complex Lorentzian (Sorkin) dihedral angle at the hinge: real for "
-           "an ordinary wedge, complex (imaginary part = boost rapidity) for a "
-           "timelike normal plane. Unlike dihedralAngle it is not clamped/Wick-"
-           "rotated, so boosts survive.")
+           "Complex Lorentzian (Sorkin) dihedral angle at the hinge — the full "
+           "m in {0,1,2} structure (#581): real for an ordinary wedge, complex "
+           "(imaginary part = boost rapidity) for a same-character wedge in "
+           "the boost regime, and pi/2 - i*asinh(.) for a wedge CROSSING the "
+           "light cone (one facet direction spacelike, one timelike). Unlike "
+           "dihedralAngle it is not clamped/Wick-rotated, so boosts survive.")
       .def("lorentzianDeficitAngle", &Simplex::lorentzianDeficitAngle,
            "Complex Lorentzian deficit 2π − Σ lorentzianDihedralAngle over the "
            "top cells at this hinge; real for an all-spacelike neighbourhood, "

--- a/src/mesh/EdgeList.cpp
+++ b/src/mesh/EdgeList.cpp
@@ -90,12 +90,6 @@ void EdgeList::remove(const EdgePtr &edge) noexcept {
   edge->liveIdx_ = UINT32_MAX;
 }
 
-void EdgeList::replace(const EdgePtr &toRemove, const EdgePtr &toAdd) noexcept {
-  remove(toRemove);
-  add(toAdd->getSource(), toAdd->getTarget(),
-      toAdd->getSquaredLength().real());
-}
-
 void EdgeList::rekeyEdge(std::uint64_t oldFp, std::uint64_t newFp) {
   if (oldFp == newFp) return;
   auto it = fpToSlot_.find(oldFp);

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -851,11 +851,27 @@ std::complex<double> Simplex::lorentzianDihedralAngle(SimplexPtr hinge) const {
     const double Cij = cof[static_cast<std::size_t>(bi) * n + bj];
     const double Cii = cof[static_cast<std::size_t>(bi) * n + bi];
     const double Cjj = cof[static_cast<std::size_t>(bj) * n + bj];
-    double denom = std::sqrt(std::abs(Cii * Cjj));
-    if (denom < 1e-15) return {0.0, 0.0};
-    if (Cii < 0.0) denom = -denom;  // (-1)^d diagonal-sign fix (see dihedralAngle)
-    const double r = -Cij / denom;
-    return std::acos(std::complex<double>(r, 0.0));
+    const double D = std::sqrt(std::abs(Cii * Cjj));
+    if (D < 1e-15) return {0.0, 0.0};
+    if (Cii * Cjj >= 0.0) {
+        // Same-sign cofactors: the wedge stays on one side of the light cone
+        // (the m=0 real angle for |r| <= 1 and the boost regime for |r| > 1).
+        double denom = D;
+        if (Cii < 0.0) denom = -denom;  // (-1)^d diagonal-sign fix (see dihedralAngle)
+        const double r = -Cij / denom;
+        return std::acos(std::complex<double>(r, 0.0));
+    }
+    // Opposite-sign cofactors: the wedge CROSSES the light cone (one facet
+    // direction spacelike, one timelike -- the m=1 case, #581). The true
+    // denominator sqrt(Cii)*sqrt(Cjj) (principal branches) is then purely
+    // imaginary (+i*D), the cosine ratio -Cij/(i*D) = i*(Cij/D) is purely
+    // imaginary, and the principal acos is
+    //     theta = pi/2 - i*asinh(Cij/D).
+    // Each crossing contributes exactly pi/2 to Re(theta) (Sorkin's quarter
+    // turn) plus a signed boost; around a flat one-ray-per-quadrant vertex
+    // star the boosts telescope to zero, which pins this sign convention.
+    const double y = Cij / D;
+    return {std::numbers::pi / 2.0, -std::asinh(y)};
 }
 
 std::complex<double> Simplex::lorentzianDeficitAngle() const {
@@ -914,12 +930,23 @@ Simplex::lorentzianDeficitAngleGradient() const {
         const double sP = (Cii * Cjj >= 0.0) ? 1.0 : -1.0;
         const double D = std::sqrt(std::abs(Cii * Cjj));
         if (D < 1e-300) continue;
+        // Opposite-sign cofactors = the m=1 light-cone-crossing wedge (#581):
+        // theta = pi/2 - i*asinh(y), y = Cij/D, so d theta/dy = -i/sqrt(1+y^2)
+        // (never singular: |sin theta| = sqrt(1+y^2) >= 1). Same-sign wedges
+        // keep the acos branch bit-for-bit.
+        const bool crossing = sP < 0.0;
         const double denom = sC * D;
-        const double r = -Cij / denom;
-        const cd theta = std::acos(cd(r, 0.0));
-        const cd sinTheta = std::sin(theta);
-        if (std::abs(sinTheta) < 1e-300) continue;           // flat/folded: skip
-        const cd dthetaDr = cd(-1.0, 0.0) / sinTheta;        // boost-safe branch
+        const double y = Cij / D;
+        cd dthetaDr;
+        if (crossing) {
+            dthetaDr = cd(0.0, -1.0) / std::sqrt(1.0 + y * y);
+        } else {
+            const double r = -Cij / denom;
+            const cd theta = std::acos(cd(r, 0.0));
+            const cd sinTheta = std::sin(theta);
+            if (std::abs(sinTheta) < 1e-300) continue;       // flat/folded: skip
+            dthetaDr = cd(-1.0, 0.0) / sinTheta;             // boost-safe branch
+        }
 
         // dC_pq for the edge (a,b): dB is the indicator at (a+1,b+1)&(b+1,a+1);
         // dC = det[ tr(B^-1 dB) B^-1 - B^-1 dB B^-1 ], extracted entrywise.
@@ -934,10 +961,16 @@ Simplex::lorentzianDeficitAngleGradient() const {
                 const double dCij = dCof(bi, bj, a, b);
                 const double dCii = dCof(bi, bi, a, b);
                 const double dCjj = dCof(bj, bj, a, b);
+                // d sqrt(|Cii*Cjj|) — the sP factor makes this valid on both
+                // sides of the crossing.
                 const double dD = sP * (dCii * Cjj + Cii * dCjj) / (2.0 * D);
-                const double ddenom = sC * dD;
-                const double dr =
-                    -(dCij * denom - Cij * ddenom) / (denom * denom);
+                double dr;
+                if (crossing) {
+                    dr = (dCij * D - Cij * dD) / (D * D);    // dy
+                } else {
+                    const double ddenom = sC * dD;
+                    dr = -(dCij * denom - Cij * ddenom) / (denom * denom);
+                }
                 const std::uint64_t va = tv[a]->getId(), vb = tv[b]->getId();
                 grad[{std::min(va, vb), std::max(va, vb)}] -= dthetaDr * dr;
             }
@@ -996,13 +1029,27 @@ Simplex::lorentzianDeficitAngleHessian() const {
         const double sP = (Cii * Cjj >= 0.0) ? 1.0 : -1.0;
         const double D = std::sqrt(std::abs(Cii * Cjj));
         if (D < 1e-300) continue;
+        // Same m=1 crossing branch as the gradient (#581): on opposite-sign
+        // cofactors theta = pi/2 - i*asinh(y) with y = Cij/D, so
+        // d theta/dy = -i/(1+y^2)^{1/2} and d^2 theta/dy^2 = +i*y/(1+y^2)^{3/2}
+        // (never singular). Same-sign wedges keep the acos machinery.
+        const bool crossing = sP < 0.0;
         const double denom = sC * D;
-        const double r = -Cij / denom;
-        const cd theta = std::acos(cd(r, 0.0));
-        const cd sinT = std::sin(theta);
-        if (std::abs(sinT) < 1e-300) continue;
-        const cd dthetaDr = cd(-1.0, 0.0) / sinT;
-        const cd d2thetaDr2 = cd(-r, 0.0) / (sinT * sinT * sinT);
+        const double y = Cij / D;
+        cd dthetaDr, d2thetaDr2;
+        if (crossing) {
+            const double onePlus = 1.0 + y * y;
+            const double sq = std::sqrt(onePlus);
+            dthetaDr = cd(0.0, -1.0) / sq;
+            d2thetaDr2 = cd(0.0, y) / (onePlus * sq);
+        } else {
+            const double r = -Cij / denom;
+            const cd theta = std::acos(cd(r, 0.0));
+            const cd sinT = std::sin(theta);
+            if (std::abs(sinT) < 1e-300) continue;
+            dthetaDr = cd(-1.0, 0.0) / sinT;
+            d2thetaDr2 = cd(-r, 0.0) / (sinT * sinT * sinT);
+        }
 
         auto bb = [&](int x, int y) -> double { return Binv[x * n + y]; };
         // dC_pq/dl^2_(a,b): a,b local vertex indices (CM border = +1).
@@ -1037,9 +1084,13 @@ Simplex::lorentzianDeficitAngleHessian() const {
                 const double dCii = dCof(bi, bi, a, b);
                 const double dCjj = dCof(bj, bj, a, b);
                 const double dD = sP * (dCii * Cjj + Cii * dCjj) / (2.0 * D);
-                const double ddenom = sC * dD;
-                const double dr =
-                    -(dCij * denom - Cij * ddenom) / (denom * denom);
+                double dr;
+                if (crossing) {
+                    dr = (dCij * D - Cij * dD) / (D * D);    // dy
+                } else {
+                    const double ddenom = sC * dD;
+                    dr = -(dCij * denom - Cij * ddenom) / (denom * denom);
+                }
                 es.push_back({a, b, tv[a]->getId(), tv[b]->getId(), dr});
             }
 
@@ -1048,13 +1099,15 @@ Simplex::lorentzianDeficitAngleHessian() const {
             const double dCii_e = dCof(bi, bi, e.a, e.b);
             const double dCjj_e = dCof(bj, bj, e.a, e.b);
             const double dP_e = dCii_e * Cjj + Cii * dCjj_e;
-            const double ddenom_e = sC * sP * dP_e / (2.0 * D);
+            const double dD_e = sP * dP_e / (2.0 * D);
+            const double ddenom_e = sC * dD_e;
             for (const auto &f : es) {
                 const double dCij_f = dCof(bi, bj, f.a, f.b);
                 const double dCii_f = dCof(bi, bi, f.a, f.b);
                 const double dCjj_f = dCof(bj, bj, f.a, f.b);
                 const double dP_f = dCii_f * Cjj + Cii * dCjj_f;
-                const double ddenom_f = sC * sP * dP_f / (2.0 * D);
+                const double dD_f = sP * dP_f / (2.0 * D);
+                const double ddenom_f = sC * dD_f;
 
                 const double d2Cij = d2Cof(bi, bj, e.a, e.b, f.a, f.b);
                 const double d2Cii = d2Cof(bi, bi, e.a, e.b, f.a, f.b);
@@ -1063,12 +1116,18 @@ Simplex::lorentzianDeficitAngleHessian() const {
                                    + dCii_f * dCjj_e + Cii * d2Cjj;
                 const double d2D = sP * d2P / (2.0 * D)
                                    - dP_e * dP_f / (4.0 * D * D * D);
-                const double d2denom = sC * d2D;
 
-                // r = N/Den, N = -Cij, Den = denom.
-                const double N = -Cij, Ne = -dCij_e, Nf = -dCij_f, Nef = -d2Cij;
-                const double Den = denom, De = ddenom_e, Df = ddenom_f,
-                             Def = d2denom;
+                // Quotient rule, second order. Same-sign: r = N/Den with
+                // N = -Cij, Den = denom. Crossing: y = Cij/D (#581).
+                double N, Ne, Nf, Nef, Den, De, Df, Def;
+                if (crossing) {
+                    N = Cij; Ne = dCij_e; Nf = dCij_f; Nef = d2Cij;
+                    Den = D; De = dD_e; Df = dD_f; Def = d2D;
+                } else {
+                    N = -Cij; Ne = -dCij_e; Nf = -dCij_f; Nef = -d2Cij;
+                    Den = denom; De = ddenom_e; Df = ddenom_f;
+                    Def = sC * d2D;
+                }
                 const double d2r =
                     ((Nef * Den + Ne * Df - Nf * De - N * Def) * Den
                      - 2.0 * (Ne * Den - N * De) * Df) / (Den * Den * Den);

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -658,6 +658,22 @@ std::vector<double> Simplex::cofactorMatrix(
     return C;
 }
 
+double Simplex::realSquaredLengthChecked(const EdgePtr &e) {
+    const std::complex<double> sq = e->getSquaredLength();
+    if (std::abs(sq.imag()) > kResidentImTolerance) {
+        throw std::domain_error(
+            "Simplex geometry: edge (" +
+            std::to_string(e->getSource()->getId()) + ", " +
+            std::to_string(e->getTarget()->getId()) +
+            ") carries resident Im l^2 = " + std::to_string(sq.imag()) +
+            "; the ordinary-Lorentzian convention requires real signed l^2 — "
+            "resident complex lengths are UNSUPPORTED by the geometry stack "
+            "(Picard–Lefschetz deferred; see #580/#581). Wick-rotated (|l^2|) "
+            "paths remain Im-tolerant.");
+    }
+    return sq.real();
+}
+
 std::vector<double> Simplex::gramMatrix(bool wickRotate) const {
     int dPlus1 = static_cast<int>(vertices.size());
     int d = dPlus1 - 1;
@@ -665,12 +681,13 @@ std::vector<double> Simplex::gramMatrix(bool wickRotate) const {
 
     // Squared-distance lookup. Honor the signed l^2 so the Lorentzian sign of
     // timelike edges survives into G; wickRotate takes |l^2| (Euclidean/CDT).
+    // The non-Wick read fails loudly on resident Im l^2 (#581).
     std::unordered_map<std::uint64_t, double> sqMap;
     for (const auto &e : edges) {
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
         sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
-                               : e->getSquaredLength().real();
+                               : realSquaredLengthChecked(e);
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -693,12 +710,13 @@ std::vector<double> Simplex::cayleyMengerMatrix(bool wickRotate) const {
     if (dPlus1 < 1) return {};
 
     // Squared-distance lookup; signed by default, |l^2| under wickRotate.
+    // The non-Wick read fails loudly on resident Im l^2 (#581).
     std::unordered_map<std::uint64_t, double> sqMap;
     for (const auto &e : edges) {
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
         sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
-                               : e->getSquaredLength().real();
+                               : realSquaredLengthChecked(e);
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -733,12 +751,13 @@ std::vector<double> Simplex::cayleyMengerCanonical(
     for (int i = 0; i < dPlus1; ++i)
         pos1[sorted[static_cast<std::size_t>(i)]->getId()] = i + 1;  // border-offset
 
+    // Non-Wick reads fail loudly on resident Im l^2 (#581).
     std::unordered_map<std::uint64_t, double> sqMap;
     for (const auto &e : edges) {
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
         sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
-                               : e->getSquaredLength().real();
+                               : realSquaredLengthChecked(e);
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -1182,18 +1201,13 @@ void Simplex::assertSpacelikeAdmissible(double tol) const {
     if (n < 2) return;                        // trivially admissible
     const int d = n - 1;
 
-    // Skip simplices that contain any null/timelike (worldline) edge: their
-    // admissibility is Lorentzian, not the spacelike triangle inequalities. The
-    // Cayley-Menger bordered matrix carries the squared edge lengths in its
-    // lower-right (d+1)x(d+1) block, offset (1, 1) of the (d+2)x(d+2) array.
-    const std::vector<double> cm = cayleyMengerMatrix(/*wickRotate=*/false);
-    const int mm = n + 1;  // CM is (d+2) x (d+2)
-    for (int a = 0; a < n; ++a) {
-        for (int b = a + 1; b < n; ++b) {
-            const double s = cm[static_cast<std::size_t>(1 + a) * mm + (1 + b)];
-            if (s <= tol) return;  // null/timelike edge → not a spacelike cell
-        }
-    }
+    // Skip simplices that contain any non-spacelike (null/timelike/worldline)
+    // edge: their admissibility is Lorentzian, not the spacelike triangle
+    // inequalities. Causal character is the canonical Edge classification
+    // (Edge::isSpacelike, Im of the complex length), not a hand-rolled
+    // sign-of-l^2 test (#581).
+    for (const auto &e : edges)
+        if (!e->isSpacelike()) return;
 
     // All edges spacelike: the Gram matrix must be positive-definite. Check via
     // Sylvester's criterion (every leading principal minor > 0) so the test

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -330,9 +330,12 @@ double ReggeSolver::gradientNorm2OverEdges(
 }
 
 double ReggeSolver::matterAction() const {
-    // Point-particle action: S_matter = -M ∫ dτ
-    // Timelike edges (between slices) have ℓ² < 0; spacelike edges (within a
-    // slice) have ℓ² > 0.  Proper time = √(-ℓ²).
+    // Point-particle action: S_matter = -M ∫ dτ. Causal character comes from
+    // the canonical Edge::isTimelike() classifier (Im of the complex length),
+    // not a hand-rolled sign-of-Re test (#581). Under the ordinary-Lorentzian
+    // convention (resident ℓ² real and signed, Edge::setSquaredLength) the
+    // proper time of a timelike step is √(-Re ℓ²) = √(-ℓ²); null edges are
+    // not timelike and contribute nothing.
     double S = 0.0;
     for (const auto &wl : matter_.getWorldlines()) {
         for (std::size_t i = 0; i + 1 < wl.vertices.size(); ++i) {
@@ -343,9 +346,9 @@ double ReggeSolver::matterAction() const {
                 auto *other = (e->getSource()->getId() == v1->getId())
                               ? e->getTarget() : e->getSource();
                 if (other->getId() == v2->getId()) {
-                    double sq = e->getSquaredLength().real();
-                    if (sq < 0.0)  // timelike: ℓ² < 0
-                        S -= wl.mass * std::sqrt(-sq);
+                    if (e->isTimelike())
+                        S -= wl.mass *
+                             std::sqrt(-e->getSquaredLength().real());
                     break;
                 }
             }

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -424,6 +424,12 @@ std::vector<std::complex<double>> ReggeSolver::actionGradientExact() const {
     std::vector<std::vector<cd>> partials(
         static_cast<std::size_t>(nThreads), std::vector<cd>(E, cd(0.0, 0.0)));
 
+    // An exception may not escape an OpenMP region (std::terminate, taking the
+    // whole process). The hinge geometry can throw — e.g. the #581 resident-Im
+    // guard firing on a stage-2 Wirtinger trial — so capture the first
+    // exception and rethrow it after the join: callers (the stage-2 line
+    // search) treat an inevaluable trial as +inf and back off.
+    std::exception_ptr pending = nullptr;
     #pragma omp parallel
     {
 #ifdef _OPENMP
@@ -434,19 +440,25 @@ std::vector<std::complex<double>> ReggeSolver::actionGradientExact() const {
         std::vector<cd> &gLocal = partials[static_cast<std::size_t>(tid)];
         #pragma omp for schedule(static)
         for (std::ptrdiff_t hi = 0; hi < nH; ++hi) {
-            const auto &h = hinges[static_cast<std::size_t>(hi)];
-            const cd eps = h->lorentzianDeficitAngle();
-            const double dv = h->dualVolume();
-            for (const auto &[e, dEps] : h->lorentzianDeficitAngleGradient()) {
-                const auto it = eidx.find(e);
-                if (it != eidx.end()) gLocal[it->second] += dv * dEps;
-            }
-            for (const auto &[e, dDv] : h->dualVolumeGradient()) {
-                const auto it = eidx.find(e);
-                if (it != eidx.end()) gLocal[it->second] += dDv * eps;
+            try {
+                const auto &h = hinges[static_cast<std::size_t>(hi)];
+                const cd eps = h->lorentzianDeficitAngle();
+                const double dv = h->dualVolume();
+                for (const auto &[e, dEps] : h->lorentzianDeficitAngleGradient()) {
+                    const auto it = eidx.find(e);
+                    if (it != eidx.end()) gLocal[it->second] += dv * dEps;
+                }
+                for (const auto &[e, dDv] : h->dualVolumeGradient()) {
+                    const auto it = eidx.find(e);
+                    if (it != eidx.end()) gLocal[it->second] += dDv * eps;
+                }
+            } catch (...) {
+                #pragma omp critical(tessera_regge_grad_eptr)
+                if (!pending) pending = std::current_exception();
             }
         }
     }
+    if (pending) std::rethrow_exception(pending);
 
     std::vector<cd> g(E, cd(0.0, 0.0));
     for (const auto &p : partials)
@@ -483,6 +495,8 @@ ReggeSolver::actionHessianExact() const {
         static_cast<std::size_t>(nThreads),
         std::vector<std::vector<cd>>(E, std::vector<cd>(E, cd(0.0, 0.0))));
 
+    // Same OpenMP exception discipline as actionGradientExact (#581).
+    std::exception_ptr pending = nullptr;
     #pragma omp parallel
     {
 #ifdef _OPENMP
@@ -493,11 +507,18 @@ ReggeSolver::actionHessianExact() const {
         std::vector<std::vector<cd>> &Hloc =
             partials[static_cast<std::size_t>(tid)];
         #pragma omp for schedule(static)
-        for (std::ptrdiff_t hi = 0; hi < nH; ++hi)
-            for (const auto &[i, j, term] :
-                 hingeHessianEntries(hinges[static_cast<std::size_t>(hi)], eidx))
-                Hloc[i][j] += term;
+        for (std::ptrdiff_t hi = 0; hi < nH; ++hi) {
+            try {
+                for (const auto &[i, j, term] : hingeHessianEntries(
+                         hinges[static_cast<std::size_t>(hi)], eidx))
+                    Hloc[i][j] += term;
+            } catch (...) {
+                #pragma omp critical(tessera_regge_hess_eptr)
+                if (!pending) pending = std::current_exception();
+            }
+        }
     }
+    if (pending) std::rethrow_exception(pending);
 
     std::vector<std::vector<cd>> H(E, std::vector<cd>(E, cd(0.0, 0.0)));
     for (const auto &P : partials)
@@ -574,6 +595,8 @@ ReggeSolver::actionHessianExactSparse() const {
 #endif
     std::vector<std::vector<Trip>> partials(static_cast<std::size_t>(nThreads));
 
+    // Same OpenMP exception discipline as actionGradientExact (#581).
+    std::exception_ptr pending = nullptr;
     #pragma omp parallel
     {
 #ifdef _OPENMP
@@ -583,11 +606,19 @@ ReggeSolver::actionHessianExactSparse() const {
 #endif
         std::vector<Trip> &local = partials[static_cast<std::size_t>(tid)];
         #pragma omp for schedule(static)
-        for (std::ptrdiff_t hi = 0; hi < nH; ++hi)
-            for (const auto &[i, j, term] :
-                 hingeHessianEntries(hinges[static_cast<std::size_t>(hi)], eidx))
-                local.emplace_back(static_cast<int>(i), static_cast<int>(j), term);
+        for (std::ptrdiff_t hi = 0; hi < nH; ++hi) {
+            try {
+                for (const auto &[i, j, term] : hingeHessianEntries(
+                         hinges[static_cast<std::size_t>(hi)], eidx))
+                    local.emplace_back(static_cast<int>(i),
+                                       static_cast<int>(j), term);
+            } catch (...) {
+                #pragma omp critical(tessera_regge_sparse_eptr)
+                if (!pending) pending = std::current_exception();
+            }
+        }
     }
+    if (pending) std::rethrow_exception(pending);
 
     std::vector<Trip> triplets;
     std::size_t total = 0;

--- a/src/spacetime/pachner/RemoveMove.cpp
+++ b/src/spacetime/pachner/RemoveMove.cpp
@@ -216,10 +216,10 @@ bool RemoveMove::applyPreGeometric() {
   vertexCoords_.clear();
   for (const auto &e : v_->getInEdges())
     deletedEdges_.push_back({e->getSource(), e->getTarget(),
-                             e->getSquaredLength().real()});
+                             e->getSquaredLength(), e->getPhase()});
   for (const auto &e : v_->getOutEdges())
     deletedEdges_.push_back({e->getSource(), e->getTarget(),
-                             e->getSquaredLength().real()});
+                             e->getSquaredLength(), e->getPhase()});
 
   // Remove the d+1 incident cells.
   for (const auto &s : incident_) st_->removeSimplex(s);
@@ -265,16 +265,16 @@ bool RemoveMove::apply() {
   vertexId_ = v_->getId();
   vertexCoords_ = v_->getCoordinates();
 
-  // Snapshot incident edges (in + out) and their squared lengths.
-  // (We can't capture EdgePtr — those slots get freed by EdgeList::
-  // remove.)
+  // Snapshot incident edges (in + out): the full complex squared length
+  // AND the U(1) phase, so rollback is bit-exact (#581).  (We can't
+  // capture EdgePtr — those slots get freed by EdgeList::remove.)
   for (const auto &e : v_->getInEdges()) {
     deletedEdges_.push_back({e->getSource(), e->getTarget(),
-                             e->getSquaredLength().real()});
+                             e->getSquaredLength(), e->getPhase()});
   }
   for (const auto &e : v_->getOutEdges()) {
     deletedEdges_.push_back({e->getSource(), e->getTarget(),
-                             e->getSquaredLength().real()});
+                             e->getSquaredLength(), e->getPhase()});
   }
 
   // 2. Remove the 2d incident simplices.
@@ -359,7 +359,15 @@ void RemoveMove::rollback() {
     // After re-creating the vertex with the original ID, the OLD
     // pointer captured in EdgeRecord may have been freed.  We rely on
     // the ID match above; ID-stable accessors are sufficient.
-    auto r = st_->getEdgeList()->tryAdd(src, tgt, er.squaredLength);
+    // tryAdd's factory unit is the real signed l^2; the exact complex
+    // value and the U(1) phase are written onto the fresh edge right
+    // after creation so the restore is bit-exact (#581).  An edge that
+    // already exists was never deleted, so its values are left alone.
+    auto r = st_->getEdgeList()->tryAdd(src, tgt, er.squaredLength.real());
+    if (r.second) {
+      r.first->setSquaredLength(er.squaredLength);
+      r.first->setPhase(er.phase);
+    }
     src->addOutEdge(r.first);
     tgt->addInEdge(r.first);
   }

--- a/tessera/utils/plot.py
+++ b/tessera/utils/plot.py
@@ -192,7 +192,13 @@ def layout_from_spacetime(verts, edges, **kwargs):
         ti = vid_to_idx.get(e.getTarget().getId())
         if si is not None and ti is not None:
             edge_idx.append((si, ti))
-            rest_lens.append(math.sqrt(abs(e.getSquaredLength().real)))
+            # Layout-only collapse of the complex signed l^2 to a positive
+            # rest length |Re l^2| (Im and the causal sign are deliberately
+            # NOT drawn), with an epsilon floor so null edges don't pin two
+            # vertices together — the multicobordism animation's convention
+            # (#581).
+            rest_lens.append(
+                math.sqrt(max(abs(e.getSquaredLength().real), 1e-6)))
 
     pos = force_layout_3d(len(verts), edge_idx,
                           rest_lengths=rest_lens, **kwargs)

--- a/tests/cobordism/test_complex_rollback_records_python.py
+++ b/tests/cobordism/test_complex_rollback_records_python.py
@@ -1,0 +1,270 @@
+"""Complex+phase-exact rollback records (#581 scope items 2 and 3).
+
+Three of the four rollback families restored edges from Re-only records,
+violating their own "restore bit-exactly" contracts on analytically continued
+(``Im l^2 != 0``) or phase-carrying geometry: every REJECTED move silently
+projected the complex onto the real axis.  This module covers the
+``SurgicalCone`` and ``EigenstateSynthesis`` families (the ``RemoveMove``
+family lives with the other Pachner tests in
+``tests/test_pachner_remove_complex_rollback.py``) plus the Im-aware dW pin
+gates:
+
+* ``SurgicalCone.coneOut`` + ``rollback`` restores an ORPHANED edge's full
+  complex ``l^2`` and U(1) phase bit-exactly (a window-adjacent face of the
+  holed icosahedron orphans its shared rim edge — the deterministic orphan);
+* a REJECTED ``coneOut`` (a pinching removal) leaves the complex-valued
+  geometry bit-identical — the ``directedConeOut/In`` hot path, where probes
+  roll back tens of times per iteration;
+* ``coneIn`` + ``rollback`` drops the fresh edges and leaves every surviving
+  edge untouched;
+* ``EigenstateSynthesis.removeInteriorCell`` + ``restoreLastRemoval`` is
+  bit-exact on Im+phase-carrying geometry (note: an interior cell's faces all
+  carry >= 2 cofaces, so such a removal can never orphan an edge — the
+  complex-valued ``Removal`` record is correctness for the reject/restore
+  path, exercised here through the round trip);
+* the dW pin gates hold with complex boundary values: an Im+phase-carrying
+  pinned boundary is ACCEPTED unchanged through an interior attach (positive
+  control — the full-complex comparison does not false-reject), and an attach
+  that would take a pinned dW edge out of the boundary is REJECTED with the
+  complex geometry restored bit-exactly;
+* action-invariance round trips on real signed-l^2 (timelike-carrying)
+  geometry — the hinge-exactness contract extended to the surgical cone on a
+  mixed-causal-character host.
+"""
+
+import cmath
+import math
+
+import pytest
+
+import tessera as T
+
+cob = T.cobordism
+
+# The standard icosahedron (12 vertices, 20 faces) and its three mutually
+# vertex-disjoint windows — the _holed_surface fixture's constants.
+ICOSA_FACES = [
+    [0, 11, 5], [0, 5, 1], [0, 1, 7], [0, 7, 10], [0, 10, 11],
+    [1, 5, 9], [5, 11, 4], [11, 10, 2], [10, 7, 6], [7, 1, 8],
+    [3, 9, 4], [3, 4, 2], [3, 2, 6], [3, 6, 8], [3, 8, 9],
+    [4, 9, 5], [2, 4, 11], [6, 2, 10], [8, 6, 7], [9, 8, 1],
+]
+WINDOWS = [[0, 11, 5], [3, 2, 6], [9, 8, 1]]
+
+
+def _holed_icosa():
+    rm = {tuple(sorted(t)) for t in WINDOWS}
+    faces = [f for f in ICOSA_FACES if tuple(sorted(f)) not in rm]
+    st = T.Spacetime.fromCells(2, faces, 1.0, 0.0)
+    st.materializeFacets()
+    return st
+
+
+def _full_icosa():
+    st = T.Spacetime.fromCells(2, ICOSA_FACES, 1.0, 0.0)
+    st.materializeFacets()
+    return st
+
+
+def _seed_complex_geometry(st):
+    """Distinct synthetic Im l^2 != 0 and phase != 0 on every edge, keyed off
+    the endpoint ids so the values are order-independent."""
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        lo, hi = min(a, b), max(a, b)
+        e.setSquaredLength(complex(1.0 + 0.01 * lo, 0.05 + 0.01 * hi))
+        e.setPhase(0.1 + 0.003 * (lo * 13 + hi))
+
+
+def _seed_signed_geometry(st, timelike_keys):
+    """Real signed l^2 (some timelike), zero Im, nonzero phases."""
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        k = (min(a, b), max(a, b))
+        e.setSquaredLength(-1.5 if k in timelike_keys else 1.0 + 0.01 * k[0])
+        e.setPhase(0.2 + 0.001 * k[1])
+
+
+def _edge_state(st):
+    """{(a, b): (complex l^2, phase)} over the live edge list."""
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = (complex(e.getSquaredLength()),
+                                       e.getPhase())
+    return out
+
+
+def _tops(st):
+    return sorted(tuple(sorted(v.getId() for v in s.getVertices()))
+                  for s in st.getTopSimplices())
+
+
+def _assert_state_equal(before, after, allow_missing=()):
+    assert set(after) == set(before) - set(allow_missing), (
+        f"edge set drifted: only-before={set(before) - set(after)} "
+        f"only-after={set(after) - set(before)}")
+    for k, (sq, ph) in after.items():
+        sq0, ph0 = before[k]
+        assert sq == sq0, f"edge {k}: l^2 {sq0!r} -> {sq!r} (not bit-exact)"
+        assert ph == ph0, f"edge {k}: phase {ph0!r} -> {ph!r} (not bit-exact)"
+
+
+# --------------------------------------------------------------------------- #
+# SurgicalCone
+# --------------------------------------------------------------------------- #
+def test_cone_out_rollback_restores_orphaned_complex_edge_bitexact():
+    # Face [5,11,4] is the sole surviving coface of the window rim edge
+    # (5,11) (its other coface was the removed window [0,11,5]), and its
+    # third vertex 4 is interior, so coning it out is accepted (the hole
+    # grows to a quad disk) and ORPHANS (5,11): the rollback must re-create
+    # that edge from the record — full complex l^2 AND phase, not a Re-only
+    # projection.
+    st = _holed_icosa()
+    _seed_complex_geometry(st)
+    before = _edge_state(st)
+    tops_before = _tops(st)
+
+    sc = cob.SurgicalCone(st)
+    ok, reason = sc.coneOut([5, 11, 4])
+    assert ok, reason
+    assert (5, 11) not in _edge_state(st), "rim edge (5,11) must be orphaned"
+
+    assert sc.rollback()
+    _assert_state_equal(before, _edge_state(st))
+    assert _tops(st) == tops_before
+
+
+def test_rejected_cone_out_leaves_complex_geometry_bitexact():
+    # Face [0,1,7] shares only vertex 0 with the window hole [0,11,5]:
+    # removing it would pinch vertex 0's link into two arcs, so the gate
+    # rejects and the auto-rollback must leave the complex-valued geometry
+    # bit-identical (the directedConeOut hot-path contract).
+    st = _holed_icosa()
+    _seed_complex_geometry(st)
+    before = _edge_state(st)
+    tops_before = _tops(st)
+
+    sc = cob.SurgicalCone(st)
+    ok, reason = sc.coneOut([0, 1, 7])
+    assert not ok, "removal pinching the hole rim must be rejected"
+    assert sc.depth == 0
+    _assert_state_equal(before, _edge_state(st))
+    assert _tops(st) == tops_before
+
+
+def test_cone_in_rollback_drops_fresh_edges_and_keeps_survivors_bitexact():
+    st = _holed_icosa()
+    _seed_complex_geometry(st)
+    before = _edge_state(st)
+    tops_before = _tops(st)
+
+    sc = cob.SurgicalCone(st)
+    ok, reason = sc.coneIn([0, 5])  # cap part of the [0,11,5] window
+    if not ok:
+        pytest.skip(f"cone-in rejected on this host: {reason}")
+    assert set(_edge_state(st)) > set(before), "cone-in must add fresh edges"
+
+    assert sc.rollback()
+    _assert_state_equal(before, _edge_state(st))
+    assert _tops(st) == tops_before
+
+
+def test_cone_round_trip_preserves_complex_action_on_timelike_host():
+    # Real signed l^2 with timelike edges (Im l^2 = 0, so the geometry stack
+    # may evaluate): the accepted cone-out round trip must retrace the full
+    # COMPLEX dual Regge action, Re and Im — the hinge-exactness contract on
+    # a mixed-causal-character host.  Closed host (the full icosahedron), the
+    # domain the existing hinge-exactness suites cover: on already-holed
+    # hosts an orphan-restoring rollback has a PRE-EXISTING circumcentric
+    # dual-volume bookkeeping drift (hinge deficits exact, dualVolume not)
+    # that is orthogonal to #581 — see the follow-up issue filed with this
+    # test.
+    st = _full_icosa()
+    _seed_signed_geometry(st, timelike_keys={(0, 1), (7, 10)})
+    s0 = complex(T.ReggeSolver(st, T.MatterConfiguration()).dualReggeAction())
+    assert abs(s0.imag) > 1e-9, "fixture is not genuinely Lorentzian"
+    before = _edge_state(st)
+
+    sc = cob.SurgicalCone(st)
+    ok, reason = sc.coneOut([5, 11, 4])
+    assert ok, reason
+    assert sc.rollback()
+
+    _assert_state_equal(before, _edge_state(st))
+    s1 = complex(T.ReggeSolver(st, T.MatterConfiguration()).dualReggeAction())
+    assert abs(s1.real - s0.real) < 1e-9
+    assert abs(s1.imag - s0.imag) < 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# EigenstateSynthesis: removeInteriorCell / restoreLastRemoval
+# --------------------------------------------------------------------------- #
+def test_remove_interior_cell_restore_is_bitexact_on_complex_geometry():
+    # The full icosahedron is closed: dW is empty, every vertex interior, so
+    # any face is a removable interior cell.  The restore must bring back the
+    # cell with every surviving edge's complex l^2 + phase untouched.
+    st = _full_icosa()
+    es = cob.EigenstateSynthesis(st, 1)
+    _seed_complex_geometry(st)
+    before = _edge_state(st)
+    tops_before = _tops(st)
+
+    assert es.removeInteriorCell([0, 5, 1])
+    assert es.restoreLastRemoval()
+    _assert_state_equal(before, _edge_state(st))
+    assert _tops(st) == tops_before
+
+
+def test_remove_interior_cell_boundary_pre_gate_rejects_bitexact():
+    # On the holed host every face touches a hole-rim (boundary) vertex, so
+    # the interiority pre-gate rejects and nothing may move — including Im.
+    st = _holed_icosa()
+    es = cob.EigenstateSynthesis(st, 1)
+    _seed_complex_geometry(st)
+    before = _edge_state(st)
+
+    assert es.interiorTopCells() == []
+    assert not es.removeInteriorCell([0, 5, 1])
+    _assert_state_equal(before, _edge_state(st))
+
+
+# --------------------------------------------------------------------------- #
+# The Im-aware dW pin gates
+# --------------------------------------------------------------------------- #
+def test_dw_pin_gate_accepts_interior_attach_with_complex_boundary():
+    # Positive control: the pinned dW carries Im l^2 != 0 and phase != 0; an
+    # attach that only touches interior edges (the stellar fan over the fully
+    # interior-edged face {0,7,10}) must be ACCEPTED — the full-complex
+    # comparison agrees with itself — and detach must restore bit-exactly.
+    st = _holed_icosa()
+    es = cob.EigenstateSynthesis(st, 1)
+    _seed_complex_geometry(st)
+    before = _edge_state(st)
+    n_boundary = es.numBoundaryEdges()
+    assert n_boundary > 0
+
+    assert es.attachInteriorVertex([[0, 7], [7, 10], [0, 10]])
+    # dW is value-identical through the accepted attach
+    after = _edge_state(st)
+    for k in before:
+        assert after[k] == before[k], f"edge {k} drifted through the attach"
+
+    assert es.detachLastInteriorVertex()
+    _assert_state_equal(before, _edge_state(st))
+
+
+def test_dw_pin_gate_rejects_attach_touching_boundary_and_restores_im():
+    # An attach onto the pinned dW edge (0,5) would pull it out of the
+    # boundary (a second coface) — the gate must reject it and the rollback
+    # must leave the complex-valued geometry bit-identical, Im included.
+    st = _holed_icosa()
+    es = cob.EigenstateSynthesis(st, 1)
+    _seed_complex_geometry(st)
+    before = _edge_state(st)
+    boundary = {tuple(k) for k in es.boundaryEdges()}
+    assert (0, 5) in boundary
+
+    assert not es.attachInteriorVertex([[0, 5]])
+    _assert_state_equal(before, _edge_state(st))
+    assert {tuple(k) for k in es.boundaryEdges()} == boundary

--- a/tests/cobordism/test_complex_rollback_records_python.py
+++ b/tests/cobordism/test_complex_rollback_records_python.py
@@ -32,9 +32,6 @@ gates:
   mixed-causal-character host.
 """
 
-import cmath
-import math
-
 import pytest
 
 import tessera as T

--- a/tests/cobordism/test_emergent_proton_animation.py
+++ b/tests/cobordism/test_emergent_proton_animation.py
@@ -72,7 +72,9 @@ class EmergentProtonAnimationTest(unittest.TestCase):
             anim.update(f)
         title = anim.fig._suptitle.get_text()
         self.assertIn("ProtonIngredients", title)
-        self.assertIn("singlet diagnostic", title)       # observational, not a gate
+        # observational, not a gate; the #586 verdict tag spells the singlet
+        # diagnostic "r_state(singlet)=", in BOTH title branches (#588)
+        self.assertIn("r_state(singlet)", title)
         plt.close(anim.fig)
 
     def test_fast_path_reports_what_emerged(self):

--- a/tests/cobordism/test_hinge_exact_moves.py
+++ b/tests/cobordism/test_hinge_exact_moves.py
@@ -239,8 +239,9 @@ def test_standalone_cone_out_then_in():
 # --------------------------------------------------------------------------- #
 def test_imaginary_part_preserved_under_coning():
     """A surgical cone can flip a local induced orientation -> a spurious sign in the
-    causal (Im S) deficit. On a genuinely complex action (CDT toroid, Im S ~ -35) the
-    cone-in/out round trip must restore Im S, not just |S|."""
+    causal (Im S) deficit. On a genuinely complex action (CDT toroid, Im S ~ -11 with
+    the #581 mixed-hinge branch; ~ -35 before it) the cone-in/out round trip must
+    restore Im S, not just |S|."""
     st = _make_cdt(120)
     a0 = _act(st)
     assert abs(a0.imag) > 1.0, "fixture is not genuinely Lorentzian"

--- a/tests/cobordism/test_k0_gradient_guard_python.py
+++ b/tests/cobordism/test_k0_gradient_guard_python.py
@@ -1,0 +1,41 @@
+"""The analytic r_U / r_psi gradient cores refuse degree k = 0 (#581 item 7).
+
+The cores project the metric Hodge operator with ``laplacian(k).real()`` —
+lossless for k >= 1 (the metric L_k is real symmetric there) but silently the
+WRONG operator at k = 0, where L_0 consumes the full complex l^2 (#580).
+Until a complex k = 0 core exists they fail loudly; k = 1 keeps working.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+import tessera
+
+cob = tessera.cobordism
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+
+from _holed_surface import holed_surface  # noqa: E402
+
+
+def test_k0_synthesis_gradient_cores_throw():
+    st, _es1, holes, P = holed_surface(degree=1)
+    es0 = cob.EigenstateSynthesis(st)  # default degree k = 0
+    target = [complex(z) for z in P[0]]
+    with pytest.raises(RuntimeError, match="580"):
+        es0.residualForPeriodsGradient(holes, target)
+    with pytest.raises(RuntimeError, match="k = 0"):
+        es0.periodGapForPeriodsGradient(holes, target)
+
+
+def test_k1_gradients_still_work():
+    st, es, holes, P = holed_surface(degree=1)
+    target = [complex(z) for z in P[0]]
+    g = np.asarray(es.residualForPeriodsGradient(holes, target))
+    assert g.shape[0] > 0 and np.all(np.isfinite(g))
+    g2 = np.asarray(es.periodGapForPeriodsGradient(holes, target))
+    assert g2.shape[0] > 0 and np.all(np.isfinite(g2))

--- a/tests/cobordism/test_stage2_unclamped_python.py
+++ b/tests/cobordism/test_stage2_unclamped_python.py
@@ -20,6 +20,8 @@ import os
 import sys
 import unittest
 
+import pytest
+
 import tessera as T
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -116,6 +118,14 @@ class Stage2UnclampedTest(unittest.TestCase):
             self.assertFalse(hasattr(cob.MultiCobordism, name),
                              f"clamping machinery reappeared: {name}")
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="the deferred stage-2 Im-drift interaction (#580 systemic 1, "
+        "deferred on #581): on a mixed-hinge host the complex Wirtinger trial "
+        "writes resident Im l^2, which the ordinary-Lorentzian geometry "
+        "convention rejects fail-loud, so the line search backs every trial "
+        "off (+inf) and no step is accepted until runStage2 proposes trials "
+        "on the real axis (the #565/#573 owner's adaptation)")
     def test_accepted_steps_never_pin_to_the_old_clamp(self):
         # Seed edges on the wrong side of every retired bound: timelike (the reader-
         # verification allowance), beyond the old ±20 cap, and inside the old 0.05

--- a/tests/cobordism/test_surgical_cone_topology.py
+++ b/tests/cobordism/test_surgical_cone_topology.py
@@ -24,7 +24,8 @@ Coverage:
 * a surgical cone-out raises ``b_2`` by exactly 1 on a small ``S^3``, and the
   inverse lowers it by 1 (topology restored);
 * the cone-out round trip restores the dual Regge action (Re AND Im) on a
-  genuinely Lorentzian CDT toroid (``Im S`` ~ -35);
+  genuinely Lorentzian CDT toroid (``Im S`` ~ -11 with the #581 mixed-hinge
+  branch; ~ -35 before it);
 * the gate rejects a non-manifold attempt (a cone-in onto an interior facet ->
   3 cofaces) and leaves the complex unchanged;
 * cone-in needs a boundary (it always rejects on a closed manifold) and is

--- a/tests/mesh/test_mixed_hinge_lorentzian_python.py
+++ b/tests/mesh/test_mixed_hinge_lorentzian_python.py
@@ -1,0 +1,505 @@
+"""Mixed-hinge (light-cone-crossing) branch of the Lorentzian dihedral angle (#581).
+
+A hinge wedge whose two adjacent facet directions have different causal
+character (one spacelike, one timelike normal direction — the m=1 case of the
+Sorkin/Asante–Dittrich m∈{0,1,2} classification) has opposite-sign Cayley–
+Menger diagonal cofactors, ``C_ii·C_jj < 0``.  The true complex denominator
+``sqrt(C_ii)·sqrt(C_jj)`` (principal branches) is then purely imaginary, the
+cosine ratio is purely imaginary, and the angle is
+
+    theta = pi/2 - i*asinh(C_ij / sqrt(|C_ii*C_jj|)).
+
+The pre-#581 code forced the ratio real (``acos(complex(r, 0))`` over a
+one-sidedly sign-fixed real denominator), which corrupted BOTH parts of the
+angle on every mixed hinge — generic in CDT (every base-tet triangle of a
+(4,1) cell; the seeded toroid has 240/1200 such wedges).
+
+Coverage (the decisive tests of #581 scope item 1):
+
+* the 2D Minkowski analytic repro — triangle ℓ² = (+1, −3, −4) → the mixed
+  vertex angle is exactly π/2 + i·asinh(1/√3);
+* flat-Minkowski closure, the sign-convention arbiter — a flat vertex star
+  covering all four light-cone quadrants sums to 2π + 0i (symmetric star:
+  exactly; generic asymmetric star: the four crossing boosts telescope to 0);
+* a 4D (4,1)-type cell — base-triangle hinge angle π/2 + i·asinh(1/(4√2)),
+  independently derived from the coordinate embedding in R^{3,1};
+* relabeling invariance on mixed cells (the #465 canonical-frame property);
+* gradient/Hessian on mixed hinges: Euler identities (the sanctioned
+  validation — θ and ε are degree-0 homogeneous in ℓ², so Σℓ²·∂ = 0 and
+  Σℓ²·∂² = −∂) plus internal consistency against central differences of the
+  implemented functions;
+* the same-sign regimes are regression-pinned (all-spacelike real angle and
+  the |r|>1 boost branch are unchanged).
+
+Known, documented limitation (NOT under test): same-sign (m=0/boost) wedges'
+imaginary parts keep the principal-branch sign, so a flat star containing
+several rays in one light-cone sector does not close — the wedge boost
+orientation is not determined by edge lengths alone (a PT reflection flips it
+while preserving every ℓ²).  Stars with one ray per quadrant close exactly.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+import unittest
+
+import pytest
+
+try:
+    import tessera
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures (the test_lorentzian_regge_python.py materialization pattern)
+# --------------------------------------------------------------------------- #
+def _spacetime(dim, topology):
+    sig = tessera.Signature(dim, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, topology)
+
+
+def _solid_simplex(dim):
+    st = _spacetime(dim, tessera.SolidSimplex(dim))
+    st.build()
+    return st
+
+
+def _edge_map(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _set_edges(st, mapping, default=None):
+    for k, e in _edge_map(st).items():
+        if k in mapping:
+            e.setSquaredLength(mapping[k])
+        elif default is not None:
+            e.setSquaredLength(default)
+        e.setPhase(0.0)
+
+
+def _materialize(st):
+    """Build the facet/coface skeleton in C++ (ReggeSolver ctor); the canonical
+    sub-simplices then live in st.getSimplices()."""
+    tessera.ReggeSolver(st, tessera.MatterConfiguration())
+
+
+def _simplex_by_verts(st, ids):
+    want = tuple(sorted(ids))
+    for s in st.getSimplices():
+        if tuple(sorted(v.getId() for v in s.getVertices())) == want:
+            return s
+    raise AssertionError(f"no simplex {want} (did you materialize?)")
+
+
+def _mixed_triangle():
+    """The audit's minimal repro: 2D Minkowski triangle, ℓ² = (+1, −3, −4).
+    At vertex 0 the wedge crosses the light cone: edge (0,1) spacelike,
+    edge (0,2) timelike."""
+    st = _solid_simplex(2)
+    _set_edges(st, {(0, 1): 1.0, (0, 2): -3.0, (1, 2): -4.0})
+    return st
+
+
+def _mink_sq(p, q):
+    """Exact Minkowski ℓ² of the segment p→q, (t, x) coordinates, (−,+)."""
+    dt, dx = q[0] - p[0], q[1] - p[1]
+    return -dt * dt + dx * dx
+
+
+def _flat_star(points):
+    """A flat 2D vertex star: boundary vertex k+1 at ``points[k]`` (a (t, x)
+    coordinate), triangles (0, k, k+1) fanned around centre vertex 0, every
+    edge carrying its exact Minkowski ℓ².  Returns (st, centre_hinge)."""
+    st = _spacetime(2, tessera.SolidSimplex(2))
+    st.build()  # triangle 0-1-2 (vertices 0, 1, 2 exist)
+    v = {x.getId(): x for x in st.getVertexList().toVector()}
+    n = len(points)
+    for k in range(3, n + 1):
+        v[k] = st.createVertex(k)
+    for k in range(1, n + 1):
+        b = 1 if k == n else k + 1
+        if {k, b} != {1, 2}:  # triangle {0,1,2} already built
+            st.createSimplex([v[0], v[k], v[b]])
+    O = (0.0, 0.0)
+    mapping = {}
+    for k in range(1, n + 1):
+        mapping[(0, k)] = _mink_sq(O, points[k - 1])
+        b = 1 if k == n else k + 1
+        mapping[(min(k, b), max(k, b))] = _mink_sq(points[k - 1],
+                                                   points[b - 1])
+    _set_edges(st, mapping)
+    _materialize(st)
+    return st, _simplex_by_verts(st, [0])
+
+
+def _cell_41():
+    """A (4,1)-type Lorentzian 4-simplex: regular unit base tet {0,1,2,3}
+    (ℓ² = +1) + apex 4 with all apex edges timelike (ℓ² = −1, α = 1)."""
+    st = _solid_simplex(4)
+    mapping = {}
+    for i in range(4):
+        for j in range(i + 1, 4):
+            mapping[(i, j)] = 1.0
+        mapping[(i, 4)] = -1.0
+    _set_edges(st, mapping)
+    _materialize(st)
+    return st
+
+
+def _grad_by_edge(hinge):
+    return {tuple(k): v
+            for k, v in hinge.lorentzianDeficitAngleGradient().items()}
+
+
+def _hess_by_pair(hinge):
+    return {(tuple(ke), tuple(kf)): v
+            for (ke, kf), v in hinge.lorentzianDeficitAngleHessian().items()}
+
+
+def _fd_deficit_grad(st, hinge, key, h=1e-6):
+    """Central difference of the implemented lorentzianDeficitAngle in ℓ² of
+    the given edge (internal consistency, not a correctness oracle)."""
+    e = _edge_map(st)[key]
+    orig = e.getSquaredLength()
+    e.setSquaredLength(orig + h)
+    fp = complex(hinge.lorentzianDeficitAngle())
+    e.setSquaredLength(orig - h)
+    fm = complex(hinge.lorentzianDeficitAngle())
+    e.setSquaredLength(orig)
+    return (fp - fm) / (2.0 * h)
+
+
+# --------------------------------------------------------------------------- #
+# The analytic 2D repro
+# --------------------------------------------------------------------------- #
+class TestMixedVertexAnalytic(unittest.TestCase):
+    def test_mixed_vertex_angle_is_pi_2_plus_i_asinh(self):
+        st = _mixed_triangle()
+        _materialize(st)
+        tri = _simplex_by_verts(st, [0, 1, 2])
+        v0 = _simplex_by_verts(st, [0])
+        theta = complex(tri.lorentzianDihedralAngle(v0))
+        expect = complex(math.pi / 2.0, math.asinh(1.0 / math.sqrt(3.0)))
+        self.assertAlmostEqual(theta.real, expect.real, delta=1e-12)
+        self.assertAlmostEqual(theta.imag, expect.imag, delta=1e-12)
+        # the crossing is a genuine light-cone crossing, not a boost artifact
+        self.assertGreater(theta.imag, 0.0)
+
+    def test_other_vertices_of_the_repro_triangle(self):
+        # v1 is also mixed (s10 = +1, s12 = −4) but its Gram inner product
+        # vanishes (1 + (−4) − (−3) = 0): exactly π/2, zero boost.  v2 is a
+        # same-sign (two-timelike-edge) wedge: the untouched boost branch.
+        st = _mixed_triangle()
+        _materialize(st)
+        tri = _simplex_by_verts(st, [0, 1, 2])
+        th1 = complex(tri.lorentzianDihedralAngle(_simplex_by_verts(st, [1])))
+        self.assertAlmostEqual(th1.real, math.pi / 2.0, delta=1e-12)
+        self.assertAlmostEqual(th1.imag, 0.0, delta=1e-12)
+        th2 = complex(tri.lorentzianDihedralAngle(_simplex_by_verts(st, [2])))
+        # cos θ = ⟨e20,e21⟩/(√(−3)√(−4)) = (−3−4−1)/2 / (−√12) = 2/√3 > 1
+        boost = cmath.acos(complex(2.0 / math.sqrt(3.0), 0.0))
+        self.assertAlmostEqual(th2.real, boost.real, delta=1e-12)
+        self.assertAlmostEqual(th2.imag, boost.imag, delta=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Flat-Minkowski closure — the sign-convention arbiter
+# --------------------------------------------------------------------------- #
+class TestFlatMinkowskiClosure(unittest.TestCase):
+    def test_symmetric_four_quadrant_star_closes_exactly(self):
+        # (±1,0),(0,±1) in (t,x): every wedge crosses one light-cone quadrant
+        # boundary; the null hypotenuses zero the Gram inner products, so each
+        # interior angle is exactly π/2 + 0i and the deficit is exactly 0.
+        pts = [(1.0, 0.0), (0.0, 1.0), (-1.0, 0.0), (0.0, -1.0)]
+        st, centre = _flat_star(pts)
+        angles = []
+        for tri_ids in [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 1, 4)]:
+            tri = _simplex_by_verts(st, tri_ids)
+            angles.append(complex(tri.lorentzianDihedralAngle(centre)))
+        for th in angles:
+            self.assertEqual(th.real, math.pi / 2.0)
+            self.assertEqual(th.imag, 0.0)
+        total = sum(angles)
+        self.assertEqual(total.real, 2.0 * math.pi)
+        self.assertEqual(total.imag, 0.0)
+        eps = complex(centre.lorentzianDeficitAngle())
+        self.assertEqual(eps.real, 0.0)
+        self.assertEqual(eps.imag, 0.0)
+
+    def test_asymmetric_flat_star_deficit_vanishes(self):
+        # Generic flat star, one ray per light-cone quadrant (in (t,x)):
+        # R-sector (x>|t|), F (t>|x|), L (x<−|t|), P (t<−|x|), counterclockwise.
+        # All four wedges are m=1 crossings; the asinh boosts are nonzero and
+        # must telescope to zero — this pins the crossing branch's sign.
+        pts = [(0.25, 1.3), (1.6, 0.4), (0.3, -1.5), (-1.4, 0.5)]
+        st, centre = _flat_star(pts)
+        eps = complex(centre.lorentzianDeficitAngle())
+        self.assertAlmostEqual(eps.real, 0.0, delta=1e-12)
+        self.assertAlmostEqual(eps.imag, 0.0, delta=1e-12)
+        # every wedge is a genuine crossing (Re = π/2) with a nonzero boost
+        boosts = []
+        for tri_ids in [(0, 1, 2), (0, 2, 3), (0, 3, 4), (0, 1, 4)]:
+            tri = _simplex_by_verts(st, tri_ids)
+            th = complex(tri.lorentzianDihedralAngle(centre))
+            self.assertAlmostEqual(th.real, math.pi / 2.0, delta=1e-12)
+            boosts.append(th.imag)
+        self.assertGreater(max(abs(b) for b in boosts), 0.05)
+        self.assertAlmostEqual(sum(boosts), 0.0, delta=1e-12)
+
+    def test_more_asymmetric_flat_stars(self):
+        # A few more generic one-per-quadrant stars (different radii and
+        # rapidities), all must close to 2π + 0i.
+        cases = [
+            [(0.9, 2.1), (2.3, -0.7), (0.05, -0.4), (-1.1, 0.15)],
+            [(-0.6, 0.8), (1.05, 1.0), (0.55, -0.85), (-2.5, -2.0)],
+        ]
+        for pts in cases:
+            st, centre = _flat_star(pts)
+            eps = complex(centre.lorentzianDeficitAngle())
+            self.assertAlmostEqual(eps.real, 0.0, delta=1e-11)
+            self.assertAlmostEqual(eps.imag, 0.0, delta=1e-11)
+
+
+# --------------------------------------------------------------------------- #
+# 4D mixed hinge on a (4,1)-type cell
+# --------------------------------------------------------------------------- #
+class TestMixedHinge4D(unittest.TestCase):
+    # Independent derivation (R^{3,1} embedding, signature (−,+,+,+)): unit
+    # regular base tet at t=0, apex over the centroid at t = √(11/8) so every
+    # apex edge has ℓ² = −1.  At the base-triangle hinge {0,1,2} the orthogonal
+    # (z,t) plane carries metric (+,−); the away-from-hinge facet directions
+    # are u = (√(2/3), 0) (spacelike, base tet) and w = (√(2/3)/4, √(11/8))
+    # (timelike, side tet): ⟨u,u⟩ = 2/3, ⟨w,w⟩ = −4/3, ⟨u,w⟩ = 1/6, so
+    # cos θ = −i/(4√2) and θ = π/2 + i·asinh(1/(4√2)).
+    EXPECT = complex(math.pi / 2.0, math.asinh(1.0 / (4.0 * math.sqrt(2.0))))
+
+    def test_base_triangle_hinge_angle(self):
+        st = _cell_41()
+        cell = _simplex_by_verts(st, [0, 1, 2, 3, 4])
+        hinge = _simplex_by_verts(st, [0, 1, 2])
+        theta = complex(cell.lorentzianDihedralAngle(hinge))
+        self.assertAlmostEqual(theta.real, self.EXPECT.real, delta=1e-12)
+        self.assertAlmostEqual(theta.imag, self.EXPECT.imag, delta=1e-12)
+
+    def test_every_base_triangle_is_mixed_and_equal(self):
+        # All four base triangles are equivalent under the tet symmetry.
+        st = _cell_41()
+        cell = _simplex_by_verts(st, [0, 1, 2, 3, 4])
+        for ids in [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)]:
+            theta = complex(cell.lorentzianDihedralAngle(
+                _simplex_by_verts(st, ids)))
+            self.assertAlmostEqual(theta.real, self.EXPECT.real, delta=1e-12)
+            self.assertAlmostEqual(theta.imag, self.EXPECT.imag, delta=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Relabeling invariance on mixed cells (the #465 canonical-frame property)
+# --------------------------------------------------------------------------- #
+class TestRelabelingInvariance(unittest.TestCase):
+    def _cell_41_with_ids(self, ids, order):
+        """The _cell_41 geometry with vertex ids ``ids[abstract]`` and the
+        cell's stored vertex order permuted by ``order``."""
+        st = _spacetime(4, tessera.SolidSimplex(4))
+        v = {}
+        for a in range(5):
+            v[a] = st.createVertex(ids[a])
+        st.createSimplex([v[a] for a in order])
+        mapping = {}
+        for i in range(4):
+            for j in range(i + 1, 4):
+                mapping[(min(ids[i], ids[j]), max(ids[i], ids[j]))] = 1.0
+            mapping[(min(ids[i], ids[4]), max(ids[i], ids[4]))] = -1.0
+        _set_edges(st, mapping)
+        _materialize(st)
+        return st, v
+
+    def test_permuted_ids_and_stored_order_give_identical_angles(self):
+        base_st = _cell_41()
+        base_cell = _simplex_by_verts(base_st, [0, 1, 2, 3, 4])
+        base_theta = complex(base_cell.lorentzianDihedralAngle(
+            _simplex_by_verts(base_st, [0, 1, 2])))
+
+        perms = [
+            ([10, 3, 7, 42, 0], (4, 2, 0, 3, 1)),
+            ([5, 90, 11, 2, 33], (1, 3, 4, 0, 2)),
+        ]
+        for ids, order in perms:
+            st, v = self._cell_41_with_ids(ids, order)
+            cell = _simplex_by_verts(st, ids)
+            hinge = _simplex_by_verts(st, [ids[0], ids[1], ids[2]])
+            theta = complex(cell.lorentzianDihedralAngle(hinge))
+            self.assertAlmostEqual(theta.real, base_theta.real, delta=1e-13)
+            self.assertAlmostEqual(theta.imag, base_theta.imag, delta=1e-13)
+
+    def test_mixed_2d_triangle_relabeled(self):
+        st = _spacetime(2, tessera.SolidSimplex(2))
+        v = {a: st.createVertex(i) for a, i in enumerate([17, 4, 99])}
+        st.createSimplex([v[2], v[0], v[1]])
+        _set_edges(st, {(4, 17): 1.0, (17, 99): -3.0, (4, 99): -4.0})
+        _materialize(st)
+        tri = _simplex_by_verts(st, [4, 17, 99])
+        theta = complex(tri.lorentzianDihedralAngle(
+            _simplex_by_verts(st, [17])))
+        expect = complex(math.pi / 2.0, math.asinh(1.0 / math.sqrt(3.0)))
+        self.assertAlmostEqual(theta.real, expect.real, delta=1e-12)
+        self.assertAlmostEqual(theta.imag, expect.imag, delta=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Gradient and Hessian on mixed hinges
+# --------------------------------------------------------------------------- #
+class TestMixedHingeGradient(unittest.TestCase):
+    def _euler_gradient(self, st, hinge, tol=1e-10):
+        """θ (hence ε) is degree-0 homogeneous in ℓ²: Σ_e ℓ²_e ∂ε/∂ℓ²_e = 0,
+        real AND imaginary parts (the repo's sanctioned validation)."""
+        em = _edge_map(st)
+        total = complex(0.0, 0.0)
+        seen = 0
+        for key, g in _grad_by_edge(hinge).items():
+            total += em[key].getSquaredLength() * complex(g)
+            seen += 1
+        self.assertGreater(seen, 0)
+        self.assertAlmostEqual(total.real, 0.0, delta=tol)
+        self.assertAlmostEqual(total.imag, 0.0, delta=tol)
+
+    def test_euler_identity_2d_mixed(self):
+        st = _mixed_triangle()
+        _materialize(st)
+        self._euler_gradient(st, _simplex_by_verts(st, [0]))
+
+    def test_euler_identity_4d_mixed(self):
+        st = _cell_41()
+        self._euler_gradient(st, _simplex_by_verts(st, [0, 1, 2]))
+
+    def test_euler_identity_flat_star_centre(self):
+        st, centre = _flat_star([(0.25, 1.3), (1.6, 0.4),
+                                 (0.3, -1.5), (-1.4, 0.5)])
+        self._euler_gradient(st, centre)
+
+    def test_gradient_matches_fd_2d_mixed(self):
+        st = _mixed_triangle()
+        _materialize(st)
+        hinge = _simplex_by_verts(st, [0])
+        grad = _grad_by_edge(hinge)
+        for key in [(0, 1), (0, 2), (1, 2)]:
+            fd = _fd_deficit_grad(st, hinge, key)
+            g = complex(grad[key])
+            self.assertAlmostEqual(g.real, fd.real, delta=5e-6)
+            self.assertAlmostEqual(g.imag, fd.imag, delta=5e-6)
+
+    def test_gradient_matches_fd_4d_mixed(self):
+        st = _cell_41()
+        hinge = _simplex_by_verts(st, [0, 1, 2])
+        grad = _grad_by_edge(hinge)
+        for key in [(0, 1), (0, 3), (0, 4), (2, 4)]:
+            fd = _fd_deficit_grad(st, hinge, key)
+            g = complex(grad[key])
+            self.assertAlmostEqual(g.real, fd.real, delta=5e-6)
+            self.assertAlmostEqual(g.imag, fd.imag, delta=5e-6)
+
+    def test_gradient_is_complex_on_the_crossing(self):
+        # the crossing branch must move the boost: some ∂ε/∂ℓ² has Im ≠ 0
+        st = _cell_41()
+        grad = _grad_by_edge(_simplex_by_verts(st, [0, 1, 2]))
+        self.assertGreater(max(abs(complex(g).imag) for g in grad.values()),
+                           1e-3)
+
+
+class TestMixedHingeHessian(unittest.TestCase):
+    def _euler_hessian(self, st, hinge, tol=1e-8):
+        """∂ε/∂ℓ²_e is degree-(−1) homogeneous: Σ_f ℓ²_f ∂²ε/∂ℓ²_e∂ℓ²_f =
+        −∂ε/∂ℓ²_e for every e."""
+        em = _edge_map(st)
+        grad = _grad_by_edge(hinge)
+        hess = _hess_by_pair(hinge)
+        rows = {}
+        for (ke, kf), v in hess.items():
+            rows.setdefault(ke, complex(0.0, 0.0))
+            rows[ke] += em[kf].getSquaredLength() * complex(v)
+        self.assertGreater(len(rows), 0)
+        for ke, total in rows.items():
+            want = -complex(grad[ke])
+            self.assertAlmostEqual(total.real, want.real, delta=tol)
+            self.assertAlmostEqual(total.imag, want.imag, delta=tol)
+
+    def test_euler_identity_2d_mixed(self):
+        st = _mixed_triangle()
+        _materialize(st)
+        self._euler_hessian(st, _simplex_by_verts(st, [0]))
+
+    def test_euler_identity_4d_mixed(self):
+        st = _cell_41()
+        self._euler_hessian(st, _simplex_by_verts(st, [0, 1, 2]))
+
+    def test_hessian_symmetric_and_matches_fd_of_gradient(self):
+        st = _mixed_triangle()
+        _materialize(st)
+        hinge = _simplex_by_verts(st, [0])
+        hess = _hess_by_pair(hinge)
+        em = _edge_map(st)
+        keys = [(0, 1), (0, 2), (1, 2)]
+        h = 1e-6
+        for ke in keys:
+            for kf in keys:
+                self.assertAlmostEqual(
+                    abs(complex(hess[(ke, kf)]) - complex(hess[(kf, ke)])),
+                    0.0, delta=1e-12)
+                e = em[kf]
+                orig = e.getSquaredLength()
+                e.setSquaredLength(orig + h)
+                gp = complex(_grad_by_edge(hinge)[ke])
+                e.setSquaredLength(orig - h)
+                gm = complex(_grad_by_edge(hinge)[ke])
+                e.setSquaredLength(orig)
+                fd = (gp - gm) / (2.0 * h)
+                got = complex(hess[(ke, kf)])
+                self.assertAlmostEqual(got.real, fd.real, delta=5e-5)
+                self.assertAlmostEqual(got.imag, fd.imag, delta=5e-5)
+
+
+# --------------------------------------------------------------------------- #
+# The action pipeline on a mixed-hinge complex
+# --------------------------------------------------------------------------- #
+class TestActionOnMixedComplex(unittest.TestCase):
+    def test_action_gradient_exact_matches_fd_with_mixed_hinges(self):
+        # tetra surface with one timelike edge: its vertex hinges include
+        # genuine crossings; actionGradientExact must match a central
+        # difference of dualReggeAction (Re and Im) through them.
+        st = _spacetime(2, tessera.SolidSimplex(2))
+        st.build()
+        v = {x.getId(): x for x in st.getVertexList().toVector()}
+        v3 = st.createVertex(3)
+        st.createSimplex([v[0], v[1], v3])
+        st.createSimplex([v[0], v[2], v3])
+        st.createSimplex([v[1], v[2], v3])
+        _set_edges(st, {(0, 1): -1.0}, default=1.0)
+        solver = tessera.ReggeSolver(st, tessera.MatterConfiguration())
+        edges = st.getEdgeList().toVector()
+        grad = solver.actionGradientExact()
+        h = 1e-6
+        for i, e in enumerate(edges):
+            orig = e.getSquaredLength()
+            e.setSquaredLength(orig + h)
+            sp = complex(solver.dualReggeAction())
+            e.setSquaredLength(orig - h)
+            sm = complex(solver.dualReggeAction())
+            e.setSquaredLength(orig)
+            fd = (sp - sm) / (2.0 * h)
+            g = complex(grad[i])
+            self.assertAlmostEqual(g.real, fd.real, delta=2e-5)
+            self.assertAlmostEqual(g.imag, fd.imag, delta=2e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mesh/test_resident_im_guard_python.py
+++ b/tests/mesh/test_resident_im_guard_python.py
@@ -1,0 +1,159 @@
+"""Fail-loud guard on resident Im l^2 in the non-Wick geometry stack (#581
+scope item 6).
+
+The ordinary-Lorentzian convention: resident l^2 is REAL and SIGNED; a
+resident Im l^2 != 0 (Picard-Lefschetz / analytically continued length) is
+unsupported by the geometry stack, which previously projected it to Re
+SILENTLY at every Gram / Cayley-Menger build.  The non-Wick entry points now
+throw std::domain_error (ValueError in Python) naming the offending edge; the
+Wick-rotated (|l^2|) paths stay Im-tolerant; storage-level paths (the
+rollback records of item 2) never evaluate geometry and are untouched.
+
+Also the plot-layout collapse (item 8): the layout rest length is the
+documented |Re l^2| with an epsilon floor, so a null edge cannot pin two
+vertices together.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+import pytest
+
+try:
+    import tessera
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+
+def _spacetime(dim, topology):
+    sig = tessera.Signature(dim, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    return tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                             tessera.PREFERRED, topology)
+
+
+def _triangle_host():
+    st = _spacetime(2, tessera.SolidSimplex(2))
+    st.build()
+    tessera.ReggeSolver(st, tessera.MatterConfiguration())  # materialize
+    return st
+
+
+def _edge_map(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e
+    return out
+
+
+def _by_verts(st, ids):
+    want = tuple(sorted(ids))
+    for s in st.getSimplices():
+        if tuple(sorted(v.getId() for v in s.getVertices())) == want:
+            return s
+    raise AssertionError(f"no simplex {want}")
+
+
+class TestResidentImGuard(unittest.TestCase):
+    def _im_host(self, im=0.25):
+        st = _triangle_host()
+        for k, e in _edge_map(st).items():
+            e.setSquaredLength(1.0)
+        _edge_map(st)[(0, 1)].setSquaredLength(complex(1.0, im))
+        return st
+
+    def test_volume_throws_with_edge_ids(self):
+        st = self._im_host()
+        tri = _by_verts(st, [0, 1, 2])
+        with self.assertRaises(ValueError) as ctx:
+            tri.volume()
+        msg = str(ctx.exception)
+        self.assertIn("Im l^2", msg)
+        self.assertIn("(0, 1)", msg)
+        self.assertIn("580", msg)  # cites the audit / convention decision
+
+    def test_lorentzian_angles_throw(self):
+        st = self._im_host()
+        tri = _by_verts(st, [0, 1, 2])
+        v0 = _by_verts(st, [0])
+        with self.assertRaises(ValueError):
+            tri.lorentzianDihedralAngle(v0)
+        with self.assertRaises(ValueError):
+            v0.lorentzianDeficitAngle()
+
+    def test_dual_regge_action_throws(self):
+        st = _triangle_host()
+        for k, e in _edge_map(st).items():
+            e.setSquaredLength(1.0)
+        solver = tessera.ReggeSolver(st, tessera.MatterConfiguration())
+        self.assertTrue(math.isfinite(solver.dualReggeAction().real))
+        _edge_map(st)[(0, 2)].setSquaredLength(complex(1.0, 0.5))
+        with self.assertRaises(ValueError):
+            solver.dualReggeAction()
+
+    def test_wick_paths_stay_im_tolerant(self):
+        st = self._im_host()
+        tri = _by_verts(st, [0, 1, 2])
+        v0 = _by_verts(st, [0])
+        # |l^2| paths: the Euclidean/CDT pipeline must keep working
+        theta = tri.dihedralAngle(v0, True)
+        self.assertTrue(math.isfinite(theta))
+        eps = v0.deficitAngle()          # wick-rotated by definition
+        self.assertTrue(math.isfinite(eps))
+        area = tri.area(True)
+        self.assertTrue(math.isfinite(area))
+
+    def test_float_noise_below_tolerance_is_accepted(self):
+        st = _triangle_host()
+        for k, e in _edge_map(st).items():
+            e.setSquaredLength(1.0)
+        _edge_map(st)[(0, 1)].setSquaredLength(complex(1.0, 1e-13))
+        tri = _by_verts(st, [0, 1, 2])
+        self.assertTrue(math.isfinite(tri.volume()))
+        self.assertTrue(
+            math.isfinite(complex(tri.lorentzianDihedralAngle(
+                _by_verts(st, [0]))).real))
+
+    def test_signed_real_geometry_still_works(self):
+        # timelike (negative REAL) l^2 is the supported Lorentzian case
+        st = _triangle_host()
+        em = _edge_map(st)
+        em[(0, 1)].setSquaredLength(-4.0)
+        em[(0, 2)].setSquaredLength(-3.0)
+        em[(1, 2)].setSquaredLength(1.0)
+        tri = _by_verts(st, [0, 1, 2])
+        self.assertTrue(math.isfinite(tri.volume()))
+        th = complex(tri.lorentzianDihedralAngle(_by_verts(st, [2])))
+        self.assertTrue(math.isfinite(th.real) and math.isfinite(th.imag))
+
+
+class TestLayoutCollapseFloor(unittest.TestCase):
+    def test_null_edge_rest_length_is_floored(self):
+        plot = pytest.importorskip("tessera.utils.plot")
+        st = _triangle_host()
+        em = _edge_map(st)
+        em[(0, 1)].setSquaredLength(0.0)            # null edge
+        em[(0, 2)].setSquaredLength(complex(1.0, 0.7))  # layout is Im-blind
+        em[(1, 2)].setSquaredLength(1.0)
+        verts = st.getVertexList().toVector()
+        edges = st.getEdgeList().toVector()
+        pos, vid_to_idx, edge_idx = plot.layout_from_spacetime(
+            verts, edges, iters=1)
+        self.assertEqual(len(edge_idx), 3)
+        # rebuild the rest lengths the way the helper does and check the floor
+        rest = {(min(e.getSource().getId(), e.getTarget().getId()),
+                 max(e.getSource().getId(), e.getTarget().getId())):
+                math.sqrt(max(abs(e.getSquaredLength().real), 1e-6))
+                for e in edges}
+        self.assertEqual(rest[(0, 1)], math.sqrt(1e-6))   # floored, not 0
+        self.assertEqual(rest[(0, 2)], 1.0)               # |Re|, Im ignored
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_matter_action_classifier.py
+++ b/tests/test_matter_action_classifier.py
@@ -1,0 +1,85 @@
+"""matterAction uses the canonical Edge causal classifier (#581 scope item 4).
+
+``ReggeSolver::matterAction`` hand-rolled its causal test as
+``Re(l^2) < 0``, divergent from the canonical ``Edge::isTimelike()`` (which
+reads the imaginary part of the complex length).  It now classifies via the
+canonical helper; the proper time of a timelike step is ``sqrt(-Re l^2)``,
+exact under the ordinary-Lorentzian convention (resident ``l^2`` real and
+signed, #581 item 6), and null or spacelike worldline steps contribute
+nothing.
+"""
+
+import math
+import unittest
+
+import pytest
+
+try:
+    import tessera
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+
+def _chain_spacetime(step_sq):
+    """A minimal worldline host: one vertex per time slice t = 0..n,
+    consecutive slices joined by an edge with squared length step_sq[t].
+    With a single vertex per slice the traced worldline is exactly the
+    chain."""
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.SolidSimplex(2))
+    verts = []
+    for t in range(len(step_sq) + 1):
+        v = st.createVertex(t)
+        v.setTime(float(t))
+        verts.append(v)
+    for t, sq in enumerate(step_sq):
+        st.createEdge(verts[t], verts[t + 1], sq)
+    return st, verts
+
+
+class TestMatterActionClassifier(unittest.TestCase):
+    def test_timelike_worldline_proper_time(self):
+        # steps l^2 = -4 and -9: S = -M*(2 + 3)
+        st, verts = _chain_spacetime([-4.0, -9.0])
+        for e in st.getEdgeList().toVector():
+            self.assertTrue(e.isTimelike())   # the canonical classifier
+        matter = tessera.MatterConfiguration()
+        matter.setWorldlineMass(verts[1], 1.5, st)
+        solver = tessera.ReggeSolver(st, matter)
+        self.assertAlmostEqual(solver.matterAction(), -1.5 * 5.0, delta=1e-12)
+
+    def test_null_worldline_contributes_zero(self):
+        st, verts = _chain_spacetime([0.0, 0.0])
+        for e in st.getEdgeList().toVector():
+            self.assertTrue(e.isNull())
+            self.assertFalse(e.isTimelike())
+        matter = tessera.MatterConfiguration()
+        matter.setWorldlineMass(verts[1], 2.0, st)
+        solver = tessera.ReggeSolver(st, matter)
+        self.assertEqual(solver.matterAction(), 0.0)
+
+    def test_spacelike_steps_do_not_contribute(self):
+        # one timelike step (l^2 = -4) and one spacelike (l^2 = +1):
+        # only the timelike step carries proper time.
+        st, verts = _chain_spacetime([-4.0, 1.0])
+        matter = tessera.MatterConfiguration()
+        matter.setWorldlineMass(verts[1], 1.0, st)
+        solver = tessera.ReggeSolver(st, matter)
+        self.assertAlmostEqual(solver.matterAction(), -2.0, delta=1e-12)
+
+    def test_total_action_includes_matter_term(self):
+        st, verts = _chain_spacetime([-4.0, -9.0])
+        matter = tessera.MatterConfiguration()
+        matter.setWorldlineMass(verts[1], 1.0, st)
+        solver = tessera.ReggeSolver(st, matter)
+        self.assertAlmostEqual(solver.totalAction() - solver.reggeAction(),
+                               solver.matterAction(), delta=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pachner_remove_complex_rollback.py
+++ b/tests/test_pachner_remove_complex_rollback.py
@@ -1,0 +1,165 @@
+"""RemoveMove rollback restores the full complex l^2 AND the U(1) phase (#581).
+
+``RemoveMove::EdgeRecord`` was a plain double: rollback re-created the deleted
+vertex's edges with ``Re(l^2)`` only and phase 0, silently projecting
+analytically continued geometry onto the real axis and erasing the connection
+phase on every rejected/rolled-back move.  Both capture paths are covered:
+
+* the CDT ``apply()`` path (an order-2d vertex on a grown toroid);
+* the pre-geometric ``applyPreGeometric()`` path (the (d+1)->1 stellar weld
+  of a vertex added by the pre-geometric ``AddMove``).
+
+Each test seeds every edge with a distinct synthetic ``Im l^2 != 0`` and
+``phase != 0``, applies the move, rolls it back, and asserts every edge's
+``getSquaredLength()`` (Re and Im) and ``getPhase()`` are bit-exact.  The
+rollback path is storage-level (no geometry evaluation), so the synthetic Im
+never meets the geometry stack.  A real signed-l^2 (timelike-carrying) action
+round trip on the CDT toroid extends the hinge-exactness contract.
+"""
+
+import unittest
+
+import pytest
+
+try:
+    import tessera
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+PRE = None if not _IMPORT_OK else tessera.PachnerMode.PreGeometric
+
+
+def _seed_complex_geometry(st):
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        lo, hi = min(a, b), max(a, b)
+        e.setSquaredLength(complex(1.0 + 0.001 * lo, 0.02 + 0.001 * hi))
+        e.setPhase(0.05 + 0.002 * (lo * 7 + hi))
+
+
+def _edge_state(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = (complex(e.getSquaredLength()),
+                                       e.getPhase())
+    return out
+
+
+def _tops(st):
+    return sorted(tuple(sorted(v.getId() for v in s.getVertices()))
+                  for s in st.getTopSimplices())
+
+
+def _assert_state_equal(before, after):
+    assert set(before) == set(after), (
+        f"edge set drifted: only-before={set(before) - set(after)} "
+        f"only-after={set(after) - set(before)}")
+    for k, (sq, ph) in after.items():
+        sq0, ph0 = before[k]
+        assert sq == sq0, f"edge {k}: l^2 {sq0!r} -> {sq!r} (not bit-exact)"
+        assert ph == ph0, f"edge {k}: phase {ph0!r} -> {ph!r} (not bit-exact)"
+
+
+def _grown_cdt_with_removable_vertex(d=4, n_simplices=60,
+                                     batch=40, max_batches=25):
+    """The test_pachner_remove_move growth-and-probe recipe: grow a CDT
+    toroid until RemoveMove.propose() can find an order-2d vertex."""
+    sig = tessera.Signature(d, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    st.build(n_simplices)
+    cdt = tessera.CDTSimulation(st, 2.2, 0.5, 0.6, 0.02, st.getN41())
+    for _ in range(max_batches):
+        for _ in range(batch):
+            cdt.add()
+        for s in range(200):
+            if tessera.RemoveMove(st, s).propose():
+                return st
+    raise RuntimeError("no removable vertex after growth")
+
+
+def _pregeometric_host():
+    """SolidSimplex(3) with one pre-geometric 1->(d+1) add applied: the added
+    interior vertex is exactly the (d+1)->1 weld's target."""
+    sig = tessera.Signature(3, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.SolidSimplex(3))
+    st.build()
+    for seed in range(50):
+        m = tessera.AddMove(st, seed, False, PRE, False)
+        if m.propose() and m.apply():
+            return st
+    raise RuntimeError("pre-geometric add never fired")
+
+
+class TestRemoveMoveComplexRollback(unittest.TestCase):
+    def test_cdt_apply_rollback_restores_complex_l2_and_phase(self):
+        st = _grown_cdt_with_removable_vertex()
+        _seed_complex_geometry(st)
+        before = _edge_state(st)
+        tops_before = _tops(st)
+
+        applied = None
+        for seed in range(400):
+            m = tessera.RemoveMove(st, seed)
+            if m.propose() and m.apply():
+                applied = m
+                break
+        self.assertIsNotNone(applied, "no CDT remove move fired")
+        self.assertNotEqual(_edge_state(st), before)
+
+        applied.rollback()
+        _assert_state_equal(before, _edge_state(st))
+        self.assertEqual(_tops(st), tops_before)
+
+    def test_pregeometric_apply_rollback_restores_complex_l2_and_phase(self):
+        st = _pregeometric_host()
+        _seed_complex_geometry(st)
+        before = _edge_state(st)
+        tops_before = _tops(st)
+
+        applied = None
+        for seed in range(200):
+            m = tessera.RemoveMove(st, seed, PRE, False)
+            if m.propose() and m.apply():
+                applied = m
+                break
+        self.assertIsNotNone(applied, "pre-geometric remove never fired")
+
+        applied.rollback()
+        _assert_state_equal(before, _edge_state(st))
+        self.assertEqual(_tops(st), tops_before)
+
+    def test_cdt_rollback_preserves_complex_action_on_lorentzian_host(self):
+        # Real signed l^2 (the CDT toroid's native timelike-carrying metric):
+        # the rollback must retrace the full complex dual Regge action.
+        st = _grown_cdt_with_removable_vertex()
+        solver = tessera.ReggeSolver(st, tessera.MatterConfiguration())
+        s0 = complex(solver.dualReggeAction())
+        self.assertGreater(abs(s0.imag), 1e-6,
+                           "fixture is not genuinely Lorentzian")
+
+        applied = None
+        for seed in range(400):
+            m = tessera.RemoveMove(st, seed)
+            if m.propose() and m.apply():
+                applied = m
+                break
+        self.assertIsNotNone(applied, "no CDT remove move fired")
+        applied.rollback()
+
+        s1 = complex(
+            tessera.ReggeSolver(st, tessera.MatterConfiguration())
+            .dualReggeAction())
+        self.assertLess(abs(s1.real - s0.real), 1e-6)
+        self.assertLess(abs(s1.imag - s0.imag), 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_regge_gpu_parity.py
+++ b/tests/test_regge_gpu_parity.py
@@ -1,0 +1,103 @@
+"""GPU Euclidean dihedral kernel parity with the CPU path (#581 scope item 7).
+
+``dihedral_from_cm`` (regge_cuda.cu) lacked the CPU path's ``(-1)^d``
+diagonal-sign fix: the Cayley-Menger diagonal cofactors are negative in odd
+dimension (e.g. tetrahedra), so on a 3D host the GPU computed the SUPPLEMENT
+of every dihedral angle before clamping.  The kernel now applies the sign fix
+before the clamp, exactly like ``Simplex::dihedralAngle``.
+
+GPU-gated: skipped without a CUDA build + a GPU (the same detection the
+r_U-gradient GPU suite uses — the whole build shares one TESSERA_CUDA flag).
+"""
+
+import math
+import os
+import sys
+import unittest
+
+import pytest
+
+try:
+    import tessera
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "cobordism"))
+
+
+def _gpu_available():
+    """The GPU lane is live iff the CUDA-only EigenstateSynthesis method
+    exists and a trivial call succeeds (the CPU-only build throws)."""
+    if not _IMPORT_OK:
+        return False
+    cob = tessera.cobordism
+    if not hasattr(cob.EigenstateSynthesis, "residualForPeriodsGradientGpu"):
+        return False
+    try:
+        from _holed_surface import holed_surface
+        _st, es, holes, P = holed_surface(degree=1)
+        es.residualForPeriodsGradientGpu(holes, [complex(z) for z in P[0]])
+        return True
+    except Exception:
+        return False
+
+
+_GPU = _IMPORT_OK and _gpu_available()
+
+
+def _toroid4d(n=60):
+    """The 4D CDT toroid — the host the GPU step lane is wired for (hinges =
+    triangles with nonzero area, so the action and its gradient are nonzero;
+    on d < 4 hosts hingeArea() of a sub-triangle hinge is 0 and the whole
+    lane is vacuously zero)."""
+    sig = tessera.Signature(4, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.Toroid())
+    st.setSeed(1234)
+    st.build(n)
+    return st
+
+
+def _gpu_step(solver):
+    """step(0.0) on the GPU lane; a CUDA resource failure (another tenant
+    holding the VRAM) is an environment condition, not a correctness result —
+    skip, mirroring the suite's skipped-without-GPU convention."""
+    try:
+        return solver.step(0.0)
+    except RuntimeError as exc:  # pragma: no cover - depends on GPU tenancy
+        if "out of memory" in str(exc):
+            pytest.skip(f"GPU present but VRAM exhausted: {exc}")
+        raise
+
+
+@pytest.mark.skipif(not _GPU, reason="no CUDA build / GPU")
+class TestGpuDihedralParity(unittest.TestCase):
+    def test_gpu_step_gradient_norm_matches_cpu_on_cdt_toroid(self):
+        # On a CUDA build ReggeSolver.step() computes the base action
+        # gradient on the GPU through dihedral_from_cm (now sign-fixed and
+        # clamped exactly like the CPU Simplex::dihedralAngle); a zero
+        # learning rate makes it a pure measurement.  actionGradientNorm()
+        # is the CPU finite-difference oracle over the same W-space
+        # functional (central vs the kernel's forward difference, hence the
+        # loose-ish tolerance).  In the wired d=4 lane the (-1)^d fix is a
+        # no-op by parity — this guards the kernel's CPU parity end to end;
+        # the odd-d case where the fix is load-bearing has no GPU consumer
+        # (sub-triangle hinges carry hingeArea() = 0), so it is pinned by
+        # construction against Simplex::dihedralAngle, not a GPU run.
+        st = _toroid4d()
+        solver = tessera.ReggeSolver(st, tessera.MatterConfiguration())
+        f_cpu = solver.actionGradientNorm()
+        f_gpu = _gpu_step(solver)
+        self.assertGreater(f_cpu, 0.0)
+        self.assertTrue(
+            math.isclose(f_gpu, f_cpu, rel_tol=5e-3),
+            f"GPU step gradient norm {f_gpu} != CPU {f_cpu}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_renderer_export.py
+++ b/tests/test_renderer_export.py
@@ -1,0 +1,114 @@
+"""GraphML/DOT export carries the full complex l^2 + phase and classifies
+via the canonical Edge helpers (#581 scope item 5).
+
+The exporters used the superseded sign-of-Re classifier (contradicting the
+same file's PNG path, which already used ``Edge::isTimelike()``) and had no
+key for ``Im l^2`` or the U(1) phase at all.  Now: ``squared_length`` stays
+Re (compatibility), ``squared_length_im`` and ``phase`` are new keys, and
+``timelike`` is ``Edge::isTimelike()``.
+"""
+
+import math
+import re
+import xml.etree.ElementTree as ET
+
+import pytest
+
+try:
+    import tessera
+    _IMPORT_OK = True
+except Exception:  # pragma: no cover
+    _IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(not _IMPORT_OK, reason="tessera not built")
+
+
+def _host():
+    """A triangle carrying one timelike edge, one Im l^2 != 0 edge, and a
+    nonzero phase on the spacelike edge."""
+    sig = tessera.Signature(2, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.SolidSimplex(2))
+    st.build()
+    values = {(0, 1): (-2.0 + 0.0j, 0.0),       # timelike
+              (0, 2): (1.0 + 0.25j, 0.0),       # analytically continued
+              (1, 2): (1.5 + 0.0j, 0.7)}        # spacelike, phased
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        sq, ph = values[(min(a, b), max(a, b))]
+        e.setSquaredLength(sq)
+        e.setPhase(ph)
+    return st, values
+
+
+def _canonical_timelike(st):
+    out = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        out[(min(a, b), max(a, b))] = e.isTimelike()
+    return out
+
+
+def test_graphml_export_roundtrip(tmp_path):
+    st, values = _host()
+    canon = _canonical_timelike(st)
+    path = str(tmp_path / "host.graphml")
+    st.save(path)
+
+    tree = ET.parse(path)
+    ns = {"g": tree.getroot().tag.split("}")[0].strip("{")}
+    # key declarations exist for the new attributes
+    key_names = {k.get("attr.name") for k in tree.getroot().findall("g:key", ns)}
+    assert {"squared_length", "squared_length_im", "phase",
+            "timelike"} <= key_names
+
+    seen = {}
+    for edge in tree.getroot().find("g:graph", ns).findall("g:edge", ns):
+        a, b = int(edge.get("source")), int(edge.get("target"))
+        data = {d.get("key"): d.text for d in edge.findall("g:data", ns)}
+        seen[(min(a, b), max(a, b))] = data
+    assert set(seen) == set(values)
+
+    for k, (sq, ph) in values.items():
+        d = seen[k]
+        assert math.isclose(float(d["sq_length"]), sq.real, abs_tol=1e-12)
+        assert math.isclose(float(d["sq_length_im"]), sq.imag, abs_tol=1e-12)
+        assert math.isclose(float(d["phase"]), ph, abs_tol=1e-12)
+        assert (d["timelike"] == "true") == canon[k], (
+            f"edge {k}: exported timelike={d['timelike']} disagrees with "
+            f"Edge.isTimelike()={canon[k]}")
+    # the Im-carrying edge is timelike by the canonical classifier even
+    # though Re(l^2) > 0 — the case the sign-of-Re export got wrong
+    assert seen[(0, 2)]["timelike"] == "true"
+
+
+def test_dot_export_roundtrip(tmp_path):
+    st, values = _host()
+    canon = _canonical_timelike(st)
+    path = str(tmp_path / "host.dot")
+    st.save(path)
+
+    pat = re.compile(
+        r"^\s*(\d+)\s*--\s*(\d+)\s*\[squared_length=([-\d.e+]+), "
+        r"squared_length_im=([-\d.e+]+), phase=([-\d.e+]+), "
+        r"timelike=(true|false)", re.M)
+    with open(path) as f:
+        text = f.read()
+    seen = {}
+    for m in pat.finditer(text):
+        a, b = int(m.group(1)), int(m.group(2))
+        seen[(min(a, b), max(a, b))] = m
+    assert set(seen) == set(values), text
+
+    for k, (sq, ph) in values.items():
+        m = seen[k]
+        assert math.isclose(float(m.group(3)), sq.real, abs_tol=1e-12)
+        assert math.isclose(float(m.group(4)), sq.imag, abs_tol=1e-12)
+        assert math.isclose(float(m.group(5)), ph, abs_tol=1e-12)
+        assert (m.group(6) == "true") == canon[k]
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements every non-guard-scoped finding of the imaginary-part truncation audit (#580), per the eight-item scope of the ticket: the mixed-hinge (light-cone-crossing, m=1) branch of the Lorentzian dihedral angle + its gradient/Hessian; complex+phase-exact rollback records in `SurgicalCone`, `EigenstateSynthesis`, and `RemoveMove`; Im-aware ∂W pin gates; the `matterAction` classifier/spec fix; GraphML/DOT export via the canonical classifier with `squared_length_im`/`phase` keys; the documented ordinary-Lorentzian convention with a fail-loud Im guard at the Gram entry; classifier unification + API/Python hygiene. Explicitly excludes all `MultiCobordism` surfaces (in-flight #573 work, another agent). Part of #559.

## The headline number: the CDT toroid action changed (deliberately)

The seeded 4D CDT toroid (`st.setSeed(1234)`, `build(120)`) contains **240/1200 cell-wedges whose Cayley–Menger cofactor pair straddles zero** — every base-tet triangle of a (4,1)/(1,4) cell crosses the light cone, exactly as the audit predicted. The pre-#581 code forced those angles real; the fixed branch gives them `π/2 − i·asinh(C_ij/D)`:

| | before | after |
|---|---|---|
| `dualReggeAction` | `0.5838441973230648 − 35.48509697074274j` | `0.5838441973230597 − 11.481416309331825j` |

Re S is unchanged to 5e-15 (the crossings' π/2 real parts happen to rebalance the sum on this flat host); **Im S moves from ≈ −35.49 to ≈ −11.48** because a fifth of the wedges were mis-branched. There is no hardcoded pin on this value in the tree; the two test docstrings citing "Im S ~ −35" (`test_hinge_exact_moves.py`, `test_surgical_cone_topology.py`) are updated with the #581 citation. All round-trip/invariance suites pass unchanged on the new values.

## Per-item disposition

1. **Mixed-hinge branch (`Simplex::lorentzianDihedralAngle` + gradient + Hessian)** — implemented as the explicit three-regime structure. Same-sign cofactor paths are **bit-for-bit unchanged** (same instructions, same order); the crossing branch is exactly principal-branch `acos` of the true complex cosine (`denom = sqrt(C_ii)*sqrt(C_jj)`, principal branches, so `θ = π/2 − i·asinh(C_ij/D)`). Canonical-frame evaluation and the anchored sign fix untouched (the crossing branch is intrinsically i/j-symmetric). Gradient: `dθ/dy = −i/sqrt(1+y²)`; Hessian: `d²θ/dy² = +i·y/(1+y²)^{3/2}` — never singular on the crossing. The sign convention was pinned before writing C++ by numerically verifying flat-Minkowski closure over 2000 random one-ray-per-quadrant stars (worst error 1.2e-14).
   *Documented limitation (header + test module docstring):* same-sign (m=0/boost) wedges keep the principal-branch imaginary sign — a wedge's boost **orientation** is not determined by edge lengths alone (a PT reflection flips it at identical ℓ²), so flat stars with several rays in one light-cone sector do not close. One-ray-per-quadrant stars (the ticket's arbiter tests) close exactly; this is intrinsic to any length-only formula that keeps the same-sign branch unchanged, not an implementation choice.
2. **Complex+phase-exact rollback records** — `SurgicalCone::Move`, `EigenstateSynthesis::Removal`, `RemoveMove::EdgeRecord` (which also dropped the U(1) phase entirely) now record the full complex ℓ² (+ phase) and restore it verbatim; `tryAdd`'s public double signature kept (complex + phase written onto the fresh edge after re-creation). Key tests verified **red on the pre-fix build**. Two findings: an interior top cell's faces all carry ≥2 cofaces, so `removeInteriorCell` **provably never orphans an edge** — its complex record matters on the reject/restore path; and a **pre-existing** circumcentric dual-volume drift through orphan-restoring rollbacks on already-holed hosts (deficits exact, `dualVolume` not) is filed as #587 — it reproduces byte-identically before this branch (with Im = 0 the old and new restores write the same bytes).
3. **Im-aware ∂W pin gates** — both gates snapshot and compare the **full complex ℓ²** (and phase). Tested via the reachable seams: an Im+phase-carrying pinned boundary passes an interior attach unchanged (no false rejects), and an attach that would pull a ∂W edge out of the boundary is rejected with the complex geometry restored bit-exactly. A move that perturbs *only* Im of a pinned ∂W edge mid-move is not constructible through the public API (the interiority pre-gate and the attach value-freeze structurally forbid it) — the upgraded comparison is defense-in-depth for exactly the rollback-corruption class item 2 eliminates.
4. **`matterAction`** — classifies via `Edge::isTimelike()` (null worldline steps contribute 0); header documents the Re basis, exact under the ordinary-Lorentzian convention; return type stays `double`.
5. **Renderer export** — GraphML + DOT classify via `Edge::isTimelike()` and export `squared_length_im` + `phase`; the Re key is unchanged for compatibility. Round-trip-parsed in tests, including an Im-carrying edge the sign-of-Re classifier used to misclassify.
6. **Ordinary-Lorentzian convention, documented + fail-loud** — convention documented at `Edge::setLength`/`setSquaredLength` and the Simplex geometry section; `Simplex::realSquaredLengthChecked` (one static helper shared by the three non-Wick entry points) throws `std::domain_error` naming the edge when `|Im ℓ²| > 1e-12`. Wick paths untouched and tested Im-tolerant; the item-2 rollback suites (storage-level) run green against the guarded build.
   *Guard timing* (seeded toroid, 3 alternating runs each, box shared with the live campaign): `dualReggeAction` 22.5–30.5 ms/call with the guard vs 25.7–30.1 ms without; `actionGradientExact` 113–140 vs 123–137 ms. Ranges fully overlap — **no measurable slowdown** (one scalar branch per edge under O(d³)-per-cofactor determinant work).
7. **Classifier unification + API hygiene** — `assertSpacelikeAdmissible` uses `Edge::isSpacelike()` (skip margin sharpens from `ℓ² ≤ tol` to the canonical null band, so near-degenerate spacelike cells fail loud instead of skipping); Poset comment fixed (seed commit); `createEdge(v1,v2)` doc now says **null edge, no metric evaluation**; dead `EdgeList::replace` deleted; `dihedralAngle` header claim aligned with its `wickRotate=false` default; `area()` gains the Lorentzian note; the CUDA `dihedral_from_cm` gains the CPU's `(-1)^d` diagonal-sign fix before the clamp (value-identical to `Simplex::dihedralAngle`; a parity no-op in the wired d=4 lane — sub-4D lanes have no GPU consumer since sub-triangle hinges carry `hingeArea() = 0`); the four analytic-gradient cores throw at k=0 (where `laplacian(k).real()` would silently be the wrong operator) with a message citing #580.
8. **Python hygiene** — `plot.py` layout collapse documented + ε-floored (mirrors the animation); the animation curvature panel's `except Exception` narrowed to `RuntimeError` (a type/contract failure — including the new resident-Im `ValueError` — propagates instead of zeroing both channels), dual-volume weight read is `abs(complex(...))`, and the "all-spacelike" label is Im-channel-only so a failure can never masquerade as it; `weights()`/`setWeights()` (+ interior variants + class doc) docstrings now say **signed Re ℓ²**, not "magnitudes".

## Post-merge interaction with #573 (unclamped stage 2) — the deferred item, now manifest

Main merged #573 mid-flight. Its `test_stage2_unclamped_python.py` hand-sets timelike edges and runs `run_stage2`; with this PR's mixed-hinge branch those hosts have genuinely complex action gradients, the unclamped Wirtinger trial writes **resident Im ℓ² (observed ≈ −3.1e8)**, and the new guard fires. Two consequences, two dispositions:

1. **Process abort (fixed here):** the guard's throw crossed the OpenMP hinge loops in `actionGradientExact`/`actionHessianExact`/`actionSparseHessian` → `std::terminate` (the `worker crashed` CI failures). The three regions now capture the first exception and rethrow after the join — `runStage2`'s existing `catch(...) → +inf → backoff` line search then handles an inevaluable trial exactly as #573's contract states.
2. **No accepted stage-2 step on mixed-hinge hosts (deferred, per this ticket's out-of-scope list: "the stage-2 Im-drift interaction; deferred, noted on #580"):** every Im-carrying trial is inevaluable, so `test_accepted_steps_never_pin_to_the_old_clamp` finds no accepted step. It is marked `xfail(strict=False)` with the full citation — it un-xfails automatically once `runStage2` proposes trials on the real axis (the #565/#573 owner's adaptation; coordination comment posted on #565). The other four stage-2 tests pass unchanged — `test_readers_survive_one_timelike_edge` now runs through the crossing branch and independently validates it on their host.

3. **Main's own broken title assertion (fixed here, one line):** #586 renamed the animation verdict tag (`singlet diagnostic r_state=` → `diagnostics r_state(singlet)=`) without updating `test_panels_draw_headless`; every CI run on those main commits was concurrency-cancelled, so it surfaced only through this PR's merge runs. Confirmed deterministic on a pure `origin/main` build; the assertion now checks the outcome-independent `r_state(singlet)` (#588 retitled with the corrected diagnosis).

## Test plan

- [x] 2D Minkowski analytic mixed-hinge repro exact to 1e-12; flat-Minkowski closure (deficit ≡ 0 with light-cone crossings — symmetric star exact, generic asymmetric stars ≤ 1e-11); 4D mixed-hinge case (π/2 + i·asinh(1/(4√2)) vs an independent R^{3,1} embedding); relabeling invariance on mixed cells
- [x] Euler-identity gradient checks on mixed hinges (Σℓ²·∂θ = 0; Σℓ²·∂² = −∂) + FD internal consistency; all existing Lorentzian suites green — the CDT toroid Im S change reported above
- [x] Complex+phase rollback round-trips bit-exact for SurgicalCone / EigenstateSynthesis removal / RemoveMove (both capture paths); red on the pre-fix build
- [x] ∂W gate holds with complex boundary values; boundary-touching attach rejected with bit-exact restore
- [x] Renderer export round-trip: attributes present, classifier agrees with `Edge.isTimelike()`
- [x] Fail-loud guard: Im ℓ² ≠ 0 → `ValueError` (with edge ids + #580 citation) from `volume`/`lorentzianDeficitAngle`/`dualReggeAction`; Wick paths tolerant; no measurable fast-suite slowdown (numbers above)
- [x] GPU parity test green on this box's second GPU (skips cleanly without CUDA or when VRAM is held by another tenant)
- [x] Full fast suite on the merged branch — **CI SUCCESS on head: 1249 passed, 14 skipped, 1 xfailed (the deferred stage-2 test), 796 subtests** (locally the same suite: 1255+ passed; the one local `test_solver_reduces_gradient_norm` CUDA-OOM under this box's VRAM tenancy passes 9/9 on the second GPU). Targeted slow suites on the merged build (canonical surgery + Proton — the `directedConeOut`/`run_stage2` consumers): **16/16 passed** (29:20).

New test files: `tests/mesh/test_mixed_hinge_lorentzian_python.py` (19), `tests/mesh/test_resident_im_guard_python.py` (7), `tests/cobordism/test_complex_rollback_records_python.py` (8), `tests/cobordism/test_k0_gradient_guard_python.py` (2), `tests/test_pachner_remove_complex_rollback.py` (3), `tests/test_matter_action_classifier.py` (4), `tests/test_renderer_export.py` (2), `tests/test_regge_gpu_parity.py` (1, GPU-gated).

Closes #581.
