### PR TITLE
feat(cobordism): Observable measurement layer — Register context, gated observables, and the ProtonIngredients three-register battery

### DIFF
--- a/examples/cobordism/emergent_mass_radius.py
+++ b/examples/cobordism/emergent_mass_radius.py
@@ -2,58 +2,20 @@
 # All rights reserved.
 """Mass and radius read the right way off a converged emergent 4D interior (#566).
 
-This ports the #451 geometric-proton methodology (see
-``docs/design/451-proton-geometry-0a1a5aa.md``) from its 3D event to the genuinely
-4D emergent builds: the canonical ``tessera.cobordism.Proton().block()`` and the
-emergent arm ``tessera.cobordism.ProtonIngredients().block()`` (or any other
-converged 4D ``Spacetime``). Everything here is a *post-hoc observable reader* —
-nothing shapes the lattice.
+The runnable battery for the #451 geometric-proton methodology ported to the
+genuinely 4D emergent builds: the canonical ``tessera.cobordism.Proton().block()``
+and the emergent arm ``tessera.cobordism.ProtonIngredients().block()`` (or any
+other converged 4D ``Spacetime``). Everything is a *post-hoc observable
+reader* — nothing shapes the lattice.
 
-The load-bearing methodology rules, ported from #451:
-
-  * **Hinges.** On a d = 4 complex the Regge hinges are the (d-2) = 2-simplices —
-    TRIANGLES (#451 was 3D, where hinges were edges). Curvature is the complex
-    Lorentzian deficit angle at each triangle.
-  * **Closed fans only.** A hinge carries an honest curvature ONLY if its coface
-    fan is closed — every tetrahedron around the triangle shared by exactly two
-    4-cells. Open-fan hinges (the ∂W input boundary, the register-hole walls) give
-    boundary artefacts near 2π, not curvature: they are EXCLUDED, and the census
-    (interior vs boundary counts) is reported with every reading. The fan test is
-    combinatorial over the CURRENT top cells, so orphan sub-simplices stranded by
-    Pachner moves never pollute the selection.
-  * **Skeleton in C++.** ``dualVolume()`` / ``lorentzianDeficitAngle()`` walk a
-    hinge up through its cofaces, so the facet/coface lattice must exist and be
-    built in C++: the ``ReggeSolver(st, MatterConfiguration())`` ctor materializes
-    tops → tetrahedra → triangle hinges, and ``ChainComplex.fromSpacetime(st)``
-    (a C++ BFS seeded from the current tops) completes the lattice down to edges
-    and vertices for the dual volumes. Never drive ``materializeFacets`` from
-    Python — the #451 lesson: a Python-driven materialization corrupted the coface
-    lists and ``dualVolume()`` saw half its cofaces.
-  * **Signature-aware readings.** Dual volumes are the circumcentric
-    ``Simplex.dualVolume`` (signed); the deficit is the complex
-    ``Simplex.lorentzianDeficitAngle``. Masses use Re ε; the imaginary part is
-    real physics (boost content), so its magnitude is always reported alongside —
-    never silently dropped.
-  * **Dimension-correct radius.** The dual radius is r = V_dual^(1/4) on a
-    4-complex (V_dual = the summed circumcentric dual 4-volume of the strictly
-    interior vertices). #451 used V_dual^(1/3) because its complex was 3D; the
-    root tracks the top dimension, nothing else. The primal cross-check is
-    r = V_primal^(1/4) over the top 4-cells.
-  * **r·m is definition-sensitive.** The #451 lesson: across reasonable mass
-    definitions (intensive shell-mean vs the two extensive sums) r·m spans orders
-    of magnitude, so the FULL table with its spread is stated up front and any
-    agreement with the physical m_p·r_p/ħc ≈ 4.0 is an order-of-magnitude claim
-    only — never one number presented as THE mass.
-
-What is measured (per converged spacetime):
-  1. interior closed-fan hinge selection + census (interior / boundary / total);
-  2. mass, intensive AND extensive: m_shell = the #352/#451 shell-mean Re-deficit,
-     m_sum = Σ Re ε, m_action = Σ |★h|·Re ε;
-  3. radius: r_dual = V_dual^(1/4) with the r_primal = V_primal^(1/4) cross-check;
-  4. localization: participation ratio of |Re ε·★h| against the equal-volume
-     uniform (round-sphere) reference, the BFS shell profile of curvature relative
-     to the register holes' vertices, and the mean deficit sign;
-  5. the r·m table across ALL mass × radius combinations, spread first.
+The reader machinery lives in ``tessera.observe.mass_radius`` (one home —
+this script imports it; the ``MassRadius`` observable of
+``tessera.observe.battery`` composes the same functions), and its module
+docstring carries the load-bearing methodology rules: triangle hinges on
+d = 4, closed-fan interior selection with the census always reported, the
+C++-built skeleton (never a Python-driven materialization), signature-aware
+readings with Im(deficit) always accounted, the dimension-correct fourth-root
+radius, and the r·m table with its definitional spread stated first.
 
 Importable (the tests reuse these): ``build_skeleton``, ``interior_hinges``,
 ``masses``, ``radii``, ``localization``, ``rm_table``, ``measure``, ``report``.
@@ -65,316 +27,22 @@ Run (bounded budgets — the fast-test pattern, one attempt per arm):
     python emergent_mass_radius.py --seed 3
 """
 import argparse
-import itertools
-import math
-from collections import Counter, defaultdict
-
-import numpy as np
 
 import tessera
 
+from tessera.observe.mass_radius import (  # noqa: F401
+    IM_TOL,
+    PHYSICAL_RM,
+    build_skeleton,
+    interior_hinges,
+    localization,
+    masses,
+    measure,
+    radii,
+    rm_table,
+)
+
 cob = tessera.cobordism
-
-# Physical anchor: m_p·r_p/ħc = 938 MeV · 0.84 fm / 197 MeV·fm ≈ 4.0 (dimensionless).
-PHYSICAL_RM = 938.0 * 0.84 / 197.0
-
-# |Im ε| above this counts as genuinely complex (boost content at the hinge).
-IM_TOL = 1e-12
-
-
-def build_skeleton(st):
-    """Materialize the full facet/coface lattice of ``st`` in C++ and return the
-    keep-alive handles ``(solver, chain_complex)``.
-
-    ``ReggeSolver(st, MatterConfiguration())`` is the blessed Regge path: its ctor
-    builds tops → tetrahedra → triangle hinges, which is everything the deficit
-    angles need. ``ChainComplex.fromSpacetime(st)`` then completes the lattice
-    down to edges and vertices — a C++ BFS seeded from the CURRENT top cells only
-    (orphan-safe) — which the vertex ``dualVolume()`` recursion needs for V_dual.
-    Both are C++ constructors; no materialization is ever driven from Python
-    (the #451 corruption lesson).
-    """
-    solver = tessera.ReggeSolver(st, tessera.MatterConfiguration())
-    chain_complex = cob.ChainComplex.fromSpacetime(st)
-    return solver, chain_complex
-
-
-def _top_vertex_ids(st):
-    """Sorted vertex-id tuples of the current top cells (4-simplices). Fails
-    loudly if the complex is not genuinely 4D — this reader is 4D-specific (the
-    hinge dimension and the radius root both track d = 4)."""
-    tops = [tuple(sorted(v.getId() for v in t.getVertices()))
-            for t in st.getTopSimplices()]
-    if not tops:
-        raise ValueError("spacetime has no top cells")
-    sizes = {len(t) for t in tops}
-    if sizes != {5}:
-        raise ValueError(
-            f"top cells have vertex counts {sorted(sizes)}; this reader is for "
-            "4-complexes (5-vertex top cells) — on a d-complex the hinges are the "
-            "(d-2)-simplices and the radius root is 1/d, so use the reader that "
-            "matches your dimension")
-    return sorted(tops)
-
-
-def _bfs_shells(tops, seed_vertex_ids):
-    """BFS shell distance from ``seed_vertex_ids`` over the 1-skeleton of the
-    CURRENT top cells (combinatorial, orphan-immune). Returns {vertex_id: shell};
-    unreachable vertices are absent. Empty seeds give an empty map (every hinge
-    then reports shell None and the shell profile is skipped)."""
-    adjacency = defaultdict(set)
-    for top in tops:
-        for a, b in itertools.combinations(top, 2):
-            adjacency[a].add(b)
-            adjacency[b].add(a)
-    dist = {v: 0 for v in sorted(set(seed_vertex_ids)) if v in adjacency}
-    frontier = sorted(dist)
-    while frontier:
-        nxt = []
-        for u in frontier:
-            for v in sorted(adjacency[u]):
-                if v not in dist:
-                    dist[v] = dist[u] + 1
-                    nxt.append(v)
-        frontier = nxt
-    return dist
-
-
-def interior_hinges(st, holes=()):
-    """Select the interior (closed-coface-fan) triangle hinges of the 4-complex
-    and read their curvature. Returns ``(hinges, census)``.
-
-    A triangle hinge is INTERIOR iff every tetrahedron of its coface fan is shared
-    by exactly two top 4-cells; hinges with any once-shared (boundary) tetrahedron
-    are boundary artefacts — their "deficit" is a near-2π opening-angle remnant,
-    not curvature — and are excluded. Both the fan and the tetrahedron counts are
-    derived combinatorially from the CURRENT top cells (never from raw coface
-    lists), so orphan simplices stranded by Pachner moves cannot leak in; the
-    readings themselves are then taken off the canonical registered triangle
-    Simplex objects (skeleton required — call ``build_skeleton`` first).
-
-    Each hinge dict carries: ``vids`` (the 3 vertex ids), ``re``/``im`` (the
-    complex Lorentzian deficit), ``dv`` (the signed circumcentric dual content
-    |★h|), and ``shell`` (BFS distance from the register holes' vertices, None
-    when ``holes`` is empty).
-
-    ``census`` reports the interior/boundary/total hinge counts, the boundary
-    tetrahedron count, and the sizes of the complex.
-    """
-    tops = _top_vertex_ids(st)
-
-    # Tetrahedron -> number of top cells sharing it, and triangle -> its fan.
-    tet_count = Counter()
-    tri_fans = defaultdict(set)
-    for top in tops:
-        for tet in itertools.combinations(top, 4):
-            tet_count[tet] += 1
-        for tri in itertools.combinations(top, 3):
-            rest = [v for v in top if v not in tri]
-            for extra in rest:
-                tri_fans[tri].add(tuple(sorted(tri + (extra,))))
-
-    # Canonical registered triangle Simplex objects, keyed by vertex set.
-    tri_by_key = {}
-    for s in st.getSimplices():
-        if len(s.getVertices()) == 3 and s.hasTopCoface():
-            tri_by_key[tuple(sorted(v.getId() for v in s.getVertices()))] = s
-
-    hole_vertex_ids = sorted(set(v for hole in holes for v in hole))
-    shell_of = _bfs_shells(tops, hole_vertex_ids)
-
-    hinges = []
-    n_boundary = 0
-    for tri in sorted(tri_fans):
-        closed = all(tet_count[tet] == 2 for tet in tri_fans[tri])
-        if not closed:
-            n_boundary += 1
-            continue
-        simplex = tri_by_key.get(tri)
-        if simplex is None:
-            raise RuntimeError(
-                f"interior hinge {tri} has no registered triangle Simplex — "
-                "the C++ skeleton was not built; call build_skeleton(st) first")
-        deficit = simplex.lorentzianDeficitAngle()
-        shell = (min(shell_of[v] for v in tri if v in shell_of)
-                 if any(v in shell_of for v in tri) else None)
-        hinges.append(dict(vids=list(tri), re=deficit.real, im=deficit.imag,
-                           dv=simplex.dualVolume(), shell=shell))
-
-    boundary_tets = sorted(t for t, c in tet_count.items() if c == 1)
-    census = dict(
-        n_tops=len(tops),
-        n_tets=len(tet_count),
-        n_hinges_total=len(tri_fans),
-        n_hinges_interior=len(hinges),
-        n_hinges_boundary=n_boundary,
-        n_boundary_tets=len(boundary_tets),
-        boundary_tets=boundary_tets,
-        n_hole_vertices=len(hole_vertex_ids),
-    )
-    return hinges, census
-
-
-def masses(hinges):
-    """The three #451 mass readings over the interior hinges — one intensive,
-    two extensive (the r·m validator is sensitive to which is called "the mass",
-    so all three are always carried together):
-
-      * ``m_shell`` (intensive): the #352/#451 shell mass — the sum over BFS
-        shells (from the register holes) of the MEAN Re-deficit in that shell.
-        With no holes every hinge sits in one unlabeled bin and m_shell reduces
-        to the plain mean Re-deficit.
-      * ``m_sum`` (extensive): Σ Re ε — the raw integrated curvature.
-      * ``m_action`` (extensive, dual-weighted): Σ |★h|·Re ε — the dual-volume-
-        weighted Regge curvature.
-
-    Also returns ``shell_means`` (the per-shell means) and the imaginary-part
-    accounting: ``max_abs_im`` and ``n_im_nonzero`` (|Im ε| > IM_TOL) — the
-    deficit is complex Lorentzian, and whether Im is zero is always reported.
-    """
-    if not hinges:
-        nan = float("nan")
-        return dict(m_shell=nan, m_sum=nan, m_action=nan, shell_means={},
-                    max_abs_im=nan, n_im_nonzero=0)
-    bins = defaultdict(list)
-    for h in hinges:
-        bins[h["shell"]].append(h["re"])
-    shell_means = {shell: float(np.mean(values))
-                   for shell, values in sorted(bins.items(),
-                                               key=lambda kv: (kv[0] is None, kv[0]))}
-    return dict(
-        m_shell=float(sum(shell_means.values())),
-        m_sum=float(sum(h["re"] for h in hinges)),
-        m_action=float(sum(h["re"] * abs(h["dv"]) for h in hinges)),
-        shell_means=shell_means,
-        max_abs_im=float(max(abs(h["im"]) for h in hinges)),
-        n_im_nonzero=sum(1 for h in hinges if abs(h["im"]) > IM_TOL),
-    )
-
-
-def radii(st, census):
-    """The emergent size of the interior, dual and primal:
-
-      * ``r_dual`` = V_dual^(1/4): V_dual = Σ |★v| over the strictly INTERIOR
-        vertices (vertices on no boundary tetrahedron) — the signature-aware
-        circumcentric dual 4-volume. The fourth root is the dimension-correct
-        volume→length map on a 4-complex (#451 took the cube root of a dual
-        3-volume on its 3D event; same rule, different d).
-      * ``r_primal`` = V_primal^(1/4): V_primal = Σ |V₄| over ALL top 4-cells —
-        the primal-side cross-check of the same 4-volume (dual/primal agreement
-        is the skeleton-sanity signal; on a closed uniform complex they are
-        equal to machine precision).
-      * ``rms_dual_cell``: sqrt(mean |★h|) over the interior hinges — an RMS
-        dual-cell length scale (|★h| is a 2-volume in 4D), reported as the
-        auxiliary scale reading, not used in the r·m table.
-    """
-    boundary_vertex_ids = set(v for tet in census["boundary_tets"] for v in tet)
-    v_dual = 0.0
-    n_interior_vertices = 0
-    vertex_simplices = [s for s in st.getSimplices() if len(s.getVertices()) == 1]
-    for s in sorted(vertex_simplices, key=lambda s: s.getVertices()[0].getId()):
-        if not s.hasTopCoface():
-            continue  # orphan 0-simplex stranded by a move
-        vid = s.getVertices()[0].getId()
-        if vid in boundary_vertex_ids:
-            continue
-        v_dual += abs(s.dualVolume())
-        n_interior_vertices += 1
-    v_primal = sum(abs(t.volume()) for t in st.getTopSimplices())
-    return dict(
-        Vdual=float(v_dual),
-        Vprimal=float(v_primal),
-        n_interior_vertices=n_interior_vertices,
-        r_dual=float(v_dual) ** 0.25 if v_dual > 0 else float("nan"),
-        r_primal=float(v_primal) ** 0.25 if v_primal > 0 else float("nan"),
-    )
-
-
-def localization(hinges):
-    """Is the curvature a localized lump or spread out?
-
-      * ``PR``: participation ratio of the weight w = |Re ε·★h| over the interior
-        hinges, in (0, 1]. The equal-volume UNIFORM reference (a round sphere
-        spreads its curvature evenly over every hinge) has PR = 1.0;
-        ``concentration`` = 1/PR is how many times more concentrated the lump is.
-      * ``mean_re`` / ``std_re`` / ``std_over_mean``: the deficit statistics;
-        mean_re > 0 is the positive-curvature (bound-state, sphere-like) sign.
-      * ``shell_profile``: per BFS shell (from the register holes' vertices) the
-        hinge count, mean Re ε, and share of the total weight; plus
-        ``rms_shell_radius`` (the weight-weighted RMS shell distance — the lump
-        size in shells) and ``frac_within_shell1`` (the weight fraction within
-        one shell of the holes). Empty when no holes were given.
-    """
-    if not hinges:
-        nan = float("nan")
-        return dict(PR=nan, concentration=nan, mean_re=nan, std_re=nan,
-                    std_over_mean=nan, shell_profile={}, rms_shell_radius=nan,
-                    frac_within_shell1=nan)
-    re = np.array([h["re"] for h in hinges])
-    weight = np.abs(re * np.array([abs(h["dv"]) for h in hinges]))
-    total_weight = float(weight.sum())
-    pr = (float(total_weight ** 2 / (len(weight) * float((weight ** 2).sum())))
-          if total_weight > 0 else float("nan"))
-
-    shells = [h["shell"] for h in hinges]
-    profile = {}
-    rms_shell = float("nan")
-    frac_near = float("nan")
-    if all(s is not None for s in shells) and total_weight > 0:
-        shell_arr = np.array(shells, dtype=float)
-        for shell in sorted(set(shells)):
-            mask = shell_arr == shell
-            profile[shell] = dict(
-                n=int(mask.sum()),
-                mean_re=float(re[mask].mean()),
-                weight_share=float(weight[mask].sum() / total_weight),
-            )
-        rms_shell = float(np.sqrt(float((weight * shell_arr ** 2).sum())
-                                  / total_weight))
-        frac_near = float(weight[shell_arr <= 1].sum() / total_weight)
-
-    mean_re = float(re.mean())
-    return dict(
-        PR=pr,
-        concentration=(1.0 / pr) if pr and pr > 0 else float("nan"),
-        mean_re=mean_re,
-        std_re=float(re.std()),
-        std_over_mean=(float(re.std() / abs(mean_re)) if mean_re != 0.0
-                       else float("inf")),
-        shell_profile=profile,
-        rms_shell_radius=rms_shell,
-        frac_within_shell1=frac_near,
-    )
-
-
-def rm_table(mass, rad):
-    """Every r·m combination — 3 mass definitions × 2 radius definitions — with
-    the definitional spread stated FIRST (#451's lesson: r·m is too definition-
-    sensitive to quote as one number; the claim is order-of-magnitude only)."""
-    combos = {}
-    for m_name in ("m_shell", "m_sum", "m_action"):
-        for r_name in ("r_dual", "r_primal"):
-            combos[f"{r_name} x {m_name}"] = rad[r_name] * mass[m_name]
-    finite = [v for v in combos.values() if math.isfinite(v)]
-    spread = ((min(finite), max(finite)) if finite
-              else (float("nan"), float("nan")))
-    return dict(spread_min=spread[0], spread_max=spread[1], combos=combos,
-                physical=PHYSICAL_RM)
-
-
-def measure(st, holes=(), label=""):
-    """Read every geometric observable off one converged 4D spacetime: build the
-    C++ skeleton, select the interior hinges, and return the readings dict.
-    ``holes`` are the register holes' vertex-id tuples (e.g. ``Proton.quark_holes()``
-    / ``ProtonIngredients.emergent_holes()``) — the BFS shell seeds."""
-    build_skeleton(st)  # registers the lattice onto st itself; idempotent
-    hinges, census = interior_hinges(st, holes)
-    mass = masses(hinges)
-    rad = radii(st, census)
-    loc = localization(hinges)
-    table = rm_table(mass, rad)
-    return dict(label=label, census=census, mass=mass, radius=rad,
-                localization=loc, rm=table, n_holes=len(holes), hinges=hinges)
 
 
 def report(o):

--- a/examples/cobordism/emergent_mass_radius.py
+++ b/examples/cobordism/emergent_mass_radius.py
@@ -1,0 +1,490 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Mass and radius read the right way off a converged emergent 4D interior (#566).
+
+This ports the #451 geometric-proton methodology (see
+``docs/design/451-proton-geometry-0a1a5aa.md``) from its 3D event to the genuinely
+4D emergent builds: the canonical ``tessera.cobordism.Proton().block()`` and the
+emergent arm ``tessera.cobordism.ProtonIngredients().block()`` (or any other
+converged 4D ``Spacetime``). Everything here is a *post-hoc observable reader* —
+nothing shapes the lattice.
+
+The load-bearing methodology rules, ported from #451:
+
+  * **Hinges.** On a d = 4 complex the Regge hinges are the (d-2) = 2-simplices —
+    TRIANGLES (#451 was 3D, where hinges were edges). Curvature is the complex
+    Lorentzian deficit angle at each triangle.
+  * **Closed fans only.** A hinge carries an honest curvature ONLY if its coface
+    fan is closed — every tetrahedron around the triangle shared by exactly two
+    4-cells. Open-fan hinges (the ∂W input boundary, the register-hole walls) give
+    boundary artefacts near 2π, not curvature: they are EXCLUDED, and the census
+    (interior vs boundary counts) is reported with every reading. The fan test is
+    combinatorial over the CURRENT top cells, so orphan sub-simplices stranded by
+    Pachner moves never pollute the selection.
+  * **Skeleton in C++.** ``dualVolume()`` / ``lorentzianDeficitAngle()`` walk a
+    hinge up through its cofaces, so the facet/coface lattice must exist and be
+    built in C++: the ``ReggeSolver(st, MatterConfiguration())`` ctor materializes
+    tops → tetrahedra → triangle hinges, and ``ChainComplex.fromSpacetime(st)``
+    (a C++ BFS seeded from the current tops) completes the lattice down to edges
+    and vertices for the dual volumes. Never drive ``materializeFacets`` from
+    Python — the #451 lesson: a Python-driven materialization corrupted the coface
+    lists and ``dualVolume()`` saw half its cofaces.
+  * **Signature-aware readings.** Dual volumes are the circumcentric
+    ``Simplex.dualVolume`` (signed); the deficit is the complex
+    ``Simplex.lorentzianDeficitAngle``. Masses use Re ε; the imaginary part is
+    real physics (boost content), so its magnitude is always reported alongside —
+    never silently dropped.
+  * **Dimension-correct radius.** The dual radius is r = V_dual^(1/4) on a
+    4-complex (V_dual = the summed circumcentric dual 4-volume of the strictly
+    interior vertices). #451 used V_dual^(1/3) because its complex was 3D; the
+    root tracks the top dimension, nothing else. The primal cross-check is
+    r = V_primal^(1/4) over the top 4-cells.
+  * **r·m is definition-sensitive.** The #451 lesson: across reasonable mass
+    definitions (intensive shell-mean vs the two extensive sums) r·m spans orders
+    of magnitude, so the FULL table with its spread is stated up front and any
+    agreement with the physical m_p·r_p/ħc ≈ 4.0 is an order-of-magnitude claim
+    only — never one number presented as THE mass.
+
+What is measured (per converged spacetime):
+  1. interior closed-fan hinge selection + census (interior / boundary / total);
+  2. mass, intensive AND extensive: m_shell = the #352/#451 shell-mean Re-deficit,
+     m_sum = Σ Re ε, m_action = Σ |★h|·Re ε;
+  3. radius: r_dual = V_dual^(1/4) with the r_primal = V_primal^(1/4) cross-check;
+  4. localization: participation ratio of |Re ε·★h| against the equal-volume
+     uniform (round-sphere) reference, the BFS shell profile of curvature relative
+     to the register holes' vertices, and the mean deficit sign;
+  5. the r·m table across ALL mass × radius combinations, spread first.
+
+Importable (the tests reuse these): ``build_skeleton``, ``interior_hinges``,
+``masses``, ``radii``, ``localization``, ``rm_table``, ``measure``, ``report``.
+
+Run (bounded budgets — the fast-test pattern, one attempt per arm):
+
+    python emergent_mass_radius.py                 # canonical Proton
+    python emergent_mass_radius.py --arm both      # + the ProtonIngredients arm
+    python emergent_mass_radius.py --seed 3
+"""
+import argparse
+import itertools
+import math
+from collections import Counter, defaultdict
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+# Physical anchor: m_p·r_p/ħc = 938 MeV · 0.84 fm / 197 MeV·fm ≈ 4.0 (dimensionless).
+PHYSICAL_RM = 938.0 * 0.84 / 197.0
+
+# |Im ε| above this counts as genuinely complex (boost content at the hinge).
+IM_TOL = 1e-12
+
+
+def build_skeleton(st):
+    """Materialize the full facet/coface lattice of ``st`` in C++ and return the
+    keep-alive handles ``(solver, chain_complex)``.
+
+    ``ReggeSolver(st, MatterConfiguration())`` is the blessed Regge path: its ctor
+    builds tops → tetrahedra → triangle hinges, which is everything the deficit
+    angles need. ``ChainComplex.fromSpacetime(st)`` then completes the lattice
+    down to edges and vertices — a C++ BFS seeded from the CURRENT top cells only
+    (orphan-safe) — which the vertex ``dualVolume()`` recursion needs for V_dual.
+    Both are C++ constructors; no materialization is ever driven from Python
+    (the #451 corruption lesson).
+    """
+    solver = tessera.ReggeSolver(st, tessera.MatterConfiguration())
+    chain_complex = cob.ChainComplex.fromSpacetime(st)
+    return solver, chain_complex
+
+
+def _top_vertex_ids(st):
+    """Sorted vertex-id tuples of the current top cells (4-simplices). Fails
+    loudly if the complex is not genuinely 4D — this reader is 4D-specific (the
+    hinge dimension and the radius root both track d = 4)."""
+    tops = [tuple(sorted(v.getId() for v in t.getVertices()))
+            for t in st.getTopSimplices()]
+    if not tops:
+        raise ValueError("spacetime has no top cells")
+    sizes = {len(t) for t in tops}
+    if sizes != {5}:
+        raise ValueError(
+            f"top cells have vertex counts {sorted(sizes)}; this reader is for "
+            "4-complexes (5-vertex top cells) — on a d-complex the hinges are the "
+            "(d-2)-simplices and the radius root is 1/d, so use the reader that "
+            "matches your dimension")
+    return sorted(tops)
+
+
+def _bfs_shells(tops, seed_vertex_ids):
+    """BFS shell distance from ``seed_vertex_ids`` over the 1-skeleton of the
+    CURRENT top cells (combinatorial, orphan-immune). Returns {vertex_id: shell};
+    unreachable vertices are absent. Empty seeds give an empty map (every hinge
+    then reports shell None and the shell profile is skipped)."""
+    adjacency = defaultdict(set)
+    for top in tops:
+        for a, b in itertools.combinations(top, 2):
+            adjacency[a].add(b)
+            adjacency[b].add(a)
+    dist = {v: 0 for v in sorted(set(seed_vertex_ids)) if v in adjacency}
+    frontier = sorted(dist)
+    while frontier:
+        nxt = []
+        for u in frontier:
+            for v in sorted(adjacency[u]):
+                if v not in dist:
+                    dist[v] = dist[u] + 1
+                    nxt.append(v)
+        frontier = nxt
+    return dist
+
+
+def interior_hinges(st, holes=()):
+    """Select the interior (closed-coface-fan) triangle hinges of the 4-complex
+    and read their curvature. Returns ``(hinges, census)``.
+
+    A triangle hinge is INTERIOR iff every tetrahedron of its coface fan is shared
+    by exactly two top 4-cells; hinges with any once-shared (boundary) tetrahedron
+    are boundary artefacts — their "deficit" is a near-2π opening-angle remnant,
+    not curvature — and are excluded. Both the fan and the tetrahedron counts are
+    derived combinatorially from the CURRENT top cells (never from raw coface
+    lists), so orphan simplices stranded by Pachner moves cannot leak in; the
+    readings themselves are then taken off the canonical registered triangle
+    Simplex objects (skeleton required — call ``build_skeleton`` first).
+
+    Each hinge dict carries: ``vids`` (the 3 vertex ids), ``re``/``im`` (the
+    complex Lorentzian deficit), ``dv`` (the signed circumcentric dual content
+    |★h|), and ``shell`` (BFS distance from the register holes' vertices, None
+    when ``holes`` is empty).
+
+    ``census`` reports the interior/boundary/total hinge counts, the boundary
+    tetrahedron count, and the sizes of the complex.
+    """
+    tops = _top_vertex_ids(st)
+
+    # Tetrahedron -> number of top cells sharing it, and triangle -> its fan.
+    tet_count = Counter()
+    tri_fans = defaultdict(set)
+    for top in tops:
+        for tet in itertools.combinations(top, 4):
+            tet_count[tet] += 1
+        for tri in itertools.combinations(top, 3):
+            rest = [v for v in top if v not in tri]
+            for extra in rest:
+                tri_fans[tri].add(tuple(sorted(tri + (extra,))))
+
+    # Canonical registered triangle Simplex objects, keyed by vertex set.
+    tri_by_key = {}
+    for s in st.getSimplices():
+        if len(s.getVertices()) == 3 and s.hasTopCoface():
+            tri_by_key[tuple(sorted(v.getId() for v in s.getVertices()))] = s
+
+    hole_vertex_ids = sorted(set(v for hole in holes for v in hole))
+    shell_of = _bfs_shells(tops, hole_vertex_ids)
+
+    hinges = []
+    n_boundary = 0
+    for tri in sorted(tri_fans):
+        closed = all(tet_count[tet] == 2 for tet in tri_fans[tri])
+        if not closed:
+            n_boundary += 1
+            continue
+        simplex = tri_by_key.get(tri)
+        if simplex is None:
+            raise RuntimeError(
+                f"interior hinge {tri} has no registered triangle Simplex — "
+                "the C++ skeleton was not built; call build_skeleton(st) first")
+        deficit = simplex.lorentzianDeficitAngle()
+        shell = (min(shell_of[v] for v in tri if v in shell_of)
+                 if any(v in shell_of for v in tri) else None)
+        hinges.append(dict(vids=list(tri), re=deficit.real, im=deficit.imag,
+                           dv=simplex.dualVolume(), shell=shell))
+
+    boundary_tets = sorted(t for t, c in tet_count.items() if c == 1)
+    census = dict(
+        n_tops=len(tops),
+        n_tets=len(tet_count),
+        n_hinges_total=len(tri_fans),
+        n_hinges_interior=len(hinges),
+        n_hinges_boundary=n_boundary,
+        n_boundary_tets=len(boundary_tets),
+        boundary_tets=boundary_tets,
+        n_hole_vertices=len(hole_vertex_ids),
+    )
+    return hinges, census
+
+
+def masses(hinges):
+    """The three #451 mass readings over the interior hinges — one intensive,
+    two extensive (the r·m validator is sensitive to which is called "the mass",
+    so all three are always carried together):
+
+      * ``m_shell`` (intensive): the #352/#451 shell mass — the sum over BFS
+        shells (from the register holes) of the MEAN Re-deficit in that shell.
+        With no holes every hinge sits in one unlabeled bin and m_shell reduces
+        to the plain mean Re-deficit.
+      * ``m_sum`` (extensive): Σ Re ε — the raw integrated curvature.
+      * ``m_action`` (extensive, dual-weighted): Σ |★h|·Re ε — the dual-volume-
+        weighted Regge curvature.
+
+    Also returns ``shell_means`` (the per-shell means) and the imaginary-part
+    accounting: ``max_abs_im`` and ``n_im_nonzero`` (|Im ε| > IM_TOL) — the
+    deficit is complex Lorentzian, and whether Im is zero is always reported.
+    """
+    if not hinges:
+        nan = float("nan")
+        return dict(m_shell=nan, m_sum=nan, m_action=nan, shell_means={},
+                    max_abs_im=nan, n_im_nonzero=0)
+    bins = defaultdict(list)
+    for h in hinges:
+        bins[h["shell"]].append(h["re"])
+    shell_means = {shell: float(np.mean(values))
+                   for shell, values in sorted(bins.items(),
+                                               key=lambda kv: (kv[0] is None, kv[0]))}
+    return dict(
+        m_shell=float(sum(shell_means.values())),
+        m_sum=float(sum(h["re"] for h in hinges)),
+        m_action=float(sum(h["re"] * abs(h["dv"]) for h in hinges)),
+        shell_means=shell_means,
+        max_abs_im=float(max(abs(h["im"]) for h in hinges)),
+        n_im_nonzero=sum(1 for h in hinges if abs(h["im"]) > IM_TOL),
+    )
+
+
+def radii(st, census):
+    """The emergent size of the interior, dual and primal:
+
+      * ``r_dual`` = V_dual^(1/4): V_dual = Σ |★v| over the strictly INTERIOR
+        vertices (vertices on no boundary tetrahedron) — the signature-aware
+        circumcentric dual 4-volume. The fourth root is the dimension-correct
+        volume→length map on a 4-complex (#451 took the cube root of a dual
+        3-volume on its 3D event; same rule, different d).
+      * ``r_primal`` = V_primal^(1/4): V_primal = Σ |V₄| over ALL top 4-cells —
+        the primal-side cross-check of the same 4-volume (dual/primal agreement
+        is the skeleton-sanity signal; on a closed uniform complex they are
+        equal to machine precision).
+      * ``rms_dual_cell``: sqrt(mean |★h|) over the interior hinges — an RMS
+        dual-cell length scale (|★h| is a 2-volume in 4D), reported as the
+        auxiliary scale reading, not used in the r·m table.
+    """
+    boundary_vertex_ids = set(v for tet in census["boundary_tets"] for v in tet)
+    v_dual = 0.0
+    n_interior_vertices = 0
+    vertex_simplices = [s for s in st.getSimplices() if len(s.getVertices()) == 1]
+    for s in sorted(vertex_simplices, key=lambda s: s.getVertices()[0].getId()):
+        if not s.hasTopCoface():
+            continue  # orphan 0-simplex stranded by a move
+        vid = s.getVertices()[0].getId()
+        if vid in boundary_vertex_ids:
+            continue
+        v_dual += abs(s.dualVolume())
+        n_interior_vertices += 1
+    v_primal = sum(abs(t.volume()) for t in st.getTopSimplices())
+    return dict(
+        Vdual=float(v_dual),
+        Vprimal=float(v_primal),
+        n_interior_vertices=n_interior_vertices,
+        r_dual=float(v_dual) ** 0.25 if v_dual > 0 else float("nan"),
+        r_primal=float(v_primal) ** 0.25 if v_primal > 0 else float("nan"),
+    )
+
+
+def localization(hinges):
+    """Is the curvature a localized lump or spread out?
+
+      * ``PR``: participation ratio of the weight w = |Re ε·★h| over the interior
+        hinges, in (0, 1]. The equal-volume UNIFORM reference (a round sphere
+        spreads its curvature evenly over every hinge) has PR = 1.0;
+        ``concentration`` = 1/PR is how many times more concentrated the lump is.
+      * ``mean_re`` / ``std_re`` / ``std_over_mean``: the deficit statistics;
+        mean_re > 0 is the positive-curvature (bound-state, sphere-like) sign.
+      * ``shell_profile``: per BFS shell (from the register holes' vertices) the
+        hinge count, mean Re ε, and share of the total weight; plus
+        ``rms_shell_radius`` (the weight-weighted RMS shell distance — the lump
+        size in shells) and ``frac_within_shell1`` (the weight fraction within
+        one shell of the holes). Empty when no holes were given.
+    """
+    if not hinges:
+        nan = float("nan")
+        return dict(PR=nan, concentration=nan, mean_re=nan, std_re=nan,
+                    std_over_mean=nan, shell_profile={}, rms_shell_radius=nan,
+                    frac_within_shell1=nan)
+    re = np.array([h["re"] for h in hinges])
+    weight = np.abs(re * np.array([abs(h["dv"]) for h in hinges]))
+    total_weight = float(weight.sum())
+    pr = (float(total_weight ** 2 / (len(weight) * float((weight ** 2).sum())))
+          if total_weight > 0 else float("nan"))
+
+    shells = [h["shell"] for h in hinges]
+    profile = {}
+    rms_shell = float("nan")
+    frac_near = float("nan")
+    if all(s is not None for s in shells) and total_weight > 0:
+        shell_arr = np.array(shells, dtype=float)
+        for shell in sorted(set(shells)):
+            mask = shell_arr == shell
+            profile[shell] = dict(
+                n=int(mask.sum()),
+                mean_re=float(re[mask].mean()),
+                weight_share=float(weight[mask].sum() / total_weight),
+            )
+        rms_shell = float(np.sqrt(float((weight * shell_arr ** 2).sum())
+                                  / total_weight))
+        frac_near = float(weight[shell_arr <= 1].sum() / total_weight)
+
+    mean_re = float(re.mean())
+    return dict(
+        PR=pr,
+        concentration=(1.0 / pr) if pr and pr > 0 else float("nan"),
+        mean_re=mean_re,
+        std_re=float(re.std()),
+        std_over_mean=(float(re.std() / abs(mean_re)) if mean_re != 0.0
+                       else float("inf")),
+        shell_profile=profile,
+        rms_shell_radius=rms_shell,
+        frac_within_shell1=frac_near,
+    )
+
+
+def rm_table(mass, rad):
+    """Every r·m combination — 3 mass definitions × 2 radius definitions — with
+    the definitional spread stated FIRST (#451's lesson: r·m is too definition-
+    sensitive to quote as one number; the claim is order-of-magnitude only)."""
+    combos = {}
+    for m_name in ("m_shell", "m_sum", "m_action"):
+        for r_name in ("r_dual", "r_primal"):
+            combos[f"{r_name} x {m_name}"] = rad[r_name] * mass[m_name]
+    finite = [v for v in combos.values() if math.isfinite(v)]
+    spread = ((min(finite), max(finite)) if finite
+              else (float("nan"), float("nan")))
+    return dict(spread_min=spread[0], spread_max=spread[1], combos=combos,
+                physical=PHYSICAL_RM)
+
+
+def measure(st, holes=(), label=""):
+    """Read every geometric observable off one converged 4D spacetime: build the
+    C++ skeleton, select the interior hinges, and return the readings dict.
+    ``holes`` are the register holes' vertex-id tuples (e.g. ``Proton.quark_holes()``
+    / ``ProtonIngredients.emergent_holes()``) — the BFS shell seeds."""
+    skeleton = build_skeleton(st)
+    hinges, census = interior_hinges(st, holes)
+    mass = masses(hinges)
+    rad = radii(st, census)
+    loc = localization(hinges)
+    table = rm_table(mass, rad)
+    del skeleton
+    return dict(label=label, census=census, mass=mass, radius=rad,
+                localization=loc, rm=table, n_holes=len(holes), hinges=hinges)
+
+
+def report(o):
+    """Print one measurement dict in the #451 layout: census first, then the r·m
+    spread up front, then the per-definition table, then localization."""
+    c, mass, rad, loc, rm = (o["census"], o["mass"], o["radius"],
+                             o["localization"], o["rm"])
+    print(f"=== {o['label'] or 'converged spacetime'} ===")
+    print(f"-- census: {c['n_hinges_interior']} interior (closed-fan) hinges of "
+          f"{c['n_hinges_total']} triangles "
+          f"({c['n_hinges_boundary']} boundary artefacts excluded); "
+          f"{c['n_tops']} top 4-cells, {c['n_boundary_tets']} boundary tetrahedra, "
+          f"{o['n_holes']} register holes ({c['n_hole_vertices']} hole vertices)")
+    if c["n_hinges_interior"] == 0:
+        print("   no interior hinges — every triangle touches the boundary; "
+              "the geometric readings below are NaN by construction\n")
+    print(f"-- r·m (physical anchor ~ {rm['physical']:.1f}; ORDER-OF-MAGNITUDE "
+          f"claim only):")
+    print(f"   definitional spread: {rm['spread_min']:.3g} .. {rm['spread_max']:.3g} "
+          f"across {len(rm['combos'])} mass x radius definitions")
+    for name, value in rm["combos"].items():
+        print(f"     {name:24s} = {value:10.4g}")
+    print(f"-- mass: m_shell (intensive) = {mass['m_shell']:.4g}   "
+          f"m_sum = {mass['m_sum']:.4g}   m_action = {mass['m_action']:.4g}")
+    if mass["n_im_nonzero"] == 0:
+        im_note = "ZERO (all-spacelike fans)"
+    else:
+        im_note = (f"NONZERO on {mass['n_im_nonzero']} hinges (boost content); "
+                   "masses use Re ε only")
+    print(f"   Im(deficit): max |Im ε| = {mass['max_abs_im']:.3g} over the interior "
+          f"hinges — {im_note}")
+    print(f"-- radius: r_dual = V_dual^(1/4) = {rad['r_dual']:.4g} "
+          f"(V_dual = {rad['Vdual']:.4g} over {rad['n_interior_vertices']} interior "
+          f"vertices)   cross-check r_primal = {rad['r_primal']:.4g} "
+          f"(V_primal = {rad['Vprimal']:.4g})")
+    print(f"-- localization: PR = {loc['PR']:.3f} (uniform reference 1.0) -> "
+          f"{loc['concentration']:.2f}x more concentrated;   "
+          f"mean Re ε = {loc['mean_re']:+.4g} "
+          f"({'positive-curvature lump' if loc['mean_re'] > 0 else 'NET NEGATIVE — not the bound-state sign'});   "
+          f"std/|mean| = {loc['std_over_mean']:.2f}")
+    if loc["shell_profile"]:
+        cells = "  ".join(
+            f"shell {shell}: n={p['n']}, mean Re ε={p['mean_re']:+.3g}, "
+            f"w={p['weight_share']:.0%}"
+            for shell, p in loc["shell_profile"].items())
+        print(f"   shell profile (BFS from the hole vertices): {cells}")
+        print(f"   weighted RMS shell radius = {loc['rms_shell_radius']:.3f} shells; "
+              f"|curvature| within shell<=1 = {loc['frac_within_shell1']:.0%}")
+    else:
+        print("   shell profile: skipped (no register holes to seed the BFS)")
+    print()
+
+
+def _measure_arm(builder, label, seed, max_restarts):
+    """Build one arm with the bounded fast-test budget and measure its block()."""
+    print(f"building {label} (seed={seed}, max_restarts={max_restarts}, "
+          f"defaults otherwise) ...")
+    arm = builder(seed=seed)
+    arm.build(max_restarts=max_restarts)
+    holes = (arm.quark_holes() if hasattr(arm, "quark_holes")
+             else arm.emergent_holes())
+    o = measure(arm.block(), holes, label)
+    o["converged"] = arm.converged()
+    return o
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--arm", choices=("canonical", "ingredients", "both"),
+                        default="canonical",
+                        help="which build to read: the canonical Proton, the "
+                             "emergent-arm ProtonIngredients, or both (the "
+                             "geometry A/B comparison)")
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--max-restarts", type=int, default=1,
+                        help="bounded validation budget (the fast-test pattern)")
+    args = parser.parse_args()
+
+    results = []
+    if args.arm in ("canonical", "both"):
+        results.append(_measure_arm(cob.Proton, "canonical Proton().block()",
+                                    args.seed, args.max_restarts))
+    if args.arm in ("ingredients", "both"):
+        results.append(_measure_arm(cob.ProtonIngredients,
+                                    "emergent-arm ProtonIngredients().block()",
+                                    args.seed, args.max_restarts))
+    print()
+    for o in results:
+        report(o)
+
+    if len(results) == 2:
+        a, b = results
+        print("-- emergent-arm vs canonical (same seed, same budget) --")
+        for key, path in (("interior hinges", ("census", "n_hinges_interior")),
+                          ("r_dual", ("radius", "r_dual")),
+                          ("m_shell", ("mass", "m_shell")),
+                          ("PR", ("localization", "PR")),
+                          ("mean Re ε", ("localization", "mean_re"))):
+            va = a[path[0]][path[1]]
+            vb = b[path[0]][path[1]]
+            print(f"   {key:16s} canonical {va:10.4g}   emergent {vb:10.4g}")
+        print()
+
+    print("VERDICT (the #451 discipline): the robust evidence is the census-clean "
+          "interior selection,\n  the localization (participation ratio vs the "
+          "uniform reference) and the sign of the mean\n  deficit — r·m is "
+          "definition-sensitive, so its table is an order-of-magnitude reading, "
+          "never\n  a sharp validator.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/emergent_mass_radius.py
+++ b/examples/cobordism/emergent_mass_radius.py
@@ -367,13 +367,12 @@ def measure(st, holes=(), label=""):
     C++ skeleton, select the interior hinges, and return the readings dict.
     ``holes`` are the register holes' vertex-id tuples (e.g. ``Proton.quark_holes()``
     / ``ProtonIngredients.emergent_holes()``) — the BFS shell seeds."""
-    skeleton = build_skeleton(st)
+    build_skeleton(st)  # registers the lattice onto st itself; idempotent
     hinges, census = interior_hinges(st, holes)
     mass = masses(hinges)
     rad = radii(st, census)
     loc = localization(hinges)
     table = rm_table(mass, rad)
-    del skeleton
     return dict(label=label, census=census, mass=mass, radius=rad,
                 localization=loc, rm=table, n_holes=len(holes), hinges=hinges)
 

--- a/examples/cobordism/observe_proton_ingredients.py
+++ b/examples/cobordism/observe_proton_ingredients.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The ONE observable-battery construction over a ProtonIngredients specimen (#583).
+
+Constructs the blessed read context (``tessera.observe.Register``) for a
+specimen and runs the full gated battery whenever the specimen carries three
+register holes — below three, every inapplicable observable reports its skip
+reason instead of crashing. One uniform JSON record + a readable table; b₃ is
+always recorded next to the hole census with the ``holes_vs_b3_divergent``
+flag (the campaign taught us holes and b₃ can disagree).
+
+## Input modes
+
+* ``--geometry dump.json`` — **the faithful path**: a schema-1 campaign
+  geometry dump (top cells in intrinsic vertex order, per-edge complex
+  squared lengths, per-vertex times) rebuilt via ``Spacetime.fromCells``.
+  The dump is an attempt's ONLY faithful record: the engine build is NOT
+  process-deterministic (identical fresh processes diverge on the same seed —
+  measured, not hypothetical), so a base seed labels an attempt, it does not
+  reproduce it. The rebuilt state is verified against the dump (cells, edge
+  lengths, and any recorded betti/holes metadata) before measuring.
+* ``--seed N`` — a **fresh bounded attempt**: drives a new
+  ``tessera.cobordism.ProtonIngredients(seed=N)`` build at the given budgets
+  (two-step by default; ``--joint`` drives ``build_joint`` — the #560
+  collapsed event graph). This is a NEW SAMPLE of the seed's attempt
+  distribution, never a reproduction of any prior record. In the joint arm
+  the kept node's output blocks (``output_blocks()``) flow into the battery
+  as block provenance automatically.
+
+Provenance (build history: the diquark pair, output blocks) travels via the
+campaign record / geometry-dump metadata or ``--provenance file.json`` — it
+is never guessed and never re-derived by re-running a build. Recognized keys:
+``diquark_pair`` (step-1 hole indices, for the pair-loop criterion (b)) and
+``blocks`` (label + vertices + target_re/target_im each, for the per-block
+residuals).
+
+## The campaign-analyzer import surface
+
+The analyzer consumes the same package surface this script drives::
+
+    from tessera.observe import Register, battery, load_geometry_dump, rebuild_spacetime
+    dump = load_geometry_dump(path)
+    st = rebuild_spacetime(dump)
+    record = battery.measure_all(make_register(st), provenance=None)
+
+(``make_register`` here is the one-liner hole-count policy: a 3-hole register
+when the specimen has one, otherwise all the holes it does have, so the
+battery can report per-observable skips.)
+
+Run:
+
+    python observe_proton_ingredients.py --geometry seed_7_geometry.json
+    python observe_proton_ingredients.py --seed 1                  # fresh two-step attempt
+    python observe_proton_ingredients.py --seed 1 --joint --out record.json
+"""
+import argparse
+import json
+
+import tessera
+
+from tessera.observe import (
+    Register,
+    battery,
+    load_geometry_dump,
+    rebuild_spacetime,
+    verify_rebuild,
+)
+
+cob = tessera.cobordism
+
+#: jointNode's output-block seeding order (baryon at v3, antibaryon at v4).
+JOINT_BLOCK_LABELS = ("baryon", "antibaryon")
+
+
+def make_register(st, degree=3):
+    """The construction's hole-count policy: ask for the full 3-hole register
+    when the specimen carries one; otherwise take every hole it does have (so
+    the battery reports per-observable skip reasons instead of this
+    constructor raising). The surplus warning still fires when more than
+    three holes exist — the read then covers a sub-register."""
+    total = len(cob.MultiCobordism.emergent_holes(st, degree))
+    return Register(st, count=min(3, total), degree=degree)
+
+
+def blocks_provenance(output_blocks):
+    """``ProtonIngredients.output_blocks()`` as battery block provenance
+    (label + vertices + target), in jointNode's seeding order."""
+    blocks = []
+    for index, block in enumerate(output_blocks):
+        label = (JOINT_BLOCK_LABELS[index]
+                 if index < len(JOINT_BLOCK_LABELS) else f"block{index}")
+        blocks.append({
+            "label": label,
+            "vertices": [int(v) for v in block.vertices],
+            "target": list(block.target),
+        })
+    return blocks
+
+
+def load_provenance(path=None, dump=None):
+    """Provenance from the recognized geometry-dump metadata keys, overlaid
+    by an explicit ``--provenance`` JSON file. Returns None when neither
+    supplies anything — the battery then reports the provenance-gated
+    channels as not evaluable, never guessed."""
+    provenance = {}
+    if dump is not None:
+        for key in ("diquark_pair", "blocks"):
+            if dump.get(key) is not None:
+                provenance[key] = dump[key]
+    if path is not None:
+        with open(path) as fh:
+            provenance.update(json.load(fh))
+    return provenance or None
+
+
+def observe_geometry_dump(path, provenance_path=None, gates=True):
+    """The faithful path: load + verify a schema-1 geometry dump, rebuild the
+    exact state, and run the battery. Returns the record."""
+    dump = load_geometry_dump(path)
+    st = rebuild_spacetime(dump)
+    mismatches = verify_rebuild(st, dump)
+    if mismatches:
+        raise RuntimeError(
+            f"rebuilt state does not match the geometry dump {path}: "
+            f"{mismatches}")
+    register = make_register(st)
+    provenance = load_provenance(provenance_path, dump)
+    record = battery.measure_all(register, provenance=provenance, gates=gates)
+    record["input"] = {
+        "mode": "geometry_dump",
+        "path": str(path),
+        "schema": dump["schema"],
+        "dump_verified": True,
+        "base_seed": dump.get("base_seed"),
+        "note": ("the dump is the attempt's faithful record; the engine "
+                 "build is not process-deterministic, so only the dump — "
+                 "never a re-run — reproduces this state"),
+    }
+    return record
+
+
+def observe_fresh_attempt(seed, joint=False, max_restarts=1, init_steps=40,
+                          evolve_steps=20, stage2_max_iters=10,
+                          provenance_path=None, gates=True):
+    """A fresh bounded ProtonIngredients attempt (a NEW SAMPLE at this seed —
+    never a reproduction of any prior attempt), measured post-hoc. The joint
+    arm feeds its kept output blocks into the battery as block provenance."""
+    ingredients = cob.ProtonIngredients(seed=seed)
+    drive = ingredients.build_joint if joint else ingredients.build
+    drive(max_restarts=max_restarts, init_steps=init_steps,
+          evolve_steps=evolve_steps, stage2_max_iters=stage2_max_iters)
+
+    register = make_register(ingredients.block())
+    provenance = load_provenance(provenance_path) or {}
+    if joint and "blocks" not in provenance:
+        provenance["blocks"] = blocks_provenance(ingredients.output_blocks())
+    record = battery.measure_all(register, provenance=provenance or None,
+                                 gates=gates)
+    record["input"] = {
+        "mode": "fresh_attempt",
+        "arm": "joint" if joint else "two_step",
+        "seed": int(seed),
+        "budgets": {"max_restarts": max_restarts, "init_steps": init_steps,
+                    "evolve_steps": evolve_steps,
+                    "stage2_max_iters": stage2_max_iters},
+        "note": ("a fresh attempt at this seed — NOT a reproduction of any "
+                 "prior record (the engine build is not "
+                 "process-deterministic); the faithful record of an attempt "
+                 "is its geometry dump"),
+    }
+    record["build"] = {
+        "converged": ingredients.converged(),
+        "stationary": ingredients.stationary(),
+        "persistent": ingredients.persistent(),
+        "kept_seed": int(ingredients.seed()),
+        "final_objective": float(ingredients.final_objective()),
+        "input_residual": float(ingredients.input_residual()),
+        "singlet_residual": float(ingredients.singlet_residual()),
+        "diquark_residual": float(ingredients.diquark_residual()),
+        "baryon_residual": float(ingredients.baryon_residual()),
+        "antibaryon_residual": float(ingredients.antibaryon_residual()),
+    }
+    return record
+
+
+def render_table(record):
+    """The readable side of the record: the register census, then one block
+    per observable (status, gates, and the observable's headline channels)."""
+    lines = []
+    reg = record["register"]
+    lines.append("=== observable battery ===")
+    if "input" in record:
+        source = record["input"]
+        detail = source.get("path", source.get("seed"))
+        lines.append(f"input: {source['mode']}"
+                     + (f" ({source.get('arm')})" if "arm" in source else "")
+                     + f" [{detail}]")
+    lines.append(
+        f"register: holes_used={reg['holes_used']} of "
+        f"holes_total={reg['holes_total']}, b3={reg['b3']}, "
+        f"divergent={reg['holes_vs_b3_divergent']}, "
+        f"degree={reg['degree']}, cells={reg['n_top_cells']}, "
+        f"causal_content={reg['causal_content']}")
+    if reg["dropped_holes"]:
+        lines.append(f"  dropped holes: {reg['dropped_holes']}")
+    if "build" in record:
+        b = record["build"]
+        lines.append(
+            f"build: converged={b['converged']} (stationary={b['stationary']}, "
+            f"persistent={b['persistent']}), F={b['final_objective']:.4g}, "
+            f"r_U={b['input_residual']:.3g}, "
+            f"singlet diag={b['singlet_residual']:.3g}")
+
+    for name, entry in record["observables"].items():
+        if entry["status"] != "measured":
+            lines.append(f"-- {name}: {entry['status']}")
+            continue
+        gates = entry.get("gates")
+        gate_note = ""
+        if gates:
+            gate_note = (f"   [gauge {gates['gauge_delta']:.1e}"
+                         f"{'' if gates['gauge_ok'] else ' FLAGGED'}, "
+                         f"relabel {gates['relabel_delta']:.1e}"
+                         f"{'' if gates['relabel_ok'] else ' FLAGGED'}]")
+        lines.append(f"-- {name}: measured{gate_note}")
+        r = entry["record"]
+        if name == "singlet_diagnostic":
+            lines.append(
+                f"     singlet r_state={r['singlet_residual']:.3g}  "
+                f"betti={r['betti']}  holes={r['holes_total']}  b3={r['b3']}  "
+                f"divergent={r['holes_vs_b3_divergent']}")
+        elif name == "block_residuals":
+            for block in r["blocks"]:
+                lines.append(
+                    f"     {block['label']}: residual={block['residual']:.3g}"
+                    f" (cells={block['n_cells_in_region']}, "
+                    f"full_leak={block['full_leak']}, "
+                    f"target_norm2={block['target_norm2']:.3g})")
+        elif name == "mass_radius":
+            lines.append(
+                f"     m_shell={r['mass']['m_shell']:.4g}  "
+                f"m_sum={r['mass']['m_sum']:.4g}  "
+                f"m_action={r['mass']['m_action']:.4g}  "
+                f"r_dual={r['radius']['r_dual']:.4g}  "
+                f"r_primal={r['radius']['r_primal']:.4g}")
+            lines.append(
+                f"     PR={r['localization']['PR']:.3f}  "
+                f"mean Re eps={r['localization']['mean_re']:+.4g}  "
+                f"r*m spread {r['rm']['spread_min']:.3g}.."
+                f"{r['rm']['spread_max']:.3g} "
+                f"(anchor ~{r['rm']['physical']:.1f}; order-of-magnitude only)")
+        elif name == "pair_loop_flavor":
+            q = ", ".join(f"{x:.5f}" for x in r["loop_q"])
+            lines.append(
+                f"     loop_q=[{q}]  odd={r['odd_loop']} (dual hole "
+                f"{r['dual_hole']})  rho={r['rho']:.3f}  "
+                f"2:1={r['multiplicity_2_1']}  r_u={r['r_u']:.2g}")
+            lines.append(
+                f"     odd_is_diquark_loop={r['odd_is_diquark_loop']} "
+                f"({r['odd_is_diquark_loop_status']})")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--geometry", metavar="DUMP_JSON",
+                        help="a schema-1 campaign geometry dump — the "
+                             "attempt's faithful record (the ONLY rebuild "
+                             "path; seeds label attempts, they do not "
+                             "reproduce them)")
+    source.add_argument("--seed", type=int,
+                        help="drive a FRESH bounded ProtonIngredients attempt "
+                             "at this seed (a new sample, never a "
+                             "reproduction)")
+    parser.add_argument("--joint", action="store_true",
+                        help="fresh attempts drive build_joint (#560) instead "
+                             "of the two-step build; the kept output blocks "
+                             "feed the per-block residuals")
+    parser.add_argument("--max-restarts", type=int, default=1)
+    parser.add_argument("--init-steps", type=int, default=40)
+    parser.add_argument("--evolve-steps", type=int, default=20)
+    parser.add_argument("--stage2-max-iters", type=int, default=10)
+    parser.add_argument("--provenance", metavar="JSON",
+                        help="build-history provenance (diquark_pair, blocks) "
+                             "— from the campaign record; never guessed")
+    parser.add_argument("--no-gates", action="store_true",
+                        help="skip the GAUGE/RELABEL gates (faster; the "
+                             "record then carries no gate residuals)")
+    parser.add_argument("--out", metavar="JSON",
+                        help="write the JSON record here (default: print it "
+                             "after the table)")
+    args = parser.parse_args()
+
+    if args.geometry:
+        record = observe_geometry_dump(args.geometry, args.provenance,
+                                       gates=not args.no_gates)
+    else:
+        record = observe_fresh_attempt(
+            args.seed, joint=args.joint, max_restarts=args.max_restarts,
+            init_steps=args.init_steps, evolve_steps=args.evolve_steps,
+            stage2_max_iters=args.stage2_max_iters,
+            provenance_path=args.provenance, gates=not args.no_gates)
+
+    print(render_table(record))
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(record, fh, indent=1)
+        print(f"\nrecord written to {args.out}")
+    else:
+        print("\n" + json.dumps(record))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/pair_loop_flavor.py
+++ b/examples/cobordism/pair_loop_flavor.py
@@ -1,0 +1,408 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Pair-loop dual-basis flavor read on a 3-hole register (#561, part of #410/#559).
+
+The `docs/theory/cobordism/proton-spin/pair_loop_quarks.tex` experiment (its §7
+"genuinely new, cheap experiment"), implemented literally. On a structure with
+three register holes carrying the color singlet `[1, ω, ω²]`:
+
+1. **Joint read.** One correlated multi-hole read — the SINGLE joint carried
+   representative `ψ = EigenstateSynthesis(st, 3).carriedRepresentative(holes,
+   target)` — never three independent per-hole extractions. The per-hole
+   carried weight is the period `w_h = ∮_[h] ψ` over hole `h`'s boundary
+   3-cycle (the five (-1)^j-signed tetrahedral facets of the removed 4-cell).
+2. **Pair loops, no new geometry.** The loop `γ_ij` encircling holes `i, j` is
+   homologous to `[i] + [j]`, so its period is `w_i + w_j` — formed
+   arithmetically from the per-hole weights. Imposing the singlet
+   (`Σ_h w_h = 0`) gives the Poincaré duality `[γ_ij] = -[k]`: each pair loop
+   is minus the complementary hole (`pair_loops` / `complement_hole`).
+3. **Flavor/taste charge.** The per-hole Dirac–Kähler charge read of the
+   retired `dk_joint_spin.per_hole_flavor` was `DiracKahler.charge(lift(3, ψ))
+   = Σ_c W_c |ψ_c|²` — the metric-weighted norm² (the DK charge density `j⁰_c
+   = W_c |ψ_c|²` summed). #509 retired `DiracKahler`, but the same number needs
+   only the surviving `HodgeLaplacian.weights(3)` (the per-3-cell metric
+   volume weights `W_c`, in the same canonical cell order as
+   `EigenstateSynthesis.cellSimplices()`). Localized to a cycle it is the
+   charge that cycle carries: per hole `q_h = Σ_{c ∈ ∂h} W_c |ψ_c|²`, and per
+   pair loop the weighted norm of ψ on the loop's combined cycle support
+   `∂i ⊔ ∂j`. Because distinct holes have disjoint boundary facets this is
+   exactly `q_i + q_j` (additivity is structural, not an approximation — see
+   the criterion-(b) honesty note below). Equivalently: the symmetric metric
+   operator is assembled with `B₄ = W₃^{1/2} ∂₄ W₄^{-1/2}`, so the CLOSED
+   cochain behind a harmonic row ψ̃ is `χ = √W₃ ψ̃` (`∂₄ᵀχ = 0`), and the
+   weighted norm is the plain norm² of that closed representative on the
+   cycle — the charge lives on the topological object.
+
+## Orientation (the RELABEL lesson)
+
+`cyclePeriods`' raw facet signs orient every hole by its sorted vertex tuple —
+a labeling convention, not physics: a vertex relabeling can flip one hole's
+boundary orientation and silently pin `-t_h`. The label-free orientation is the
+induced one: `ChainComplex.endSignCovector(top_cells, holes)` returns the
+per-hole signs `σ_h = ±1` from the complex's own coherent (facet-sharing)
+orientation, under which every closed form's signed periods obey
+`Σ_h σ_h p_h = 0`. Targets are pinned as `σ_h · t_h` and weights read back as
+`w_h = σ_h ∮_h ψ`, so `w` carries the singlet in the induced orientation. The
+one remaining ambiguity is a single GLOBAL sign (the propagation root), which
+is `-1 ∈ U(1)` on the register — gauge, not physics (see the GAUGE gate).
+
+## Pre-registered criteria (pair_loop_quarks.tex §7; falsifiable)
+
+(a) **Multiplicity 2:1** — the three pair-loop charges cluster as {u, u, d}:
+    two alike, one apart. Quantified by `rho` = (spread of the closest pair) /
+    (its separation from the odd one); `rho < RHO_MAX = 0.5` counts as 2:1.
+(b) **The odd-one-out loop is the diquark loop** — the dual of the spectator
+    (step-2) quark hole. HONESTY NOTE: with the additive pair charge, the
+    charge-odd loop is automatically the dual of the charge-odd hole, so on a
+    fixture (no build history) only the odd loop's IDENTITY is reportable.
+    The falsifiable content of (b) is that the charge-odd hole coincides with
+    the quark the build added last (the two step-1 holes are the diquark) —
+    pass `diquark_pair` (the step-1 hole indices) when the specimen's build
+    history is known; the criterion then passes iff the odd loop IS that pair.
+(c) **GAUGE and RELABEL invariance** — see the gates below.
+
+Failure of (b) on a genuine specimen falsifies the dual-flavor framing; either
+outcome is a finding.
+
+## Gates (post-hoc validation, never a loop condition)
+
+* GAUGE — this readout is built from periods and metric-weighted norms only:
+  no embedding, no per-cell frame exists to SO(4)-rotate (that gate is vacuous
+  here by construction). The register's surviving gauge freedom is the global
+  U(1) phase of the target, `t → e^{iθ} t` — which contains the Z₃ cyclic
+  recolor of the singlet (a cyclic shift of `[1, ω, ω²]` is `ω^{±1}` times it)
+  and the global orientation flip (`-1`). Charges must be invariant and loop
+  periods covariant (`w → e^{iθ} w`).
+* RELABEL — random vertex-id permutation, rebuild the complex from the
+  permuted cells and edge lengths, re-read with the permuted holes: charges,
+  `rho`, and the odd-one-out identity must match, and the oriented loop
+  periods must match up to the global orientation sign.
+
+Both gates hold to machine precision: directly-read quantities (charges,
+periods, duality residuals) reproduce to `GATE_TOL = 1e-12` (observed ~1e-16
+on the fixtures); the derived clustering ratio `rho` divides two small charge
+differences, which amplifies eigensolve roundoff (observed ~1e-13), so tests
+give `d_rho` the looser `RHO_GATE_TOL = 1e-9` while the odd-one-out identity
+must match exactly.
+
+Run `python pair_loop_flavor.py` for the per-fixture table over the synthetic
+b₃ = 3..5 fixtures (+ the real converged_b3_3) in
+`tests/fixtures/composite_spin/`. The read takes the structure's first three
+register holes (`MultiCobordism.emergent_holes(st, 3)[:3]`, the #485 fixture
+convention). `read_structure` is the specimen entry point — point it at a
+built proton block (e.g. `Proton.block()` + `Proton.quark_holes()`) with
+`diquark_pair` from the build history once a 3-hole specimen is available.
+"""
+import cmath
+import json
+import math
+import os
+import random
+
+import numpy as np
+
+import tessera as T
+
+cob = T.cobordism
+
+OMEGA = cmath.exp(2j * math.pi / 3)
+#: The color singlet `[1, ω, ω²]` — the carried register state (Σ = 0).
+SINGLET = (1.0 + 0.0j, OMEGA, OMEGA * OMEGA)
+
+#: The three pair loops as (i, j) hole-index pairs; `γ_ij` encircles holes i, j.
+PAIR_LOOPS = ((0, 1), (0, 2), (1, 2))
+
+#: Criterion (a): the closest pair's spread over its separation from the odd
+#: one must stay below this for a 2:1 (u:u:d) verdict.
+RHO_MAX = 0.5
+
+#: Both gates must reproduce every directly-read quantity to this tolerance.
+GATE_TOL = 1e-12
+
+#: Looser gate tolerance for the derived ratio `rho` (a quotient of two small
+#: charge differences — it amplifies eigensolve roundoff by ~1/separation).
+RHO_GATE_TOL = 1e-9
+
+_FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         "..", "..", "tests", "fixtures", "composite_spin")
+
+
+def complement_hole(pair):
+    """The hole index dual to the pair loop `γ_ij`: `[γ_ij] = -[k]`, the third
+    index. The Poincaré-duality bookkeeping of pair_loop_quarks.tex Eq. (dual)."""
+    (i, j) = pair
+    return 3 - i - j
+
+
+def load_fixture(name, fixtures_dir=_FIXTURES):
+    """A composite_spin fixture as (meta, cells, edges): `cells` the 5-vertex
+    top 4-cells, `edges` {(min_id, max_id): complex squared length}."""
+    with open(os.path.join(fixtures_dir, name)) as f:
+        meta = json.load(f)
+    cells = [list(c) for c in meta["cells"]]
+    edges = {}
+    for key, (re, im) in meta["edges"].items():
+        a, b = (int(x) for x in key.split(","))
+        edges[(a, b)] = complex(re, im)
+    return meta, cells, edges
+
+
+def build_spacetime(cells, edges, perm=None):
+    """The live complex from explicit top cells + edge squared lengths,
+    optionally relabeled by `perm` (vertex id -> vertex id). The skeleton is
+    materialized in C++ (`ReggeSolver`), so the degree-3 cell universe exists."""
+    if perm is not None:
+        cells = [[perm[v] for v in c] for c in cells]
+        edges = {tuple(sorted((perm[a], perm[b]))): z
+                 for (a, b), z in edges.items()}
+    st = T.Spacetime.fromCells(4, cells, 1.0, 0.0)
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        e.setSquaredLength(edges[(a, b) if a < b else (b, a)])
+    T.ReggeSolver(st, T.MatterConfiguration())
+    return st
+
+
+def register_holes(st, count=3):
+    """The structure's first `count` register holes (removed top 4-cells), in
+    `MultiCobordism.emergent_holes` order — the #485 fixture convention."""
+    holes = [tuple(h) for h in cob.MultiCobordism.emergent_holes(st, 3)]
+    if len(holes) < count:
+        raise ValueError(f"need >= {count} register holes, found {len(holes)}")
+    return holes[:count]
+
+
+def induced_orientation_signs(st, holes):
+    """The induced-orientation signs `σ_h = ±1` of the holes' boundary cycles
+    relative to the complex's own coherent orientation
+    (`ChainComplex.endSignCovector`): the label-free orientation under which
+    every closed form's signed periods obey `Σ_h σ_h p_h = 0`. Determined up
+    to one global sign (the propagation root) = `-1 ∈ U(1)` on the register."""
+    tops = [[v.getId() for v in s.getVertices()] for s in st.getTopSimplices()]
+    return list(cob.ChainComplex.endSignCovector(tops, [list(h) for h in holes]))
+
+
+def _facet_indices(cell_index, hole):
+    """Hole `h`'s five boundary tetrahedra as (cochain index, (-1)^j sign)
+    pairs. Facet j of the sorted hole drops vertex v_j and carries (-1)^j —
+    the same boundary-operator convention `cyclePeriods` documents, mirrored
+    here so ψ's periods are read in the operator's own indexing. Facets are
+    matched by vertex SET (never by an imposed order); the physical
+    orientation is supplied separately by `induced_orientation_signs`."""
+    hs = sorted(hole)
+    out = []
+    for j in range(len(hs)):
+        facet = frozenset(hs[:j] + hs[j + 1:])
+        out.append((cell_index[facet], (-1) ** j))
+    return out
+
+
+def joint_read(st, holes, target=SINGLET):
+    """The single correlated multi-hole read. Returns a dict:
+
+    * ``sigma`` — induced-orientation signs of the three holes;
+    * ``psi`` — the joint carried representative of `σ·target` over `holes`;
+    * ``r_u`` — `residualForPeriods` of that pin (~0 = the register carries it);
+    * ``w`` — oriented per-hole carried weights `w_h = σ_h ∮_h ψ` (== target);
+    * ``q`` — per-hole DK-style charges `q_h = Σ_{c ∈ ∂h} W_c |ψ_c|²`;
+    * ``loop_w`` — pair-loop periods `w_i + w_j` in `PAIR_LOOPS` order;
+    * ``loop_q`` — pair-loop charges (weighted norm² of ψ on `∂i ⊔ ∂j`);
+    * ``dual_residual`` — `|w_i + w_j + w_k|` per loop (the `[γ_ij] = -[k]`
+      bookkeeping; ~0 whenever the pinned target sums to zero).
+    """
+    if len(holes) != 3 or len(target) != 3:
+        raise ValueError("the pair-loop read is over exactly 3 holes")
+    es = cob.EigenstateSynthesis(st, 3)
+    cell_index = {frozenset(t): i for i, t in enumerate(es.cellSimplices())}
+    weights = np.asarray(cob.HodgeLaplacian(st).weights(3), float)
+    sigma = induced_orientation_signs(st, holes)
+    hole_lists = [list(h) for h in holes]
+    raw_target = [s * t for s, t in zip(sigma, target)]
+    psi = np.asarray(es.carriedRepresentative(hole_lists, raw_target), complex)
+    r_u = es.residualForPeriods(hole_lists, raw_target)
+
+    facets = [_facet_indices(cell_index, h) for h in holes]
+    w = [sigma[h] * sum(sgn * psi[c] for c, sgn in facets[h]) for h in range(3)]
+    q = [float(sum(weights[c] * abs(psi[c]) ** 2 for c, _ in facets[h]))
+         for h in range(3)]
+
+    loop_w, loop_q, dual_residual = [], [], []
+    for (i, j) in PAIR_LOOPS:
+        loop_w.append(w[i] + w[j])
+        support = {c for c, _ in facets[i]} | {c for c, _ in facets[j]}
+        loop_q.append(float(sum(weights[c] * abs(psi[c]) ** 2 for c in support)))
+        dual_residual.append(abs(w[i] + w[j] + w[complement_hole((i, j))]))
+    return dict(sigma=sigma, psi=psi, r_u=r_u, w=w, q=q,
+                loop_w=loop_w, loop_q=loop_q, dual_residual=dual_residual)
+
+
+def odd_one_out(loop_q):
+    """(odd loop index, rho): the loop whose charge sits farthest from the
+    mean of the other two, and `rho` = |spread of the other two| / |that
+    separation| — small `rho` is a clean 2:1 (u:u:d) clustering."""
+    separations = []
+    for k in range(3):
+        others = [loop_q[i] for i in range(3) if i != k]
+        separations.append(abs(loop_q[k] - (others[0] + others[1]) / 2.0))
+    odd = int(np.argmax(separations))
+    others = [loop_q[i] for i in range(3) if i != odd]
+    rho = (abs(others[0] - others[1]) / separations[odd]
+           if separations[odd] > 0 else float("inf"))
+    return odd, rho
+
+
+def evaluate_criteria(read, diquark_pair=None, rho_max=RHO_MAX):
+    """The pre-registered criteria on a finished `joint_read`.
+
+    (a) `multiplicity_2_1`: `rho < rho_max`.
+    (b) `odd_is_diquark_loop`: only decidable with `diquark_pair` (the step-1
+        hole-index pair from the specimen's build history) — True iff the
+        charge-odd loop is exactly that pair; None on fixtures (no history).
+    Duality bookkeeping and the gates are (2)/(c), reported alongside.
+    """
+    odd, rho = odd_one_out(read["loop_q"])
+    verdict = dict(odd_loop=PAIR_LOOPS[odd],
+                   dual_hole=complement_hole(PAIR_LOOPS[odd]),
+                   rho=rho,
+                   multiplicity_2_1=bool(rho < rho_max),
+                   odd_is_diquark_loop=None)
+    if diquark_pair is not None:
+        verdict["odd_is_diquark_loop"] = (
+            tuple(sorted(diquark_pair)) == PAIR_LOOPS[odd])
+    return verdict
+
+
+def read_structure(st, holes=None, target=SINGLET, diquark_pair=None):
+    """The specimen entry point: `joint_read` + `evaluate_criteria` on a live
+    complex (e.g. a built proton block: `st = Proton.block()`, holes from
+    `Proton.quark_holes()`, `diquark_pair` from the build's step-1 history)."""
+    holes = register_holes(st) if holes is None else [tuple(h) for h in holes]
+    read = joint_read(st, holes, target)
+    return read, evaluate_criteria(read, diquark_pair=diquark_pair)
+
+
+# ---------------------------------------------------------------------------
+# The gates — post-hoc validation, never a loop condition.
+# ---------------------------------------------------------------------------
+
+def gauge_gate(st, holes, base, theta=2.0 * math.pi * 0.371, target=SINGLET):
+    """GAUGE: re-read with the target rotated by the global U(1) phase
+    `e^{iθ}`. Returns the residual dict — every entry must be < `GATE_TOL`:
+    charges invariant, loop periods covariant, duality/oddity unchanged."""
+    phase = cmath.exp(1j * theta)
+    gauged = joint_read(st, holes, [phase * t for t in target])
+    odd0, rho0 = odd_one_out(base["loop_q"])
+    odd1, rho1 = odd_one_out(gauged["loop_q"])
+    return {
+        "d_charge": max(abs(a - b) for a, b in zip(gauged["q"], base["q"])),
+        "d_loop_charge": max(abs(a - b)
+                             for a, b in zip(gauged["loop_q"], base["loop_q"])),
+        "d_loop_period": max(abs(a - phase * b)
+                             for a, b in zip(gauged["loop_w"], base["loop_w"])),
+        "d_rho": abs(rho1 - rho0),
+        "d_odd": float(odd1 != odd0),
+    }
+
+
+def relabel_gate(cells, edges, holes, base, seed=3, target=SINGLET):
+    """RELABEL: random vertex-id permutation, rebuild, re-read with the
+    permuted holes. Returns the residual dict — every entry must be
+    < `GATE_TOL`. Oriented loop periods are compared up to the one global
+    orientation sign (the `endSignCovector` propagation root, `-1 ∈ U(1)`)."""
+    all_vertices = sorted({v for c in cells for v in c})
+    shuffled = all_vertices[:]
+    random.Random(seed).shuffle(shuffled)
+    perm = dict(zip(all_vertices, shuffled))
+    st2 = build_spacetime(cells, edges, perm=perm)
+    holes2 = [tuple(perm[v] for v in h) for h in holes]
+    relabeled = joint_read(st2, holes2, target)
+    flip = -1.0 if (abs(relabeled["w"][0] + base["w"][0])
+                    < abs(relabeled["w"][0] - base["w"][0])) else 1.0
+    odd0, rho0 = odd_one_out(base["loop_q"])
+    odd1, rho1 = odd_one_out(relabeled["loop_q"])
+    return {
+        "d_charge": max(abs(a - b) for a, b in zip(relabeled["q"], base["q"])),
+        "d_loop_charge": max(abs(a - b) for a, b in
+                             zip(relabeled["loop_q"], base["loop_q"])),
+        "d_loop_period": max(abs(a - flip * b) for a, b in
+                             zip(relabeled["loop_w"], base["loop_w"])),
+        "d_rho": abs(rho1 - rho0),
+        "d_odd": float(odd1 != odd0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# The fixture battery.
+# ---------------------------------------------------------------------------
+
+def read_fixture(name, fixtures_dir=_FIXTURES, relabel_seed=3):
+    """One full row: joint read + criteria + both gates on a fixture."""
+    meta, cells, edges = load_fixture(name, fixtures_dir)
+    st = build_spacetime(cells, edges)
+    holes = register_holes(st)
+    read = joint_read(st, holes)
+    verdict = evaluate_criteria(read)
+    gauge = gauge_gate(st, holes, read)
+    relabel = relabel_gate(cells, edges, holes, read, seed=relabel_seed)
+    return dict(name=name, b3=meta["b3"], kind=meta.get("kind", "?"),
+                holes=holes, read=read, verdict=verdict,
+                gauge=gauge, relabel=relabel)
+
+
+def main():
+    print("Pair-loop dual-basis flavor read (#561) — pair_loop_quarks.tex §7")
+    print(f"target singlet [1, ω, ω²]; loops {PAIR_LOOPS} dual to holes "
+          f"{[complement_hole(p) for p in PAIR_LOOPS]}; rho_max={RHO_MAX}, "
+          f"gate tol={GATE_TOL:.0e}\n")
+    names = ["synthetic_b3_3.json", "synthetic_b3_4.json",
+             "synthetic_b3_5.json", "converged_b3_3.json"]
+    rows = [read_fixture(n) for n in names]
+
+    head = (f"{'fixture':<22} {'b3':>2} {'r_U':>8} "
+            f"{'q(γ01)':>9} {'q(γ02)':>9} {'q(γ12)':>9} "
+            f"{'odd':>5} {'dual':>4} {'rho':>6} {'2:1':>4} "
+            f"{'dual_res':>9} {'gauge':>8} {'relabel':>8}")
+    print(head)
+    print("-" * len(head))
+    for r in rows:
+        v, rd = r["verdict"], r["read"]
+        gate_g = max(r["gauge"].values())
+        gate_r = max(r["relabel"].values())
+        print(f"{r['name']:<22} {r['b3']:>2} {rd['r_u']:>8.1e} "
+              f"{rd['loop_q'][0]:>9.5f} {rd['loop_q'][1]:>9.5f} "
+              f"{rd['loop_q'][2]:>9.5f} "
+              f"{'γ' + str(v['odd_loop']):>5} {v['dual_hole']:>4} "
+              f"{v['rho']:>6.3f} {str(v['multiplicity_2_1']):>4} "
+              f"{max(rd['dual_residual']):>9.1e} {gate_g:>8.1e} {gate_r:>8.1e}")
+
+    print("\nper-hole detail (oriented weights w_h == the pinned singlet; "
+          "charges q_h):")
+    for r in rows:
+        rd = r["read"]
+        w_str = ", ".join(f"{w:.3f}" for w in rd["w"])
+        q_str = ", ".join(f"{q:.5f}" for q in rd["q"])
+        print(f"  {r['name']:<22} σ={rd['sigma']}  w=[{w_str}]  q=[{q_str}]")
+
+    print("\nfindings:")
+    print("  * duality bookkeeping [γ_ij] = -[k]: |w_i + w_j + w_k| ~ 1e-16 "
+          "on every fixture (exact under the pinned singlet).")
+    print("  * GAUGE and RELABEL hold to machine precision — the read is a "
+          "label-free, gauge-clean observable (criterion c).")
+    synth = [r for r in rows if r["kind"] == "synthetic"]
+    conv = [r for r in rows if r["kind"] != "synthetic"]
+    ok = sum(r["verdict"]["multiplicity_2_1"] for r in synth)
+    rhos = ", ".join(f"{r['verdict']['rho']:.3f}" for r in synth)
+    print(f"  * multiplicity 2:1 (criterion a): {ok}/{len(synth)} synthetic "
+          f"fixtures cluster u:u:d (rho {rhos}).")
+    for r in conv:
+        print(f"  * {r['name']}: rho={r['verdict']['rho']:.3f} — the relaxed "
+              "geometry is near-degenerate across the three loops; the "
+              "clustering verdict needs a genuine built specimen.")
+    print("  * criterion (b) (odd loop == the diquark loop) needs the build's "
+          "step-1 pair: fixtures carry no build history, so it is reported as "
+          "the odd loop's identity only. Run `read_structure(st, holes, "
+          "diquark_pair=...)` on the first 3-hole specimen.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cobordism/pair_loop_flavor.py
+++ b/examples/cobordism/pair_loop_flavor.py
@@ -2,88 +2,17 @@
 # All rights reserved.
 """Pair-loop dual-basis flavor read on a 3-hole register (#561, part of #410/#559).
 
-The `docs/theory/cobordism/proton-spin/pair_loop_quarks.tex` experiment (its §7
-"genuinely new, cheap experiment"), implemented literally. On a structure with
-three register holes carrying the color singlet `[1, ω, ω²]`:
-
-1. **Joint read.** One correlated multi-hole read — the SINGLE joint carried
-   representative `ψ = EigenstateSynthesis(st, 3).carriedRepresentative(holes,
-   target)` — never three independent per-hole extractions. The per-hole
-   carried weight is the period `w_h = ∮_[h] ψ` over hole `h`'s boundary
-   3-cycle (the five (-1)^j-signed tetrahedral facets of the removed 4-cell).
-2. **Pair loops, no new geometry.** The loop `γ_ij` encircling holes `i, j` is
-   homologous to `[i] + [j]`, so its period is `w_i + w_j` — formed
-   arithmetically from the per-hole weights. Imposing the singlet
-   (`Σ_h w_h = 0`) gives the Poincaré duality `[γ_ij] = -[k]`: each pair loop
-   is minus the complementary hole (`pair_loops` / `complement_hole`).
-3. **Flavor/taste charge.** The per-hole Dirac–Kähler charge read of the
-   retired `dk_joint_spin.per_hole_flavor` was `DiracKahler.charge(lift(3, ψ))
-   = Σ_c W_c |ψ_c|²` — the metric-weighted norm² (the DK charge density `j⁰_c
-   = W_c |ψ_c|²` summed). #509 retired `DiracKahler`, but the same number needs
-   only the surviving `HodgeLaplacian.weights(3)` (the per-3-cell metric
-   volume weights `W_c`, in the same canonical cell order as
-   `EigenstateSynthesis.cellSimplices()`). Localized to a cycle it is the
-   charge that cycle carries: per hole `q_h = Σ_{c ∈ ∂h} W_c |ψ_c|²`, and per
-   pair loop the weighted norm of ψ on the loop's combined cycle support
-   `∂i ⊔ ∂j`. Because distinct holes have disjoint boundary facets this is
-   exactly `q_i + q_j` (additivity is structural, not an approximation — see
-   the criterion-(b) honesty note below). Equivalently: the symmetric metric
-   operator is assembled with `B₄ = W₃^{1/2} ∂₄ W₄^{-1/2}`, so the CLOSED
-   cochain behind a harmonic row ψ̃ is `χ = √W₃ ψ̃` (`∂₄ᵀχ = 0`), and the
-   weighted norm is the plain norm² of that closed representative on the
-   cycle — the charge lives on the topological object.
-
-## Orientation (the RELABEL lesson)
-
-`cyclePeriods`' raw facet signs orient every hole by its sorted vertex tuple —
-a labeling convention, not physics: a vertex relabeling can flip one hole's
-boundary orientation and silently pin `-t_h`. The label-free orientation is the
-induced one: `ChainComplex.endSignCovector(top_cells, holes)` returns the
-per-hole signs `σ_h = ±1` from the complex's own coherent (facet-sharing)
-orientation, under which every closed form's signed periods obey
-`Σ_h σ_h p_h = 0`. Targets are pinned as `σ_h · t_h` and weights read back as
-`w_h = σ_h ∮_h ψ`, so `w` carries the singlet in the induced orientation. The
-one remaining ambiguity is a single GLOBAL sign (the propagation root), which
-is `-1 ∈ U(1)` on the register — gauge, not physics (see the GAUGE gate).
-
-## Pre-registered criteria (pair_loop_quarks.tex §7; falsifiable)
-
-(a) **Multiplicity 2:1** — the three pair-loop charges cluster as {u, u, d}:
-    two alike, one apart. Quantified by `rho` = (spread of the closest pair) /
-    (its separation from the odd one); `rho < RHO_MAX = 0.5` counts as 2:1.
-(b) **The odd-one-out loop is the diquark loop** — the dual of the spectator
-    (step-2) quark hole. HONESTY NOTE: with the additive pair charge, the
-    charge-odd loop is automatically the dual of the charge-odd hole, so on a
-    fixture (no build history) only the odd loop's IDENTITY is reportable.
-    The falsifiable content of (b) is that the charge-odd hole coincides with
-    the quark the build added last (the two step-1 holes are the diquark) —
-    pass `diquark_pair` (the step-1 hole indices) when the specimen's build
-    history is known; the criterion then passes iff the odd loop IS that pair.
-(c) **GAUGE and RELABEL invariance** — see the gates below.
-
-Failure of (b) on a genuine specimen falsifies the dual-flavor framing; either
-outcome is a finding.
-
-## Gates (post-hoc validation, never a loop condition)
-
-* GAUGE — this readout is built from periods and metric-weighted norms only:
-  no embedding, no per-cell frame exists to SO(4)-rotate (that gate is vacuous
-  here by construction). The register's surviving gauge freedom is the global
-  U(1) phase of the target, `t → e^{iθ} t` — which contains the Z₃ cyclic
-  recolor of the singlet (a cyclic shift of `[1, ω, ω²]` is `ω^{±1}` times it)
-  and the global orientation flip (`-1`). Charges must be invariant and loop
-  periods covariant (`w → e^{iθ} w`).
-* RELABEL — random vertex-id permutation, rebuild the complex from the
-  permuted cells and edge lengths, re-read with the permuted holes: charges,
-  `rho`, and the odd-one-out identity must match, and the oriented loop
-  periods must match up to the global orientation sign.
-
-Both gates hold to machine precision: directly-read quantities (charges,
-periods, duality residuals) reproduce to `GATE_TOL = 1e-12` (observed ~1e-16
-on the fixtures); the derived clustering ratio `rho` divides two small charge
-differences, which amplifies eigensolve roundoff (observed ~1e-13), so tests
-give `d_rho` the looser `RHO_GATE_TOL = 1e-9` while the odd-one-out identity
-must match exactly.
+The fixture battery for the pair_loop_quarks.tex §7 experiment. The reader
+machinery lives in ``tessera.observe.pair_loop_flavor`` (one home — this
+script imports it; the ``PairLoopFlavor`` observable of
+``tessera.observe.battery`` composes the same functions), and its module
+docstring carries the full methodology: the single joint carried
+representative, the arithmetic pair loops `∮_{γ_ij} ψ = w_i + w_j` with the
+Poincaré duality `[γ_ij] = -[k]`, the metric-weighted DK-style charges, the
+`endSignCovector` induced orientation (the RELABEL lesson), the
+pre-registered criteria (a) multiplicity 2:1, (b) odd-one-out == the diquark
+loop — decidable only with build-history provenance — and (c) the GAUGE +
+RELABEL gates.
 
 Run `python pair_loop_flavor.py` for the per-fixture table over the synthetic
 b₃ = 3..5 fixtures (+ the real converged_b3_3) in
@@ -91,262 +20,31 @@ b₃ = 3..5 fixtures (+ the real converged_b3_3) in
 register holes (`MultiCobordism.emergent_holes(st, 3)[:3]`, the #485 fixture
 convention). `read_structure` is the specimen entry point — point it at a
 built proton block (e.g. `Proton.block()` + `Proton.quark_holes()`) with
-`diquark_pair` from the build history once a 3-hole specimen is available.
+`diquark_pair` from the specimen's recorded build history (the campaign
+record / geometry-dump metadata) once a 3-hole specimen is available.
 """
-import cmath
-import json
-import math
-import os
-import random
-
-import numpy as np
-
-import tessera as T
-
-cob = T.cobordism
-
-OMEGA = cmath.exp(2j * math.pi / 3)
-#: The color singlet `[1, ω, ω²]` — the carried register state (Σ = 0).
-SINGLET = (1.0 + 0.0j, OMEGA, OMEGA * OMEGA)
-
-#: The three pair loops as (i, j) hole-index pairs; `γ_ij` encircles holes i, j.
-PAIR_LOOPS = ((0, 1), (0, 2), (1, 2))
-
-#: Criterion (a): the closest pair's spread over its separation from the odd
-#: one must stay below this for a 2:1 (u:u:d) verdict.
-RHO_MAX = 0.5
-
-#: Both gates must reproduce every directly-read quantity to this tolerance.
-GATE_TOL = 1e-12
-
-#: Looser gate tolerance for the derived ratio `rho` (a quotient of two small
-#: charge differences — it amplifies eigensolve roundoff by ~1/separation).
-RHO_GATE_TOL = 1e-9
-
-_FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                         "..", "..", "tests", "fixtures", "composite_spin")
-
-
-def complement_hole(pair):
-    """The hole index dual to the pair loop `γ_ij`: `[γ_ij] = -[k]`, the third
-    index. The Poincaré-duality bookkeeping of pair_loop_quarks.tex Eq. (dual)."""
-    (i, j) = pair
-    return 3 - i - j
-
-
-def load_fixture(name, fixtures_dir=_FIXTURES):
-    """A composite_spin fixture as (meta, cells, edges): `cells` the 5-vertex
-    top 4-cells, `edges` {(min_id, max_id): complex squared length}."""
-    with open(os.path.join(fixtures_dir, name)) as f:
-        meta = json.load(f)
-    cells = [list(c) for c in meta["cells"]]
-    edges = {}
-    for key, (re, im) in meta["edges"].items():
-        a, b = (int(x) for x in key.split(","))
-        edges[(a, b)] = complex(re, im)
-    return meta, cells, edges
-
-
-def build_spacetime(cells, edges, perm=None):
-    """The live complex from explicit top cells + edge squared lengths,
-    optionally relabeled by `perm` (vertex id -> vertex id). The skeleton is
-    materialized in C++ (`ReggeSolver`), so the degree-3 cell universe exists."""
-    if perm is not None:
-        cells = [[perm[v] for v in c] for c in cells]
-        edges = {tuple(sorted((perm[a], perm[b]))): z
-                 for (a, b), z in edges.items()}
-    st = T.Spacetime.fromCells(4, cells, 1.0, 0.0)
-    for e in st.getEdgeList().toVector():
-        a, b = e.getSource().getId(), e.getTarget().getId()
-        e.setSquaredLength(edges[(a, b) if a < b else (b, a)])
-    T.ReggeSolver(st, T.MatterConfiguration())
-    return st
-
-
-def register_holes(st, count=3):
-    """The structure's first `count` register holes (removed top 4-cells), in
-    `MultiCobordism.emergent_holes` order — the #485 fixture convention."""
-    holes = [tuple(h) for h in cob.MultiCobordism.emergent_holes(st, 3)]
-    if len(holes) < count:
-        raise ValueError(f"need >= {count} register holes, found {len(holes)}")
-    return holes[:count]
-
-
-def induced_orientation_signs(st, holes):
-    """The induced-orientation signs `σ_h = ±1` of the holes' boundary cycles
-    relative to the complex's own coherent orientation
-    (`ChainComplex.endSignCovector`): the label-free orientation under which
-    every closed form's signed periods obey `Σ_h σ_h p_h = 0`. Determined up
-    to one global sign (the propagation root) = `-1 ∈ U(1)` on the register."""
-    tops = [[v.getId() for v in s.getVertices()] for s in st.getTopSimplices()]
-    return list(cob.ChainComplex.endSignCovector(tops, [list(h) for h in holes]))
-
-
-def _facet_indices(cell_index, hole):
-    """Hole `h`'s five boundary tetrahedra as (cochain index, (-1)^j sign)
-    pairs. Facet j of the sorted hole drops vertex v_j and carries (-1)^j —
-    the same boundary-operator convention `cyclePeriods` documents, mirrored
-    here so ψ's periods are read in the operator's own indexing. Facets are
-    matched by vertex SET (never by an imposed order); the physical
-    orientation is supplied separately by `induced_orientation_signs`."""
-    hs = sorted(hole)
-    out = []
-    for j in range(len(hs)):
-        facet = frozenset(hs[:j] + hs[j + 1:])
-        out.append((cell_index[facet], (-1) ** j))
-    return out
-
-
-def joint_read(st, holes, target=SINGLET):
-    """The single correlated multi-hole read. Returns a dict:
-
-    * ``sigma`` — induced-orientation signs of the three holes;
-    * ``psi`` — the joint carried representative of `σ·target` over `holes`;
-    * ``r_u`` — `residualForPeriods` of that pin (~0 = the register carries it);
-    * ``w`` — oriented per-hole carried weights `w_h = σ_h ∮_h ψ` (== target);
-    * ``q`` — per-hole DK-style charges `q_h = Σ_{c ∈ ∂h} W_c |ψ_c|²`;
-    * ``loop_w`` — pair-loop periods `w_i + w_j` in `PAIR_LOOPS` order;
-    * ``loop_q`` — pair-loop charges (weighted norm² of ψ on `∂i ⊔ ∂j`);
-    * ``dual_residual`` — `|w_i + w_j + w_k|` per loop (the `[γ_ij] = -[k]`
-      bookkeeping; ~0 whenever the pinned target sums to zero).
-    """
-    if len(holes) != 3 or len(target) != 3:
-        raise ValueError("the pair-loop read is over exactly 3 holes")
-    es = cob.EigenstateSynthesis(st, 3)
-    cell_index = {frozenset(t): i for i, t in enumerate(es.cellSimplices())}
-    weights = np.asarray(cob.HodgeLaplacian(st).weights(3), float)
-    sigma = induced_orientation_signs(st, holes)
-    hole_lists = [list(h) for h in holes]
-    raw_target = [s * t for s, t in zip(sigma, target)]
-    psi = np.asarray(es.carriedRepresentative(hole_lists, raw_target), complex)
-    r_u = es.residualForPeriods(hole_lists, raw_target)
-
-    facets = [_facet_indices(cell_index, h) for h in holes]
-    w = [sigma[h] * sum(sgn * psi[c] for c, sgn in facets[h]) for h in range(3)]
-    q = [float(sum(weights[c] * abs(psi[c]) ** 2 for c, _ in facets[h]))
-         for h in range(3)]
-
-    loop_w, loop_q, dual_residual = [], [], []
-    for (i, j) in PAIR_LOOPS:
-        loop_w.append(w[i] + w[j])
-        support = {c for c, _ in facets[i]} | {c for c, _ in facets[j]}
-        loop_q.append(float(sum(weights[c] * abs(psi[c]) ** 2 for c in support)))
-        dual_residual.append(abs(w[i] + w[j] + w[complement_hole((i, j))]))
-    return dict(sigma=sigma, psi=psi, r_u=r_u, w=w, q=q,
-                loop_w=loop_w, loop_q=loop_q, dual_residual=dual_residual)
-
-
-def odd_one_out(loop_q):
-    """(odd loop index, rho): the loop whose charge sits farthest from the
-    mean of the other two, and `rho` = |spread of the other two| / |that
-    separation| — small `rho` is a clean 2:1 (u:u:d) clustering."""
-    separations = []
-    for k in range(3):
-        others = [loop_q[i] for i in range(3) if i != k]
-        separations.append(abs(loop_q[k] - (others[0] + others[1]) / 2.0))
-    odd = int(np.argmax(separations))
-    others = [loop_q[i] for i in range(3) if i != odd]
-    rho = (abs(others[0] - others[1]) / separations[odd]
-           if separations[odd] > 0 else float("inf"))
-    return odd, rho
-
-
-def evaluate_criteria(read, diquark_pair=None, rho_max=RHO_MAX):
-    """The pre-registered criteria on a finished `joint_read`.
-
-    (a) `multiplicity_2_1`: `rho < rho_max`.
-    (b) `odd_is_diquark_loop`: only decidable with `diquark_pair` (the step-1
-        hole-index pair from the specimen's build history) — True iff the
-        charge-odd loop is exactly that pair; None on fixtures (no history).
-    Duality bookkeeping and the gates are (2)/(c), reported alongside.
-    """
-    odd, rho = odd_one_out(read["loop_q"])
-    verdict = dict(odd_loop=PAIR_LOOPS[odd],
-                   dual_hole=complement_hole(PAIR_LOOPS[odd]),
-                   rho=rho,
-                   multiplicity_2_1=bool(rho < rho_max),
-                   odd_is_diquark_loop=None)
-    if diquark_pair is not None:
-        verdict["odd_is_diquark_loop"] = (
-            tuple(sorted(diquark_pair)) == PAIR_LOOPS[odd])
-    return verdict
-
-
-def read_structure(st, holes=None, target=SINGLET, diquark_pair=None):
-    """The specimen entry point: `joint_read` + `evaluate_criteria` on a live
-    complex (e.g. a built proton block: `st = Proton.block()`, holes from
-    `Proton.quark_holes()`, `diquark_pair` from the build's step-1 history)."""
-    holes = register_holes(st) if holes is None else [tuple(h) for h in holes]
-    read = joint_read(st, holes, target)
-    return read, evaluate_criteria(read, diquark_pair=diquark_pair)
-
-
-# ---------------------------------------------------------------------------
-# The gates — post-hoc validation, never a loop condition.
-# ---------------------------------------------------------------------------
-
-def gauge_gate(st, holes, base, theta=2.0 * math.pi * 0.371, target=SINGLET):
-    """GAUGE: re-read with the target rotated by the global U(1) phase
-    `e^{iθ}`. Returns the residual dict — every entry must be < `GATE_TOL`:
-    charges invariant, loop periods covariant, duality/oddity unchanged."""
-    phase = cmath.exp(1j * theta)
-    gauged = joint_read(st, holes, [phase * t for t in target])
-    odd0, rho0 = odd_one_out(base["loop_q"])
-    odd1, rho1 = odd_one_out(gauged["loop_q"])
-    return {
-        "d_charge": max(abs(a - b) for a, b in zip(gauged["q"], base["q"])),
-        "d_loop_charge": max(abs(a - b)
-                             for a, b in zip(gauged["loop_q"], base["loop_q"])),
-        "d_loop_period": max(abs(a - phase * b)
-                             for a, b in zip(gauged["loop_w"], base["loop_w"])),
-        "d_rho": abs(rho1 - rho0),
-        "d_odd": float(odd1 != odd0),
-    }
-
-
-def relabel_gate(cells, edges, holes, base, seed=3, target=SINGLET):
-    """RELABEL: random vertex-id permutation, rebuild, re-read with the
-    permuted holes. Returns the residual dict — every entry must be
-    < `GATE_TOL`. Oriented loop periods are compared up to the one global
-    orientation sign (the `endSignCovector` propagation root, `-1 ∈ U(1)`)."""
-    all_vertices = sorted({v for c in cells for v in c})
-    shuffled = all_vertices[:]
-    random.Random(seed).shuffle(shuffled)
-    perm = dict(zip(all_vertices, shuffled))
-    st2 = build_spacetime(cells, edges, perm=perm)
-    holes2 = [tuple(perm[v] for v in h) for h in holes]
-    relabeled = joint_read(st2, holes2, target)
-    flip = -1.0 if (abs(relabeled["w"][0] + base["w"][0])
-                    < abs(relabeled["w"][0] - base["w"][0])) else 1.0
-    odd0, rho0 = odd_one_out(base["loop_q"])
-    odd1, rho1 = odd_one_out(relabeled["loop_q"])
-    return {
-        "d_charge": max(abs(a - b) for a, b in zip(relabeled["q"], base["q"])),
-        "d_loop_charge": max(abs(a - b) for a, b in
-                             zip(relabeled["loop_q"], base["loop_q"])),
-        "d_loop_period": max(abs(a - flip * b) for a, b in
-                             zip(relabeled["loop_w"], base["loop_w"])),
-        "d_rho": abs(rho1 - rho0),
-        "d_odd": float(odd1 != odd0),
-    }
-
-
-# ---------------------------------------------------------------------------
-# The fixture battery.
-# ---------------------------------------------------------------------------
-
-def read_fixture(name, fixtures_dir=_FIXTURES, relabel_seed=3):
-    """One full row: joint read + criteria + both gates on a fixture."""
-    meta, cells, edges = load_fixture(name, fixtures_dir)
-    st = build_spacetime(cells, edges)
-    holes = register_holes(st)
-    read = joint_read(st, holes)
-    verdict = evaluate_criteria(read)
-    gauge = gauge_gate(st, holes, read)
-    relabel = relabel_gate(cells, edges, holes, read, seed=relabel_seed)
-    return dict(name=name, b3=meta["b3"], kind=meta.get("kind", "?"),
-                holes=holes, read=read, verdict=verdict,
-                gauge=gauge, relabel=relabel)
+from tessera.observe.pair_loop_flavor import (  # noqa: F401
+    GATE_TOL,
+    OMEGA,
+    PAIR_LOOPS,
+    RHO_GATE_TOL,
+    RHO_MAX,
+    SINGLET,
+    _FIXTURES,
+    _facet_indices,
+    build_spacetime,
+    complement_hole,
+    evaluate_criteria,
+    gauge_gate,
+    induced_orientation_signs,
+    joint_read,
+    load_fixture,
+    odd_one_out,
+    read_fixture,
+    read_structure,
+    register_holes,
+    relabel_gate,
+)
 
 
 def main():

--- a/include/cobordism/ProtonIngredients.h
+++ b/include/cobordism/ProtonIngredients.h
@@ -10,14 +10,13 @@
 #include <memory>
 #include <vector>
 
+#include "cobordism/MultiCobordism.h"  // BoundaryBlock (the block-provenance read)
 #include "cobordism/Proton.h"
 
 namespace tessera::spacetime { class Spacetime; }
 
 namespace tessera::cobordism {
 using ::tessera::spacetime::Spacetime;
-
-class MultiCobordism;  // returned (seeded, not run) by the node factories below
 
 /// # ProtonIngredients
 ///
@@ -165,6 +164,13 @@ class ProtonIngredients {
   /// location, not the residual's value). NaN unless `buildJoint()` ran. Triggers
   /// `build()`.
   [[nodiscard]] double antibaryonResidual();
+  /// The kept attempt's output boundary blocks — the after-the-fact block PROVENANCE
+  /// (each block's emergent vertex region and its target), so an external observable
+  /// reader can re-score the blocks exactly as `baryonResidual()`/`antibaryonResidual()`
+  /// did. Two blocks (baryon first, antibaryon second — `jointNode`'s seeding order)
+  /// after `buildJoint()`; EMPTY after the two-step `build()` (its step B pins nothing
+  /// downstream, so there are no output blocks — never a stale pair). Triggers `build()`.
+  [[nodiscard]] std::vector<MultiCobordism::BoundaryBlock> outputBlocks();
 
  private:
   /// Lazily run `build()` with default parameters on first accessor use.
@@ -232,6 +238,9 @@ class ProtonIngredients {
   // header stays <limits>-free.
   double baryonResidual_;
   double antibaryonResidual_;
+  // The kept attempt's output blocks (buildJoint only; empty for the two-step) —
+  // the block provenance behind the residuals above, exposed via outputBlocks().
+  std::vector<MultiCobordism::BoundaryBlock> outputBlocks_;
 };
 
 }  // namespace tessera::cobordism

--- a/include/cobordism/ProtonIngredients.h
+++ b/include/cobordism/ProtonIngredients.h
@@ -5,6 +5,7 @@
 #define TESSERA_COBORDISM_PROTON_INGREDIENTS_H
 
 #include <complex>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -37,6 +38,16 @@ class MultiCobordism;  // returned (seeded, not run) by the node factories below
 ///   * **Step B — formation, nothing pinned**: the same ideal diquark `{1,ω}` + third
 ///     quark `{ω²}` inputs on the same single-Δ⁴ seed as `Proton::formationNode`, but
 ///     with an **empty output-target list** — no singlet anywhere in the drive.
+///
+/// The class also hosts the **joint arm** (#560, rung 1 of the design note): the
+/// two-step event graph collapsed into ONE co-optimized node (`jointNode` /
+/// `buildJoint`) — inputs = the Z₃-orbit neutral triple, outputs = a baryon ⊔
+/// antibaryon block pair — driven by the same per-node drive and judged by the same
+/// stationarity + persistence convergence as `build()`. Exactly one variable then
+/// differs from `Proton::build()`: the event graph (joint vs two-step). Microcausality
+/// lives in the **move history** (every accepted change is one gated local move), not
+/// in the boundary-block count, so the joint node is physically admissible (epic #559
+/// decision log).
 ///
 /// The seed stays uniform and all-spacelike (`ℓ² = +1`) **by design**: at initialization
 /// no time has passed — causal structure marks sequences of events (in the causal-set
@@ -75,6 +86,20 @@ class ProtonIngredients {
              double stage2Beta = 1.0, int stage2MaxIters = 10,
              double persistRelTol = 0.05);
 
+  /// Build the JOINT arm (#560): identical to `build()` — the same per-node drive, the
+  /// same stationarity + persistence convergence, the same restart policy — except each
+  /// attempt drives ONE `jointNode` instead of the A-then-B pair (restart `i` seeds it
+  /// at `seed + i`; there is only one node, so the enumeration is dense). Observables
+  /// are read after the fact exactly as in `build()`, plus the per-output-block singlet
+  /// residuals `baryonResidual()`/`antibaryonResidual()`; `diquarkResidual()` is NaN
+  /// (the diquark intermediate is collapsed away — nothing measured it). Idempotent,
+  /// and mutually exclusive with `build()`: whichever runs first claims the instance
+  /// (the accessors' lazy default remains the two-step `build()`).
+  void buildJoint(int maxRestarts = 16, int initSteps = 180, int evolveSteps = 60,
+                  int stage1CandidateMoves = 8, int stage1Patience = 15,
+                  double stage2Beta = 1.0, int stage2MaxIters = 10,
+                  double persistRelTol = 0.05);
+
   /// Step A verbatim: `Proton::recombinationNode` on the composed canonical `Proton` —
   /// the identical seeded (not-yet-run) 2→2 node `Proton::build()` drives.
   [[nodiscard]] std::shared_ptr<MultiCobordism> recombinationNode(std::uint64_t seed) const;
@@ -82,6 +107,19 @@ class ProtonIngredients {
   /// third quark `{ω²}` inputs as `Proton::formationNode`, but `outputTargets = {}` —
   /// the final state emerges and is read off the whole afterwards.
   [[nodiscard]] std::shared_ptr<MultiCobordism> formationNode(std::uint64_t seed) const;
+  /// The JOINT formation node (#560, rung 1): the #489 two-step event graph collapsed
+  /// into ONE fresh, seeded, NOT-run co-optimized node. Inputs = the **Z₃-orbit neutral
+  /// triple** `{1,-1,0}`, `{0,1,-1}`, `{-1,0,1}` (the #398 symmetric-input lesson),
+  /// seeded at the Δ⁴ seed's v0,v1,v2. Outputs = **two localized blocks** (the
+  /// multi-output `rU` branch, exactly as the 2→2 recombination): the baryon
+  /// `[1,ω,ω²]` at v3 ⊔ the antibaryon `[1,ω̄,ω̄²]` at v4 — with three pairs the whole
+  /// must also host the conjugate sector, so a single whole-read singlet would fight
+  /// the antibaryon's periods. **Conjugation subtlety:** `[1,ω̄,ω̄²]` is a
+  /// component-permutation of `[1,ω,ω²]` (ω̄ = ω²) and the block residual is
+  /// relabeling-invariant, so the two targets score identically as multisets — the
+  /// conjugation is carried by the block's *location/orientation* in the emergent
+  /// complex (which region hosts which sector), never by the residual's value.
+  [[nodiscard]] std::shared_ptr<MultiCobordism> jointNode(std::uint64_t seed) const;
 
   /// True iff the kept attempt was stationary AND persistent (never a statement about
   /// the singlet or the hole count). Triggers `build()`.
@@ -107,13 +145,26 @@ class ProtonIngredients {
   /// result is comparable to the canonical build's carried level (`≈0` there). It never
   /// steers or gates this build. Triggers `build()`.
   [[nodiscard]] double singletResidual();
-  /// Step B's inputs-only realizability residual `r_U` (the whole matter term of the
-  /// emergent arm's objective). Triggers `build()`.
+  /// The kept node's full matter term `r_U`: after `build()` this is step B's
+  /// inputs-only residual (nothing is pinned downstream there); after `buildJoint()`
+  /// it also contains the two output-block terms. Triggers `build()`.
   [[nodiscard]] double inputResidual();
   /// The kept attempt's final objective `F`. Triggers `build()`.
   [[nodiscard]] double finalObjective();
-  /// Step A's `r_U` — reported exactly as `Proton` reports it. Triggers `build()`.
+  /// Step A's `r_U` — reported exactly as `Proton` reports it. NaN after
+  /// `buildJoint()`: the joint arm has no step A (never a stale zero). Triggers
+  /// `build()`.
   [[nodiscard]] double diquarkResidual();
+  /// The baryon output block's singlet residual (#560) — its target `[1,ω,ω²]` scored
+  /// against the block's OWN emergent sub-complex, read after the fact exactly as the
+  /// drive's `rU` scores it. NaN unless `buildJoint()` ran (the two-step's step B has
+  /// no localized output blocks). Triggers `build()`.
+  [[nodiscard]] double baryonResidual();
+  /// The antibaryon output block's residual — its conjugate target `[1,ω̄,ω̄²]` against
+  /// its own sub-complex (see `jointNode` on why the conjugation lives in the block's
+  /// location, not the residual's value). NaN unless `buildJoint()` ran. Triggers
+  /// `build()`.
+  [[nodiscard]] double antibaryonResidual();
 
  private:
   /// Lazily run `build()` with default parameters on first accessor use.
@@ -122,6 +173,36 @@ class ProtonIngredients {
   /// all-spacelike metric (`ℓ² = +1`; see the class note on why no causal structure is
   /// initialized). Mirrors `Proton::buildMinimalSeed`, which is private there.
   [[nodiscard]] static std::shared_ptr<Spacetime> buildMinimalSeed();
+  /// `Proton::build()`'s exact per-node drive, shared by `build()` and `buildJoint()`:
+  /// INITIALIZATION pass (`grow_boundaries=true`), optional directed cone-out,
+  /// EVOLUTION pass (∂W frozen), optional directed cone-in, then the geometric
+  /// relaxation.
+  void driveNode(MultiCobordism &node, int initSteps, int evolveSteps,
+                 int stage1CandidateMoves, int stage1Patience, double stage2Beta,
+                 int stage2MaxIters) const;
+  /// The persistence verdict shared by `build()` and `buildJoint()`: continued
+  /// evolution (∂W frozen) + relaxation must leave the answer-agnostic summary — the
+  /// emergent hole count, `b_k`, and `F` (within `persistRelTol` relative) — stable.
+  /// Up to `kMaxPersistencePasses` passes may settle a not-quite-stationary complex;
+  /// the LAST pass has to be the stable one.
+  [[nodiscard]] bool settleAndVerifyPersistence(MultiCobordism &node, int evolveSteps,
+                                                int stage1CandidateMoves,
+                                                int stage1Patience, double stage2Beta,
+                                                int stage2MaxIters,
+                                                double persistRelTol) const;
+  /// The emergent hole count at `registerDegree_` (one leg of the answer-agnostic
+  /// persistence summary).
+  [[nodiscard]] int emergentHoleCount(const std::shared_ptr<Spacetime> &whole) const;
+  /// `b_k` at `registerDegree_` (the other combinatorial leg of the summary).
+  [[nodiscard]] int bettiAtRegisterDegree(const std::shared_ptr<Spacetime> &whole) const;
+  /// One output block's residual, read after the fact for `buildJoint()`'s per-block
+  /// observables: the block's own sub-complex (the ambient complex's top cells whose
+  /// vertices all lie in the block's region) scored against the block's target —
+  /// mirroring `MultiCobordism::residualForBoundaryBlock` (private there) at this
+  /// class's single register degree, so the read matches how the drive's `rU` scored
+  /// the block. The full leak `‖target‖²` when the region contains no full cell.
+  [[nodiscard]] double outputBlockResidual(const MultiCobordism &node,
+                                           std::size_t blockIndex) const;
 
   // ---- configuration ----
   /// The canonical arm, composed unchanged: supplies step A's node verbatim and the
@@ -146,6 +227,11 @@ class ProtonIngredients {
   double inputResidual_ = 0.0;
   double finalObjective_ = 0.0;
   double diquarkResidual_ = 0.0;
+  // Joint-arm per-output-block reads (#560); NaN whenever the two-step build() ran
+  // instead (its step B has no localized output blocks), set in the .cpp so the
+  // header stays <limits>-free.
+  double baryonResidual_;
+  double antibaryonResidual_;
 };
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -977,7 +977,15 @@ and may only emerge. Convergence carries no answer-shaped gate: an attempt
 converges iff it is STATIONARY (stage 2 stopped on its stationarity test) and
 PERSISTENT (a continued evolve+relax pass leaves holes, b_k, and F stable).
 Everything physical is a post-hoc observable, including the singlet residual —
-a diagnostic for comparing against the canonical build's carried level.)doc")
+a diagnostic for comparing against the canonical build's carried level.
+
+The class also hosts the JOINT arm (#560, rung 1): the two-step event graph
+collapsed into ONE co-optimized node (joint_node / build_joint) — inputs = the
+Z3-orbit neutral triple, outputs = a baryon + antibaryon block pair — driven and
+judged exactly as build(). Exactly one variable then differs from Proton.build():
+the event graph (joint vs two-step). Microcausality lives in the move history
+(every accepted change is one gated local move), not in the boundary-block
+count, so the joint node is physically admissible (epic #559 decision log).)doc")
       .def(py::init<std::uint64_t, int, double, double, int, bool>(),
            py::arg("seed") = 0, py::arg("register_degree") = 3,
            py::arg("gamma") = 50.0, py::arg("input_weight") = 20.0,
@@ -990,6 +998,18 @@ a diagnostic for comparing against the canonical build's carried level.)doc")
            "Restart across seeds until an attempt is stationary AND persistent (no "
            "color tolerance, no minimum hole count); otherwise keep the lowest-F "
            "attempt. Same drive per node as Proton.build().")
+      .def("build_joint", &ProtonIngredients::buildJoint, py::arg("max_restarts") = 16,
+           py::arg("init_steps") = 180, py::arg("evolve_steps") = 60,
+           py::arg("stage1_candidate_moves") = 8, py::arg("stage1_patience") = 15,
+           py::arg("stage2_beta") = 1.0, py::arg("stage2_max_iters") = 10,
+           py::arg("persist_rel_tol") = 0.05,
+           "The JOINT arm (#560): identical to build() — same per-node drive, same "
+           "stationarity + persistence convergence, same restart policy — except each "
+           "attempt drives ONE joint_node (restart i seeds it at seed + i). Extra "
+           "after-the-fact observables: baryon_residual/antibaryon_residual (per-"
+           "output-block singlet residuals); diquark_residual is NaN (no step A "
+           "exists). Mutually exclusive with build(): whichever runs first claims "
+           "the instance.")
       .def("recombination_node", &ProtonIngredients::recombinationNode,
            py::arg("seed"),
            "Step A verbatim: the composed canonical Proton's recombination_node.")
@@ -997,6 +1017,16 @@ a diagnostic for comparing against the canonical build's carried level.)doc")
            "Step B with nothing pinned: the same ideal diquark {1,w} + third quark "
            "{w*w} inputs on the same single Delta^4 seed as Proton.formation_node, "
            "but with an EMPTY output-target list — the final state emerges.")
+      .def("joint_node", &ProtonIngredients::jointNode, py::arg("seed"),
+           "The JOINT formation node (#560, rung 1), fresh, seeded, NOT run: inputs = "
+           "the Z3-orbit neutral triple {1,-1,0}, {0,1,-1}, {-1,0,1} at the Delta^4 "
+           "seed's v0,v1,v2; outputs = TWO localized blocks (the multi-output r_u "
+           "branch, as the 2->2 recombination) — the baryon {1,w,w*w} at v3 and the "
+           "antibaryon {1,conj(w),conj(w)^2} at v4. NOTE: the antibaryon target is a "
+           "component-permutation of the baryon's (conj(w) = w^2) and the block "
+           "residual is relabeling-invariant, so the two targets score identically as "
+           "multisets — the conjugation is carried by the block's location in the "
+           "emergent complex, never by the residual's value.")
       .def("converged", &ProtonIngredients::converged,
            "True iff the kept attempt was stationary AND persistent — never a "
            "statement about the singlet or the hole count.")
@@ -1018,11 +1048,23 @@ a diagnostic for comparing against the canonical build's carried level.)doc")
            "whole, read after the fact for comparison with the canonical build. It "
            "never steers or gates this build.")
       .def("input_residual", &ProtonIngredients::inputResidual,
-           "Step B's inputs-only r_U — the whole matter term of the emergent arm.")
+           "The kept node's full matter term r_U: after build() the inputs-only "
+           "residual (nothing pinned downstream there); after build_joint() it also "
+           "contains the two output-block terms.")
       .def("final_objective", &ProtonIngredients::finalObjective,
            "The kept attempt's final objective F.")
       .def("diquark_residual", &ProtonIngredients::diquarkResidual,
-           "Step A's r_U — reported exactly as Proton reports it.");
+           "Step A's r_U — reported exactly as Proton reports it. NaN after "
+           "build_joint(): the joint arm has no step A (never a stale zero).")
+      .def("baryon_residual", &ProtonIngredients::baryonResidual,
+           "The baryon output block's singlet residual (#560): its target {1,w,w*w} "
+           "scored against the block's OWN emergent sub-complex, read after the fact "
+           "exactly as the drive's r_u scored it. NaN unless build_joint() ran (the "
+           "two-step's step B has no localized output blocks).")
+      .def("antibaryon_residual", &ProtonIngredients::antibaryonResidual,
+           "The antibaryon output block's residual: its conjugate target against its "
+           "own sub-complex (the conjugation lives in the block's location, not the "
+           "residual's value — see joint_node). NaN unless build_joint() ran.");
 
   // ----- Gated surgical cone-out/cone-in (topology change, #460) -----
   py::class_<SurgicalCone>(m, "SurgicalCone",

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -1064,7 +1064,14 @@ count, so the joint node is physically admissible (epic #559 decision log).)doc"
       .def("antibaryon_residual", &ProtonIngredients::antibaryonResidual,
            "The antibaryon output block's residual: its conjugate target against its "
            "own sub-complex (the conjugation lives in the block's location, not the "
-           "residual's value — see joint_node). NaN unless build_joint() ran.");
+           "residual's value — see joint_node). NaN unless build_joint() ran.")
+      .def("output_blocks", &ProtonIngredients::outputBlocks,
+           "The kept attempt's output boundary blocks (MultiCobordismBlock: vertex "
+           "region + target) — the after-the-fact block PROVENANCE behind "
+           "baryon_residual/antibaryon_residual, so an external observable reader "
+           "can re-score the blocks exactly. Two blocks (baryon first, antibaryon "
+           "second) after build_joint(); EMPTY after the two-step build() (its step "
+           "B pins nothing downstream — never a stale pair).");
 
   // ----- Gated surgical cone-out/cone-in (topology change, #460) -----
   py::class_<SurgicalCone>(m, "SurgicalCone",

--- a/src/cobordism/ProtonIngredients.cpp
+++ b/src/cobordism/ProtonIngredients.cpp
@@ -4,12 +4,14 @@
 #include "cobordism/ProtonIngredients.h"
 
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <utility>
 
 #include "cobordism/MultiCobordism.h"
 #include "mesh/Edge.h"
 #include "mesh/EdgeList.h"
+#include "mesh/Simplex.h"
 #include "mesh/Vertex.h"
 #include "mesh/VertexList.h"
 #include "spacetime/Foliation.h"
@@ -42,7 +44,11 @@ ProtonIngredients::ProtonIngredients(std::uint64_t seed, int registerDegree,
       gamma_(gamma),
       inputResidualWeight_(inputWeight),
       precone_(precone),
-      shouldUseDirectedSurgery_(shouldUseDirectedSurgery) {}
+      shouldUseDirectedSurgery_(shouldUseDirectedSurgery),
+      // The joint-arm per-block reads stay NaN unless buildJoint() runs — the
+      // two-step's step B has no localized output blocks to read.
+      baryonResidual_(std::numeric_limits<double>::quiet_NaN()),
+      antibaryonResidual_(std::numeric_limits<double>::quiet_NaN()) {}
 
 std::shared_ptr<Spacetime> ProtonIngredients::buildMinimalSeed() {
   using namespace ::tessera::spacetime;
@@ -93,40 +99,107 @@ std::shared_ptr<MultiCobordism> ProtonIngredients::formationNode(
   return node;
 }
 
+std::shared_ptr<MultiCobordism> ProtonIngredients::jointNode(
+    std::uint64_t seed) const {
+  // The JOINT node (#560, rung 1): the two-step event graph collapsed into one
+  // co-optimized node. Inputs: the Z₃ ORBIT of the neutral q-q̄ pair — {1,-1,0} and its
+  // two cyclic rotations (the #398 symmetric-input lesson) — at v0,v1,v2. Outputs: TWO
+  // localized blocks (the multi-output rU branch, exactly as the 2→2 recombination) —
+  // the baryon [1,ω,ω²] at v3 ⊔ its component-wise conjugate, the antibaryon
+  // [1,ω̄,ω̄²], at v4. The conjugate is a component-permutation of the singlet
+  // (ω̄ = ω²) and the block residual is relabeling-invariant, so the conjugation is
+  // carried by the block's location in the emergent complex, not the residual's value
+  // (see the header note).
+  const std::vector<std::vector<complexd>> pairTriple = {
+      {complexd(1.0, 0.0), complexd(-1.0, 0.0), complexd(0.0, 0.0)},
+      {complexd(0.0, 0.0), complexd(1.0, 0.0), complexd(-1.0, 0.0)},
+      {complexd(-1.0, 0.0), complexd(0.0, 0.0), complexd(1.0, 0.0)}};
+  const std::vector<complexd> baryon = Proton::singlet();  // {1, ω, ω²}
+  std::vector<complexd> antibaryon;
+  antibaryon.reserve(baryon.size());
+  for (const auto &component : baryon) antibaryon.push_back(std::conj(component));
+  auto host = buildMinimalSeed();
+  // Capture the seed vertex IDS before constructing the node (see
+  // Proton::recombinationNode): precone_ > 0 regrows the complex in the ctor, but the
+  // seed ids persist.
+  std::vector<std::uint64_t> seedVertexIds;
+  for (const auto *vertex : host->getVertexList()->toVector())
+    seedVertexIds.push_back(vertex->getId());
+  auto node = std::make_shared<MultiCobordism>(
+      host, pairTriple, std::vector<std::vector<complexd>>{baryon, antibaryon},
+      std::vector<int>{registerDegree_}, gamma_, seed, precone_);
+  node->setInputResidualWeight(inputResidualWeight_);
+  node->seedInputs({seedVertexIds[0], seedVertexIds[1], seedVertexIds[2]});
+  node->seedOutputs({seedVertexIds[3], seedVertexIds[4]});
+  return node;
+}
+
+void ProtonIngredients::driveNode(MultiCobordism &node, int initSteps,
+                                  int evolveSteps, int stage1CandidateMoves,
+                                  int stage1Patience, double stage2Beta,
+                                  int stage2MaxIters) const {
+  // Proton::build()'s exact drive per node: INITIALIZATION pass (grow_boundaries=true),
+  // optional directed cone-out, EVOLUTION pass (∂W frozen), optional directed cone-in,
+  // then the geometric relaxation. Shared verbatim by build() and buildJoint() — the
+  // joint arm changes the event graph, never the drive.
+  node.runStage1(initSteps, stage1CandidateMoves, stage1Patience,
+                 /*growBoundaries=*/true);
+  if (shouldUseDirectedSurgery_)
+    (void)node.directedConeOut();
+  node.runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
+                 /*growBoundaries=*/false);
+  if (shouldUseDirectedSurgery_)
+    (void)node.directedConeIn();
+  node.runStage2(stage2Beta, stage2MaxIters);
+}
+
+int ProtonIngredients::emergentHoleCount(
+    const std::shared_ptr<Spacetime> &whole) const {
+  return static_cast<int>(
+      MultiCobordism::emergentHoles(*whole, registerDegree_).size());
+}
+
+int ProtonIngredients::bettiAtRegisterDegree(
+    const std::shared_ptr<Spacetime> &whole) const {
+  const auto betti = MultiCobordism::betti(*whole);
+  return registerDegree_ < static_cast<int>(betti.size()) ? betti[registerDegree_]
+                                                          : 0;
+}
+
+bool ProtonIngredients::settleAndVerifyPersistence(
+    MultiCobordism &node, int evolveSteps, int stage1CandidateMoves,
+    int stage1Patience, double stage2Beta, int stage2MaxIters,
+    double persistRelTol) const {
+  // Persistence: continued evolution (∂W frozen) + relaxation must leave the
+  // answer-agnostic summary — the emergent hole count, b_k, and the objective;
+  // deliberately NOT the singlet residual, since no answer-shaped quantity may steer
+  // or gate these builds — stable. Up to kMaxPersistencePasses passes may settle a
+  // not-quite-stationary complex; the LAST pass has to be the stable one.
+  bool persisted = false;
+  for (int pass = 0; pass < kMaxPersistencePasses && !persisted; ++pass) {
+    const auto whole = node.spacetime();
+    const int holesBefore = emergentHoleCount(whole);
+    const int bettiBefore = bettiAtRegisterDegree(whole);
+    const double objectiveBefore = node.objective();
+    node.runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
+                   /*growBoundaries=*/false);
+    node.runStage2(stage2Beta, stage2MaxIters);
+    const auto settled = node.spacetime();
+    const double objectiveAfter = node.objective();
+    persisted = emergentHoleCount(settled) == holesBefore &&
+                bettiAtRegisterDegree(settled) == bettiBefore &&
+                std::abs(objectiveAfter - objectiveBefore) <=
+                    persistRelTol * std::max(std::abs(objectiveBefore), 1.0);
+  }
+  return persisted;
+}
+
 void ProtonIngredients::build(int maxRestarts, int initSteps, int evolveSteps,
                               int stage1CandidateMoves, int stage1Patience,
                               double stage2Beta, int stage2MaxIters,
                               double persistRelTol) {
   if (attempted_) return;
   attempted_ = true;
-
-  // Proton::build()'s exact drive per node: INITIALIZATION pass (grow_boundaries=true),
-  // optional directed cone-out, EVOLUTION pass (∂W frozen), optional directed cone-in,
-  // then the geometric relaxation.
-  const auto runNode = [&](MultiCobordism &node) {
-    node.runStage1(initSteps, stage1CandidateMoves, stage1Patience,
-                   /*growBoundaries=*/true);
-    if (shouldUseDirectedSurgery_)
-      (void)node.directedConeOut();
-    node.runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
-                   /*growBoundaries=*/false);
-    if (shouldUseDirectedSurgery_)
-      (void)node.directedConeIn();
-    node.runStage2(stage2Beta, stage2MaxIters);
-  };
-
-  // The answer-agnostic summary the persistence check compares: the emergent hole
-  // count, b_k, and the objective. Deliberately NOT the singlet residual — no
-  // answer-shaped quantity may steer or gate this build.
-  const auto holeCount = [&](const std::shared_ptr<Spacetime> &whole) {
-    return static_cast<int>(
-        MultiCobordism::emergentHoles(*whole, registerDegree_).size());
-  };
-  const auto bettiAtRegisterDegree = [&](const std::shared_ptr<Spacetime> &whole) {
-    const auto betti = MultiCobordism::betti(*whole);
-    return registerDegree_ < static_cast<int>(betti.size()) ? betti[registerDegree_]
-                                                            : 0;
-  };
 
   double bestObjective = std::numeric_limits<double>::infinity();
 
@@ -136,32 +209,18 @@ void ProtonIngredients::build(int maxRestarts, int initSteps, int evolveSteps,
 
     // ---- Step A — recombination: best-effort; its r_U is reported, not gated. ----
     auto stepA = recombinationNode(seedA);
-    runNode(*stepA);
+    driveNode(*stepA, initSteps, evolveSteps, stage1CandidateMoves, stage1Patience,
+              stage2Beta, stage2MaxIters);
     const double diquarkR = stepA->rU(stepA->spacetime());
 
     // ---- Step B — formation with nothing pinned ----
     auto stepB = formationNode(seedB);
-    runNode(*stepB);
+    driveNode(*stepB, initSteps, evolveSteps, stage1CandidateMoves, stage1Patience,
+              stage2Beta, stage2MaxIters);
 
-    // Persistence: continued evolution (∂W frozen) + relaxation must leave the
-    // answer-agnostic summary stable. Up to kMaxPersistencePasses passes may settle a
-    // not-quite-stationary complex; the LAST pass has to be the stable one.
-    bool persisted = false;
-    for (int pass = 0; pass < kMaxPersistencePasses && !persisted; ++pass) {
-      const auto whole = stepB->spacetime();
-      const int holesBefore = holeCount(whole);
-      const int bettiBefore = bettiAtRegisterDegree(whole);
-      const double objectiveBefore = stepB->objective();
-      stepB->runStage1(evolveSteps, stage1CandidateMoves, stage1Patience,
-                       /*growBoundaries=*/false);
-      stepB->runStage2(stage2Beta, stage2MaxIters);
-      const auto settled = stepB->spacetime();
-      const double objectiveAfter = stepB->objective();
-      persisted = holeCount(settled) == holesBefore &&
-                  bettiAtRegisterDegree(settled) == bettiBefore &&
-                  std::abs(objectiveAfter - objectiveBefore) <=
-                      persistRelTol * std::max(std::abs(objectiveBefore), 1.0);
-    }
+    const bool persisted = settleAndVerifyPersistence(
+        *stepB, evolveSteps, stage1CandidateMoves, stage1Patience, stage2Beta,
+        stage2MaxIters, persistRelTol);
     const bool isStationary = stepB->lastStage2Stationary();
     const bool ok = isStationary && persisted;
 
@@ -183,6 +242,94 @@ void ProtonIngredients::build(int maxRestarts, int initSteps, int evolveSteps,
       inputResidual_ = stepB->rU(whole);
       finalObjective_ = finalObjective;
       diquarkResidual_ = diquarkR;
+    }
+    if (ok) return;  // a stationary, persistent structure emerged — stop restarting
+  }
+}
+
+double ProtonIngredients::outputBlockResidual(const MultiCobordism &node,
+                                              std::size_t blockIndex) const {
+  // The after-the-fact per-output-block read (#560): the block's own sub-complex —
+  // the ambient complex's top cells all of whose vertices lie in the block's region —
+  // scored against the block's target. Mirrors MultiCobordism's private
+  // residualForBoundaryBlock at this class's single register degree (uniform-metric
+  // sub-complex via fromCells), so the read matches how the drive's rU scored the
+  // block; with no full cell inside the region, the full leak ‖target‖².
+  const auto &block = node.outputs().at(blockIndex);
+  std::vector<std::vector<std::uint64_t>> cellsInsideRegion;
+  for (const auto &topSimplex : node.spacetime()->getTopSimplices()) {
+    std::vector<std::uint64_t> cellVertexIds;
+    bool cellIsInsideRegion = true;
+    for (const auto *vertex : topSimplex->getVertices()) {
+      if (!block.vertices.count(vertex->getId())) {
+        cellIsInsideRegion = false;
+        break;
+      }
+      cellVertexIds.push_back(vertex->getId());
+    }
+    if (cellIsInsideRegion) cellsInsideRegion.push_back(std::move(cellVertexIds));
+  }
+  if (cellsInsideRegion.empty()) {
+    double targetNormSquared = 0.0;
+    for (const auto &component : block.target)
+      targetNormSquared += std::norm(component);
+    return targetNormSquared;  // the full leak — nothing carries the block yet
+  }
+  const auto blockSubcomplex = Spacetime::fromCells(kDim, cellsInsideRegion, 1.0, 0.0);
+  return MultiCobordism::residualOfTargetStateAgainstHarmonic(
+      blockSubcomplex, registerDegree_, block.target);
+}
+
+void ProtonIngredients::buildJoint(int maxRestarts, int initSteps, int evolveSteps,
+                                   int stage1CandidateMoves, int stage1Patience,
+                                   double stage2Beta, int stage2MaxIters,
+                                   double persistRelTol) {
+  if (attempted_) return;
+  attempted_ = true;
+
+  // The joint arm has no step A — the diquark intermediate is collapsed away — so its
+  // observable is explicitly not-a-number, never a stale zero.
+  diquarkResidual_ = std::numeric_limits<double>::quiet_NaN();
+
+  double bestObjective = std::numeric_limits<double>::infinity();
+
+  for (int attempt = 0; attempt < maxRestarts; ++attempt) {
+    // ONE node per attempt (the collapsed event graph is the experiment), so the
+    // restart enumeration is dense: seed + attempt.
+    const std::uint64_t seed = baseSeed_ + static_cast<std::uint64_t>(attempt);
+
+    auto node = jointNode(seed);
+    driveNode(*node, initSteps, evolveSteps, stage1CandidateMoves, stage1Patience,
+              stage2Beta, stage2MaxIters);
+
+    const bool persisted = settleAndVerifyPersistence(
+        *node, evolveSteps, stage1CandidateMoves, stage1Patience, stage2Beta,
+        stage2MaxIters, persistRelTol);
+    const bool isStationary = node->lastStage2Stationary();
+    const bool ok = isStationary && persisted;
+
+    const auto whole = node->spacetime();
+    const double finalObjective = node->objective();
+
+    // Keep the converged attempt, or the lowest-objective one so far otherwise — the
+    // objective itself is the only ranking, never a target state.
+    if (ok || finalObjective < bestObjective) {
+      bestObjective = finalObjective;
+      converged_ = ok;
+      stationary_ = isStationary;
+      persistent_ = persisted;
+      keptSeed_ = seed;
+      spacetime_ = whole;
+      emergentHoles_ = MultiCobordism::emergentHoles(*whole, registerDegree_);
+      singletResidual_ = MultiCobordism::residualOfTargetStateAgainstHarmonic(
+          whole, registerDegree_, Proton::singlet());  // diagnostic read, after the fact
+      inputResidual_ = node->rU(whole);  // full matter term: inputs + output blocks
+      finalObjective_ = finalObjective;
+      // The per-output-block singlet residuals, read after the fact off each block's
+      // own emergent sub-complex: baryon first, antibaryon second (jointNode's
+      // seeding order).
+      baryonResidual_ = outputBlockResidual(*node, 0);
+      antibaryonResidual_ = outputBlockResidual(*node, 1);
     }
     if (ok) return;  // a stationary, persistent structure emerged — stop restarting
   }
@@ -245,6 +392,16 @@ double ProtonIngredients::finalObjective() {
 double ProtonIngredients::diquarkResidual() {
   ensureBuilt();
   return diquarkResidual_;
+}
+
+double ProtonIngredients::baryonResidual() {
+  ensureBuilt();
+  return baryonResidual_;  // NaN unless buildJoint() ran (see the header note)
+}
+
+double ProtonIngredients::antibaryonResidual() {
+  ensureBuilt();
+  return antibaryonResidual_;  // NaN unless buildJoint() ran (see the header note)
 }
 
 }  // namespace tessera::cobordism

--- a/src/cobordism/ProtonIngredients.cpp
+++ b/src/cobordism/ProtonIngredients.cpp
@@ -330,6 +330,9 @@ void ProtonIngredients::buildJoint(int maxRestarts, int initSteps, int evolveSte
       // seeding order).
       baryonResidual_ = outputBlockResidual(*node, 0);
       antibaryonResidual_ = outputBlockResidual(*node, 1);
+      // Keep the blocks themselves as the after-the-fact provenance behind those two
+      // residuals (region + target), so external readers can re-score them exactly.
+      outputBlocks_ = node->outputs();
     }
     if (ok) return;  // a stationary, persistent structure emerged — stop restarting
   }
@@ -402,6 +405,11 @@ double ProtonIngredients::baryonResidual() {
 double ProtonIngredients::antibaryonResidual() {
   ensureBuilt();
   return antibaryonResidual_;  // NaN unless buildJoint() ran (see the header note)
+}
+
+std::vector<MultiCobordism::BoundaryBlock> ProtonIngredients::outputBlocks() {
+  ensureBuilt();
+  return outputBlocks_;  // empty unless buildJoint() ran (see the header note)
 }
 
 }  // namespace tessera::cobordism

--- a/tessera/observe/__init__.py
+++ b/tessera/observe/__init__.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""tessera.observe — the observable measurement layer (#583, part of #559).
+
+The emergent-proton readouts as first-class gated Observables: one shared
+read context (``Register``), one gate harness (``Observable.gated_measure``
+— GAUGE/RELABEL over every numeric leaf), one record shape (JSON-able,
+complex values as explicit re/im pairs), and one battery call for the
+campaign analyzer::
+
+    from tessera.observe import Register, battery
+    record = battery.measure_all(Register(st, count=3), provenance=None)
+
+Observables are read after the fact — never loop conditions; nothing here
+shapes the lattice. The faithful input path for campaign attempts is the
+geometry dump (``load_geometry_dump`` / ``rebuild_spacetime``): the engine
+build is not process-deterministic, so a base seed labels an attempt — it
+does not reproduce it.
+"""
+from tessera.observe.adapters import (          # noqa: F401
+    DEFAULT_OBSERVABLES,
+    BlockResiduals,
+    MassRadius,
+    PairLoopFlavor,
+    SingletDiagnostic,
+)
+from tessera.observe.battery import Battery, battery, measure_all  # noqa: F401
+from tessera.observe.geometry_dump import (     # noqa: F401
+    GEOMETRY_SCHEMA,
+    load_geometry_dump,
+    rebuild_spacetime,
+    verify_rebuild,
+    write_geometry_dump,
+)
+from tessera.observe.observable import (        # noqa: F401
+    Observable,
+    ensure_jsonable,
+    report_delta,
+    split_complex,
+)
+from tessera.observe.register import (          # noqa: F401
+    GATE_SEED,
+    GAUGE_THETA,
+    OMEGA,
+    SINGLET,
+    Register,
+    build_complex,
+    induced_orientation_signs,
+    register_holes,
+)

--- a/tessera/observe/adapters.py
+++ b/tessera/observe/adapters.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The battery's observables — the three readout surfaces migrated by
+composition (#583).
+
+Each adapter composes its source machinery (never re-derives it): the
+migration contract is that an adapter's values EQUAL the source's on the same
+fixtures, proven by the migration-equivalence tests. Records contain only
+gauge- and relabel-invariant JSON-able channels (complex values as explicit
+re/im pairs; covariant raw periods reported in the propagation-root-fixed
+convention).
+
+* ``SingletDiagnostic`` — the #574 surface: the relabeling-invariant singlet
+  ``r_state`` of ``Proton.singlet()`` against the whole complex (DIAGNOSTIC
+  only — it never steers anything), plus the hole/Betti census with the
+  ``holes_vs_b3_divergent`` flag.
+* ``BlockResiduals`` — the #574 per-output-block reads: each provenance block
+  (vertex region + target, e.g. ``ProtonIngredients.output_blocks()`` or the
+  campaign record) scored against its OWN sub-complex exactly as
+  ``baryonResidual()``/``antibaryonResidual()`` score it (uniform-metric
+  ``fromCells`` sub-complex + ``r_state``; the full leak ``‖target‖²`` when
+  the region contains no full cell).
+* ``MassRadius`` — the #575 battery: closed-fan interior census, intensive +
+  extensive masses, dual-volume radius with the primal cross-check,
+  participation/localization, and the r·m table with its definitional spread.
+* ``PairLoopFlavor`` — the #576 read: dual-basis pair-loop charges, the 2:1
+  multiplicity criterion, the duality residual — with the
+  odd-one-out-vs-spectator criterion evaluated ONLY when provenance supplies
+  the diquark pair (build history travels via the campaign record /
+  geometry-dump metadata; it is never guessed).
+"""
+import tessera as _T
+
+from tessera.observe import mass_radius as _mass_radius
+from tessera.observe import pair_loop_flavor as _pair_loop
+from tessera.observe.observable import Observable, split_complex
+
+_cob = _T.cobordism
+
+
+class SingletDiagnostic(Observable):
+    """The whole-complex singlet diagnostic + hole/Betti census (#574)."""
+
+    name = "singlet_diagnostic"
+    requires = {}
+    #: r_state is an eigensolve read re-run on a relabeled rebuild; direct
+    #: values sit at ~1e-16 on the fixtures.
+    gate_tol = 1e-9
+
+    def measure(self, register, provenance=None):
+        target = _cob.Proton.singlet()
+        residual = float(_cob.MultiCobordism.r_state(
+            register.st, register.degree, target))
+        return {
+            "singlet_residual": residual,
+            "holes_used": len(register.holes),
+            "holes_total": register.holes_total,
+            "b3": register.b3,
+            "betti": list(register.betti),
+            "holes_vs_b3_divergent": register.holes_vs_b3_divergent,
+            **split_complex("target", target),
+        }
+
+
+class BlockResiduals(Observable):
+    """Per-output-block carry residuals from provenance blocks (#574).
+
+    Provenance shape: ``provenance["blocks"]`` is a list of blocks, each with
+    ``label`` (optional), ``vertices`` (the block's emergent vertex region)
+    and its target — either ``target`` (a complex sequence, e.g. straight off
+    ``ProtonIngredients.output_blocks()``) or the JSON-able ``target_re`` /
+    ``target_im`` pair (a campaign record). The residual mirrors
+    ``ProtonIngredients::outputBlockResidual`` exactly: the ambient top cells
+    whose vertices ALL lie in the region form the block's own sub-complex
+    (uniform-metric ``fromCells``, matching how the drive's ``rU`` scored the
+    block), scored with ``MultiCobordism.r_state``; an empty region reports
+    the full leak ``‖target‖²``.
+    """
+
+    name = "block_residuals"
+    requires = {"needs_provenance": ("blocks",)}
+    gate_tol = 1e-9
+
+    @staticmethod
+    def _block_target(block, index):
+        if "target" in block:
+            return [complex(t) for t in block["target"]]
+        if "target_re" in block and "target_im" in block:
+            return [complex(re, im)
+                    for re, im in zip(block["target_re"], block["target_im"])]
+        raise ValueError(
+            f"provenance block {index} has neither 'target' nor "
+            f"'target_re'/'target_im'")
+
+    def measure(self, register, provenance=None):
+        rows = []
+        for index, block in enumerate(provenance["blocks"]):
+            vertices = {int(v) for v in block["vertices"]}
+            target = self._block_target(block, index)
+            cells_inside = []
+            for cell in register.cells:
+                vids = [v.getId() for v in cell.getVertices()]
+                if all(v in vertices for v in vids):
+                    cells_inside.append(vids)
+            target_norm2 = float(sum(abs(t) ** 2 for t in target))
+            if not cells_inside:
+                residual = target_norm2  # the full leak — nothing carries it
+            else:
+                sub = _T.Spacetime.fromCells(
+                    register.dimensions, cells_inside, 1.0, 0.0)
+                residual = float(_cob.MultiCobordism.r_state(
+                    sub, register.degree, target))
+            rows.append({
+                "label": str(block.get("label", f"block{index}")),
+                "n_region_vertices": len(vertices),
+                "n_cells_in_region": len(cells_inside),
+                "full_leak": not cells_inside,
+                "residual": residual,
+                "target_norm2": target_norm2,
+                **split_complex("target", target),
+            })
+        return {"n_blocks": len(rows), "blocks": rows}
+
+    def transform_provenance(self, provenance, perm):
+        """Block regions are vertex-id sets — map them through the RELABEL
+        permutation (targets and labels are id-free)."""
+        blocks = [dict(block, vertices=[perm[int(v)] for v in block["vertices"]])
+                  for block in provenance["blocks"]]
+        return dict(provenance, blocks=blocks)
+
+
+class MassRadius(Observable):
+    """The #575 mass/radius battery on the relaxed 4D interior."""
+
+    name = "mass_radius"
+    requires = {"dimensions": 4}
+    #: Geometric aggregates (sums over hundreds of hinges, r·m products up to
+    #: ~1e3) are re-summed in a different container order on the relabeled
+    #: rebuild — order-ULP noise scales with the magnitudes, so this gate
+    #: tolerance is absolute-loose while the raw residuals stay reported.
+    gate_tol = 1e-6
+
+    @staticmethod
+    def _shell_key(shell):
+        return "unshelled" if shell is None else str(int(shell))
+
+    def measure(self, register, provenance=None):
+        reading = _mass_radius.measure(register.st, register.holes)
+        census = {k: v for k, v in reading["census"].items()
+                  if k != "boundary_tets"}  # vertex-id tuples: label-bound
+        mass = dict(reading["mass"])
+        mass["shell_means"] = {self._shell_key(k): v
+                               for k, v in mass["shell_means"].items()}
+        localization = dict(reading["localization"])
+        localization["shell_profile"] = {
+            self._shell_key(k): v
+            for k, v in localization["shell_profile"].items()}
+        return {
+            "census": census,
+            "mass": mass,
+            "radius": reading["radius"],
+            "localization": localization,
+            "rm": reading["rm"],
+            "n_holes": reading["n_holes"],
+        }
+
+
+class PairLoopFlavor(Observable):
+    """The #576 pair-loop dual-basis flavor read on the 3-hole register."""
+
+    name = "pair_loop_flavor"
+    requires = {"min_holes": 3, "dimensions": 4}
+    #: Direct reads reproduce to ~1e-16; the derived clustering ratio rho
+    #: divides two small charge differences and amplifies eigensolve roundoff
+    #: to ~1e-13 (the source's RHO_GATE_TOL) — one tolerance covers the
+    #: record's every leaf, raw residuals reported alongside.
+    gate_tol = _pair_loop.RHO_GATE_TOL
+
+    def measure(self, register, provenance=None):
+        read = register.derived(
+            ("pair_loop_read", register.target),
+            lambda: _pair_loop.joint_read(
+                register.st, register.holes, register.target,
+                es=register.es,
+                sigma=register.eps,
+                weights=register.derived(
+                    "hodge_weights",
+                    lambda: _cob.HodgeLaplacian(register.st).weights(
+                        register.degree)),
+                cell_index=register.derived(
+                    "cell_index",
+                    lambda: {frozenset(t): i
+                             for i, t in enumerate(register.es.cellSimplices())}),
+            ))
+        diquark_pair = None
+        if provenance is not None and provenance.get("diquark_pair") is not None:
+            diquark_pair = tuple(int(i) for i in provenance["diquark_pair"])
+        verdict = _pair_loop.evaluate_criteria(read, diquark_pair=diquark_pair)
+
+        # The oriented periods are U(1)-covariant (w -> e^{i theta} w under the
+        # GAUGE knob) and flip with the endSignCovector propagation root under
+        # RELABEL; dividing out w0's unit phase reports them in the one
+        # propagation-root-fixed convention, so every record leaf is invariant.
+        w = list(read["w"])
+        phase0 = (w[0] / abs(w[0])) if abs(w[0]) > 0 else 1.0
+        w_fixed = [wi / phase0 for wi in w]
+        loop_w_fixed = [wi / phase0 for wi in read["loop_w"]]
+
+        record = {
+            "r_u": float(read["r_u"]),
+            "q": [float(x) for x in read["q"]],
+            "loop_q": [float(x) for x in read["loop_q"]],
+            "dual_residual": [float(x) for x in read["dual_residual"]],
+            "pair_loops": [list(p) for p in _pair_loop.PAIR_LOOPS],
+            "odd_loop": list(verdict["odd_loop"]),
+            "dual_hole": int(verdict["dual_hole"]),
+            "rho": float(verdict["rho"]),
+            "rho_max": float(_pair_loop.RHO_MAX),
+            "multiplicity_2_1": bool(verdict["multiplicity_2_1"]),
+            "odd_is_diquark_loop": verdict["odd_is_diquark_loop"],
+            "odd_is_diquark_loop_status": (
+                "evaluated" if diquark_pair is not None
+                else "not_evaluable(no_provenance)"),
+            **split_complex("w", w_fixed),
+            **split_complex("loop_w", loop_w_fixed),
+        }
+        return record
+
+
+#: The battery's default line-up, in measurement order.
+DEFAULT_OBSERVABLES = (SingletDiagnostic, BlockResiduals, MassRadius,
+                       PairLoopFlavor)

--- a/tessera/observe/adapters.py
+++ b/tessera/observe/adapters.py
@@ -123,8 +123,18 @@ class BlockResiduals(Observable):
 
     def transform_provenance(self, provenance, perm):
         """Block regions are vertex-id sets — map them through the RELABEL
-        permutation (targets and labels are id-free)."""
-        blocks = [dict(block, vertices=[perm[int(v)] for v in block["vertices"]])
+        permutation (targets and labels are id-free).
+
+        An emergent block region can reference vertices that are no longer in
+        any top cell (surgical moves orphan them); such ids are INERT in the
+        residual (they never match a cell vertex — the C++ read ignores them
+        the same way). The permutation maps the live vertex-id set onto
+        itself, so an inert id kept as itself stays inert on the relabeled
+        complex — ``perm.get(v, v)`` is exact, and the region's size (a
+        reported channel) is preserved."""
+        blocks = [dict(block,
+                       vertices=[perm.get(int(v), int(v))
+                                 for v in block["vertices"]])
                   for block in provenance["blocks"]]
         return dict(provenance, blocks=blocks)
 

--- a/tessera/observe/battery.py
+++ b/tessera/observe/battery.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The observable battery: a registry + ``measure_all`` (#583).
+
+``Battery`` holds named observables and measures them all against one
+``Register``, producing ONE flat JSON-able record: the register census block,
+then per-observable ``status: measured`` entries (record + GAUGE/RELABEL gate
+residuals) or ``status: skipped(reason)`` entries — an inapplicable
+observable is a reported skip, never a crash and never a silent hole in the
+record.
+
+The default ``battery`` instance carries the three migrated readout surfaces
+(``SingletDiagnostic``, ``BlockResiduals``, ``MassRadius``,
+``PairLoopFlavor``); the campaign analyzer imports it directly::
+
+    from tessera.observe import Register, battery
+    record = battery.measure_all(Register(st, count=3), provenance=None)
+"""
+from tessera.observe.adapters import DEFAULT_OBSERVABLES
+from tessera.observe.observable import ensure_jsonable
+from tessera.observe.register import GATE_SEED, GAUGE_THETA
+
+
+class Battery:
+    """An ordered registry of ``Observable`` instances."""
+
+    def __init__(self, observables=()):
+        self._observables = []
+        for observable in observables:
+            self.register(observable)
+
+    def register(self, observable):
+        """Add an observable (unique non-empty ``name`` required). Returns it,
+        so the call composes as a decorator on instances-by-construction."""
+        if not observable.name:
+            raise ValueError("observable has no name")
+        if any(o.name == observable.name for o in self._observables):
+            raise ValueError(f"duplicate observable name: {observable.name}")
+        self._observables.append(observable)
+        return observable
+
+    @property
+    def observables(self):
+        return tuple(self._observables)
+
+    def measure_all(self, register, provenance=None, gates=True,
+                    gate_seed=GATE_SEED, gauge_theta=GAUGE_THETA):
+        """Measure every registered observable against ``register``.
+
+        Returns the flat battery record::
+
+            {
+              "register": {...census, b3, divergence flag...},
+              "provenance_keys": [...],
+              "observables": {
+                name: {"status": "measured", "record": {...},
+                       "gates": {"gauge_delta": .., "relabel_delta": ..,
+                                 "gauge_ok": .., "relabel_ok": ..,
+                                 "gate_tol": ..}}
+                    | {"status": "skipped(<reason>)", "reason": "<reason>"},
+              },
+            }
+
+        With ``gates=True`` the GAUGE and RELABEL transforms are built ONCE
+        (lazily, on the first measured observable) and shared across the
+        battery — one relabeled rebuild per record, not per observable.
+        Provenance is passed through to each observable, which maps it
+        through the relabel permutation itself (``transform_provenance``).
+        """
+        record = {
+            "register": register.summary(),
+            "provenance_keys": sorted(provenance) if provenance else [],
+            "observables": {},
+        }
+        gauge_register = None
+        relabel = None
+        for observable in self._observables:
+            reason = observable.skip_reason(register, provenance)
+            if reason is not None:
+                record["observables"][observable.name] = {
+                    "status": f"skipped({reason})",
+                    "reason": reason,
+                }
+                continue
+            if not gates:
+                record["observables"][observable.name] = {
+                    "status": "measured",
+                    "record": observable.measure(register, provenance),
+                }
+                continue
+            if gauge_register is None:
+                gauge_register = register.gauged(gauge_theta)
+                relabel = register.relabeled(gate_seed)
+            record["observables"][observable.name] = observable.gated_measure(
+                register, provenance,
+                gauge_register=gauge_register, relabel=relabel)
+        return ensure_jsonable(record)
+
+
+#: The default battery — the three migrated readout surfaces, in order.
+battery = Battery(cls() for cls in DEFAULT_OBSERVABLES)
+
+
+def measure_all(register, provenance=None, **kwargs):
+    """``battery.measure_all`` on the default battery (the analyzer-facing
+    one-call surface)."""
+    return battery.measure_all(register, provenance=provenance, **kwargs)

--- a/tessera/observe/geometry_dump.py
+++ b/tessera/observe/geometry_dump.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Campaign geometry dumps: the attempt's ONLY faithful record (#578 finding).
+
+The engine build is NOT process-deterministic — identical fresh processes
+diverge on the same seed (measured, not hypothetical) — so a base seed labels
+an attempt, it does not reproduce it. The faithful record of a converged
+state is therefore its GEOMETRY DUMP: schema-1 JSON with
+
+* ``schema`` — 1 (this format);
+* ``dimensions`` — the top-cell dimension;
+* ``cells`` — top cells in INTRINSIC vertex order (each cell's stored order
+  carries the orientation and is never sorted; the cell LIST is sorted by
+  vertex-set key so the same state always serializes to the same bytes);
+* ``edges`` — every edge as ``[src, tgt, re(l2), im(l2)]`` rows, sorted by
+  the (min, max) id pair;
+* ``vertex_times`` — sorted ``[vertex_id, time]`` pairs;
+
+plus any attempt metadata the writer recorded (base_seed, verdicts, betti,
+holes, singlet, ...). This is exactly the #562 campaign worker's dump format
+(the frozen, sha256-manifested scripts of #579 under
+``examples/cobordism/proton_campaign/`` are the schema's provenance; this
+module is its IMPORTABLE home, and the writer is byte-identical to the frozen
+one on the same state — guarded by test). ``Spacetime.fromCells`` + the
+recorded lengths/times rebuild the exact state without re-running anything.
+
+``rebuild_spacetime`` builds the skeleton C++-side (the ``ReggeSolver`` ctor
+via ``build_complex``) — never a Python-driven materialization (the #451
+lesson; the campaign analyzer's own rebuild is a separate frozen script).
+"""
+import json
+import os
+
+from tessera.observe.register import build_complex
+
+#: The dump format this module reads and writes; bump on any format change.
+GEOMETRY_SCHEMA = 1
+
+
+def write_geometry_dump(st, path, meta=None):
+    """Write ``st``'s faithful record to ``path`` (atomic; canonically
+    ordered so the same state always serializes to the same bytes). ``meta``
+    entries (attempt metadata) are merged in first — the geometry keys win on
+    any collision. Reads state only; returns ``path``."""
+    top = st.getTopSimplices()
+    cells = sorted(([int(v.getId()) for v in c.getVertices()] for c in top),
+                   key=sorted)
+    times = {}
+    for c in top:
+        for v in c.getVertices():
+            times[int(v.getId())] = float(v.getTime())
+    edges = sorted(([int(e.getSource().getId()), int(e.getTarget().getId()),
+                     e.getSquaredLength().real, e.getSquaredLength().imag]
+                    for e in st.getEdgeList().toVector()),
+                   key=lambda r: (min(r[0], r[1]), max(r[0], r[1])))
+    record = dict(meta or {})
+    record.update({
+        "schema": GEOMETRY_SCHEMA,
+        "dimensions": (len(cells[0]) - 1) if cells else 0,
+        "cells": cells,
+        "edges": edges,
+        "vertex_times": sorted(times.items()),
+    })
+    tmp = path + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(record, fh)
+    os.replace(tmp, path)
+    return path
+
+
+def load_geometry_dump(path):
+    """Load and validate a schema-1 geometry dump. Raises ``ValueError`` on a
+    missing/unknown schema or missing geometry keys — a record that is not a
+    faithful geometry dump is never silently half-read."""
+    with open(path) as fh:
+        dump = json.load(fh)
+    schema = dump.get("schema")
+    if schema != GEOMETRY_SCHEMA:
+        raise ValueError(
+            f"{path}: geometry dump schema {schema!r} is not the supported "
+            f"schema {GEOMETRY_SCHEMA}")
+    missing = [k for k in ("dimensions", "cells", "edges", "vertex_times")
+               if k not in dump]
+    if missing:
+        raise ValueError(f"{path}: geometry dump is missing {missing}")
+    return dump
+
+
+def rebuild_spacetime(dump):
+    """A live ``Spacetime`` carrying the dumped final state: ``fromCells`` on
+    the top cells (intrinsic vertex order preserved), then the recorded
+    per-vertex times and per-edge complex squared lengths, with the skeleton
+    materialized C++-side (``ReggeSolver`` ctor)."""
+    edges = {}
+    for u, v, re_l2, im_l2 in dump["edges"]:
+        key = (min(int(u), int(v)), max(int(u), int(v)))
+        edges[key] = complex(re_l2, im_l2)
+    times = {int(vid): float(t) for vid, t in dump["vertex_times"]}
+    return build_complex(dump["cells"], edges, vertex_times=times,
+                         dimensions=int(dump["dimensions"]))
+
+
+def verify_rebuild(st, dump):
+    """Check the rebuilt state carries exactly the dumped complex: same top
+    cells (as vertex sets), same edge squared lengths, and — when the dump's
+    metadata recorded them — the same combinatorial reads. Returns a
+    ``{key: (expected, actual)}`` mismatch dict (empty = verified)."""
+    import tessera as T
+    cob = T.cobordism
+
+    mismatches = {}
+    cells = sorted(sorted(int(v.getId()) for v in c.getVertices())
+                   for c in st.getTopSimplices())
+    dumped = sorted(sorted(int(v) for v in c) for c in dump["cells"])
+    if cells != dumped:
+        mismatches["cells"] = (len(dumped), len(cells))
+    lengths = {}
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        l2 = e.getSquaredLength()
+        lengths[(min(a, b), max(a, b))] = (l2.real, l2.imag)
+    dumped_lengths = {(min(int(u), int(v)), max(int(u), int(v))): (re, im)
+                      for u, v, re, im in dump["edges"]}
+    if lengths != dumped_lengths:
+        wrong = sum(1 for k, val in dumped_lengths.items()
+                    if lengths.get(k) != val)
+        mismatches["edge_lengths"] = (len(dumped_lengths), wrong)
+    checks = {
+        "betti": lambda: list(cob.MultiCobordism.betti(st)),
+        "holes": lambda: len(cob.MultiCobordism.emergent_holes(st, 3)),
+    }
+    for key, compute in checks.items():
+        if key in dump:
+            value = compute()
+            if dump[key] != value:
+                mismatches[key] = (dump[key], value)
+    return mismatches

--- a/tessera/observe/mass_radius.py
+++ b/tessera/observe/mass_radius.py
@@ -1,0 +1,364 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Mass and radius read the right way off a converged emergent 4D interior.
+
+The #451 geometric-proton methodology ported from its 3D event to the
+genuinely 4D emergent builds (#566) — the shared reader core behind the
+``MassRadius`` observable and the ``examples/cobordism/emergent_mass_radius.py``
+battery script (which imports from here; the machinery lives in exactly one
+place). Everything here is a *post-hoc observable reader* — nothing shapes
+the lattice.
+
+The load-bearing methodology rules, ported from #451:
+
+  * **Hinges.** On a d = 4 complex the Regge hinges are the (d-2) = 2-simplices —
+    TRIANGLES (#451 was 3D, where hinges were edges). Curvature is the complex
+    Lorentzian deficit angle at each triangle.
+  * **Closed fans only.** A hinge carries an honest curvature ONLY if its coface
+    fan is closed — every tetrahedron around the triangle shared by exactly two
+    4-cells. Open-fan hinges (the ∂W input boundary, the register-hole walls) give
+    boundary artefacts near 2π, not curvature: they are EXCLUDED, and the census
+    (interior vs boundary counts) is reported with every reading. The fan test is
+    combinatorial over the CURRENT top cells, so orphan sub-simplices stranded by
+    Pachner moves never pollute the selection.
+  * **Skeleton in C++.** ``dualVolume()`` / ``lorentzianDeficitAngle()`` walk a
+    hinge up through its cofaces, so the facet/coface lattice must exist and be
+    built in C++: the ``ReggeSolver(st, MatterConfiguration())`` ctor materializes
+    tops → tetrahedra → triangle hinges, and ``ChainComplex.fromSpacetime(st)``
+    (a C++ BFS seeded from the current tops) completes the lattice down to edges
+    and vertices for the dual volumes. Never drive ``materializeFacets`` from
+    Python — the #451 lesson: a Python-driven materialization corrupted the coface
+    lists and ``dualVolume()`` saw half its cofaces.
+  * **Signature-aware readings.** Dual volumes are the circumcentric
+    ``Simplex.dualVolume`` (signed); the deficit is the complex
+    ``Simplex.lorentzianDeficitAngle``. Masses use Re ε; the imaginary part is
+    real physics (boost content), so its magnitude is always reported alongside —
+    never silently dropped.
+  * **Dimension-correct radius.** The dual radius is r = V_dual^(1/4) on a
+    4-complex (V_dual = the summed circumcentric dual 4-volume of the strictly
+    interior vertices). #451 used V_dual^(1/3) because its complex was 3D; the
+    root tracks the top dimension, nothing else. The primal cross-check is
+    r = V_primal^(1/4) over the top 4-cells.
+  * **r·m is definition-sensitive.** The #451 lesson: across reasonable mass
+    definitions (intensive shell-mean vs the two extensive sums) r·m spans orders
+    of magnitude, so the FULL table with its spread is stated up front and any
+    agreement with the physical m_p·r_p/ħc ≈ 4.0 is an order-of-magnitude claim
+    only — never one number presented as THE mass.
+
+What is measured (per converged spacetime):
+  1. interior closed-fan hinge selection + census (interior / boundary / total);
+  2. mass, intensive AND extensive: m_shell = the #352/#451 shell-mean Re-deficit,
+     m_sum = Σ Re ε, m_action = Σ |★h|·Re ε;
+  3. radius: r_dual = V_dual^(1/4) with the r_primal = V_primal^(1/4) cross-check;
+  4. localization: participation ratio of |Re ε·★h| against the equal-volume
+     uniform (round-sphere) reference, the BFS shell profile of curvature relative
+     to the register holes' vertices, and the mean deficit sign;
+  5. the r·m table across ALL mass × radius combinations, spread first.
+"""
+import itertools
+import math
+from collections import Counter, defaultdict
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+# Physical anchor: m_p·r_p/ħc = 938 MeV · 0.84 fm / 197 MeV·fm ≈ 4.0 (dimensionless).
+PHYSICAL_RM = 938.0 * 0.84 / 197.0
+
+# |Im ε| above this counts as genuinely complex (boost content at the hinge).
+IM_TOL = 1e-12
+
+
+def build_skeleton(st):
+    """Materialize the full facet/coface lattice of ``st`` in C++ and return the
+    keep-alive handles ``(solver, chain_complex)``.
+
+    ``ReggeSolver(st, MatterConfiguration())`` is the blessed Regge path: its ctor
+    builds tops → tetrahedra → triangle hinges, which is everything the deficit
+    angles need. ``ChainComplex.fromSpacetime(st)`` then completes the lattice
+    down to edges and vertices — a C++ BFS seeded from the CURRENT top cells only
+    (orphan-safe) — which the vertex ``dualVolume()`` recursion needs for V_dual.
+    Both are C++ constructors; no materialization is ever driven from Python
+    (the #451 corruption lesson).
+    """
+    solver = tessera.ReggeSolver(st, tessera.MatterConfiguration())
+    chain_complex = cob.ChainComplex.fromSpacetime(st)
+    return solver, chain_complex
+
+
+def _top_vertex_ids(st):
+    """Sorted vertex-id tuples of the current top cells (4-simplices). Fails
+    loudly if the complex is not genuinely 4D — this reader is 4D-specific (the
+    hinge dimension and the radius root both track d = 4)."""
+    tops = [tuple(sorted(v.getId() for v in t.getVertices()))
+            for t in st.getTopSimplices()]
+    if not tops:
+        raise ValueError("spacetime has no top cells")
+    sizes = {len(t) for t in tops}
+    if sizes != {5}:
+        raise ValueError(
+            f"top cells have vertex counts {sorted(sizes)}; this reader is for "
+            "4-complexes (5-vertex top cells) — on a d-complex the hinges are the "
+            "(d-2)-simplices and the radius root is 1/d, so use the reader that "
+            "matches your dimension")
+    return sorted(tops)
+
+
+def _bfs_shells(tops, seed_vertex_ids):
+    """BFS shell distance from ``seed_vertex_ids`` over the 1-skeleton of the
+    CURRENT top cells (combinatorial, orphan-immune). Returns {vertex_id: shell};
+    unreachable vertices are absent. Empty seeds give an empty map (every hinge
+    then reports shell None and the shell profile is skipped)."""
+    adjacency = defaultdict(set)
+    for top in tops:
+        for a, b in itertools.combinations(top, 2):
+            adjacency[a].add(b)
+            adjacency[b].add(a)
+    dist = {v: 0 for v in sorted(set(seed_vertex_ids)) if v in adjacency}
+    frontier = sorted(dist)
+    while frontier:
+        nxt = []
+        for u in frontier:
+            for v in sorted(adjacency[u]):
+                if v not in dist:
+                    dist[v] = dist[u] + 1
+                    nxt.append(v)
+        frontier = nxt
+    return dist
+
+
+def interior_hinges(st, holes=()):
+    """Select the interior (closed-coface-fan) triangle hinges of the 4-complex
+    and read their curvature. Returns ``(hinges, census)``.
+
+    A triangle hinge is INTERIOR iff every tetrahedron of its coface fan is shared
+    by exactly two top 4-cells; hinges with any once-shared (boundary) tetrahedron
+    are boundary artefacts — their "deficit" is a near-2π opening-angle remnant,
+    not curvature — and are excluded. Both the fan and the tetrahedron counts are
+    derived combinatorially from the CURRENT top cells (never from raw coface
+    lists), so orphan simplices stranded by Pachner moves cannot leak in; the
+    readings themselves are then taken off the canonical registered triangle
+    Simplex objects (skeleton required — call ``build_skeleton`` first).
+
+    Each hinge dict carries: ``vids`` (the 3 vertex ids), ``re``/``im`` (the
+    complex Lorentzian deficit), ``dv`` (the signed circumcentric dual content
+    |★h|), and ``shell`` (BFS distance from the register holes' vertices, None
+    when ``holes`` is empty).
+
+    ``census`` reports the interior/boundary/total hinge counts, the boundary
+    tetrahedron count, and the sizes of the complex.
+    """
+    tops = _top_vertex_ids(st)
+
+    # Tetrahedron -> number of top cells sharing it, and triangle -> its fan.
+    tet_count = Counter()
+    tri_fans = defaultdict(set)
+    for top in tops:
+        for tet in itertools.combinations(top, 4):
+            tet_count[tet] += 1
+        for tri in itertools.combinations(top, 3):
+            rest = [v for v in top if v not in tri]
+            for extra in rest:
+                tri_fans[tri].add(tuple(sorted(tri + (extra,))))
+
+    # Canonical registered triangle Simplex objects, keyed by vertex set.
+    tri_by_key = {}
+    for s in st.getSimplices():
+        if len(s.getVertices()) == 3 and s.hasTopCoface():
+            tri_by_key[tuple(sorted(v.getId() for v in s.getVertices()))] = s
+
+    hole_vertex_ids = sorted(set(v for hole in holes for v in hole))
+    shell_of = _bfs_shells(tops, hole_vertex_ids)
+
+    hinges = []
+    n_boundary = 0
+    for tri in sorted(tri_fans):
+        closed = all(tet_count[tet] == 2 for tet in tri_fans[tri])
+        if not closed:
+            n_boundary += 1
+            continue
+        simplex = tri_by_key.get(tri)
+        if simplex is None:
+            raise RuntimeError(
+                f"interior hinge {tri} has no registered triangle Simplex — "
+                "the C++ skeleton was not built; call build_skeleton(st) first")
+        deficit = simplex.lorentzianDeficitAngle()
+        shell = (min(shell_of[v] for v in tri if v in shell_of)
+                 if any(v in shell_of for v in tri) else None)
+        hinges.append(dict(vids=list(tri), re=deficit.real, im=deficit.imag,
+                           dv=simplex.dualVolume(), shell=shell))
+
+    boundary_tets = sorted(t for t, c in tet_count.items() if c == 1)
+    census = dict(
+        n_tops=len(tops),
+        n_tets=len(tet_count),
+        n_hinges_total=len(tri_fans),
+        n_hinges_interior=len(hinges),
+        n_hinges_boundary=n_boundary,
+        n_boundary_tets=len(boundary_tets),
+        boundary_tets=boundary_tets,
+        n_hole_vertices=len(hole_vertex_ids),
+    )
+    return hinges, census
+
+
+def masses(hinges):
+    """The three #451 mass readings over the interior hinges — one intensive,
+    two extensive (the r·m validator is sensitive to which is called "the mass",
+    so all three are always carried together):
+
+      * ``m_shell`` (intensive): the #352/#451 shell mass — the sum over BFS
+        shells (from the register holes) of the MEAN Re-deficit in that shell.
+        With no holes every hinge sits in one unlabeled bin and m_shell reduces
+        to the plain mean Re-deficit.
+      * ``m_sum`` (extensive): Σ Re ε — the raw integrated curvature.
+      * ``m_action`` (extensive, dual-weighted): Σ |★h|·Re ε — the dual-volume-
+        weighted Regge curvature.
+
+    Also returns ``shell_means`` (the per-shell means) and the imaginary-part
+    accounting: ``max_abs_im`` and ``n_im_nonzero`` (|Im ε| > IM_TOL) — the
+    deficit is complex Lorentzian, and whether Im is zero is always reported.
+    """
+    if not hinges:
+        nan = float("nan")
+        return dict(m_shell=nan, m_sum=nan, m_action=nan, shell_means={},
+                    max_abs_im=nan, n_im_nonzero=0)
+    bins = defaultdict(list)
+    for h in hinges:
+        bins[h["shell"]].append(h["re"])
+    shell_means = {shell: float(np.mean(values))
+                   for shell, values in sorted(bins.items(),
+                                               key=lambda kv: (kv[0] is None, kv[0]))}
+    return dict(
+        m_shell=float(sum(shell_means.values())),
+        m_sum=float(sum(h["re"] for h in hinges)),
+        m_action=float(sum(h["re"] * abs(h["dv"]) for h in hinges)),
+        shell_means=shell_means,
+        max_abs_im=float(max(abs(h["im"]) for h in hinges)),
+        n_im_nonzero=sum(1 for h in hinges if abs(h["im"]) > IM_TOL),
+    )
+
+
+def radii(st, census):
+    """The emergent size of the interior, dual and primal:
+
+      * ``r_dual`` = V_dual^(1/4): V_dual = Σ |★v| over the strictly INTERIOR
+        vertices (vertices on no boundary tetrahedron) — the signature-aware
+        circumcentric dual 4-volume. The fourth root is the dimension-correct
+        volume→length map on a 4-complex (#451 took the cube root of a dual
+        3-volume on its 3D event; same rule, different d).
+      * ``r_primal`` = V_primal^(1/4): V_primal = Σ |V₄| over ALL top 4-cells —
+        the primal-side cross-check of the same 4-volume (dual/primal agreement
+        is the skeleton-sanity signal; on a closed uniform complex they are
+        equal to machine precision).
+    """
+    boundary_vertex_ids = set(v for tet in census["boundary_tets"] for v in tet)
+    v_dual = 0.0
+    n_interior_vertices = 0
+    vertex_simplices = [s for s in st.getSimplices() if len(s.getVertices()) == 1]
+    for s in sorted(vertex_simplices, key=lambda s: s.getVertices()[0].getId()):
+        if not s.hasTopCoface():
+            continue  # orphan 0-simplex stranded by a move
+        vid = s.getVertices()[0].getId()
+        if vid in boundary_vertex_ids:
+            continue
+        v_dual += abs(s.dualVolume())
+        n_interior_vertices += 1
+    v_primal = sum(abs(t.volume()) for t in st.getTopSimplices())
+    return dict(
+        Vdual=float(v_dual),
+        Vprimal=float(v_primal),
+        n_interior_vertices=n_interior_vertices,
+        r_dual=float(v_dual) ** 0.25 if v_dual > 0 else float("nan"),
+        r_primal=float(v_primal) ** 0.25 if v_primal > 0 else float("nan"),
+    )
+
+
+def localization(hinges):
+    """Is the curvature a localized lump or spread out?
+
+      * ``PR``: participation ratio of the weight w = |Re ε·★h| over the interior
+        hinges, in (0, 1]. The equal-volume UNIFORM reference (a round sphere
+        spreads its curvature evenly over every hinge) has PR = 1.0;
+        ``concentration`` = 1/PR is how many times more concentrated the lump is.
+      * ``mean_re`` / ``std_re`` / ``std_over_mean``: the deficit statistics;
+        mean_re > 0 is the positive-curvature (bound-state, sphere-like) sign.
+      * ``shell_profile``: per BFS shell (from the register holes' vertices) the
+        hinge count, mean Re ε, and share of the total weight; plus
+        ``rms_shell_radius`` (the weight-weighted RMS shell distance — the lump
+        size in shells) and ``frac_within_shell1`` (the weight fraction within
+        one shell of the holes). Empty when no holes were given.
+    """
+    if not hinges:
+        nan = float("nan")
+        return dict(PR=nan, concentration=nan, mean_re=nan, std_re=nan,
+                    std_over_mean=nan, shell_profile={}, rms_shell_radius=nan,
+                    frac_within_shell1=nan)
+    re = np.array([h["re"] for h in hinges])
+    weight = np.abs(re * np.array([abs(h["dv"]) for h in hinges]))
+    total_weight = float(weight.sum())
+    pr = (float(total_weight ** 2 / (len(weight) * float((weight ** 2).sum())))
+          if total_weight > 0 else float("nan"))
+
+    shells = [h["shell"] for h in hinges]
+    profile = {}
+    rms_shell = float("nan")
+    frac_near = float("nan")
+    if all(s is not None for s in shells) and total_weight > 0:
+        shell_arr = np.array(shells, dtype=float)
+        for shell in sorted(set(shells)):
+            mask = shell_arr == shell
+            profile[shell] = dict(
+                n=int(mask.sum()),
+                mean_re=float(re[mask].mean()),
+                weight_share=float(weight[mask].sum() / total_weight),
+            )
+        rms_shell = float(np.sqrt(float((weight * shell_arr ** 2).sum())
+                                  / total_weight))
+        frac_near = float(weight[shell_arr <= 1].sum() / total_weight)
+
+    mean_re = float(re.mean())
+    return dict(
+        PR=pr,
+        concentration=(1.0 / pr) if pr and pr > 0 else float("nan"),
+        mean_re=mean_re,
+        std_re=float(re.std()),
+        std_over_mean=(float(re.std() / abs(mean_re)) if mean_re != 0.0
+                       else float("inf")),
+        shell_profile=profile,
+        rms_shell_radius=rms_shell,
+        frac_within_shell1=frac_near,
+    )
+
+
+def rm_table(mass, rad):
+    """Every r·m combination — 3 mass definitions × 2 radius definitions — with
+    the definitional spread stated FIRST (#451's lesson: r·m is too definition-
+    sensitive to quote as one number; the claim is order-of-magnitude only)."""
+    combos = {}
+    for m_name in ("m_shell", "m_sum", "m_action"):
+        for r_name in ("r_dual", "r_primal"):
+            combos[f"{r_name} x {m_name}"] = rad[r_name] * mass[m_name]
+    finite = [v for v in combos.values() if math.isfinite(v)]
+    spread = ((min(finite), max(finite)) if finite
+              else (float("nan"), float("nan")))
+    return dict(spread_min=spread[0], spread_max=spread[1], combos=combos,
+                physical=PHYSICAL_RM)
+
+
+def measure(st, holes=(), label=""):
+    """Read every geometric observable off one converged 4D spacetime: build the
+    C++ skeleton, select the interior hinges, and return the readings dict.
+    ``holes`` are the register holes' vertex-id tuples (e.g. ``Proton.quark_holes()``
+    / ``ProtonIngredients.emergent_holes()``) — the BFS shell seeds."""
+    build_skeleton(st)  # registers the lattice onto st itself; idempotent
+    hinges, census = interior_hinges(st, holes)
+    mass = masses(hinges)
+    rad = radii(st, census)
+    loc = localization(hinges)
+    table = rm_table(mass, rad)
+    return dict(label=label, census=census, mass=mass, radius=rad,
+                localization=loc, rm=table, n_holes=len(holes), hinges=hinges)

--- a/tessera/observe/observable.py
+++ b/tessera/observe/observable.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The thin gated ``Observable`` base (#583).
+
+An Observable is a pure post-hoc reader over a ``Register``: it never shapes
+the lattice, never loops, never steers — it measures and reports. The base is
+deliberately thin:
+
+* ``name`` — the record key.
+* ``requires`` — declarative preconditions the battery evaluates BEFORE
+  measuring, so an inapplicable observable is skipped WITH A REASON instead
+  of crashing: ``min_holes`` (register holes needed), ``dimensions`` (top-cell
+  dimension), ``needs_provenance`` (True, or the provenance keys required —
+  e.g. the diquark pair or the output blocks travel via the campaign record /
+  geometry-dump metadata, never guessed and never re-derived by re-running a
+  build), ``needs_causal_content`` (the observable reads causal structure;
+  all-spacelike specimens skip it).
+* ``measure(register, provenance=None) -> dict`` — the pure read. Records are
+  JSON-able by contract: float/int/bool/str/None and (nested) lists/dicts
+  only. Complex values are stored as explicit re/im pairs via
+  ``split_complex`` (the #580 propagation discipline at the reporting layer:
+  a channel is real BY CONSTRUCTION or it carries both parts explicitly —
+  nothing is silently ``.real``-ed).
+* ``gated_measure`` — the GAUGE/RELABEL harness: re-measure on the
+  transformed register and compare EVERY numeric leaf of the record
+  (``report_delta``, adapted from the C_ij chamber readout's every-channel
+  gate). Records must therefore contain only gauge- and relabel-invariant
+  channels; covariant raw values (e.g. complex periods) are reported in a
+  gauge-fixed convention by their adapter. The gates are post-hoc validation,
+  never a loop condition.
+
+The self-test pattern: ``report_delta`` flags a perturbed channel (any leaf,
+however deep) with a nonzero delta, mismatched strings/None with ``inf``, and
+raises on a record-shape mismatch — the framework tests prove all three, so a
+silently-passing gate cannot be a comparison that never happened.
+"""
+import json
+import math
+
+from tessera.observe.register import GATE_SEED, GAUGE_THETA
+
+
+def split_complex(name, value):
+    """A complex scalar or sequence as the two explicit JSON-able leaves
+    ``{name}_re`` / ``{name}_im`` — the one naming convention for complex
+    record channels (#580 discipline: the imaginary part is real physics and
+    is always carried, never silently dropped)."""
+    try:
+        values = list(value)
+    except TypeError:
+        z = complex(value)
+        return {f"{name}_re": z.real, f"{name}_im": z.imag}
+    zs = [complex(v) for v in values]
+    return {f"{name}_re": [z.real for z in zs],
+            f"{name}_im": [z.imag for z in zs]}
+
+
+def ensure_jsonable(record):
+    """Assert ``record`` serializes to JSON (NaN/inf allowed, Python-style)
+    and return it. Raises ``TypeError`` on any non-JSON-able leaf — complex
+    values must go through ``split_complex`` first."""
+    json.dumps(record)
+    return record
+
+
+def report_delta(a, b):
+    """The max absolute difference over every numeric leaf of two nested
+    records (the C_ij chamber readout's every-channel gate metric, adapted):
+
+    * dicts must have identical keys (a shape mismatch raises ``KeyError``);
+    * lists/tuples must have identical lengths (else ``inf``);
+    * strings and ``None`` must be equal (else ``inf`` — a changed status IS
+      a flagged channel);
+    * bools compare as 0/1; numbers as ``|a - b|``; two NaNs agree (delta 0 —
+      NaN is a legitimate reported value, e.g. a not-applicable reading), a
+      NaN against a number is ``inf`` (an appeared/vanished reading is a
+      flagged channel, never a silent NaN poisoning the max).
+    """
+    if isinstance(a, dict) or isinstance(b, dict):
+        if not (isinstance(a, dict) and isinstance(b, dict)):
+            return float("inf")
+        if set(a) != set(b):
+            raise KeyError(
+                f"record keys differ: {sorted(a)} vs {sorted(b)}")
+        deltas = [report_delta(a[k], b[k]) for k in a]
+        return max(deltas) if deltas else 0.0
+    if isinstance(a, str) or isinstance(b, str):
+        return 0.0 if a == b else float("inf")
+    if a is None or b is None:
+        return 0.0 if (a is None and b is None) else float("inf")
+    if isinstance(a, (list, tuple)) or isinstance(b, (list, tuple)):
+        if not (isinstance(a, (list, tuple)) and isinstance(b, (list, tuple))):
+            return float("inf")
+        if len(a) != len(b):
+            return float("inf")
+        deltas = [report_delta(x, y) for x, y in zip(a, b)]
+        return max(deltas) if deltas else 0.0
+    if isinstance(a, bool) or isinstance(b, bool):
+        return float(abs(int(a) - int(b)))
+    x, y = float(a), float(b)
+    if math.isnan(x) or math.isnan(y):
+        return 0.0 if (math.isnan(x) and math.isnan(y)) else float("inf")
+    return abs(x - y)
+
+
+class Observable:
+    """Base class for gated post-hoc observables. Subclasses set ``name``,
+    ``requires`` and ``gate_tol``, implement ``measure``, and (when their
+    provenance references vertex ids) override ``transform_provenance``."""
+
+    #: The record key; must be unique within a battery.
+    name = None
+
+    #: Declarative preconditions — see the module docstring for the keys.
+    requires = {}
+
+    #: Both gate residuals must stay below this for the ``*_ok`` verdicts.
+    #: Direct period/charge reads sit at ~1e-16; derived ratios (rho) amplify
+    #: eigensolve roundoff to ~1e-13; geometric aggregates re-summed in a
+    #: relabeled container order carry order-ULP noise — adapters pick the
+    #: tolerance their channels warrant and the raw residuals are always
+    #: reported alongside.
+    gate_tol = 1e-9
+
+    def measure(self, register, provenance=None):
+        """The pure read: a JSON-able record of invariant channels."""
+        raise NotImplementedError
+
+    def skip_reason(self, register, provenance=None):
+        """The reason this observable cannot measure this register (a string
+        the battery reports), or None when it can."""
+        requires = self.requires
+        min_holes = requires.get("min_holes", 0)
+        if len(register.holes) < min_holes:
+            return f"holes={len(register.holes)} < min_holes={min_holes}"
+        dimensions = requires.get("dimensions")
+        if dimensions is not None and register.dimensions != dimensions:
+            return f"dimensions={register.dimensions} != {dimensions}"
+        needs = requires.get("needs_provenance")
+        if needs:
+            if provenance is None:
+                return "no_provenance"
+            if needs is not True:
+                keys = (needs,) if isinstance(needs, str) else tuple(needs)
+                missing = sorted(k for k in keys if k not in provenance)
+                if missing:
+                    return f"provenance_missing:{','.join(missing)}"
+        if requires.get("needs_causal_content") and not register.causal_content:
+            return "no_causal_content"
+        return None
+
+    def transform_provenance(self, provenance, perm):
+        """Map provenance through the RELABEL permutation so the gate compares
+        like with like. The default is identity — correct for provenance that
+        references hole INDICES or carries no vertex ids; provenance carrying
+        vertex ids (e.g. block regions) must override."""
+        return provenance
+
+    def gated_measure(self, register, provenance=None, gauge_register=None,
+                      relabel=None):
+        """Measure, then run both gates and report their residuals:
+
+        * GAUGE — re-measure with the register target rotated by the global
+          U(1) phase (``Register.gauged``); every numeric leaf must agree.
+        * RELABEL — re-measure on the vertex-relabeled rebuild
+          (``Register.relabeled``), with provenance mapped through the
+          permutation; every numeric leaf must agree.
+
+        ``gauge_register`` / ``relabel`` (the ``(register, perm)`` pair) let a
+        battery share one transformed register across its observables.
+        Returns the full battery entry:
+        ``{"status": "measured", "record": ..., "gates": ...}``.
+        """
+        record = ensure_jsonable(self.measure(register, provenance))
+        if gauge_register is None:
+            gauge_register = register.gauged(GAUGE_THETA)
+        gauge_delta = report_delta(
+            record, self.measure(gauge_register, provenance))
+        if relabel is None:
+            relabel = register.relabeled(GATE_SEED)
+        relabeled_register, perm = relabel
+        relabel_delta = report_delta(
+            record, self.measure(relabeled_register,
+                                 self.transform_provenance(provenance, perm)))
+        gates = {
+            "gauge_delta": float(gauge_delta),
+            "relabel_delta": float(relabel_delta),
+            "gauge_ok": bool(gauge_delta <= self.gate_tol),
+            "relabel_ok": bool(relabel_delta <= self.gate_tol),
+            "gate_tol": float(self.gate_tol),
+        }
+        return {"status": "measured", "record": record, "gates": gates}

--- a/tessera/observe/pair_loop_flavor.py
+++ b/tessera/observe/pair_loop_flavor.py
@@ -1,0 +1,346 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Pair-loop dual-basis flavor read on a 3-hole register (#561, part of #410/#559).
+
+The `docs/theory/cobordism/proton-spin/pair_loop_quarks.tex` experiment (its §7
+"genuinely new, cheap experiment"), implemented literally — the shared reader
+core behind the ``PairLoopFlavor`` observable and the
+``examples/cobordism/pair_loop_flavor.py`` fixture battery (which imports from
+here; the machinery lives in exactly one place). On a structure with three
+register holes carrying the color singlet `[1, ω, ω²]`:
+
+1. **Joint read.** One correlated multi-hole read — the SINGLE joint carried
+   representative `ψ = EigenstateSynthesis(st, 3).carriedRepresentative(holes,
+   target)` — never three independent per-hole extractions. The per-hole
+   carried weight is the period `w_h = ∮_[h] ψ` over hole `h`'s boundary
+   3-cycle (the five (-1)^j-signed tetrahedral facets of the removed 4-cell).
+2. **Pair loops, no new geometry.** The loop `γ_ij` encircling holes `i, j` is
+   homologous to `[i] + [j]`, so its period is `w_i + w_j` — formed
+   arithmetically from the per-hole weights. Imposing the singlet
+   (`Σ_h w_h = 0`) gives the Poincaré duality `[γ_ij] = -[k]`: each pair loop
+   is minus the complementary hole (`pair_loops` / `complement_hole`).
+3. **Flavor/taste charge.** The per-hole Dirac–Kähler charge read of the
+   retired `dk_joint_spin.per_hole_flavor` was `DiracKahler.charge(lift(3, ψ))
+   = Σ_c W_c |ψ_c|²` — the metric-weighted norm² (the DK charge density `j⁰_c
+   = W_c |ψ_c|²` summed). #509 retired `DiracKahler`, but the same number needs
+   only the surviving `HodgeLaplacian.weights(3)` (the per-3-cell metric
+   volume weights `W_c`, in the same canonical cell order as
+   `EigenstateSynthesis.cellSimplices()`). Localized to a cycle it is the
+   charge that cycle carries: per hole `q_h = Σ_{c ∈ ∂h} W_c |ψ_c|²`, and per
+   pair loop the weighted norm of ψ on the loop's combined cycle support
+   `∂i ⊔ ∂j`. Because distinct holes have disjoint boundary facets this is
+   exactly `q_i + q_j` (additivity is structural, not an approximation — see
+   the criterion-(b) honesty note below). Equivalently: the symmetric metric
+   operator is assembled with `B₄ = W₃^{1/2} ∂₄ W₄^{-1/2}`, so the CLOSED
+   cochain behind a harmonic row ψ̃ is `χ = √W₃ ψ̃` (`∂₄ᵀχ = 0`), and the
+   weighted norm is the plain norm² of that closed representative on the
+   cycle — the charge lives on the topological object.
+
+## Orientation (the RELABEL lesson)
+
+`cyclePeriods`' raw facet signs orient every hole by its sorted vertex tuple —
+a labeling convention, not physics: a vertex relabeling can flip one hole's
+boundary orientation and silently pin `-t_h`. The label-free orientation is the
+induced one: `ChainComplex.endSignCovector(top_cells, holes)` returns the
+per-hole signs `σ_h = ±1` from the complex's own coherent (facet-sharing)
+orientation, under which every closed form's signed periods obey
+`Σ_h σ_h p_h = 0`. Targets are pinned as `σ_h · t_h` and weights read back as
+`w_h = σ_h ∮_h ψ`, so `w` carries the singlet in the induced orientation. The
+one remaining ambiguity is a single GLOBAL sign (the propagation root), which
+is `-1 ∈ U(1)` on the register — gauge, not physics (see the GAUGE gate).
+
+## Pre-registered criteria (pair_loop_quarks.tex §7; falsifiable)
+
+(a) **Multiplicity 2:1** — the three pair-loop charges cluster as {u, u, d}:
+    two alike, one apart. Quantified by `rho` = (spread of the closest pair) /
+    (its separation from the odd one); `rho < RHO_MAX = 0.5` counts as 2:1.
+(b) **The odd-one-out loop is the diquark loop** — the dual of the spectator
+    (step-2) quark hole. HONESTY NOTE: with the additive pair charge, the
+    charge-odd loop is automatically the dual of the charge-odd hole, so on a
+    fixture (no build history) only the odd loop's IDENTITY is reportable.
+    The falsifiable content of (b) is that the charge-odd hole coincides with
+    the quark the build added last (the two step-1 holes are the diquark) —
+    pass `diquark_pair` (the step-1 hole indices) when the specimen's build
+    history is known; the criterion then passes iff the odd loop IS that pair.
+    Build history travels via the campaign record / geometry-dump metadata —
+    never guessed, never re-derived by re-running a build (the engine build is
+    not process-deterministic).
+(c) **GAUGE and RELABEL invariance** — see the gates below.
+
+Failure of (b) on a genuine specimen falsifies the dual-flavor framing; either
+outcome is a finding.
+
+## Gates (post-hoc validation, never a loop condition)
+
+* GAUGE — this readout is built from periods and metric-weighted norms only:
+  no embedding, no per-cell frame exists to SO(4)-rotate (that gate is vacuous
+  here by construction). The register's surviving gauge freedom is the global
+  U(1) phase of the target, `t → e^{iθ} t` — which contains the Z₃ cyclic
+  recolor of the singlet (a cyclic shift of `[1, ω, ω²]` is `ω^{±1}` times it)
+  and the global orientation flip (`-1`). Charges must be invariant and loop
+  periods covariant (`w → e^{iθ} w`).
+* RELABEL — random vertex-id permutation, rebuild the complex from the
+  permuted cells and edge lengths, re-read with the permuted holes: charges,
+  `rho`, and the odd-one-out identity must match, and the oriented loop
+  periods must match up to the global orientation sign.
+
+Both gates hold to machine precision: directly-read quantities (charges,
+periods, duality residuals) reproduce to `GATE_TOL = 1e-12` (observed ~1e-16
+on the fixtures); the derived clustering ratio `rho` divides two small charge
+differences, which amplifies eigensolve roundoff (observed ~1e-13), so tests
+give `d_rho` the looser `RHO_GATE_TOL = 1e-9` while the odd-one-out identity
+must match exactly.
+"""
+import cmath
+import json
+import math
+import os
+import random
+
+import numpy as np
+
+import tessera as T
+from tessera.observe.register import (
+    OMEGA,
+    SINGLET,
+    build_complex,
+    induced_orientation_signs,
+)
+from tessera.observe.register import register_holes as _validated_register_holes
+
+cob = T.cobordism
+
+#: The three pair loops as (i, j) hole-index pairs; `γ_ij` encircles holes i, j.
+PAIR_LOOPS = ((0, 1), (0, 2), (1, 2))
+
+#: Criterion (a): the closest pair's spread over its separation from the odd
+#: one must stay below this for a 2:1 (u:u:d) verdict.
+RHO_MAX = 0.5
+
+#: Both gates must reproduce every directly-read quantity to this tolerance.
+GATE_TOL = 1e-12
+
+#: Looser gate tolerance for the derived ratio `rho` (a quotient of two small
+#: charge differences — it amplifies eigensolve roundoff by ~1/separation).
+RHO_GATE_TOL = 1e-9
+
+_FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         "..", "..", "tests", "fixtures", "composite_spin")
+
+
+def complement_hole(pair):
+    """The hole index dual to the pair loop `γ_ij`: `[γ_ij] = -[k]`, the third
+    index. The Poincaré-duality bookkeeping of pair_loop_quarks.tex Eq. (dual)."""
+    (i, j) = pair
+    return 3 - i - j
+
+
+def load_fixture(name, fixtures_dir=_FIXTURES):
+    """A composite_spin fixture as (meta, cells, edges): `cells` the 5-vertex
+    top 4-cells, `edges` {(min_id, max_id): complex squared length}. The
+    default directory resolves inside the repo tree (test-fixture
+    convenience); pass `fixtures_dir` anywhere else."""
+    with open(os.path.join(fixtures_dir, name)) as f:
+        meta = json.load(f)
+    cells = [list(c) for c in meta["cells"]]
+    edges = {}
+    for key, (re, im) in meta["edges"].items():
+        a, b = (int(x) for x in key.split(","))
+        edges[(a, b)] = complex(re, im)
+    return meta, cells, edges
+
+
+def build_spacetime(cells, edges, perm=None):
+    """The live complex from explicit top cells + edge squared lengths,
+    optionally relabeled by `perm` (vertex id -> vertex id). The skeleton is
+    materialized in C++ (`ReggeSolver` via `build_complex`), so the degree-3
+    cell universe exists."""
+    if perm is not None:
+        cells = [[perm[v] for v in c] for c in cells]
+        edges = {tuple(sorted((perm[a], perm[b]))): z
+                 for (a, b), z in edges.items()}
+    return build_complex(cells, edges, dimensions=4)
+
+
+def register_holes(st, count=3):
+    """The structure's first `count` register holes (removed top 4-cells), in
+    `MultiCobordism.emergent_holes` order — delegating to the single validated
+    selection entry point (`tessera.observe.register.register_holes`: a
+    deficit raises, a surplus warns naming the dropped holes) and returning
+    the selected holes."""
+    holes, _dropped = _validated_register_holes(st, count, degree=3)
+    return holes
+
+
+def _facet_indices(cell_index, hole):
+    """Hole `h`'s five boundary tetrahedra as (cochain index, (-1)^j sign)
+    pairs. Facet j of the sorted hole drops vertex v_j and carries (-1)^j —
+    the same boundary-operator convention `cyclePeriods` documents, mirrored
+    here so ψ's periods are read in the operator's own indexing. Facets are
+    matched by vertex SET (never by an imposed order); the physical
+    orientation is supplied separately by `induced_orientation_signs`."""
+    hs = sorted(hole)
+    out = []
+    for j in range(len(hs)):
+        facet = frozenset(hs[:j] + hs[j + 1:])
+        out.append((cell_index[facet], (-1) ** j))
+    return out
+
+
+def joint_read(st, holes, target=SINGLET, es=None, sigma=None, weights=None,
+               cell_index=None):
+    """The single correlated multi-hole read. Returns a dict:
+
+    * ``sigma`` — induced-orientation signs of the three holes;
+    * ``psi`` — the joint carried representative of `σ·target` over `holes`;
+    * ``r_u`` — `residualForPeriods` of that pin (~0 = the register carries it);
+    * ``w`` — oriented per-hole carried weights `w_h = σ_h ∮_h ψ` (== target);
+    * ``q`` — per-hole DK-style charges `q_h = Σ_{c ∈ ∂h} W_c |ψ_c|²`;
+    * ``loop_w`` — pair-loop periods `w_i + w_j` in `PAIR_LOOPS` order;
+    * ``loop_q`` — pair-loop charges (weighted norm² of ψ on `∂i ⊔ ∂j`);
+    * ``dual_residual`` — `|w_i + w_j + w_k|` per loop (the `[γ_ij] = -[k]`
+      bookkeeping; ~0 whenever the pinned target sums to zero).
+
+    ``es`` / ``sigma`` / ``weights`` / ``cell_index`` let a shared read
+    context (``tessera.observe.Register``) inject its cached
+    `EigenstateSynthesis`, orientation signs, metric weights and canonical
+    cell index; by default each is built fresh (identical values — the read
+    is deterministic given the complex).
+    """
+    if len(holes) != 3 or len(target) != 3:
+        raise ValueError("the pair-loop read is over exactly 3 holes")
+    if es is None:
+        es = cob.EigenstateSynthesis(st, 3)
+    if cell_index is None:
+        cell_index = {frozenset(t): i for i, t in enumerate(es.cellSimplices())}
+    if weights is None:
+        weights = np.asarray(cob.HodgeLaplacian(st).weights(3), float)
+    if sigma is None:
+        sigma = induced_orientation_signs(st, holes)
+    hole_lists = [list(h) for h in holes]
+    raw_target = [s * t for s, t in zip(sigma, target)]
+    psi = np.asarray(es.carriedRepresentative(hole_lists, raw_target), complex)
+    r_u = es.residualForPeriods(hole_lists, raw_target)
+
+    facets = [_facet_indices(cell_index, h) for h in holes]
+    w = [sigma[h] * sum(sgn * psi[c] for c, sgn in facets[h]) for h in range(3)]
+    q = [float(sum(weights[c] * abs(psi[c]) ** 2 for c, _ in facets[h]))
+         for h in range(3)]
+
+    loop_w, loop_q, dual_residual = [], [], []
+    for (i, j) in PAIR_LOOPS:
+        loop_w.append(w[i] + w[j])
+        support = {c for c, _ in facets[i]} | {c for c, _ in facets[j]}
+        loop_q.append(float(sum(weights[c] * abs(psi[c]) ** 2 for c in support)))
+        dual_residual.append(abs(w[i] + w[j] + w[complement_hole((i, j))]))
+    return dict(sigma=list(sigma), psi=psi, r_u=r_u, w=w, q=q,
+                loop_w=loop_w, loop_q=loop_q, dual_residual=dual_residual)
+
+
+def odd_one_out(loop_q):
+    """(odd loop index, rho): the loop whose charge sits farthest from the
+    mean of the other two, and `rho` = |spread of the other two| / |that
+    separation| — small `rho` is a clean 2:1 (u:u:d) clustering."""
+    separations = []
+    for k in range(3):
+        others = [loop_q[i] for i in range(3) if i != k]
+        separations.append(abs(loop_q[k] - (others[0] + others[1]) / 2.0))
+    odd = int(np.argmax(separations))
+    others = [loop_q[i] for i in range(3) if i != odd]
+    rho = (abs(others[0] - others[1]) / separations[odd]
+           if separations[odd] > 0 else float("inf"))
+    return odd, rho
+
+
+def evaluate_criteria(read, diquark_pair=None, rho_max=RHO_MAX):
+    """The pre-registered criteria on a finished `joint_read`.
+
+    (a) `multiplicity_2_1`: `rho < rho_max`.
+    (b) `odd_is_diquark_loop`: only decidable with `diquark_pair` (the step-1
+        hole-index pair from the specimen's build history) — True iff the
+        charge-odd loop is exactly that pair; None on fixtures (no history).
+    Duality bookkeeping and the gates are (2)/(c), reported alongside.
+    """
+    odd, rho = odd_one_out(read["loop_q"])
+    verdict = dict(odd_loop=PAIR_LOOPS[odd],
+                   dual_hole=complement_hole(PAIR_LOOPS[odd]),
+                   rho=rho,
+                   multiplicity_2_1=bool(rho < rho_max),
+                   odd_is_diquark_loop=None)
+    if diquark_pair is not None:
+        verdict["odd_is_diquark_loop"] = (
+            tuple(sorted(diquark_pair)) == PAIR_LOOPS[odd])
+    return verdict
+
+
+def read_structure(st, holes=None, target=SINGLET, diquark_pair=None):
+    """The specimen entry point: `joint_read` + `evaluate_criteria` on a live
+    complex (e.g. a built proton block: `st = Proton.block()`, holes from
+    `Proton.quark_holes()`, `diquark_pair` from the build's step-1 history)."""
+    holes = register_holes(st) if holes is None else [tuple(h) for h in holes]
+    read = joint_read(st, holes, target)
+    return read, evaluate_criteria(read, diquark_pair=diquark_pair)
+
+
+# ---------------------------------------------------------------------------
+# The gates — post-hoc validation, never a loop condition.
+# ---------------------------------------------------------------------------
+
+def gauge_gate(st, holes, base, theta=2.0 * math.pi * 0.371, target=SINGLET):
+    """GAUGE: re-read with the target rotated by the global U(1) phase
+    `e^{iθ}`. Returns the residual dict — every entry must be < `GATE_TOL`:
+    charges invariant, loop periods covariant, duality/oddity unchanged."""
+    phase = cmath.exp(1j * theta)
+    gauged = joint_read(st, holes, [phase * t for t in target])
+    odd0, rho0 = odd_one_out(base["loop_q"])
+    odd1, rho1 = odd_one_out(gauged["loop_q"])
+    return {
+        "d_charge": max(abs(a - b) for a, b in zip(gauged["q"], base["q"])),
+        "d_loop_charge": max(abs(a - b)
+                             for a, b in zip(gauged["loop_q"], base["loop_q"])),
+        "d_loop_period": max(abs(a - phase * b)
+                             for a, b in zip(gauged["loop_w"], base["loop_w"])),
+        "d_rho": abs(rho1 - rho0),
+        "d_odd": float(odd1 != odd0),
+    }
+
+
+def relabel_gate(cells, edges, holes, base, seed=3, target=SINGLET):
+    """RELABEL: random vertex-id permutation, rebuild, re-read with the
+    permuted holes. Returns the residual dict — every entry must be
+    < `GATE_TOL`. Oriented loop periods are compared up to the one global
+    orientation sign (the `endSignCovector` propagation root, `-1 ∈ U(1)`)."""
+    all_vertices = sorted({v for c in cells for v in c})
+    shuffled = all_vertices[:]
+    random.Random(seed).shuffle(shuffled)
+    perm = dict(zip(all_vertices, shuffled))
+    st2 = build_spacetime(cells, edges, perm=perm)
+    holes2 = [tuple(perm[v] for v in h) for h in holes]
+    relabeled = joint_read(st2, holes2, target)
+    flip = -1.0 if (abs(relabeled["w"][0] + base["w"][0])
+                    < abs(relabeled["w"][0] - base["w"][0])) else 1.0
+    odd0, rho0 = odd_one_out(base["loop_q"])
+    odd1, rho1 = odd_one_out(relabeled["loop_q"])
+    return {
+        "d_charge": max(abs(a - b) for a, b in zip(relabeled["q"], base["q"])),
+        "d_loop_charge": max(abs(a - b) for a, b in
+                             zip(relabeled["loop_q"], base["loop_q"])),
+        "d_loop_period": max(abs(a - flip * b) for a, b in
+                             zip(relabeled["loop_w"], base["loop_w"])),
+        "d_rho": abs(rho1 - rho0),
+        "d_odd": float(odd1 != odd0),
+    }
+
+
+def read_fixture(name, fixtures_dir=_FIXTURES, relabel_seed=3):
+    """One full row: joint read + criteria + both gates on a fixture."""
+    meta, cells, edges = load_fixture(name, fixtures_dir)
+    st = build_spacetime(cells, edges)
+    holes = register_holes(st)
+    read = joint_read(st, holes)
+    verdict = evaluate_criteria(read)
+    gauge = gauge_gate(st, holes, read)
+    relabel = relabel_gate(cells, edges, holes, read, seed=relabel_seed)
+    return dict(name=name, b3=meta["b3"], kind=meta.get("kind", "?"),
+                holes=holes, read=read, verdict=verdict,
+                gauge=gauge, relabel=relabel)

--- a/tessera/observe/register.py
+++ b/tessera/observe/register.py
@@ -1,0 +1,344 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The blessed read context for register observables (#583, part of #559).
+
+``Register`` composes — never refactors — the C++ readers behind every
+emergent-proton observable:
+
+* **Skeleton in C++ only.** The ``ReggeSolver(st, MatterConfiguration())``
+  constructor materializes the facet/coface lattice (tops → tetrahedra →
+  triangle hinges); nothing is ever materialized from Python (the #451
+  corruption lesson: a Python-driven materialization corrupted coface lists
+  and ``dualVolume()`` saw half its cofaces).
+* **Hole selection validated at one entry point.** ``register_holes(st,
+  count)`` — a deficit RAISES with a clear message; a surplus WARNS naming the
+  dropped holes (never a silent slice); both the used and the total census are
+  recorded (``holes_used`` / ``holes_total``) alongside ``b3``, with the
+  ``holes_vs_b3_divergent`` flag (the campaign taught us holes and b₃ can
+  disagree — e.g. holes=3/b₃=2).
+* **One orientation convention.** The induced-orientation signs ``ε_h = ±1``
+  come from ``ChainComplex.endSignCovector`` — the label-free orientation
+  under which every closed form's signed periods obey ``Σ_h ε_h p_h = 0``,
+  determined up to one global sign (the propagation root, ``-1 ∈ U(1)`` on
+  the register — gauge, not physics).
+* **One cached ``EigenstateSynthesis``** at the register degree, plus
+  lazily-built structures every observable may share: the top-cell list, the
+  C++ dual adjacency (``Spacetime.getDualAdjacency``), and a generic
+  ``derived(name, build)`` memo so heavier per-complex structures (e.g. the
+  dual-edge cell frames of the transport readouts) are built once per
+  Register when their observables land.
+
+The GAUGE and RELABEL gates act on the Register, not on the observables:
+``gauged(theta)`` rotates the register target by the surviving global U(1)
+phase (which contains the Z₃ cyclic recolor of the singlet and the
+orientation flip), and ``relabeled(seed)`` rebuilds the whole complex under a
+random vertex-id permutation with the cell enumeration order shuffled too,
+re-deriving the holes on the relabeled complex and matching the original
+register's images by permuted vertex SET (vertex-order agnostic — nothing is
+ever sorted to impose a convention).
+"""
+import cmath
+import copy
+import math
+import warnings
+
+import numpy as np
+
+import tessera as _T
+
+_cob = _T.cobordism
+
+#: The primitive cube root of unity, `ω = exp(2πi/3)`.
+OMEGA = cmath.exp(2j * math.pi / 3)
+
+#: The color singlet `[1, ω, ω²]` — the carried register state (Σ = 0).
+SINGLET = (1.0 + 0.0j, OMEGA, OMEGA * OMEGA)
+
+#: Default GAUGE-gate angle: an incommensurate fraction of 2π, so the rotated
+#: target never lands on a symmetry of the singlet by accident.
+GAUGE_THETA = 2.0 * math.pi * 0.371
+
+#: Default RELABEL-gate permutation seed (the pair-loop readout's choice).
+GATE_SEED = 3
+
+
+def build_complex(cells, edges, vertex_times=None, dimensions=None):
+    """A live complex from explicit top cells + per-edge complex squared
+    lengths, with the skeleton materialized in C++ (the ``ReggeSolver`` ctor).
+
+    ``cells`` keep their intrinsic vertex order (never sorted — the stored
+    order carries the orientation); ``edges`` maps ``(min_id, max_id)`` to the
+    complex squared length; ``vertex_times`` (optional) maps vertex id to its
+    recorded time, applied before the lengths. ``dimensions`` defaults to the
+    first cell's dimension. Raises ``KeyError`` if an edge of the built
+    complex has no recorded length — a partial metric is never silently
+    defaulted.
+    """
+    cells = [list(c) for c in cells]
+    if not cells:
+        raise ValueError("build_complex needs at least one top cell")
+    if dimensions is None:
+        dimensions = len(cells[0]) - 1
+    st = _T.Spacetime.fromCells(int(dimensions), cells, 1.0, 0.0)
+    if vertex_times:
+        vertex_list = st.getVertexList()
+        for vid, t in dict(vertex_times).items():
+            vertex_list.get(int(vid)).setTime(float(t))
+    for e in st.getEdgeList().toVector():
+        a, b = e.getSource().getId(), e.getTarget().getId()
+        e.setSquaredLength(edges[(a, b) if a < b else (b, a)])
+    _T.ReggeSolver(st, _T.MatterConfiguration())
+    return st
+
+
+def register_holes(st, count=3, degree=3):
+    """The structure's ``count`` register holes (removed top cells) in
+    ``MultiCobordism.emergent_holes`` order — the single validated selection
+    entry point (the #485 fixture convention with PR #577's semantics).
+
+    A deficit raises; a surplus is an explicit, warned truncation NAMING the
+    dropped holes, never a silent slice. Returns ``(holes, dropped)``.
+    """
+    holes = [tuple(h) for h in _cob.MultiCobordism.emergent_holes(st, degree)]
+    if len(holes) < count:
+        raise ValueError(
+            f"need >= {count} register holes at degree {degree}, found "
+            f"{len(holes)}{': ' + str(holes) if holes else ''} — this specimen "
+            f"cannot host the requested register")
+    if len(holes) > count:
+        warnings.warn(
+            f"register selection: {len(holes)} emergent holes; using the first "
+            f"{count} (emergent_holes order), dropping {holes[count:]} — the "
+            f"confinement constraint ranges over ALL holes, so the read covers "
+            f"a sub-register", stacklevel=2)
+    return holes[:count], holes[count:]
+
+
+def induced_orientation_signs(st, holes):
+    """The induced-orientation signs ``ε_h = ±1`` of the holes' boundary
+    cycles relative to the complex's own coherent (facet-sharing) orientation
+    (``ChainComplex.endSignCovector`` — lex-rooted, component-aware, and a
+    hard error on any facet with more than two cofaces): the label-free
+    orientation under which every closed form's signed periods obey
+    ``Σ_h ε_h p_h = 0``. Determined up to one global sign (the propagation
+    root) = ``-1 ∈ U(1)`` on the register."""
+    tops = [[v.getId() for v in s.getVertices()] for s in st.getTopSimplices()]
+    return list(_cob.ChainComplex.endSignCovector(
+        tops, [list(h) for h in holes]))
+
+
+class Register:
+    """The shared per-complex read context every ``Observable`` measures.
+
+    Parameters
+    ----------
+    st : Spacetime
+        The converged complex to read. Its C++ skeleton is ensured here
+        (``ReggeSolver`` ctor — idempotent).
+    holes : optional list of vertex-id tuples
+        An explicit register selection (e.g. from a build's own census); when
+        omitted, ``register_holes(st, count, degree)`` selects and validates.
+        A supplied list is validated with the same count semantics.
+    count : int
+        How many holes the register must carry: fewer raises, more warns
+        naming the dropped ones. Pass the specimen's own hole count to read
+        sub-3-hole specimens (the battery then skips per-observable with
+        reasons instead of crashing here).
+    degree : int
+        The register degree k (holes are (k+2)-vertex removed top cells; the
+        cached ``EigenstateSynthesis`` reads at this k). The record field
+        ``b3`` is Betti at this degree (named for the k=3 default).
+    target : sequence of complex
+        The register target state, one component per hole convention slot —
+        the color singlet ``[1, ω, ω²]`` by default. The GAUGE gate rotates
+        exactly this.
+    """
+
+    def __init__(self, st, holes=None, count=3, degree=3, target=SINGLET):
+        self.st = st
+        self.degree = int(degree)
+        self.target = tuple(complex(t) for t in target)
+        # The skeleton, C++-side only (idempotent; the #451 lesson).
+        _T.ReggeSolver(st, _T.MatterConfiguration())
+        emergent = [tuple(h) for h in
+                    _cob.MultiCobordism.emergent_holes(st, self.degree)]
+        self.holes_total = len(emergent)
+        if holes is None:
+            self.holes, self.dropped = register_holes(st, count, self.degree)
+        else:
+            supplied = [tuple(h) for h in holes]
+            if len(supplied) < count:
+                raise ValueError(
+                    f"need >= {count} register holes, got {len(supplied)}")
+            if len(supplied) > count:
+                warnings.warn(
+                    f"register selection: given {len(supplied)} holes; using "
+                    f"the first {count}, dropping {supplied[count:]}",
+                    stacklevel=2)
+            self.holes, self.dropped = supplied[:count], supplied[count:]
+        self._derived = {}
+
+    # ---- lazily-built shared structures -----------------------------------
+
+    def derived(self, name, build):
+        """Memoize ``build()`` under ``name`` — one construction per Register
+        for anything heavier observables share (frames, facet indices,
+        metric weights, ...). ``gauged`` copies SHARE this cache (the gauge
+        knob only rotates the target), so target-dependent entries must key
+        their name by target."""
+        if name not in self._derived:
+            self._derived[name] = build()
+        return self._derived[name]
+
+    @property
+    def es(self):
+        """The one cached ``EigenstateSynthesis(st, degree)`` every period
+        readout shares."""
+        return self.derived(
+            "es", lambda: _cob.EigenstateSynthesis(self.st, self.degree))
+
+    @property
+    def eps(self):
+        """Induced-orientation signs of ``holes`` (``endSignCovector``)."""
+        return self.derived(
+            "eps", lambda: induced_orientation_signs(self.st, self.holes))
+
+    @property
+    def cells(self):
+        """The top-cell ``Simplex`` list, in enumeration order."""
+        return self.derived("cells", lambda: list(self.st.getTopSimplices()))
+
+    @property
+    def adjacency(self):
+        """The C++ dual adjacency as ``{cell_index: [neighbor indices]}``
+        over ``cells`` (``Spacetime.getDualAdjacency``), validated against
+        the top-cell count."""
+        def build():
+            rows, cols, n = self.st.getDualAdjacency()
+            if n != len(self.cells):
+                raise RuntimeError(
+                    f"dual adjacency count {n} != top cells {len(self.cells)}")
+            adjacency = {}
+            for r, c in zip(rows, cols):
+                adjacency.setdefault(int(r), []).append(int(c))
+            return adjacency
+        return self.derived("adjacency", build)
+
+    @property
+    def betti(self):
+        """The full Betti vector of the complex (GF(2) ranks)."""
+        return self.derived(
+            "betti", lambda: [int(b) for b in _cob.MultiCobordism.betti(self.st)])
+
+    @property
+    def b3(self):
+        """Betti at the register degree (b₃ for the k=3 default)."""
+        betti = self.betti
+        return betti[self.degree] if len(betti) > self.degree else 0
+
+    @property
+    def holes_vs_b3_divergent(self):
+        """True when the emergent-hole census and Betti at the register
+        degree disagree — the campaign's holes=3/b₃=2 style finding, always
+        recorded, never papered over."""
+        return self.holes_total != self.b3
+
+    @property
+    def dimensions(self):
+        """The top-cell dimension, or None when top cells are mixed-size
+        (declarative ``requires={"dimensions": d}`` gates read this)."""
+        def build():
+            sizes = {len(c.getVertices()) for c in self.cells}
+            return next(iter(sizes)) - 1 if len(sizes) == 1 else None
+        return self.derived("dimensions", build)
+
+    @property
+    def causal_content(self):
+        """True iff any edge is non-spacelike (timelike or null) — the
+        ``needs_causal_content`` skip path reads this. At initialization no
+        time has passed; causal structure may only emerge, so all-spacelike
+        specimens honestly report False."""
+        def build():
+            return bool(any((not e.isSpacelike())
+                            for e in self.st.getEdgeList().toVector()))
+        return self.derived("causal_content", build)
+
+    def summary(self):
+        """The register block of every battery record: the hole census, the
+        Betti census, and the divergence flag (JSON-able)."""
+        return {
+            "degree": self.degree,
+            "dimensions": self.dimensions,
+            "n_top_cells": len(self.cells),
+            "holes_used": len(self.holes),
+            "holes_total": self.holes_total,
+            "dropped_holes": [list(h) for h in self.dropped],
+            "b3": self.b3,
+            "betti": self.betti,
+            "holes_vs_b3_divergent": self.holes_vs_b3_divergent,
+            "causal_content": self.causal_content,
+        }
+
+    # ---- the gate transforms ----------------------------------------------
+
+    def gauged(self, theta=GAUGE_THETA):
+        """The GAUGE-gate variant: the same complex and register with the
+        target rotated by the global U(1) phase ``e^{iθ}`` (the register's one
+        surviving gauge freedom — it contains the Z₃ cyclic recolor of the
+        singlet and the orientation flip). Shares this Register's caches (the
+        complex is untouched)."""
+        rotated = copy.copy(self)
+        rotated.target = tuple(cmath.exp(1j * theta) * t for t in self.target)
+        return rotated
+
+    def relabeled(self, seed=GATE_SEED):
+        """The RELABEL-gate variant: rebuild the whole complex under a random
+        vertex-id permutation with the cell enumeration order shuffled too
+        (catching enumeration-order dependence), carry the metric (complex
+        squared lengths) and vertex times across, re-derive the emergent
+        holes on the relabeled complex, and match this register's images
+        among them by permuted vertex SET (a missing image is an error — the
+        gate must compare like with like). Returns ``(register, perm)``."""
+        rng = np.random.default_rng(seed)
+        cells = [[v.getId() for v in c.getVertices()] for c in self.cells]
+        edges = {}
+        for e in self.st.getEdgeList().toVector():
+            a, b = e.getSource().getId(), e.getTarget().getId()
+            edges[(a, b) if a < b else (b, a)] = e.getSquaredLength()
+        times = {}
+        for cell in cells:
+            for v in cell:
+                times.setdefault(v, None)
+        vertex_list = self.st.getVertexList()
+        for v in times:
+            times[v] = float(vertex_list.get(v).getTime())
+
+        all_vertices = sorted({v for c in cells for v in c})
+        shuffled = list(all_vertices)
+        rng.shuffle(shuffled)
+        perm = dict(zip(all_vertices, shuffled))
+        permuted_cells = [[perm[v] for v in c] for c in cells]
+        order = rng.permutation(len(permuted_cells))
+        st2 = build_complex(
+            [permuted_cells[i] for i in order],
+            {tuple(sorted((perm[a], perm[b]))): l2
+             for (a, b), l2 in edges.items()},
+            vertex_times={perm[v]: t for v, t in times.items()},
+            dimensions=self.dimensions)
+
+        rederived = [tuple(h) for h in
+                     _cob.MultiCobordism.emergent_holes(st2, self.degree)]
+        found = {frozenset(h): h for h in rederived}
+        holes2 = []
+        for h in self.holes:
+            image = frozenset(perm[v] for v in h)
+            if image not in found:
+                raise ValueError(
+                    f"emergent_holes on the relabeled complex is missing the "
+                    f"image of hole {h}")
+            holes2.append(found[image])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            register = Register(st2, holes=holes2, count=len(holes2),
+                                degree=self.degree, target=self.target)
+        return register, perm

--- a/tests/cobordism/test_emergent_mass_radius.py
+++ b/tests/cobordism/test_emergent_mass_radius.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Mass/radius reader on converged emergent 4D interiors (#566).
+
+Three layers, mirroring the #451 methodology the example ports to 4D:
+
+  * closed-fan hinge selection proved on hand-checkable complexes — the boundary
+    of Δ⁵ (the minimal closed S⁴: every one of its 20 triangles has a closed
+    3-pentatope fan) and the star of one vertex in it (a solid 4-ball where
+    exactly the 10 triangles containing the apex are interior);
+  * the C++-skeleton rule — after ``build_skeleton`` the readings are finite and
+    nonzero, dual and primal 4-volumes agree to machine precision (the guard that
+    ``dualVolume`` sees ALL its cofaces), and the deficit matches the closed form
+    2π − 3·arccos(¼) with Im = 0; without the skeleton the reader fails loudly;
+  * determinism — independent same-parameter builds read bit-identically, and
+    re-reading one complex is bit-identical;
+
+plus the bounded canonical ``Proton`` build validation (@slow, the fast-test
+budget: seed=1, max_restarts=1, defaults otherwise).
+"""
+import importlib.util
+import itertools
+import math
+import os
+import sys
+import unittest
+
+import pytest
+
+import tessera
+
+cob = tessera.cobordism
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+emr = _load("emergent_mass_radius")
+
+# Regular 4-simplex dihedral angle at a triangle hinge is arccos(1/4); three
+# pentatopes close each fan of dDelta^5, so every deficit is 2pi - 3 arccos(1/4).
+S4_DEFICIT = 2.0 * math.pi - 3.0 * math.acos(0.25)
+# Volume of the regular unit-side 4-simplex is sqrt(5)/96; dDelta^5 has 6 of them.
+S4_VOLUME = 6.0 * math.sqrt(5.0) / 96.0
+
+
+def _boundary_delta5():
+    """The closed S^4 = dDelta^5 (6 pentatopes on {0..5}), uniform l^2 = 1."""
+    cells = [list(c) for c in itertools.combinations(range(6), 5)]
+    return tessera.Spacetime.fromCells(4, cells, 1.0, 0.0)
+
+
+def _star_of_apex():
+    """The star of vertex 5 in dDelta^5: the 5 pentatopes containing vertex 5 —
+    a solid 4-ball whose boundary is the dropped cell's dDelta^4. Hand count:
+    the 10 triangles containing the apex 5 have closed fans (each fan
+    tetrahedron contains 5, so both its pentatopes survive the drop); the 10
+    triangles inside {0..4} touch a once-shared tetrahedron and are boundary."""
+    cells = [list(c) for c in itertools.combinations(range(6), 5) if 5 in c]
+    return tessera.Spacetime.fromCells(4, cells, 1.0, 0.0)
+
+
+class ClosedFanSelectionTest(unittest.TestCase):
+    """Interior selection + census on hand-checkable 4-complexes."""
+
+    def test_closed_s4_all_hinges_interior(self):
+        st = _boundary_delta5()
+        emr.build_skeleton(st)
+        hinges, census = emr.interior_hinges(st)
+        self.assertEqual(census["n_hinges_total"], 20)
+        self.assertEqual(census["n_hinges_interior"], 20)
+        self.assertEqual(census["n_hinges_boundary"], 0)
+        self.assertEqual(census["n_tops"], 6)
+        self.assertEqual(census["n_tets"], 15)
+        self.assertEqual(census["n_boundary_tets"], 0)
+        self.assertEqual(len(hinges), 20)
+
+    def test_star_of_apex_census_matches_hand_count(self):
+        st = _star_of_apex()
+        emr.build_skeleton(st)
+        hinges, census = emr.interior_hinges(st)
+        self.assertEqual(census["n_hinges_total"], 20)
+        self.assertEqual(census["n_hinges_interior"], 10)
+        self.assertEqual(census["n_hinges_boundary"], 10)
+        self.assertEqual(census["n_boundary_tets"], 5)
+        # exactly the triangles containing the apex vertex 5 are interior
+        for h in hinges:
+            self.assertIn(5, h["vids"])
+        # the boundary tetrahedra are getBoundary()'s (independent C++ count)
+        self.assertEqual({tuple(sorted(t)) for t in st.getBoundary()},
+                         set(census["boundary_tets"]))
+
+    def test_single_pentatope_has_no_interior_hinge(self):
+        st = tessera.Spacetime.fromCells(4, [list(range(5))], 1.0, 0.0)
+        emr.build_skeleton(st)
+        hinges, census = emr.interior_hinges(st)
+        self.assertEqual(census["n_hinges_total"], 10)
+        self.assertEqual(census["n_hinges_interior"], 0)
+        self.assertEqual(census["n_hinges_boundary"], 10)
+        self.assertEqual(hinges, [])
+
+    def test_non_4d_complex_fails_loudly(self):
+        # dDelta^4 is a 3-complex — hinges would be edges there, not triangles.
+        cells = [list(c) for c in itertools.combinations(range(5), 4)]
+        st = tessera.Spacetime.fromCells(3, cells, 1.0, 0.0)
+        with self.assertRaises(ValueError):
+            emr.interior_hinges(st)
+
+
+class SkeletonRuleTest(unittest.TestCase):
+    """The C++-built skeleton rule: readings finite/nonzero, dual == primal."""
+
+    def test_readings_on_closed_s4(self):
+        st = _boundary_delta5()
+        o = emr.measure(st, label="dDelta^5")
+        census, mass, rad, loc = (o["census"], o["mass"], o["radius"],
+                                  o["localization"])
+        self.assertEqual(census["n_hinges_interior"], 20)
+        # every deficit is the closed form, purely real
+        self.assertAlmostEqual(mass["m_sum"], 20 * S4_DEFICIT, places=10)
+        self.assertEqual(mass["n_im_nonzero"], 0)
+        self.assertLess(mass["max_abs_im"], 1e-12)
+        # m_shell with no holes reduces to the plain mean deficit
+        self.assertAlmostEqual(mass["m_shell"], S4_DEFICIT, places=10)
+        self.assertGreater(mass["m_action"], 0.0)
+        # dual 4-volume == primal 4-volume == 6*sqrt(5)/96 to machine precision:
+        # the "dualVolume sees ALL its cofaces" guard (a corrupt skeleton halves it)
+        self.assertAlmostEqual(rad["Vdual"], rad["Vprimal"], places=12)
+        self.assertAlmostEqual(rad["Vprimal"], S4_VOLUME, places=12)
+        self.assertEqual(rad["n_interior_vertices"], 6)
+        # the dimension-correct FOURTH root on a 4-complex (#451 used the cube
+        # root on its 3D event)
+        self.assertAlmostEqual(rad["r_dual"], rad["Vdual"] ** 0.25, places=15)
+        self.assertGreater(rad["r_dual"], 0.0)
+        # a perfectly uniform complex IS the round reference: PR = 1 exactly
+        self.assertAlmostEqual(loc["PR"], 1.0, places=12)
+        self.assertGreater(loc["mean_re"], 0.0)  # positive curvature
+        # the r.m table: 6 finite combos and an honest spread
+        self.assertEqual(len(o["rm"]["combos"]), 6)
+        self.assertTrue(all(math.isfinite(v) for v in o["rm"]["combos"].values()))
+        self.assertLessEqual(o["rm"]["spread_min"], o["rm"]["spread_max"])
+
+    def test_hole_seeded_shells_on_star_fixture(self):
+        # Treat the dropped pentatope {0..4} as the register hole: its vertices
+        # seed the BFS, every interior hinge touches shell 0, and the whole
+        # curvature weight sits within shell <= 1.
+        st = _star_of_apex()
+        o = emr.measure(st, holes=[(0, 1, 2, 3, 4)], label="star")
+        self.assertEqual(o["census"]["n_hole_vertices"], 5)
+        self.assertEqual(sorted(o["localization"]["shell_profile"]), [0])
+        self.assertAlmostEqual(o["localization"]["frac_within_shell1"], 1.0,
+                               places=12)
+        self.assertAlmostEqual(o["mass"]["m_shell"], S4_DEFICIT, places=10)
+
+    def test_reader_fails_loudly_without_skeleton(self):
+        # fromCells registers only the top cells; without the C++ skeleton the
+        # canonical triangle Simplex objects don't exist and the reader must
+        # refuse rather than silently reading nothing.
+        st = _boundary_delta5()
+        with self.assertRaises(RuntimeError):
+            emr.interior_hinges(st)
+
+
+class DeterminismTest(unittest.TestCase):
+    """Same parameters => identical numbers, and re-reads are bit-identical."""
+
+    @staticmethod
+    def _flat(o):
+        """Every numeric leaf of a measurement dict, in a stable order — down to
+        the per-hinge deficits, so equality is bit-for-bit (NaN normalized to a
+        sentinel so an absent reading equals an absent reading)."""
+        def norm(v):
+            return "nan" if isinstance(v, float) and math.isnan(v) else v
+
+        flat = []
+        for section in ("census", "mass", "radius", "localization", "rm"):
+            for key, value in sorted(o[section].items()):
+                if isinstance(value, (int, float)):
+                    flat.append((section, key, norm(value)))
+        flat.extend(("combo", k, v) for k, v in sorted(o["rm"]["combos"].items()))
+        flat.extend(("shell_mean", k, v)
+                    for k, v in sorted(o["mass"]["shell_means"].items(),
+                                       key=lambda kv: (kv[0] is None, kv[0])))
+        flat.extend(("shell_profile", k, tuple(sorted(p.items())))
+                    for k, p in sorted(o["localization"]["shell_profile"].items()))
+        for h in o["hinges"]:
+            flat.append(("hinge", tuple(h["vids"]),
+                         (h["re"], h["im"], h["dv"], h["shell"])))
+        return flat
+
+    def test_independent_builds_read_identically(self):
+        a = emr.measure(_boundary_delta5())
+        b = emr.measure(_boundary_delta5())
+        self.assertEqual(self._flat(a), self._flat(b))
+
+    def test_rereading_one_complex_is_identical(self):
+        st = _star_of_apex()
+        holes = [(0, 1, 2, 3, 4)]
+        a = emr.measure(st, holes)
+        b = emr.measure(st, holes)
+        self.assertEqual(self._flat(a), self._flat(b))
+
+
+@pytest.mark.slow
+class ProtonMassRadiusValidationTest(unittest.TestCase):
+    """The bounded canonical build (the fast-test budget): one real emergent
+    proton, read end-to-end. The numeric values are REPORTED findings (printed
+    for the record); the assertions pin structure, finiteness, and reader
+    determinism — never a particular mass."""
+
+    SEED = 1
+    MAX_RESTARTS = 1
+
+    @classmethod
+    def setUpClass(cls):
+        cls.proton = cob.Proton(seed=cls.SEED)
+        cls.proton.build(max_restarts=cls.MAX_RESTARTS)
+        cls.holes = cls.proton.quark_holes()
+        cls.reading = emr.measure(cls.proton.block(), cls.holes,
+                                  "canonical Proton().block()")
+
+    def test_census_is_consistent_and_reported(self):
+        census = self.reading["census"]
+        self.assertEqual(census["n_hinges_interior"] + census["n_hinges_boundary"],
+                         census["n_hinges_total"])
+        self.assertGreater(census["n_hinges_total"], 0)
+        self.assertGreater(census["n_tops"], 0)
+        emr.report(self.reading)  # the readings table, for the record
+
+    def test_relaxed_interior_readings_are_finite(self):
+        # The emergent block must expose a relaxed interior at all — the whole
+        # point of the reader — and every reading off it must be finite.
+        census, mass, rad = (self.reading["census"], self.reading["mass"],
+                             self.reading["radius"])
+        self.assertGreater(census["n_hinges_interior"], 0,
+                           "no closed-fan hinge — nothing interior to read")
+        for name in ("m_shell", "m_sum", "m_action"):
+            self.assertTrue(math.isfinite(mass[name]), name)
+        self.assertTrue(math.isfinite(mass["max_abs_im"]))
+        self.assertGreater(rad["Vprimal"], 0.0)
+        self.assertTrue(math.isfinite(rad["r_primal"]))
+        pr = self.reading["localization"]["PR"]
+        self.assertTrue(math.isfinite(pr))
+        self.assertGreater(pr, 0.0)
+        self.assertLessEqual(pr, 1.0 + 1e-12)
+
+    def test_rm_table_covers_all_definitions(self):
+        rm = self.reading["rm"]
+        self.assertEqual(
+            sorted(rm["combos"]),
+            sorted(f"{r} x {m}" for m in ("m_shell", "m_sum", "m_action")
+                   for r in ("r_dual", "r_primal")))
+        self.assertLessEqual(rm["spread_min"], rm["spread_max"])
+
+    def test_reader_is_deterministic_on_the_built_block(self):
+        # Same complex, same holes => bit-identical numbers. (The BUILD itself is
+        # documented FP-thread-variable — test_proton_cpp_python.py — so reader
+        # determinism, not build determinism, is the assertable contract.)
+        again = emr.measure(self.proton.block(), self.holes,
+                            "canonical Proton().block()")
+        self.assertEqual(DeterminismTest._flat(self.reading),
+                         DeterminismTest._flat(again))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_observe_adapters.py
+++ b/tests/cobordism/test_observe_adapters.py
@@ -1,0 +1,368 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Migration equivalence of the battery adapters (#583): each adapter's
+values EQUAL its source example's values on the same fixtures.
+
+The sources are the three readout surfaces this layer migrates by
+composition: the #576 pair-loop flavor read, the #575 mass/radius battery,
+and the #574 singlet/per-block reads. The example scripts are loaded through
+the repo's example-loading pattern and must expose the SAME functions the
+package owns (moved-shared-helper — one home, no second copy). The published
+per-fixture table of PR #576 anchors the values non-circularly.
+
+Fast throughout; the real-build (ProtonIngredients) equivalence runs in the
+@slow end-to-end of test_observe_proton_ingredients.py.
+"""
+import importlib.util
+import json
+import os
+import sys
+import unittest
+import warnings
+
+import tessera
+from tessera.observe import Register, battery, measure_all
+from tessera.observe import mass_radius as mass_radius_module
+from tessera.observe import pair_loop_flavor as pair_loop_module
+from tessera.observe.adapters import (
+    BlockResiduals,
+    MassRadius,
+    PairLoopFlavor,
+    SingletDiagnostic,
+)
+
+cob = tessera.cobordism
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples",
+                   "cobordism")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _quiet_register(st, **kwargs):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Register(st, **kwargs)
+
+
+class AdapterFixtureBase(unittest.TestCase):
+    fixture = "synthetic_b3_3.json"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.plf = _load("pair_loop_flavor")
+        cls.meta, cls.cells, cls.edges = pair_loop_module.load_fixture(
+            cls.fixture)
+        cls.st = pair_loop_module.build_spacetime(cls.cells, cls.edges)
+        cls.register = _quiet_register(cls.st, count=3)
+
+
+class MovedSharedHelperTest(AdapterFixtureBase):
+    """The examples import the package machinery — one home, no second copy."""
+
+    def test_pair_loop_example_reexports_the_package_functions(self):
+        for name in ("joint_read", "odd_one_out", "evaluate_criteria",
+                     "complement_hole", "register_holes", "build_spacetime",
+                     "load_fixture", "gauge_gate", "relabel_gate",
+                     "read_structure", "_facet_indices"):
+            self.assertIs(getattr(self.plf, name),
+                          getattr(pair_loop_module, name),
+                          f"{name} is duplicated instead of shared")
+        self.assertEqual(self.plf.SINGLET, pair_loop_module.SINGLET)
+        self.assertEqual(self.plf.PAIR_LOOPS, pair_loop_module.PAIR_LOOPS)
+
+    def test_mass_radius_example_reexports_the_package_functions(self):
+        emr = _load("emergent_mass_radius")
+        for name in ("build_skeleton", "interior_hinges", "masses", "radii",
+                     "localization", "rm_table", "measure"):
+            self.assertIs(getattr(emr, name),
+                          getattr(mass_radius_module, name),
+                          f"{name} is duplicated instead of shared")
+
+
+class PairLoopFlavorEquivalenceTest(AdapterFixtureBase):
+    """The adapter's values equal the source read's on the same fixture."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.source_read = pair_loop_module.joint_read(
+            cls.st, cls.register.holes)
+        cls.source_verdict = pair_loop_module.evaluate_criteria(
+            cls.source_read)
+        cls.record = PairLoopFlavor().measure(cls.register)
+
+    def test_direct_channels_equal_the_source(self):
+        self.assertEqual(self.record["r_u"], float(self.source_read["r_u"]))
+        self.assertEqual(self.record["q"],
+                         [float(x) for x in self.source_read["q"]])
+        self.assertEqual(self.record["loop_q"],
+                         [float(x) for x in self.source_read["loop_q"]])
+        self.assertEqual(self.record["dual_residual"],
+                         [float(x) for x in self.source_read["dual_residual"]])
+
+    def test_verdict_channels_equal_the_source(self):
+        self.assertEqual(tuple(self.record["odd_loop"]),
+                         self.source_verdict["odd_loop"])
+        self.assertEqual(self.record["dual_hole"],
+                         self.source_verdict["dual_hole"])
+        self.assertEqual(self.record["rho"], self.source_verdict["rho"])
+        self.assertEqual(self.record["multiplicity_2_1"],
+                         self.source_verdict["multiplicity_2_1"])
+
+    def test_periods_equal_the_source_in_the_root_fixed_convention(self):
+        w = self.source_read["w"]
+        phase0 = w[0] / abs(w[0])
+        for record_re, record_im, source in zip(
+                self.record["w_re"], self.record["w_im"],
+                [wi / phase0 for wi in w]):
+            self.assertEqual(complex(record_re, record_im), source)
+        for record_re, record_im, source in zip(
+                self.record["loop_w_re"], self.record["loop_w_im"],
+                [wi / phase0 for wi in self.source_read["loop_w"]]):
+            self.assertEqual(complex(record_re, record_im), source)
+
+    def test_register_cache_injection_changes_nothing(self):
+        # joint_read with the Register's cached synthesis/signs/weights ==
+        # the from-scratch read, bit for bit (the read is deterministic).
+        reg = self.register
+        cached = pair_loop_module.joint_read(
+            self.st, reg.holes, reg.target,
+            es=reg.es, sigma=reg.eps,
+            weights=cob.HodgeLaplacian(self.st).weights(3),
+            cell_index={frozenset(t): i
+                        for i, t in enumerate(reg.es.cellSimplices())})
+        fresh = pair_loop_module.joint_read(self.st, reg.holes, reg.target)
+        self.assertEqual(cached["r_u"], fresh["r_u"])
+        for key in ("q", "loop_q", "dual_residual", "w", "loop_w", "sigma"):
+            self.assertEqual(list(cached[key]), list(fresh[key]), key)
+
+    def test_provenance_decides_criterion_b_and_absence_reports_not_evaluable(self):
+        record_none = PairLoopFlavor().measure(self.register, None)
+        self.assertIsNone(record_none["odd_is_diquark_loop"])
+        self.assertEqual(record_none["odd_is_diquark_loop_status"],
+                         "not_evaluable(no_provenance)")
+        # the odd loop on this fixture is (0, 2) — supplying that pair as the
+        # recorded diquark decides True; a different pair decides False
+        record_hit = PairLoopFlavor().measure(
+            self.register, {"diquark_pair": [2, 0]})
+        self.assertIs(record_hit["odd_is_diquark_loop"], True)
+        self.assertEqual(record_hit["odd_is_diquark_loop_status"], "evaluated")
+        record_miss = PairLoopFlavor().measure(
+            self.register, {"diquark_pair": [0, 1]})
+        self.assertIs(record_miss["odd_is_diquark_loop"], False)
+        self.assertEqual(record_miss["odd_is_diquark_loop_status"],
+                         "evaluated")
+
+
+class PublishedTableAnchorTest(unittest.TestCase):
+    """The #576 per-fixture table, re-measured through the battery adapter —
+    the non-circular anchor that migration preserved the physics."""
+
+    # fixture -> (loop_q to 5 decimals, odd_loop, dual_hole, rho to 3
+    # decimals, multiplicity_2_1)
+    TABLE = {
+        "synthetic_b3_3.json": ((0.06054, 0.05971, 0.06063), (0, 2), 1,
+                                0.103, True),
+        "synthetic_b3_4.json": ((0.05726, 0.05971, 0.06074), (0, 1), 2,
+                                0.348, True),
+        "synthetic_b3_5.json": ((0.05542, 0.05722, 0.05772), (0, 1), 2,
+                                0.248, True),
+        "converged_b3_3.json": ((0.05153, 0.05165, 0.05177), (0, 1), 2,
+                                0.665, False),
+    }
+
+    def test_adapter_reproduces_the_published_rows(self):
+        for name, (loop_q, odd, dual, rho, verdict) in self.TABLE.items():
+            meta, cells, edges = pair_loop_module.load_fixture(name)
+            register = _quiet_register(
+                pair_loop_module.build_spacetime(cells, edges), count=3)
+            record = PairLoopFlavor().measure(register)
+            with self.subTest(fixture=name):
+                for measured, published in zip(record["loop_q"], loop_q):
+                    self.assertAlmostEqual(measured, published, places=5)
+                self.assertEqual(tuple(record["odd_loop"]), odd)
+                self.assertEqual(record["dual_hole"], dual)
+                self.assertAlmostEqual(record["rho"], rho, places=3)
+                self.assertEqual(record["multiplicity_2_1"], verdict)
+                self.assertLess(record["r_u"], 1e-20)
+
+
+class MassRadiusEquivalenceTest(AdapterFixtureBase):
+    """The adapter record equals the source reader's blocks on the same
+    complex and holes (shell keys stringified, the vertex-id-carrying
+    boundary_tets list dropped — reporting shape, not values)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.source = mass_radius_module.measure(cls.st, cls.register.holes)
+        cls.record = MassRadius().measure(cls.register)
+
+    def test_census_equals_the_source(self):
+        expected = {k: v for k, v in self.source["census"].items()
+                    if k != "boundary_tets"}
+        self.assertEqual(self.record["census"], expected)
+
+    def test_masses_equal_the_source(self):
+        expected = dict(self.source["mass"])
+        expected["shell_means"] = {
+            ("unshelled" if k is None else str(int(k))): v
+            for k, v in expected["shell_means"].items()}
+        self.assertEqual(self.record["mass"], expected)
+
+    def test_radius_rm_and_localization_equal_the_source(self):
+        self.assertEqual(self.record["radius"], self.source["radius"])
+        self.assertEqual(self.record["rm"], self.source["rm"])
+        expected = dict(self.source["localization"])
+        expected["shell_profile"] = {
+            ("unshelled" if k is None else str(int(k))): v
+            for k, v in expected["shell_profile"].items()}
+        self.assertEqual(self.record["localization"], expected)
+        self.assertEqual(self.record["n_holes"], self.source["n_holes"])
+
+
+class SingletDiagnosticEquivalenceTest(AdapterFixtureBase):
+    """The adapter is the #574 diagnostic: the relabeling-invariant singlet
+    r_state of Proton.singlet() against the whole, plus the census."""
+
+    def test_residual_equals_the_direct_r_state_read(self):
+        record = SingletDiagnostic().measure(self.register)
+        self.assertEqual(
+            record["singlet_residual"],
+            float(cob.MultiCobordism.r_state(self.st, 3, cob.Proton.singlet())))
+        self.assertEqual(record["holes_total"], 4)
+        self.assertEqual(record["holes_used"], 3)
+        self.assertEqual(record["b3"], 3)
+        self.assertEqual(record["betti"], [1, 0, 0, 3, 0])
+        self.assertTrue(record["holes_vs_b3_divergent"])
+
+    def test_divergence_flag_follows_the_register(self):
+        meta, cells, edges = pair_loop_module.load_fixture(
+            "converged_b3_3.json")
+        register = _quiet_register(
+            pair_loop_module.build_spacetime(cells, edges), count=3)
+        record = SingletDiagnostic().measure(register)
+        self.assertFalse(record["holes_vs_b3_divergent"])
+        self.assertEqual((record["holes_total"], record["b3"]), (3, 3))
+
+
+class BlockResidualsEquivalenceTest(AdapterFixtureBase):
+    """The Python mirror of ProtonIngredients::outputBlockResidual, branch by
+    branch: empty region -> the full leak ||target||^2; occupied region ->
+    r_state on the block's own UNIFORM-metric fromCells sub-complex. (The
+    real-build equivalence against baryon_residual()/antibaryon_residual()
+    runs in the @slow end-to-end.)"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.singlet = list(cob.Proton.singlet())
+
+    def test_empty_region_reports_the_full_leak(self):
+        record = BlockResiduals().measure(
+            self.register,
+            {"blocks": [{"label": "empty", "vertices": [0],
+                         "target": self.singlet}]})
+        (row,) = record["blocks"]
+        self.assertTrue(row["full_leak"])
+        self.assertEqual(row["n_cells_in_region"], 0)
+        self.assertEqual(row["residual"], row["target_norm2"])
+        self.assertAlmostEqual(row["residual"], 3.0, places=12)
+
+    def test_whole_region_equals_direct_r_state_on_the_uniform_rebuild(self):
+        vertices = sorted({v for c in self.cells for v in c})
+        record = BlockResiduals().measure(
+            self.register,
+            {"blocks": [{"label": "whole", "vertices": vertices,
+                         "target": self.singlet}]})
+        (row,) = record["blocks"]
+        self.assertFalse(row["full_leak"])
+        self.assertEqual(row["n_cells_in_region"], len(self.cells))
+        # the mirror's own construction, driven directly
+        cells_inside = [[v.getId() for v in c.getVertices()]
+                        for c in self.st.getTopSimplices()]
+        sub = tessera.Spacetime.fromCells(4, cells_inside, 1.0, 0.0)
+        expected = float(cob.MultiCobordism.r_state(sub, 3, self.singlet))
+        self.assertEqual(row["residual"], expected)
+
+    def test_sub_region_scores_only_its_own_cells(self):
+        # one ambient cell's own vertex set: a genuine strict sub-region —
+        # only the cells living entirely on those five vertices qualify
+        region = sorted(self.cells[0])
+        record = BlockResiduals().measure(
+            self.register,
+            {"blocks": [{"label": "one_cell", "vertices": region,
+                         "target": self.singlet}]})
+        (row,) = record["blocks"]
+        self.assertGreater(row["n_cells_in_region"], 0)
+        self.assertLess(row["n_cells_in_region"], len(self.cells))
+        self.assertFalse(row["full_leak"])
+        self.assertGreaterEqual(row["residual"], 0.0)
+
+    def test_target_re_im_pairs_equal_complex_targets(self):
+        vertices = sorted({v for c in self.cells for v in c})
+        by_complex = BlockResiduals().measure(
+            self.register,
+            {"blocks": [{"label": "b", "vertices": vertices,
+                         "target": self.singlet}]})
+        by_pairs = BlockResiduals().measure(
+            self.register,
+            {"blocks": [{"label": "b", "vertices": vertices,
+                         "target_re": [t.real for t in self.singlet],
+                         "target_im": [t.imag for t in self.singlet]}]})
+        self.assertEqual(by_complex, by_pairs)
+
+    def test_block_order_and_labels_are_preserved(self):
+        vertices = sorted({v for c in self.cells for v in c})
+        record = BlockResiduals().measure(
+            self.register,
+            {"blocks": [
+                {"label": "baryon", "vertices": vertices,
+                 "target": self.singlet},
+                {"label": "antibaryon", "vertices": [0],
+                 "target": self.singlet},
+            ]})
+        self.assertEqual([b["label"] for b in record["blocks"]],
+                         ["baryon", "antibaryon"])
+        self.assertEqual(record["n_blocks"], 2)
+
+
+class BatteryGatesOnFixtureTest(AdapterFixtureBase):
+    """The full gated battery on the fixture: every measured observable's
+    GAUGE and RELABEL residuals sit below its gate tolerance (BlockResiduals
+    exercises transform_provenance — its regions are vertex-id sets)."""
+
+    def test_full_battery_gates_hold(self):
+        vertices = sorted({v for c in self.cells for v in c})
+        provenance = {
+            "diquark_pair": [0, 2],
+            "blocks": [{"label": "whole", "vertices": vertices,
+                        "target": list(cob.Proton.singlet())}],
+        }
+        record = measure_all(self.register, provenance=provenance)
+        for name, entry in record["observables"].items():
+            with self.subTest(observable=name):
+                self.assertEqual(entry["status"], "measured")
+                self.assertTrue(entry["gates"]["gauge_ok"],
+                                entry["gates"])
+                self.assertTrue(entry["gates"]["relabel_ok"],
+                                entry["gates"])
+        json.dumps(record)
+
+    def test_default_battery_lineup(self):
+        self.assertEqual([o.name for o in battery.observables],
+                         ["singlet_diagnostic", "block_residuals",
+                          "mass_radius", "pair_loop_flavor"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_observe_adapters.py
+++ b/tests/cobordism/test_observe_adapters.py
@@ -321,6 +321,30 @@ class BlockResidualsEquivalenceTest(AdapterFixtureBase):
                          "target_im": [t.imag for t in self.singlet]}]})
         self.assertEqual(by_complex, by_pairs)
 
+    def test_orphaned_region_ids_are_inert_and_survive_the_relabel_gate(self):
+        # An emergent block region can reference vertices no longer in any
+        # top cell (surgical moves orphan them — observed on a real joint
+        # build). They are inert in the residual, and the relabel gate must
+        # carry them without a KeyError while preserving the region size.
+        region = sorted(self.cells[0]) + [10 ** 6]  # one id not in the complex
+        provenance = {"blocks": [{"label": "with_orphan", "vertices": region,
+                                  "target": self.singlet}]}
+        observable = BlockResiduals()
+        entry = observable.gated_measure(self.register, provenance)
+        self.assertEqual(entry["status"], "measured")
+        (row,) = entry["record"]["blocks"]
+        self.assertEqual(row["n_region_vertices"], len(region))
+        # the orphan changed nothing vs the same region without it
+        (clean_row,) = observable.measure(
+            self.register, {"blocks": [{"label": "with_orphan",
+                                        "vertices": region[:-1],
+                                        "target": self.singlet}]})["blocks"]
+        self.assertEqual(row["residual"], clean_row["residual"])
+        self.assertEqual(row["n_cells_in_region"],
+                         clean_row["n_cells_in_region"])
+        self.assertTrue(entry["gates"]["gauge_ok"], entry["gates"])
+        self.assertTrue(entry["gates"]["relabel_ok"], entry["gates"])
+
     def test_block_order_and_labels_are_preserved(self):
         vertices = sorted({v for c in self.cells for v in c})
         record = BlockResiduals().measure(

--- a/tests/cobordism/test_observe_framework.py
+++ b/tests/cobordism/test_observe_framework.py
@@ -1,0 +1,452 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The observable measurement layer's framework (#583): Register validation,
+requires/skip logic, the gate harness and its self-test, record shape.
+
+Fast — everything runs on the composite_spin fixtures (74–105 top cells) and
+hand-built complexes. The adapters' migration equivalence lives in
+test_observe_adapters.py; the ProtonIngredients construction in
+test_observe_proton_ingredients.py.
+"""
+import itertools
+import json
+import math
+import os
+import unittest
+import warnings
+
+import tessera
+from tessera.observe import (
+    GEOMETRY_SCHEMA,
+    Battery,
+    Observable,
+    Register,
+    battery,
+    build_complex,
+    ensure_jsonable,
+    load_geometry_dump,
+    measure_all,
+    rebuild_spacetime,
+    register_holes,
+    report_delta,
+    split_complex,
+    verify_rebuild,
+    write_geometry_dump,
+)
+from tessera.observe.pair_loop_flavor import build_spacetime, load_fixture
+
+cob = tessera.cobordism
+
+
+def _fixture(name="synthetic_b3_3.json"):
+    meta, cells, edges = load_fixture(name)
+    return meta, cells, edges
+
+
+def _quiet_register(st, **kwargs):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Register(st, **kwargs)
+
+
+class RegisterValidationTest(unittest.TestCase):
+    """Hole selection is validated at ONE entry point: deficit raises,
+    surplus warns NAMING the dropped holes; the census fields are recorded."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.meta, cls.cells, cls.edges = _fixture()
+        # The stored fixture holes (removed top cells) let us FILL holes to
+        # produce genuine deficit / divergence specimens.
+        cls.holes_meta = [list(h) for h in cls.meta["holes"]]
+
+    def test_surplus_warns_naming_dropped_hole_and_records_census(self):
+        # synthetic_b3_3 stores FOUR emergent holes with b3 = 3 — the ticket's
+        # 4-hole surplus fixture.
+        st = build_spacetime(self.cells, self.edges)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            reg = Register(st, count=3)
+        messages = [str(w.message) for w in caught
+                    if "register selection" in str(w.message)]
+        self.assertEqual(len(messages), 1)
+        self.assertIn("4 emergent holes", messages[0])
+        self.assertIn("(1, 4, 5, 6, 12)", messages[0])  # the dropped hole, NAMED
+        self.assertEqual(len(reg.holes), 3)
+        self.assertEqual(reg.holes_total, 4)
+        self.assertEqual(reg.dropped, [(1, 4, 5, 6, 12)])
+        self.assertEqual(reg.b3, 3)
+        self.assertEqual(reg.summary()["holes_used"], 3)
+        self.assertEqual(reg.summary()["holes_total"], 4)
+        self.assertEqual(reg.summary()["b3"], 3)
+
+    def test_deficit_raises_with_clear_message_on_two_hole_specimen(self):
+        # Fill two of the four stored holes: a genuine 2-hole specimen.
+        st = build_spacetime(self.cells + self.holes_meta[2:], self.edges)
+        self.assertEqual(
+            len(cob.MultiCobordism.emergent_holes(st, 3)), 2)
+        with self.assertRaises(ValueError) as ctx:
+            Register(st, count=3)
+        self.assertIn("need >= 3 register holes", str(ctx.exception))
+        self.assertIn("found 2", str(ctx.exception))
+
+    def test_register_holes_returns_selection_and_dropped(self):
+        st = build_spacetime(self.cells, self.edges)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            holes, dropped = register_holes(st, 3)
+        self.assertEqual(len(holes), 3)
+        self.assertEqual(dropped, [(1, 4, 5, 6, 12)])
+
+    def test_divergence_flag_on_holes_3_b3_2_specimen(self):
+        # Fill ONE stored hole: 3 emergent holes remain but b3 drops to 2 —
+        # exactly the campaign's holes-vs-b3 divergence.
+        st = build_spacetime(self.cells + self.holes_meta[3:], self.edges)
+        reg = Register(st, count=3)
+        self.assertEqual(reg.holes_total, 3)
+        self.assertEqual(reg.b3, 2)
+        self.assertTrue(reg.holes_vs_b3_divergent)
+        self.assertTrue(reg.summary()["holes_vs_b3_divergent"])
+
+    def test_divergence_flag_false_on_matching_specimen(self):
+        # converged_b3_3 carries exactly 3 emergent holes with b3 = 3.
+        meta, cells, edges = _fixture("converged_b3_3.json")
+        reg = Register(build_spacetime(cells, edges), count=3)
+        self.assertEqual((reg.holes_total, reg.b3), (3, 3))
+        self.assertFalse(reg.holes_vs_b3_divergent)
+
+    def test_supplied_holes_validated_with_same_semantics(self):
+        st = build_spacetime(self.cells, self.edges)
+        all_holes = [tuple(h) for h in cob.MultiCobordism.emergent_holes(st, 3)]
+        with self.assertRaises(ValueError):
+            Register(st, holes=all_holes[:2], count=3)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            reg = Register(st, holes=all_holes, count=3)
+        self.assertTrue(any("dropping" in str(w.message) for w in caught))
+        self.assertEqual(len(reg.holes), 3)
+
+    def test_eps_are_unit_signs_from_the_one_orientation_convention(self):
+        st = build_spacetime(self.cells, self.edges)
+        reg = _quiet_register(st, count=3)
+        self.assertEqual(len(reg.eps), 3)
+        self.assertTrue(all(s in (-1, 1) for s in reg.eps))
+
+    def test_build_complex_fails_loudly_on_missing_edge_length(self):
+        edges = dict(self.edges)
+        edges.pop(next(iter(edges)))
+        with self.assertRaises(KeyError):
+            build_complex(self.cells, edges, dimensions=4)
+
+
+class RegisterGateTransformsTest(unittest.TestCase):
+    """The GAUGE/RELABEL transforms the gate harness runs on."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.meta, cls.cells, cls.edges = _fixture()
+        cls.st = build_spacetime(cls.cells, cls.edges)
+        cls.reg = _quiet_register(cls.st, count=3)
+
+    def test_gauged_rotates_target_and_shares_the_complex(self):
+        gauged = self.reg.gauged(0.25)
+        self.assertIs(gauged.st, self.reg.st)
+        self.assertEqual(gauged.holes, self.reg.holes)
+        ratio = gauged.target[0] / self.reg.target[0]
+        self.assertAlmostEqual(abs(ratio), 1.0, places=12)
+        self.assertNotEqual(gauged.target, self.reg.target)
+        # caches are shared (the gauge knob only rotates the target)
+        self.assertIs(gauged.es, self.reg.es)
+
+    def test_relabeled_matches_holes_by_permuted_vertex_set(self):
+        reg2, perm = self.reg.relabeled(seed=5)
+        self.assertEqual(len(reg2.holes), 3)
+        for original, image in zip(self.reg.holes, reg2.holes):
+            self.assertEqual({perm[v] for v in original}, set(image))
+        # census invariants carry over
+        self.assertEqual(reg2.holes_total, self.reg.holes_total)
+        self.assertEqual(reg2.b3, self.reg.b3)
+        self.assertEqual(reg2.dimensions, self.reg.dimensions)
+        # the relabeled complex is a genuine rebuild
+        self.assertIsNot(reg2.st, self.reg.st)
+
+
+class SkipLogicTest(unittest.TestCase):
+    """requires -> skipped-with-reason, never a crash."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.meta, cls.cells, cls.edges = _fixture()
+        cls.st = build_spacetime(cls.cells, cls.edges)
+        cls.reg = _quiet_register(cls.st, count=3)
+
+    def test_min_holes_skip_reason(self):
+        class NeedsFive(Observable):
+            name = "needs_five"
+            requires = {"min_holes": 5}
+
+            def measure(self, register, provenance=None):
+                return {}
+
+        self.assertEqual(NeedsFive().skip_reason(self.reg),
+                         "holes=3 < min_holes=5")
+
+    def test_needs_provenance_skip_reasons(self):
+        class NeedsBlocks(Observable):
+            name = "needs_blocks"
+            requires = {"needs_provenance": ("blocks",)}
+
+            def measure(self, register, provenance=None):
+                return {}
+
+        obs = NeedsBlocks()
+        self.assertEqual(obs.skip_reason(self.reg, None), "no_provenance")
+        self.assertEqual(obs.skip_reason(self.reg, {"diquark_pair": [0, 1]}),
+                         "provenance_missing:blocks")
+        self.assertIsNone(obs.skip_reason(self.reg, {"blocks": []}))
+
+    def test_needs_causal_content_skips_all_spacelike_specimen(self):
+        class NeedsCausal(Observable):
+            name = "needs_causal"
+            requires = {"needs_causal_content": True}
+
+            def measure(self, register, provenance=None):
+                return {}
+
+        # The fixture is all-spacelike: at initialization no time has passed,
+        # causal structure may only emerge — so this honestly skips.
+        self.assertFalse(self.reg.causal_content)
+        self.assertEqual(NeedsCausal().skip_reason(self.reg),
+                         "no_causal_content")
+
+    def test_dimensions_requirement(self):
+        cells3 = [list(c) for c in itertools.combinations(range(5), 4)]
+        st3 = tessera.Spacetime.fromCells(3, cells3, 1.0, 0.0)
+        reg3 = Register(st3, count=0)
+
+        class Needs4D(Observable):
+            name = "needs_4d"
+            requires = {"dimensions": 4}
+
+            def measure(self, register, provenance=None):
+                return {}
+
+        self.assertEqual(Needs4D().skip_reason(reg3), "dimensions=3 != 4")
+
+    def test_battery_reports_skips_with_reason_per_observable(self):
+        # A sub-3-hole register: the default battery skips the register-only
+        # observables WITH REASONS and still measures the rest.
+        holes_meta = [list(h) for h in self.meta["holes"]]
+        st = build_spacetime(self.cells + holes_meta[2:], self.edges)
+        reg = Register(st, count=2)
+        record = measure_all(reg, provenance=None, gates=False)
+        status = {k: v["status"] for k, v in record["observables"].items()}
+        self.assertEqual(status["pair_loop_flavor"],
+                         "skipped(holes=2 < min_holes=3)")
+        self.assertEqual(status["block_residuals"], "skipped(no_provenance)")
+        self.assertEqual(status["singlet_diagnostic"], "measured")
+        self.assertEqual(status["mass_radius"], "measured")
+        self.assertEqual(record["observables"]["pair_loop_flavor"]["reason"],
+                         "holes=2 < min_holes=3")
+
+
+class ReportDeltaSelfTest(unittest.TestCase):
+    """The gate metric flags perturbed channels — the self-test pattern: a
+    passing gate can never be a comparison that silently skipped a leaf."""
+
+    BASE = {"a": 1.0, "nested": {"xs": [0.5, 0.25], "flag": True},
+            "label": "ok", "maybe": None, "nan": float("nan")}
+
+    def test_identical_records_have_zero_delta(self):
+        self.assertEqual(report_delta(self.BASE, json.loads(
+            json.dumps(self.BASE))), 0.0)
+
+    def test_perturbed_deep_leaf_is_flagged(self):
+        perturbed = json.loads(json.dumps(self.BASE))
+        perturbed["nested"]["xs"][1] += 1e-3
+        self.assertAlmostEqual(report_delta(self.BASE, perturbed), 1e-3,
+                               places=12)
+
+    def test_flipped_bool_is_flagged(self):
+        perturbed = json.loads(json.dumps(self.BASE))
+        perturbed["nested"]["flag"] = False
+        self.assertEqual(report_delta(self.BASE, perturbed), 1.0)
+
+    def test_changed_string_and_none_are_flagged_inf(self):
+        perturbed = json.loads(json.dumps(self.BASE))
+        perturbed["label"] = "changed"
+        self.assertEqual(report_delta(self.BASE, perturbed), float("inf"))
+        perturbed = json.loads(json.dumps(self.BASE))
+        perturbed["maybe"] = 0.0
+        self.assertEqual(report_delta(self.BASE, perturbed), float("inf"))
+
+    def test_shape_mismatches(self):
+        with self.assertRaises(KeyError):
+            report_delta({"a": 1.0}, {"b": 1.0})
+        self.assertEqual(report_delta([1.0, 2.0], [1.0]), float("inf"))
+
+    def test_nan_agrees_with_nan_but_flags_against_a_number(self):
+        self.assertEqual(report_delta(float("nan"), float("nan")), 0.0)
+        # an appeared/vanished reading is a FLAGGED channel, never a silent
+        # NaN poisoning the max
+        self.assertEqual(report_delta(float("nan"), 1.0), float("inf"))
+
+    def test_gate_harness_flags_a_label_sensitive_observable(self):
+        # An observable that (wrongly) reports a labeling-dependent quantity:
+        # the RELABEL gate must flag it.
+        class LabelLeak(Observable):
+            name = "label_leak"
+            gate_tol = 1e-9
+
+            def measure(self, register, provenance=None):
+                return {"vertex_id_sum": float(sum(
+                    v for hole in register.holes for v in hole))}
+
+        meta, cells, edges = _fixture()
+        reg = _quiet_register(build_spacetime(cells, edges), count=3)
+        entry = LabelLeak().gated_measure(reg)
+        self.assertFalse(entry["gates"]["relabel_ok"])
+        self.assertGreater(entry["gates"]["relabel_delta"], 1.0)
+
+    def test_gate_harness_flags_a_gauge_sensitive_observable(self):
+        # An observable that (wrongly) reports the raw target phase: the
+        # GAUGE gate must flag it.
+        class GaugeLeak(Observable):
+            name = "gauge_leak"
+            gate_tol = 1e-9
+
+            def measure(self, register, provenance=None):
+                return split_complex("raw_target0", register.target[0])
+
+        meta, cells, edges = _fixture()
+        reg = _quiet_register(build_spacetime(cells, edges), count=3)
+        entry = GaugeLeak().gated_measure(reg)
+        self.assertFalse(entry["gates"]["gauge_ok"])
+        self.assertGreater(entry["gates"]["gauge_delta"], 0.1)
+
+
+class RecordShapeTest(unittest.TestCase):
+    """Records are JSON-able; complex values travel as explicit re/im pairs."""
+
+    def test_split_complex_scalar_and_sequence(self):
+        self.assertEqual(split_complex("z", 1 + 2j),
+                         {"z_re": 1.0, "z_im": 2.0})
+        pairs = split_complex("w", [1 + 2j, 3 - 4j])
+        self.assertEqual(pairs, {"w_re": [1.0, 3.0], "w_im": [2.0, -4.0]})
+        json.dumps(pairs)
+
+    def test_ensure_jsonable_rejects_raw_complex(self):
+        with self.assertRaises(TypeError):
+            ensure_jsonable({"z": 1 + 2j})
+
+    def test_battery_record_is_json_serializable(self):
+        meta, cells, edges = _fixture()
+        reg = _quiet_register(build_spacetime(cells, edges), count=3)
+        record = measure_all(reg, provenance={"diquark_pair": [0, 2]})
+        text = json.dumps(record)  # includes complex-as-re/im channels
+        self.assertIn("w_re", text)
+        self.assertIn("w_im", text)
+        round_tripped = json.loads(text)
+        self.assertEqual(sorted(round_tripped["observables"]),
+                         ["block_residuals", "mass_radius",
+                          "pair_loop_flavor", "singlet_diagnostic"])
+
+    def test_battery_registry_semantics(self):
+        class One(Observable):
+            name = "one"
+
+            def measure(self, register, provenance=None):
+                return {}
+
+        b = Battery([One()])
+        with self.assertRaises(ValueError):
+            b.register(One())  # duplicate name
+        self.assertEqual([o.name for o in b.observables], ["one"])
+        self.assertEqual([o.name for o in battery.observables],
+                         ["singlet_diagnostic", "block_residuals",
+                          "mass_radius", "pair_loop_flavor"])
+
+
+class GeometryDumpTest(unittest.TestCase):
+    """The faithful record: schema-1 dumps round-trip byte-identically and a
+    tampered rebuild is caught."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.meta, cls.cells, cls.edges = _fixture()
+        cls.st = build_spacetime(cls.cells, cls.edges)
+
+    def test_round_trip_is_byte_identical(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            p1 = os.path.join(tmp, "a.json")
+            p2 = os.path.join(tmp, "b.json")
+            write_geometry_dump(self.st, p1, meta={"base_seed": 7})
+            dump = load_geometry_dump(p1)
+            self.assertEqual(dump["schema"], GEOMETRY_SCHEMA)
+            self.assertEqual(dump["base_seed"], 7)
+            st2 = rebuild_spacetime(dump)
+            self.assertEqual(verify_rebuild(st2, dump), {})
+            write_geometry_dump(st2, p2, meta={"base_seed": 7})
+            with open(p1) as f1, open(p2) as f2:
+                self.assertEqual(f1.read(), f2.read())
+
+    def test_unknown_schema_and_missing_keys_raise(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "bad.json")
+            with open(path, "w") as fh:
+                json.dump({"schema": 99, "cells": []}, fh)
+            with self.assertRaises(ValueError):
+                load_geometry_dump(path)
+            with open(path, "w") as fh:
+                json.dump({"schema": GEOMETRY_SCHEMA, "cells": []}, fh)
+            with self.assertRaises(ValueError):
+                load_geometry_dump(path)
+
+    def test_verify_rebuild_catches_a_tampered_length(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "a.json")
+            write_geometry_dump(self.st, path)
+            dump = load_geometry_dump(path)
+            st2 = rebuild_spacetime(dump)
+            dump_tampered = dict(dump)
+            dump_tampered["edges"] = [list(row) for row in dump["edges"]]
+            dump_tampered["edges"][0][2] += 0.5
+            mismatches = verify_rebuild(st2, dump_tampered)
+            self.assertIn("edge_lengths", mismatches)
+
+    def test_writer_is_byte_identical_to_the_frozen_campaign_writer(self):
+        # tessera.observe.geometry_dump is the IMPORTABLE home of the schema;
+        # the frozen campaign scripts (examples/cobordism/proton_campaign,
+        # sha256-manifested by #579) are its provenance. One schema, no
+        # divergence: both writers must serialize the same state to the same
+        # bytes. (The frozen scripts land in this tree when the stack rebases
+        # onto main >= #579; until then this guard is pending, verified
+        # out-of-band against origin/main's copy.)
+        import importlib.util
+        import tempfile
+        worker_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "examples", "cobordism",
+            "proton_campaign", "worker.py")
+        if not os.path.exists(worker_path):
+            self.skipTest("frozen campaign scripts not in this tree yet "
+                          "(they arrive with the stack's rebase onto "
+                          "main >= #579)")
+        spec = importlib.util.spec_from_file_location("campaign_worker",
+                                                      worker_path)
+        worker = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(worker)
+        self.assertEqual(worker.GEOMETRY_SCHEMA, GEOMETRY_SCHEMA)
+        with tempfile.TemporaryDirectory() as tmp:
+            p_frozen = os.path.join(tmp, "frozen.json")
+            p_ours = os.path.join(tmp, "ours.json")
+            worker.dump_geometry(self.st, p_frozen, {"base_seed": 9})
+            write_geometry_dump(self.st, p_ours, {"base_seed": 9})
+            with open(p_frozen) as f1, open(p_ours) as f2:
+                self.assertEqual(f1.read(), f2.read())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_observe_proton_ingredients.py
+++ b/tests/cobordism/test_observe_proton_ingredients.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The ONE battery construction (#583): observe_proton_ingredients.
+
+Fast: the geometry-dump path on a synthetic b3=3 fixture — the round trip the
+campaign relies on (dump-format record -> Spacetime.fromCells rebuild ->
+Register -> full battery), provenance flowing from dump metadata, the
+sub-3-hole skip reporting, the dump-verification wiring, and the readable
+table.
+
+Slow: ONE bounded real ProtonIngredients end-to-end at smoke budgets (the
+joint arm: it exercises the output-block provenance and the per-block
+residual equivalence against the C++ oracle). Assertions are answer-agnostic
+— hole counts, residual values and convergence are REPORTED observables of
+the experiment, never requirements.
+"""
+import importlib.util
+import json
+import math
+import os
+import sys
+import tempfile
+import unittest
+import warnings
+
+import pytest
+
+import tessera
+from tessera.observe import battery, load_geometry_dump, write_geometry_dump
+from tessera.observe import mass_radius as mass_radius_module
+from tessera.observe.pair_loop_flavor import build_spacetime, load_fixture
+
+cob = tessera.cobordism
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples",
+                   "cobordism")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+observe = _load("observe_proton_ingredients")
+
+
+class GeometryDumpConstructionTest(unittest.TestCase):
+    """The faithful path: schema-1 dump -> rebuild -> Register -> battery."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.meta, cls.cells, cls.edges = load_fixture("synthetic_b3_3.json")
+        cls.st = build_spacetime(cls.cells, cls.edges)
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.dump_path = os.path.join(cls.tmp.name, "seed_42_geometry.json")
+        write_geometry_dump(cls.st, cls.dump_path, meta={
+            "base_seed": 42,
+            "betti": [1, 0, 0, 3, 0],
+            "holes": 4,
+        })
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def test_round_trip_runs_the_full_battery(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            record = observe.observe_geometry_dump(self.dump_path)
+        reg = record["register"]
+        self.assertEqual(reg["holes_used"], 3)
+        self.assertEqual(reg["holes_total"], 4)
+        self.assertEqual(reg["b3"], 3)
+        self.assertTrue(reg["holes_vs_b3_divergent"])
+        status = {k: v["status"] for k, v in record["observables"].items()}
+        self.assertEqual(status["singlet_diagnostic"], "measured")
+        self.assertEqual(status["mass_radius"], "measured")
+        self.assertEqual(status["pair_loop_flavor"], "measured")
+        self.assertEqual(status["block_residuals"], "skipped(no_provenance)")
+        source = record["input"]
+        self.assertEqual(source["mode"], "geometry_dump")
+        self.assertTrue(source["dump_verified"])
+        self.assertEqual(source["base_seed"], 42)
+        self.assertIn("not process-deterministic", source["note"])
+        json.dumps(record)
+
+    def test_provenance_flows_from_dump_metadata(self):
+        path = os.path.join(self.tmp.name, "seed_43_geometry.json")
+        write_geometry_dump(self.st, path, meta={
+            "base_seed": 43,
+            "diquark_pair": [0, 2],
+        })
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            record = observe.observe_geometry_dump(path)
+        self.assertEqual(record["provenance_keys"], ["diquark_pair"])
+        flavor = record["observables"]["pair_loop_flavor"]["record"]
+        self.assertEqual(flavor["odd_is_diquark_loop_status"], "evaluated")
+        self.assertIs(flavor["odd_is_diquark_loop"], True)  # odd loop is (0,2)
+
+    def test_provenance_file_overrides_and_extends_dump_metadata(self):
+        provenance_path = os.path.join(self.tmp.name, "provenance.json")
+        with open(provenance_path, "w") as fh:
+            json.dump({"diquark_pair": [0, 1]}, fh)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            record = observe.observe_geometry_dump(
+                self.dump_path, provenance_path=provenance_path)
+        flavor = record["observables"]["pair_loop_flavor"]["record"]
+        self.assertIs(flavor["odd_is_diquark_loop"], False)
+
+    def test_mismatching_dump_metadata_fails_the_verification(self):
+        path = os.path.join(self.tmp.name, "seed_44_geometry.json")
+        write_geometry_dump(self.st, path, meta={
+            "base_seed": 44,
+            "holes": 12,  # not this specimen's census
+        })
+        with self.assertRaises(RuntimeError) as ctx:
+            observe.observe_geometry_dump(path)
+        self.assertIn("does not match", str(ctx.exception))
+
+    def test_sub_three_hole_dump_reports_skip_reasons(self):
+        # fill two stored holes -> a genuine 2-hole specimen
+        holes_meta = [list(h) for h in self.meta["holes"]]
+        st2 = build_spacetime(self.cells + holes_meta[2:], self.edges)
+        path = os.path.join(self.tmp.name, "seed_45_geometry.json")
+        write_geometry_dump(st2, path, meta={"base_seed": 45})
+        record = observe.observe_geometry_dump(path)
+        self.assertEqual(record["register"]["holes_used"], 2)
+        self.assertEqual(record["register"]["holes_total"], 2)
+        status = {k: v["status"] for k, v in record["observables"].items()}
+        self.assertEqual(status["pair_loop_flavor"],
+                         "skipped(holes=2 < min_holes=3)")
+        self.assertEqual(status["singlet_diagnostic"], "measured")
+        self.assertEqual(status["mass_radius"], "measured")
+
+    def test_render_table_is_readable(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            record = observe.observe_geometry_dump(self.dump_path)
+        table = observe.render_table(record)
+        self.assertIn("observable battery", table)
+        self.assertIn("holes_used=3 of holes_total=4", table)
+        self.assertIn("divergent=True", table)
+        self.assertIn("singlet_diagnostic: measured", table)
+        self.assertIn("skipped(no_provenance)", table)
+        self.assertIn("order-of-magnitude only", table)
+
+    def test_dump_loader_rejects_a_non_dump_record(self):
+        path = os.path.join(self.tmp.name, "not_a_dump.json")
+        with open(path, "w") as fh:
+            json.dump({"base_seed": 1}, fh)
+        with self.assertRaises(ValueError):
+            load_geometry_dump(path)
+
+
+class FreshAttemptContractTest(unittest.TestCase):
+    """The --seed mode is a FRESH SAMPLE, never a reproduction — the #578
+    finding (the engine build is not process-deterministic) is part of the
+    construction's documented contract."""
+
+    def test_docstring_and_helpers_carry_the_non_reproduction_language(self):
+        doc = " ".join(observe.__doc__.split())
+        self.assertIn("NOT process-deterministic", doc)
+        self.assertIn("never a reproduction", doc)
+        self.assertIn("faithful", doc)
+        self.assertIn("from tessera.observe import", doc)  # analyzer surface
+        self.assertIn("NEW SAMPLE",
+                      " ".join(observe.observe_fresh_attempt.__doc__.split()))
+
+    def test_make_register_policy(self):
+        meta, cells, edges = load_fixture("synthetic_b3_3.json")
+        st = build_spacetime(cells, edges)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            reg = observe.make_register(st)
+        self.assertEqual(len(reg.holes), 3)   # 3-hole register when available
+        holes_meta = [list(h) for h in meta["holes"]]
+        st2 = build_spacetime(cells + holes_meta[2:], edges)
+        reg2 = observe.make_register(st2)
+        self.assertEqual(len(reg2.holes), 2)  # otherwise all it has
+
+
+@pytest.mark.slow
+class ProtonIngredientsBatteryEndToEndTest(unittest.TestCase):
+    """ONE bounded real build at smoke budgets (#574's joint arm), measured
+    through the battery. Answer-agnostic: every physical value is a reported
+    observable; the assertions check the RECORD's coherence and the
+    per-block/singlet equivalence against the C++ oracle."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ingredients = cob.ProtonIngredients(seed=1)
+        cls.ingredients.build_joint(max_restarts=1, init_steps=40,
+                                    evolve_steps=20, stage2_max_iters=10)
+        cls.blocks = cls.ingredients.output_blocks()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cls.register = observe.make_register(cls.ingredients.block())
+            cls.provenance = {
+                "blocks": observe.blocks_provenance(cls.blocks)}
+            cls.record = battery.measure_all(cls.register,
+                                             provenance=cls.provenance)
+
+    def test_joint_build_exposes_its_two_output_blocks(self):
+        self.assertEqual(len(self.blocks), 2)
+        for block in self.blocks:
+            self.assertTrue(len(block.vertices) >= 1)
+            self.assertEqual(len(block.target), 3)
+
+    def test_record_is_json_serializable_and_census_coherent(self):
+        text = json.dumps(self.record)
+        self.assertIn("holes_vs_b3_divergent", text)
+        reg = self.record["register"]
+        self.assertEqual(reg["holes_used"], len(self.register.holes))
+        self.assertEqual(reg["b3"], self.register.b3)
+        # the flag IS the comparison, whatever this attempt produced
+        self.assertEqual(reg["holes_vs_b3_divergent"],
+                         reg["holes_total"] != reg["b3"])
+
+    def test_singlet_diagnostic_equals_the_cpp_oracle(self):
+        entry = self.record["observables"]["singlet_diagnostic"]
+        self.assertEqual(entry["status"], "measured")
+        self.assertAlmostEqual(
+            entry["record"]["singlet_residual"],
+            self.ingredients.singlet_residual(), places=12)
+
+    def test_block_residuals_equal_the_cpp_oracle(self):
+        entry = self.record["observables"]["block_residuals"]
+        self.assertEqual(entry["status"], "measured")
+        rows = entry["record"]["blocks"]
+        self.assertEqual([r["label"] for r in rows],
+                         ["baryon", "antibaryon"])
+        oracle = (self.ingredients.baryon_residual(),
+                  self.ingredients.antibaryon_residual())
+        for row, expected in zip(rows, oracle):
+            self.assertTrue(math.isfinite(row["residual"]))
+            self.assertAlmostEqual(
+                row["residual"], expected,
+                delta=1e-12 * max(1.0, abs(expected)),
+                msg=f"{row['label']} residual diverged from the C++ read")
+
+    def test_mass_radius_matches_the_source_reader_on_the_same_block(self):
+        entry = self.record["observables"]["mass_radius"]
+        self.assertEqual(entry["status"], "measured")
+        source = mass_radius_module.measure(self.ingredients.block(),
+                                            self.register.holes)
+        record = entry["record"]
+        self.assertEqual(record["census"]["n_hinges_interior"],
+                         source["census"]["n_hinges_interior"])
+        self.assertEqual(record["mass"]["m_sum"], source["mass"]["m_sum"])
+        self.assertEqual(record["radius"]["r_dual"],
+                         source["radius"]["r_dual"])
+
+    def test_pair_loop_flavor_measures_or_skips_with_reason(self):
+        entry = self.record["observables"]["pair_loop_flavor"]
+        if len(self.register.holes) >= 3:
+            self.assertEqual(entry["status"], "measured")
+            flavor = entry["record"]
+            # no diquark provenance in the joint arm: reported, not guessed
+            self.assertIsNone(flavor["odd_is_diquark_loop"])
+            self.assertEqual(flavor["odd_is_diquark_loop_status"],
+                             "not_evaluable(no_provenance)")
+        else:
+            self.assertEqual(
+                entry["status"],
+                f"skipped(holes={len(self.register.holes)} < min_holes=3)")
+
+    def test_gates_hold_on_the_real_specimen(self):
+        for name, entry in self.record["observables"].items():
+            if entry["status"] != "measured":
+                continue
+            with self.subTest(observable=name):
+                self.assertTrue(entry["gates"]["gauge_ok"], entry["gates"])
+                self.assertTrue(entry["gates"]["relabel_ok"], entry["gates"])
+
+    def test_readable_table_renders(self):
+        table = observe.render_table(self.record)
+        self.assertIn("observable battery", table)
+        for name in ("singlet_diagnostic", "block_residuals", "mass_radius",
+                     "pair_loop_flavor"):
+            self.assertIn(name, table)
+        print("\n" + table)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_pair_loop_flavor.py
+++ b/tests/cobordism/test_pair_loop_flavor.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Pair-loop dual-basis flavor read (#561) — duality bookkeeping, gates, determinism.
+
+Covers `examples/cobordism/pair_loop_flavor.py` on the controlled
+`tests/fixtures/composite_spin` fixtures:
+
+  * the Poincaré-duality bookkeeping — pair-loop index ↔ complementary hole,
+    `w_i + w_j = -w_k` under the pinned singlet, and the label-free
+    closed-form relation `Σ_h σ_h p_h = 0` behind the induced-orientation
+    signs (`ChainComplex.endSignCovector`);
+  * the DK-style charge — positive, and structurally additive over a pair
+    loop's disjoint cycle support;
+  * the GAUGE gate (global U(1) target phase: charges invariant, loop periods
+    covariant) and the RELABEL gate (random vertex-id permutation, rebuild,
+    re-read: everything must match, loop periods up to the one global
+    orientation sign) on a fixture;
+  * determinism — two independent rebuild+read passes agree exactly.
+
+Everything here runs on the smallest fixture (74 top cells; a read is ~0.3 s),
+so no `slow` marks are needed; the full fixture battery lives in the example's
+`__main__`.
+"""
+import cmath
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+import tessera
+
+cob = tessera.cobordism
+
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+
+
+def _load(name):
+    sys.path.insert(0, _EX)
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_EX, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class PairLoopFlavorBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.plf = _load("pair_loop_flavor")
+        cls.meta, cls.cells, cls.edges = cls.plf.load_fixture("synthetic_b3_3.json")
+        cls.st = cls.plf.build_spacetime(cls.cells, cls.edges)
+        cls.holes = cls.plf.register_holes(cls.st)
+        cls.read = cls.plf.joint_read(cls.st, cls.holes)
+
+
+class TestDualityBookkeeping(PairLoopFlavorBase):
+    def test_pair_loop_index_maps_to_complementary_hole(self):
+        # [γ_ij] = -[k]: the loop over (i, j) is dual to the third hole.
+        plf = self.plf
+        self.assertEqual(plf.PAIR_LOOPS, ((0, 1), (0, 2), (1, 2)))
+        self.assertEqual([plf.complement_hole(p) for p in plf.PAIR_LOOPS],
+                         [2, 1, 0])
+        for pair in plf.PAIR_LOOPS:
+            k = plf.complement_hole(pair)
+            self.assertEqual(set(pair) | {k}, {0, 1, 2})
+            self.assertNotIn(k, pair)
+
+    def test_oriented_weights_pin_the_singlet(self):
+        # The joint carried representative's oriented per-hole periods are the
+        # pinned singlet exactly (the leak construction), and the pin carries.
+        for w, t in zip(self.read["w"], self.plf.SINGLET):
+            self.assertLess(abs(w - t), 1e-12)
+        self.assertLess(self.read["r_u"], 1e-20)
+
+    def test_pair_loop_period_is_minus_the_complementary_weight(self):
+        # w_i + w_j = -w_k, loop by loop, and the recorded duality residual.
+        read, plf = self.read, self.plf
+        for loop_idx, pair in enumerate(plf.PAIR_LOOPS):
+            k = plf.complement_hole(pair)
+            self.assertLess(abs(read["loop_w"][loop_idx] + read["w"][k]), 1e-12)
+            self.assertLess(read["dual_residual"][loop_idx], 1e-12)
+
+    def test_induced_signs_give_the_closed_form_relation(self):
+        # The label-free content of endSignCovector: a CLOSED 3-cochain's
+        # signed periods over all of the structure's hole cycles sum to zero
+        # (Σ_h σ_h p_h = 0 — the holes' induced boundaries cancel against the
+        # present top cells' coherent boundary). The symmetric metric operator
+        # is assembled with B₄ = W₃^{1/2} ∂₄ W₄^{-1/2}, so a kernel row ψ̃ of
+        # harmonicMatrix(3) satisfies ∂₄ᵀ(√W₃ ψ̃) = 0: the closed cochain is
+        # χ = √W₃ ψ̃ (ψ̃ itself is not closed, and its raw signed periods do
+        # NOT cancel — the register's period pin is a convention, not Stokes).
+        all_holes = [list(h) for h in cob.MultiCobordism.emergent_holes(self.st, 3)]
+        sigma = self.plf.induced_orientation_signs(self.st, all_holes)
+        es = cob.EigenstateSynthesis(self.st, 3)
+        cell_index = {frozenset(t): i for i, t in enumerate(es.cellSimplices())}
+        hl = cob.HodgeLaplacian(self.st)
+        sqrt_w = np.sqrt(np.asarray(hl.weights(3), float))
+        harmonics = np.asarray(hl.harmonicMatrix(3), complex)
+        harmonics = harmonics.reshape(-1, len(sqrt_w))
+        self.assertGreater(harmonics.shape[0], 0)
+
+        def period(vec, hole):
+            pairs = self.plf._facet_indices(cell_index, hole)
+            return sum(sign * vec[c] for c, sign in pairs)
+
+        for row in harmonics:
+            chi = sqrt_w * row
+            signed_sum = sum(s * period(chi, h)
+                             for s, h in zip(sigma, all_holes))
+            self.assertLess(abs(signed_sum), 1e-12)
+
+    def test_charges_positive_and_additive_over_the_pair_support(self):
+        # q_h > 0 (a weighted norm²), and the pair-loop charge over the
+        # disjoint union of the two boundary cycles is exactly q_i + q_j.
+        read, plf = self.read, self.plf
+        for q in read["q"]:
+            self.assertGreater(q, 0.0)
+        for loop_idx, (i, j) in enumerate(plf.PAIR_LOOPS):
+            self.assertAlmostEqual(read["loop_q"][loop_idx],
+                                   read["q"][i] + read["q"][j], places=15)
+
+
+class TestCriteria(PairLoopFlavorBase):
+    def test_odd_one_out_on_a_clean_triple(self):
+        odd, rho = self.plf.odd_one_out([1.0, 1.01, 2.0])
+        self.assertEqual(odd, 2)
+        self.assertLess(rho, 0.02)
+
+    def test_evaluate_criteria_verdict_shape(self):
+        verdict = self.plf.evaluate_criteria(self.read)
+        self.assertIn(verdict["odd_loop"], self.plf.PAIR_LOOPS)
+        self.assertEqual(verdict["dual_hole"],
+                         self.plf.complement_hole(verdict["odd_loop"]))
+        self.assertIsInstance(verdict["multiplicity_2_1"], bool)
+        # fixtures carry no build history: criterion (b) must stay undecided
+        self.assertIsNone(verdict["odd_is_diquark_loop"])
+
+    def test_criterion_b_decides_with_build_history(self):
+        # With a supplied step-1 diquark pair the criterion becomes decidable:
+        # True iff the charge-odd loop is exactly that pair.
+        odd_pair = self.plf.evaluate_criteria(self.read)["odd_loop"]
+        other = next(p for p in self.plf.PAIR_LOOPS if p != odd_pair)
+        hit = self.plf.evaluate_criteria(self.read, diquark_pair=odd_pair)
+        miss = self.plf.evaluate_criteria(self.read, diquark_pair=other)
+        self.assertTrue(hit["odd_is_diquark_loop"])
+        self.assertFalse(miss["odd_is_diquark_loop"])
+
+
+class TestGates(PairLoopFlavorBase):
+    def _assert_gate(self, residuals):
+        for key, value in residuals.items():
+            tol = (self.plf.RHO_GATE_TOL if key == "d_rho"
+                   else self.plf.GATE_TOL)
+            self.assertLess(value, tol, f"{key} = {value:.3e} exceeds {tol:.0e}")
+
+    def test_gauge_gate(self):
+        self._assert_gate(self.plf.gauge_gate(self.st, self.holes, self.read))
+
+    def test_gauge_gate_covers_the_cyclic_recolor(self):
+        # A cyclic recolor of the singlet assignment IS a global U(1) phase:
+        # shifting [1, ω, ω²] by one slot equals ω² · [1, ω, ω²], so the
+        # charges must be blind to which hole carries which color.
+        t = list(self.plf.SINGLET)
+        shifted = [t[2], t[0], t[1]]
+        expected = [t[i] * (self.plf.OMEGA ** 2) for i in range(3)]
+        for a, b in zip(shifted, expected):
+            self.assertLess(abs(a - b), 1e-15)
+        recolored = self.plf.joint_read(self.st, self.holes, shifted)
+        for a, b in zip(recolored["q"], self.read["q"]):
+            self.assertLess(abs(a - b), self.plf.GATE_TOL)
+
+    def test_relabel_gate_two_permutations(self):
+        for seed in (3, 11):
+            with self.subTest(seed=seed):
+                self._assert_gate(self.plf.relabel_gate(
+                    self.cells, self.edges, self.holes, self.read, seed=seed))
+
+    def test_determinism(self):
+        st2 = self.plf.build_spacetime(self.cells, self.edges)
+        again = self.plf.joint_read(st2, self.plf.register_holes(st2))
+        self.assertEqual(again["sigma"], self.read["sigma"])
+        for key in ("w", "q", "loop_w", "loop_q", "dual_residual"):
+            for a, b in zip(again[key], self.read[key]):
+                self.assertLess(abs(a - b), 1e-15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_proton_ingredients_python.py
+++ b/tests/cobordism/test_proton_ingredients_python.py
@@ -13,6 +13,12 @@ terms scale linearly with the input weight; the canonical node carries a
 weight-independent whole-read singlet term on top), and (3) that the slow build reports a
 coherent, answer-agnostic summary — deliberately asserting nothing about the singlet or
 the hole count, which are observables of the experiment, not requirements.
+
+The JOINT arm (#560) is locked in the same way: `joint_node` collapses the two-step
+event graph into one co-optimized node — the Z₃-orbit neutral triple in, a baryon ⊔
+antibaryon block pair out (the multi-output `r_u` branch, so `r_u` is NOT linear in the
+input weight) — and the bounded slow smoke checks `build_joint` reports the same
+answer-agnostic summary plus the per-output-block residuals.
 """
 import math
 import unittest
@@ -90,6 +96,64 @@ class ProtonIngredientsNodesTest(unittest.TestCase):
         self.assertLess(r_at_weight_2, 2.0 * r_at_weight_1 - 0.1)
 
 
+class ProtonIngredientsJointNodeTest(unittest.TestCase):
+    """The joint node factory (#560): the two-step event graph collapsed into ONE
+    co-optimized node — Z₃-orbit neutral triple in, baryon ⊔ antibaryon blocks out."""
+
+    def test_joint_node_has_three_inputs_and_two_localized_outputs(self):
+        # Inputs at v0,v1,v2 and outputs at v3,v4 of the single Δ⁴ seed: 3 input blocks
+        # and 2 localized output blocks (the multi-output r_u branch, exactly the shape
+        # the 2->2 recombination exercises).
+        node = cob.ProtonIngredients(seed=5).joint_node(5)
+        self.assertEqual(len(node.inputs), 3)
+        self.assertEqual(len(node.outputs), 2)
+
+    def test_joint_node_inputs_are_the_z3_orbit(self):
+        # The #398 symmetric-input lesson: the three pairs are ONE Z₃ orbit — {1,-1,0}
+        # and its two cyclic rotations — not an ad-hoc triple. Each is neutral (Σ = 0).
+        node = cob.ProtonIngredients(seed=5).joint_node(5)
+        orbit = [[1, -1, 0], [0, 1, -1], [-1, 0, 1]]
+        for block, expected in zip(node.inputs, orbit):
+            self.assertEqual([complex(c) for c in block.target],
+                             [complex(c) for c in expected])
+            self.assertAlmostEqual(abs(sum(block.target)), 0.0, places=12)
+
+    def test_joint_node_output_targets_are_conjugates(self):
+        # Baryon [1,w,w^2] at v3, antibaryon = its component-wise conjugate at v4.
+        node = cob.ProtonIngredients(seed=5).joint_node(5)
+        baryon, antibaryon = node.outputs[0].target, node.outputs[1].target
+        self.assertEqual(len(baryon), 3)
+        singlet = cob.Proton.singlet()
+        for got, expected in zip(baryon, singlet):
+            self.assertAlmostEqual(abs(got - expected), 0.0, places=12)
+        for got, expected in zip(antibaryon, baryon):
+            self.assertAlmostEqual(abs(got - expected.conjugate()), 0.0, places=12)
+
+    def test_conjugate_targets_score_identically_as_multisets(self):
+        # The documented subtlety: [1,conj(w),conj(w)^2] is a component-PERMUTATION of
+        # [1,w,w^2] and the block residual is relabeling-invariant, so the two targets
+        # score identically against any one complex — the conjugation is carried by the
+        # block's location in the emergent complex, never by the residual's value.
+        host = cob.ProtonIngredients().formation_node(1).st
+        baryon = cob.Proton.singlet()
+        antibaryon = [c.conjugate() for c in baryon]
+        self.assertAlmostEqual(cob.MultiCobordism.r_state(host, 3, baryon),
+                               cob.MultiCobordism.r_state(host, 3, antibaryon),
+                               places=12)
+
+    def test_joint_r_u_includes_the_output_block_terms(self):
+        # The joint node pins outputs as LOCALIZED BLOCKS, so r_u = weight * (input
+        # terms) + (output-block terms): strictly sublinear in the input weight —
+        # unlike the two-step's step B, whose r_u is purely the weighted input terms.
+        node = cob.ProtonIngredients(seed=5).joint_node(6)
+        node.set_input_residual_weight(1.0)
+        r_at_weight_1 = node.r_u(node.st)
+        node.set_input_residual_weight(2.0)
+        r_at_weight_2 = node.r_u(node.st)
+        self.assertGreater(r_at_weight_1, 0.0)
+        self.assertLess(r_at_weight_2, 2.0 * r_at_weight_1 - 0.1)
+
+
 @pytest.mark.slow
 class ProtonIngredientsBuildTest(unittest.TestCase):
     """Slow: one real emergent-arm attempt. The assertions are deliberately
@@ -129,6 +193,57 @@ class ProtonIngredientsBuildTest(unittest.TestCase):
         self.assertEqual(len(block.getTopSimplices()), len(whole.getTopSimplices()))
         self.assertEqual(len(block.getEdgeList().toVector()),
                          len(whole.getEdgeList().toVector()))
+
+
+@pytest.mark.slow
+class ProtonIngredientsJointBuildTest(unittest.TestCase):
+    """Slow: ONE bounded joint-arm attempt (#560) at smoke budgets. As with the
+    two-step, the assertions are answer-agnostic — hole count, singlet diagnostic, and
+    the per-output-block residuals are REPORTED observables, never requirements."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ingredients = cob.ProtonIngredients(seed=1)
+        cls.ingredients.build_joint(max_restarts=1, init_steps=40, evolve_steps=20,
+                                    stage2_max_iters=10)
+
+    def test_summary_is_coherent(self):
+        # converged ⟺ stationary AND persistent — never a statement about the singlet.
+        converged = self.ingredients.converged()
+        stationary = self.ingredients.stationary()
+        persistent = self.ingredients.persistent()
+        self.assertIsInstance(converged, bool)
+        self.assertEqual(converged, stationary and persistent)
+
+    def test_observables_are_read_and_finite(self):
+        self.assertTrue(math.isfinite(self.ingredients.singlet_residual()))
+        self.assertTrue(math.isfinite(self.ingredients.input_residual()))
+        self.assertTrue(math.isfinite(self.ingredients.final_objective()))
+        self.assertIsInstance(self.ingredients.emergent_holes(), list)
+
+    def test_per_output_block_residuals_are_read(self):
+        # The joint arm's extra observables: one residual per output block, finite and
+        # non-negative (each is a least-squares residual against the block's own
+        # sub-complex — or the full leak while nothing carries the block).
+        baryon_r = self.ingredients.baryon_residual()
+        antibaryon_r = self.ingredients.antibaryon_residual()
+        self.assertTrue(math.isfinite(baryon_r))
+        self.assertTrue(math.isfinite(antibaryon_r))
+        self.assertGreaterEqual(baryon_r, 0.0)
+        self.assertGreaterEqual(antibaryon_r, 0.0)
+
+    def test_diquark_residual_is_nan_without_a_step_a(self):
+        # The joint arm collapses the diquark intermediate away — its observable is
+        # explicitly not-a-number, never a stale zero pretending step A converged.
+        self.assertTrue(math.isnan(self.ingredients.diquark_residual()))
+
+    def test_whole_complex_exists_and_block_is_the_whole(self):
+        whole = self.ingredients.spacetime()
+        self.assertIsNotNone(whole)
+        self.assertTrue(whole.getEdgeList().toVector(),
+                        "emergent complex has no edges")
+        block = self.ingredients.block()
+        self.assertEqual(len(block.getTopSimplices()), len(whole.getTopSimplices()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements #583: the emergent-proton readouts become first-class **Observables** — a `tessera/observe/` package (a real importable package; the examples-importlib hack is gone for this machinery) with the blessed `Register` read context, a thin gated `Observable` base, three adapters migrating the #574/#575/#576 readout surfaces **by composition**, and ONE Python construction that runs the full battery against a `ProtonIngredients` specimen. Part of #559.

**DRAFT because it is stacked on the three unmerged PRs #574, #575, #576** (their branches are octopus-merged here; this PR's effective diff shrinks to the observable layer as they merge). It flips ready when they merge.

## What shipped, per scope item

1. **`tessera/observe/`** — `Register` (skeleton C++-side only via the `ReggeSolver` ctor; `register_holes(st, count)` validation at ONE entry point — deficit raises, surplus warns NAMING the dropped holes; `holes_used`/`holes_total`/`b3` recorded with the `holes_vs_b3_divergent` flag; ε from `ChainComplex.endSignCovector`; one cached `EigenstateSynthesis`; lazy `getDualAdjacency` adjacency + a `derived()` memo for shared per-complex structures; `gauged()`/`relabeled()` gate transforms). `Observable` (declarative `requires` → `skipped(reason)`, JSON-able records with complex channels as explicit `_re`/`_im` pairs — the #580 discipline; `gated_measure` = GAUGE/RELABEL over EVERY numeric leaf via `report_delta`, adapted from PR #577's pattern, with the perturbed-channel self-test). `Battery`/`measure_all` → one flat record; `battery` is the default analyzer-facing instance.
2. **Adapters** (values EQUAL the sources' on the same fixtures — equivalence tests + the published #576 table re-measured as a non-circular anchor):
   - `SingletDiagnostic` — `MultiCobordism.r_state(st, k, Proton.singlet())` + hole/Betti census with the divergence flag.
   - `BlockResiduals` — provenance blocks re-scored exactly as `ProtonIngredients::outputBlockResidual` (uniform-metric `fromCells` sub-complex + `r_state`; full leak `‖target‖²` on an empty region); equivalence vs `baryon_residual()`/`antibaryon_residual()` proven on the real @slow build.
   - `MassRadius` — composes the moved #575 reader (`tessera.observe.mass_radius`).
   - `PairLoopFlavor` — composes the moved #576 reader; criterion (b) evaluated ONLY when provenance supplies `diquark_pair`, else `not_evaluable(no_provenance)`. Oriented periods reported in the propagation-root-fixed convention (divided by w₀'s unit phase) so every record leaf is gauge/relabel-invariant.
3. **The construction** `examples/cobordism/observe_proton_ingredients.py`:
   - `--geometry dump.json` — **the faithful path** (mid-flight #578/#579 correction): schema-1 campaign geometry dump → `fromCells` rebuild → verified vs the dump → `Register` → battery. `tessera.observe.geometry_dump` is the IMPORTABLE home of the schema; its writer is **byte-identical to the frozen campaign writer** on the same state (guarded by test — skip-guarded until the frozen `proton_campaign/` scripts arrive with the stack's rebase onto main ≥ #579, verified out-of-band against `origin/main`'s copy today).
   - `--seed N [--joint]` — a **fresh bounded attempt**, documented and recorded as a NEW SAMPLE, never a reproduction (the engine build is not process-deterministic). The joint arm auto-feeds the kept `output_blocks()` into the battery as block provenance.
   - ≥ 3 register holes → full battery; below → per-observable skip reasons. One JSON record (stdout or `--out`) + a readable table. Docstring documents the `from tessera.observe import battery` analyzer surface.
4. **Tests** — 60 fast (framework 31, adapters 20, construction 9) + 8 @slow (1 new end-to-end + the inherited suites kept green; see the test plan).

## The one small hook in a brought-in file (justified)

`ProtonIngredients::outputBlocks()` (+ member + binding): the kept joint attempt's output boundary blocks — the after-the-fact **provenance** behind `baryonResidual()`/`antibaryonResidual()`, so the battery's `BlockResiduals` can re-score the blocks exactly and the construction can supply block provenance without re-deriving anything. Empty after the two-step `build()` (never a stale pair). `MultiCobordism` untouched; no reader refactored.

## Moved-shared-helper (no second copy)

The reader cores of the two example scripts MOVED into the package (`tessera/observe/pair_loop_flavor.py`, `tessera/observe/mass_radius.py`); the examples became thin shims importing them back (assertIs-guarded in the tests). `examples/cobordism/pair_loop_flavor.py`'s `register_holes` now delegates to the validated entry point, so it warns on surplus (the #577 semantics the ticket requires) — values unchanged, inherited tests green.

## The battery record (synthetic b₃=3 fixture, `--geometry` path, diquark provenance from dump metadata)

```
=== observable battery ===
input: geometry_dump [geometry/seed_42_geometry.json]
register: holes_used=3 of holes_total=4, b3=3, divergent=True, degree=3, cells=74, causal_content=False
  dropped holes: [[1, 4, 5, 6, 12]]
-- singlet_diagnostic: measured   [gauge 0.0e+00, relabel 6.7e-31]
     singlet r_state=1.89e-31  betti=[1, 0, 0, 3, 0]  holes=4  b3=3  divergent=True
-- block_residuals: skipped(provenance_missing:blocks)
-- mass_radius: measured   [gauge 0.0e+00, relabel 2.8e-14]
     m_shell=3.773  m_sum=254.1  m_action=24.07  r_dual=0.8827  r_primal=1.181
     PR=0.571  mean Re eps=+1.549  r*m spread 3.33..300 (anchor ~4.0; order-of-magnitude only)
-- pair_loop_flavor: measured   [gauge 8.2e-16, relabel 6.3e-14]
     loop_q=[0.06054, 0.05971, 0.06063]  odd=[0, 2] (dual hole 1)  rho=0.103  2:1=True  r_u=2e-27
     odd_is_diquark_loop=True (evaluated)
```

(The synthetic_b3_3 fixture is itself a holes-vs-b₃-divergent specimen — 4 emergent holes, b₃=3; filling one stored hole produces the campaign's holes=3/b₃=2 case, which the tests pin. The pair-loop row equals PR #576's published table to the printed digits.)

<details><summary>Full JSON record</summary>

```json
{
 "register": {
  "degree": 3,
  "dimensions": 4,
  "n_top_cells": 74,
  "holes_used": 3,
  "holes_total": 4,
  "dropped_holes": [
   [
    1,
    4,
    5,
    6,
    12
   ]
  ],
  "b3": 3,
  "betti": [
   1,
   0,
   0,
   3,
   0
  ],
  "holes_vs_b3_divergent": true,
  "causal_content": false
 },
 "provenance_keys": [
  "diquark_pair"
 ],
 "observables": {
  "singlet_diagnostic": {
   "status": "measured",
   "record": {
    "singlet_residual": 1.8874113454994911e-31,
    "holes_used": 3,
    "holes_total": 4,
    "b3": 3,
    "betti": [
     1,
     0,
     0,
     3,
     0
    ],
    "holes_vs_b3_divergent": true,
    "target_re": [
     1.0,
     -0.4999999999999998,
     -0.5000000000000003
    ],
    "target_im": [
     0.0,
     0.8660254037844387,
     -0.8660254037844384
    ]
   },
   "gates": {
    "gauge_delta": 0.0,
    "relabel_delta": 6.686828766912483e-31,
    "gauge_ok": true,
    "relabel_ok": true,
    "gate_tol": 1e-09
   }
  },
  "block_residuals": {
   "status": "skipped(provenance_missing:blocks)",
   "reason": "provenance_missing:blocks"
  },
  "mass_radius": {
   "status": "measured",
   "record": {
    "census": {
     "n_tops": 74,
     "n_tets": 195,
     "n_hinges_total": 200,
     "n_hinges_interior": 164,
     "n_hinges_boundary": 36,
     "n_boundary_tets": 20,
     "n_hole_vertices": 8
    },
    "mass": {
     "m_shell": 3.7730789734335914,
     "m_sum": 254.102031196773,
     "m_action": 24.06670599922648,
     "shell_means": {
      "0": 1.5365999637751406,
      "1": 2.2364790096584506
     },
     "max_abs_im": 0.0,
     "n_im_nonzero": 0
    },
    "radius": {
     "Vdual": 0.6071250804215924,
     "Vprimal": 1.9484067394045557,
     "n_interior_vertices": 15,
     "r_dual": 0.8827130424237054,
     "r_primal": 1.1814624027008098
    },
    "localization": {
     "PR": 0.5705112886930511,
     "concentration": 1.7528136950468376,
     "mean_re": 1.5494026292486158,
     "std_re": 1.3305614501657803,
     "std_over_mean": 0.8587577076792733,
     "shell_profile": {
      "0": {
       "n": 161,
       "mean_re": 1.5365999637751406,
       "weight_share": 0.9822670080858806
      },
      "1": {
       "n": 3,
       "mean_re": 2.2364790096584506,
       "weight_share": 0.017732991914119256
      }
     },
     "rms_shell_radius": 0.1331652804379552,
     "frac_within_shell1": 1.0
    },
    "rm": {
     "spread_min": 3.3305460199444767,
     "spread_max": 300.21199630889555,
     "combos": {
      "r_dual x m_shell": 3.3305460199444767,
      "r_primal x m_shell": 4.457750949532756,
      "r_dual x m_sum": 224.2991770437468,
      "r_primal x m_sum": 300.21199630889555,
      "r_dual x m_action": 21.243995273694047,
      "r_primal x m_action": 28.43390829494011
     },
     "physical": 3.9995939086294414
    },
    "n_holes": 3
   },
   "gates": {
    "gauge_delta": 0.0,
    "relabel_delta": 2.842170943040401e-14,
    "gauge_ok": true,
    "relabel_ok": true,
    "gate_tol": 1e-06
   }
  },
  "pair_loop_flavor": {
   "status": "measured",
   "record": {
    "r_u": 2.0129477694088412e-27,
    "q": [
     0.0298121883979804,
     0.03073188676971647,
     0.02990226224557105
    ],
    "loop_q": [
     0.060544075167696866,
     0.05971445064355145,
     0.06063414901528751
    ],
    "dual_residual": [
     2.482534153247273e-16,
     2.482534153247273e-16,
     2.482534153247273e-16
    ],
    "pair_loops": [
     [
      0,
      1
     ],
     [
      0,
      2
     ],
     [
      1,
      2
     ]
    ],
    "odd_loop": [
     0,
     2
    ],
    "dual_hole": 1,
    "rho": 0.10298138531509772,
    "rho_max": 0.5,
    "multiplicity_2_1": true,
    "odd_is_diquark_loop": true,
    "odd_is_diquark_loop_status": "evaluated",
    "w_re": [
     1.0,
     -0.49999999999999967,
     -0.5000000000000002
    ],
    "w_im": [
     0.0,
     0.8660254037844387,
     -0.8660254037844385
    ],
    "loop_w_re": [
     0.5000000000000003,
     0.4999999999999998,
     -0.9999999999999999
    ],
    "loop_w_im": [
     0.8660254037844387,
     -0.8660254037844385,
     2.220446049250313e-16
    ]
   },
   "gates": {
    "gauge_delta": 8.187894806610529e-16,
    "relabel_delta": 6.265821195228227e-14,
    "gauge_ok": true,
    "relabel_ok": true,
    "gate_tol": 1e-09
   }
  }
 },
 "input": {
  "mode": "geometry_dump",
  "path": "geometry/seed_42_geometry.json",
  "schema": 1,
  "dump_verified": true,
  "base_seed": 42,
  "note": "the dump is the attempt's faithful record; the engine build is not process-deterministic, so only the dump \u2014 never a re-run \u2014 reproduces this state"
 }
}
```
</details>

## Mid-flight main movement (recorded, not merged here)

- **#579 merged** (campaign hardening): its dump helpers live in the frozen, sha256-manifested `examples/cobordism/proton_campaign/` scripts — not an importable surface, and the analyzer direction of import is `analyzer → tessera.observe` by #583's design. This PR ships the importable home; byte-equality with the frozen writer is guarded by test (out-of-band verified against `origin/main` today, in-tree once the stack rebases).
- **#586 merged**: main's `ProtonIngredients::jointNode` is now the **inputs-only** joint arm (empty `outputTargets`), while the unmerged #574 in this stack has the outputs-pinned variant with `buildJoint`. Reconciling the two joint arms is #574's rebase, not the observable layer's: `BlockResiduals` is provenance-driven (blocks from ANY source — campaign record, dump metadata, or `output_blocks()`), so it survives either resolution; only the construction's one auto-provenance line and the @slow test's oracle comparison touch the #574 surface.

## Test plan

- [x] Framework: requires/skip logic, gate self-test (perturbed channels flagged), record shape, Register validation (deficit raises; surplus warns naming the dropped hole on the 4-hole fixture) — 31 tests
- [x] Migration equivalence: each adapter reproduces its source example's values on the composite_spin fixtures (+ the published #576 table anchor) — 20 tests
- [x] Three-register construction on a synthetic b₃=3 fixture: full battery record + readable table; below-threshold specimens report per-observable skip reasons; geometry-dump round trip — 9 tests
- [x] Bounded @slow end-to-end on a real ProtonIngredients build at smoke budgets (joint arm, seed 1, max_restarts=1/init 40/evolve 20/stage2 10 — 8/8 green; this attempt stalled at 0 holes (30 cells), so the record honestly shows the skip branch (pair_loop_flavor skipped(holes=0 < min_holes=3)) while singlet/blocks/mass-radius measured with gates 0 .. 2.3e-13, and the per-block residuals equal baryon_residual()/antibaryon_residual() exactly. The FIRST sweep of this class surfaced a real bug — a genuine joint build's block region carried Pachner-orphaned vertex ids and the relabel gate KeyError'd — fixed (inert ids kept as themselves, region size preserved) with a fast regression. Inherited slow suites all green: ProtonIngredientsBuildTest 3/3, ProtonIngredientsJointBuildTest 5/5, ProtonMassRadiusValidationTest 4/4)
- [x] Full fast cobordism suite green at the final head: 454 passed, 2 skipped (`pytest tests/cobordism -m "not slow" -n 2`; the 2 skips are one pre-existing skip and the skip-guarded frozen-writer byte-equality test that activates post-rebase)
- [x] CI green on head 0370a09 (build.yml full suite, via workflow_dispatch on the branch). NOTE: pull_request CI cannot run on this PR right now — #586 made the stack unmergeable (`mergeable_state: dirty`), so GitHub cannot create the PR merge ref; that resolves with #574's rebase, not here.

Closes #583.
