### PR TITLE
feat(cobordism): joint three-pair arm — the proton from just the initial q-q̄ pairs

### DIFF
--- a/examples/cobordism/emergent_proton.py
+++ b/examples/cobordism/emergent_proton.py
@@ -1,43 +1,52 @@
 # Copyright (c) 2026 Twin Vector Labs LLC.
 # All rights reserved.
-"""Real-time animation of the **ProtonIngredients** build — the emergent arm (#555).
+"""Real-time animation of the **ProtonIngredients** build — the emergent arm (#555, #585).
 
-`Proton.cpp` is the canonical line in the sand; `ProtonIngredients` runs the SAME two-step
-drive except that **the final state is never pinned** — step B's output-target list is
-empty, so the objective is `F = ‖∇S‖² + Γ·Σᵢ r_U(inputᵢ)` and whatever the whole cobordism
-comes to carry is *read* afterwards, never driven:
+`Proton.cpp` is the canonical line in the sand; the emergent arm prepares **only the
+initial state** and reads everything else off the relaxed whole. The default drive is the
+**joint three-pair node** (`ProtonIngredients.joint_node`): ONE `MultiCobordism` whose
+inputs are the three Z₃-symmetric neutral q-q̄ pairs `{1,−1,0} ⊔ {0,1,−1} ⊔ {−1,0,1}`
+(each Σ = 0 — the only prepared content, fixed for the whole build) and whose
+output-target list is EMPTY, so the objective is `F = ‖∇S‖² + Γ·Σᵢ r_U(inputᵢ)` and the
+proton — the pre-registered expectation is a baryon with a conjugate partner — must
+emerge from just those pairs. No diquark, no bare quark, no intermediate is imposed.
+
+`--two-step` drives the reference oracle instead (kept for A-vs-B comparison):
 
   * **Step A — recombination** (`ProtonIngredients.recombination_node`, the composed
     canonical `Proton`'s node verbatim): two neutral q-q̄ pairs ⟶ a colored diquark
     `{1, ω}` ⊔ anti-diquark `{1, ω²}`;
-  * **Step B — formation, nothing pinned** (`ProtonIngredients.formation_node`): the same
-    ideal diquark `{1, ω}` + third quark `{ω²}` inputs on the same single-Δ⁴ seed as the
-    canonical `Proton.formation_node` — but with NO output target. The final state emerges.
+  * **Step B — formation, nothing pinned** (`ProtonIngredients.formation_node`): the
+    ideal diquark `{1, ω}` + third quark `{ω²}` inputs on a fresh single-Δ⁴ seed — the
+    imposed intermediate is exactly why this is an oracle and not the arm.
 
-The charts are **identical to `multicobordism_animation.py`'s** — the same 2×4 grid
-(metrics `F`/`‖∇S‖²`/`r_U`; color-register count + Betti `b_k`; primal complex panels for
-Step A/B; dual spatial/temporal curvature panels) — because the drawing code is reused
-verbatim (`ProtonAnimator` is subclassed; only the drive labels and the verdict wording
-change). So the emergent arm can be compared panel-for-panel against the canonical build.
+The charts are **identical to `multicobordism_animation.py`'s** — the same
+[traces | primal | dual-spatial (Re ε) | dual-temporal (Im ε)] row per node (the grid is
+node-count-generic: one row for the joint drive, two for the oracle) — because the
+drawing code is reused verbatim (`ProtonAnimator` is subclassed; only the drive labels
+and the verdict wording change).
 
-The **verdict is observational, never a gate**: the title reports whether step B ended
-STATIONARY (its `run_stage2` stopped on the stationarity test rather than the budget) and
-what emerged — the register (hole) count, `b_k`, and the **singlet diagnostic**
-`r_state({1, ω, ω²})`, read after the fact purely for comparison with the canonical
-build's carried level (≈ 0 there). There is no color tolerance and no minimum hole count.
-The fast batched path additionally runs `ProtonIngredients.build()`'s persistence check
+The **verdict is observational, never a gate**: the title reports whether the driven node
+ended STATIONARY (its `run_stage2` stopped on the stationarity test rather than the
+budget) and what emerged — the register (hole) count, `b_k`, and the **diagnostics**
+`r_state({1, ω, ω²})` and its conjugate `r_state({1, ω̄, ω̄²})` (the expected partner
+sector), read after the fact purely for comparison with the canonical build's carried
+level (≈ 0 there). There is no color tolerance and no minimum hole count. The fast
+batched path additionally runs `ProtonIngredients.build()`'s persistence check
 (continued evolve+relax passes must leave holes, `b_k`, and `F` stable).
 
 Visualization is **off by default** — the default run takes the fast batched path and
 prints the observable summary. Opt in with `--live`/`--save` to animate.
 
-    # default: run the emergent-arm two-step build fast, print what emerged
+    # default: the joint three-pair build, fast; print what emerged
     python emergent_proton.py
     # live (interactive backend):
     python emergent_proton.py --live
     # headless: write a GIF (no display needed):
     python emergent_proton.py --save emergent_proton.gif
-    # pre-grow each node's single-Δ⁴ seed by 12 gated cone-ins before optimizing:
+    # the two-step reference oracle instead of the joint node:
+    python emergent_proton.py --two-step
+    # pre-grow the single-Δ⁴ seed by 12 gated cone-ins before optimizing:
     python emergent_proton.py --precone 12
 """
 import argparse
@@ -59,11 +68,23 @@ _PERSIST_PASSES = 3
 _PERSIST_REL_TOL = 0.05
 
 
+def build_joint_node(seed=3, precone=0):
+    """The joint inputs-only node — the campaign arm: ONE `MultiCobordism` whose inputs
+    are the three Z₃-symmetric neutral q-q̄ pairs `{1,−1,0} ⊔ {0,1,−1} ⊔ {−1,0,1}` (each
+    Σ = 0, the only prepared content, fixed for the whole build) and whose output-target
+    list is EMPTY. No diquark, no bare quark, no intermediate imposed — whatever the
+    relaxed whole carries is read afterwards."""
+    ingredients = cob.ProtonIngredients(seed=seed, precone=precone)
+    return [(ingredients.joint_node(seed),
+             "Joint — 3 neutral q-q̄ pairs (nothing else prepared)")]
+
+
 def build_ingredients_nodes(seed=3, precone=0):
-    """The two `MultiCobordism` nodes the `ProtonIngredients` class drives, in build
-    order: Step A recombination (the canonical node, targets intact) then Step B
-    formation with NOTHING pinned (empty output-target list), each on its own single-Δ⁴
-    seed, with `ProtonIngredients.build`'s attempt-0 seeds (A = `seed`, B = `seed + 1`)."""
+    """The two-step reference-oracle nodes, in build order: Step A recombination (the
+    canonical node, targets intact) then Step B formation with NOTHING pinned (empty
+    output-target list), each on its own single-Δ⁴ seed, with `ProtonIngredients.build`'s
+    attempt-0 seeds (A = `seed`, B = `seed + 1`). Kept for A-vs-B comparison against the
+    joint drive — the ideal-diquark intermediate makes it an oracle, not the arm."""
     ingredients = cob.ProtonIngredients(seed=seed, precone=precone)
     return [
         (ingredients.recombination_node(seed),
@@ -73,43 +94,40 @@ def build_ingredients_nodes(seed=3, precone=0):
     ]
 
 
+def _conjugate_singlet():
+    """The antibaryon diagnostic target `{1, ω̄, ω̄²}` — the conjugate of
+    `Proton.singlet()`, read (never driven) because the pre-registered expectation of
+    the joint drive is a baryon WITH a conjugate partner."""
+    return [complex(z).conjugate() for z in cob.Proton.singlet()]
+
+
 class EmergentProtonAnimator(mca.ProtonAnimator):
-    """The canonical animator with ONLY the verdict semantics changed: the panels, the
-    schedule, and the drive are inherited verbatim, so the charts match
-    `multicobordism_animation.py` panel-for-panel. The verdict reports what EMERGED —
+    """The canonical animator with ONLY the verdict semantics changed, via the
+    announce/paint text hooks — so `--save` AND the responsive `--live` driver both
+    report the emergent-arm wording. The panels, the schedule, and the drive are
+    inherited verbatim (node-count-generic, so the joint single-node drive and the
+    two-step oracle share the machinery). The verdict reports what EMERGED —
     stationarity plus the observable summary — instead of gating on the singlet."""
 
+    _TITLE_PREFIX = "ProtonIngredients build (final state unpinned)"
+
     def verdict(self):
-        """(stationary, singlet_diagnostic, holes) read off step B's current whole
-        cobordism. `singlet_diagnostic` is `r_state({1, ω, ω²})` — reported ONLY for
-        comparison with the canonical build's carried level, never as a pass/fail."""
+        """(stationary, singlet_diagnostic, holes) read off the last node's current
+        whole cobordism. `singlet_diagnostic` is `r_state({1, ω, ω²})` — reported ONLY
+        for comparison with the canonical build's carried level, never as a pass/fail."""
         node = self.nodes[-1][0]
         st = node.st
         res = float(cob.MultiCobordism.r_state(st, self.k, cob.Proton.singlet()))
         holes = len(cob.MultiCobordism.emergent_holes(st, self.k))
         return bool(node.last_stage2_stationary), res, holes
 
-    def update(self, frame):
-        node_index, phase, _count = self._schedule[frame]
-        label = f"{self.nodes[node_index][1]} · {self._PHASE_NAMES[phase]}"
-        if not self._done:
-            self.fig.suptitle("ProtonIngredients build (two-step, final state unpinned) "
-                              f"— frame {frame + 1}/{self._frames} · {label}")
-            print(f"\rframe {frame + 1}/{self._frames} ({label})", end="", flush=True)
-        self._advance(frame)
-        self._redraw()
-        if frame >= self._frames - 1 and not self._done:   # last frame: report what emerged
-            self._done = True
-            stationary, res, holes = self.verdict()
-            st = self.nodes[-1][0].st
-            b_k = int(cob.MultiCobordism.betti(st)[self.k])
-            tag = (f"{'stationary ✓' if stationary else 'hit budget (not stationary)'} — "
-                   f"{holes} register{'s' if holes != 1 else ''} emerged, b{self.k}={b_k}, "
-                   f"singlet diagnostic r_state={res:.2g}")
-            self.fig.suptitle(
-                f"ProtonIngredients build (two-step, final state unpinned) — {tag}")
-            print(f"\rframe {frame + 1}/{self._frames} ({label}) — {tag}")
-        return []
+    def _verdict_tag(self, stationary, res, holes):
+        st = self.nodes[-1][0].st
+        b_k = int(cob.MultiCobordism.betti(st)[self.k])
+        conj = float(cob.MultiCobordism.r_state(st, self.k, _conjugate_singlet()))
+        return (f"{'stationary ✓' if stationary else 'hit budget (not stationary)'} — "
+                f"{holes} register{'s' if holes != 1 else ''} emerged, b{self.k}={b_k}, "
+                f"diagnostics r_state(singlet)={res:.2g} / r_state(conjugate)={conj:.2g}")
 
 
 def _persistence_check(node, evolve_steps, stage1_candidates, stage1_patience,
@@ -172,6 +190,7 @@ def run_build(nodes, visualize=False, save=None, degree=3,
                                                 stage2_iters, degree)
         st = step_b.st
         res = float(cob.MultiCobordism.r_state(st, degree, cob.Proton.singlet()))
+        conj = float(cob.MultiCobordism.r_state(st, degree, _conjugate_singlet()))
         holes = len(cob.MultiCobordism.emergent_holes(st, degree))
         stationary = bool(step_b.last_stage2_stationary)
         out.append(("what emerged", {
@@ -180,7 +199,8 @@ def run_build(nodes, visualize=False, save=None, degree=3,
             "persistence_passes": passes,
             "registers": holes,
             "b3": int(cob.MultiCobordism.betti(st)[degree]),
-            "singlet_diagnostic": res}))
+            "singlet_diagnostic": res,
+            "conjugate_diagnostic": conj}))
         return out
     import matplotlib
     if save:
@@ -193,15 +213,15 @@ def run_build(nodes, visualize=False, save=None, degree=3,
                                   stage1_candidates=stage1_candidates,
                                   stage1_patience=stage1_patience, stage2_beta=stage2_beta)
     anim._setup(plt)
-    anim.fig.suptitle("ProtonIngredients build (two-step, final state unpinned) — live")
-    fa = FuncAnimation(anim.fig, anim.update, frames=anim._frames, interval=interval,
-                       repeat=False, blit=False)
-    if save:
+    anim.fig.suptitle(f"{anim._TITLE_PREFIX} — live")
+    if save:                                  # off-screen Agg: synchronous per-frame render
+        fa = FuncAnimation(anim.fig, anim.update, frames=anim._frames, interval=interval,
+                           repeat=False, blit=False)
         fa.save(save, writer="pillow" if save.endswith(".gif") else "ffmpeg", dpi=90)
         print(f"saved animation -> {save}")
-    else:
-        plt.show()
-    anim._anim = fa  # keep a ref so it isn't GC'd in live mode
+        anim._anim = fa  # keep a ref so it isn't GC'd
+    else:                                     # responsive live window (compute off GUI thread)
+        anim._run_live(plt, interval)
     return anim.hist
 
 
@@ -220,12 +240,19 @@ def main():
     ap.add_argument("--precone", type=int, default=0,
                     help="pre-grow each node's single-Δ⁴ seed by this many gated "
                          "cone-in moves before optimization (0 = bare seed)")
+    ap.add_argument("--two-step", action="store_true", dest="two_step",
+                    help="drive the two-step reference oracle (Step A recombination + "
+                         "Step B formation) instead of the joint three-pair node")
     args = ap.parse_args()
-    nodes = build_ingredients_nodes(seed=args.seed, precone=args.precone)
+    if args.two_step:
+        nodes = build_ingredients_nodes(seed=args.seed, precone=args.precone)
+    else:
+        nodes = build_joint_node(seed=args.seed, precone=args.precone)
     result = run_build(nodes, visualize=args.live, save=args.save, init_steps=args.init,
                        evolve_steps=args.evolve, stage2_iters=args.stage2)
     if not args.live and not args.save:
-        print("emergent-arm two-step build finished (final state unpinned; "
+        arm = "two-step reference-oracle" if args.two_step else "joint three-pair"
+        print(f"emergent-arm {arm} build finished (final state unpinned; "
               "pass --live or --save to watch it):")
         for label, metrics in result:
             print(f"  {label}:  " + "  ".join(f"{k}={v}" for k, v in metrics.items()))

--- a/examples/cobordism/multicobordism_animation.py
+++ b/examples/cobordism/multicobordism_animation.py
@@ -327,19 +327,30 @@ class ProtonAnimator:
     def _setup(self, plt):
         from matplotlib.cm import ScalarMappable
         from matplotlib.colors import Normalize
-        # One step per row: [traces | primal complex | spatial-curvature dual | temporal-
+        # One node per row: [traces | primal complex | spatial-curvature dual | temporal-
         # curvature dual]. The two dual panels split the COMPLEX Lorentzian deficit: the
         # spatial one shows its real part (Re ε, the rotation angle-defect, from timelike
         # hinges), the temporal one its imaginary part (Im ε, the boost/light-cone content,
-        # from spacelike hinges — those whose normal plane is timelike).
-        self.fig, axes = plt.subplots(2, 4, figsize=(21, 9))
-        self.axm, self.axA, self.axDA, self.axTA = axes[0]   # metrics,  A primal, A Re, A Im
-        self.axr, self.axB, self.axDB, self.axTB = axes[1]   # register, B primal, B Re, B Im
+        # from spacelike hinges — those whose normal plane is timelike). The grid is
+        # node-count-generic (the joint single-node drive gets one panel row; the two-step
+        # keeps its two) with the metrics/register traces always on rows 0/1 of column 0.
+        n_nodes = len(self.nodes)
+        n_rows = max(2, n_nodes)
+        self.fig, axes = plt.subplots(n_rows, 4, figsize=(21, 4.5 * n_rows),
+                                      squeeze=False)
+        self.axm = axes[0][0]                                # metrics trace
+        self.axr = axes[1][0]                                # register trace
+        for row in range(2, n_rows):
+            axes[row][0].axis("off")
+        self._primal_axes = [axes[i][1] for i in range(n_nodes)]
+        self._re_axes = [axes[i][2] for i in range(n_nodes)]
+        self._im_axes = [axes[i][3] for i in range(n_nodes)]
+        for row in range(n_nodes, n_rows):                   # single node: blank row 1 panels
+            for column in (1, 2, 3):
+                axes[row][column].axis("off")
         # Persistent colorbars (created ONCE — recreating per frame piles them up). Each dual
         # panel self-normalizes per frame; we just update the mappable's clim. Re (spatial) and
         # Im (temporal) use distinct diverging colormaps so the two channels read apart.
-        self._re_axes = [self.axDA, self.axDB]
-        self._im_axes = [self.axTA, self.axTB]
         self._re_sms, self._im_sms = [], []
         for axset, sms, cmap, label in (
                 (self._re_axes, self._re_sms, _HEAT_CMAP, "spatial curvature  Re ε·|★|"),
@@ -517,14 +528,13 @@ class ProtonAnimator:
         self.axr.set_xlabel("frame")
         self.axr.legend(loc="upper left", fontsize=8)
 
-        # One step per row: primal complex, then its dual split into spatial-curvature (Re ε)
-        # and temporal-curvature (Im ε) panels. The active node animates; the other holds its
-        # current complex — both steps on screen at one time. Each node's layout is computed
+        # One node per row: primal complex, then its dual split into spatial-curvature (Re ε)
+        # and temporal-curvature (Im ε) panels. The active node animates; any other holds its
+        # current complex — every node on screen at one time. Each node's layout is computed
         # once and shared by its primal + both dual panels.
-        primal_axes = [self.axA, self.axB]
-        for ni in (0, 1):
+        for ni in range(len(self.nodes)):
             coords = self._layouts[ni].coords(self.nodes[ni][0].st)
-            self._draw_complex(primal_axes[ni], ni, coords, self.nodes[ni][1])
+            self._draw_complex(self._primal_axes[ni], ni, coords, self.nodes[ni][1])
             self._draw_dual(self._re_axes[ni], self._re_sms[ni], ni, coords,
                             0, _HEAT_CMAP, "dual — spatial curvature (Re ε)")
             self._draw_dual(self._im_axes[ni], self._im_sms[ni], ni, coords,

--- a/examples/cobordism/proton_campaign/analyze_attempt.py
+++ b/examples/cobordism/proton_campaign/analyze_attempt.py
@@ -43,7 +43,7 @@ cob = tessera.cobordism
 # Wall-time/host fields (elapsed_s, rss_mb) and artifact paths are excluded.
 REPLAY_KEYS = ("converged", "stationary", "persistent", "stage2_iters_total",
                "holes", "max_holes", "max_b3", "betti", "singlet", "input_ru",
-               "F", "cells", "edges", "re_min", "re_max", "im_max", "diquark_ru")
+               "singlet_conj", "F", "cells", "edges", "re_min", "re_max", "im_max")
 
 
 def find_verdict(run_dir, seed):
@@ -73,12 +73,11 @@ def replay(seed):
     attempt distribution, not a reconstruction (the build is not process-
     deterministic). Returns (result_record, final_formation_spacetime, state)."""
     ingredients = cob.ProtonIngredients(seed=seed)
-    nodes = [(ingredients.recombination_node(seed), worker.STEP_A_LABEL),
-             (ingredients.formation_node(seed + 1), worker.STEP_B_LABEL)]
+    nodes = [(ingredients.joint_node(seed), worker.JOINT_LABEL)]
     state = worker.AttemptState()
     result = worker.run_attempt_on_nodes(seed, lambda record: None, None, state,
                                          nodes)
-    return result, nodes[1][0].st, state
+    return result, nodes[-1][0].st, state
 
 
 def rebuild_from_dump(dump):

--- a/examples/cobordism/proton_campaign/cutover_joint_arm.sh
+++ b/examples/cobordism/proton_campaign/cutover_joint_arm.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Campaign cutover to the joint three-pair arm (#585): stop the running generation,
+# preserve its data, rebuild the campaign worktree's engine at the generation
+# boundary, and relaunch 16 workers on the joint drive with the SAME deadline.
+#
+# DELIBERATELY MANUAL: step 1 kills in-flight attempts (hours of compute each) —
+# run this only on an explicit go. Everything it does is idempotent/resumable.
+#
+# Usage, from the campaign worktree (e.g. ~/feat-proton-ingredients):
+#   bash examples/cobordism/proton_campaign/cutover_joint_arm.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+RUN=.overnight
+UNIT=tessera-campaign-562.service
+
+echo "== 1/6: stop the running generation (kills in-flight attempts)"
+systemctl --user stop "$UNIT" 2>/dev/null || echo "   ($UNIT not running)"
+
+echo "== 2/6: archive the old arm's data (nothing deleted)"
+STAMP=$(date +%Y%m%d-%H%M%S)
+mkdir -p "$RUN/arm-two-step-$STAMP"
+mv "$RUN"/worker_*.jsonl "$RUN"/worker_*.progress.jsonl "$RUN"/worker_*.log \
+   "$RUN/arm-two-step-$STAMP/" 2>/dev/null || true
+cp -p "$RUN/supervisor.log" "$RUN/arm-two-step-$STAMP/" 2>/dev/null || true
+echo "   archived to $RUN/arm-two-step-$STAMP (animations/ and geometry/ stay shared)"
+
+echo "== 3/6: update the worktree to the joint-arm code (detached on main)"
+# The campaign branch was squash-merged, so it cannot fast-forward; the campaign
+# runs main directly from here on. Untracked .overnight/ data is untouched.
+git fetch origin main
+git checkout --detach origin/main
+
+echo "== 4/6: rebuild the engine (generation boundary — sanctioned)"
+OMP_NUM_THREADS=8 CMAKE_BUILD_PARALLEL_LEVEL=8 \
+  .venv-build/bin/python -m pip install -e ".[dev]" >/dev/null
+.venv-build/bin/python -c "import tessera; n = tessera.cobordism.ProtonIngredients(seed=1).joint_node(1); assert len(n.inputs) == 3 and len(n.outputs) == 0" \
+  && echo "   engine OK: joint_node = 3 fixed pair inputs, nothing pinned"
+
+echo "== 5/6: install the joint-arm campaign scripts"
+cp -p examples/cobordism/proton_campaign/{worker.py,renderer.py,launch_campaign.sh,analyze_attempt.py,aggregate.py} "$RUN/"
+
+echo "== 6/6: relaunch the supervisor (same persisted deadline)"
+systemd-run --user --unit "$UNIT" \
+  /usr/bin/bash -c "bash $PWD/$RUN/launch_campaign.sh >> $PWD/$RUN/supervisor.log 2>&1"
+sleep 8
+systemctl --user is-active "$UNIT" && pgrep -cf "worker.py --worker" | xargs echo "   workers up:"
+echo "done — the joint three-pair arm is live"

--- a/examples/cobordism/proton_campaign/renderer.py
+++ b/examples/cobordism/proton_campaign/renderer.py
@@ -1,8 +1,9 @@
 # Throwaway sweep renderer (#555): record an attempt as an animation in the style of
-# the animation scripts. Reuses emergent_proton.EmergentProtonAnimator's 2x4 panels
-# verbatim (metrics F/‖∇S‖²/r_U; register+Betti; primal A/B; dual spatial/temporal
-# curvature) — but frames are driven EXTERNALLY at the worker's real pass/chunk
-# boundaries, so the animation shows the exact recorded attempt, not a re-run.
+# the animation scripts. Reuses emergent_proton.EmergentProtonAnimator's panels
+# verbatim (metrics F/‖∇S‖²/r_U; register+Betti; one primal + dual spatial/temporal
+# curvature row per node — node-count-generic, so the joint single-node drive and the
+# two-step oracle both render) — but frames are driven EXTERNALLY at the worker's real
+# pass/chunk boundaries, so the animation shows the exact recorded attempt, not a re-run.
 import os
 import sys
 
@@ -11,7 +12,9 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 
-sys.path.insert(0, "/home/andrew/feat-proton-ingredients/examples/cobordism")
+# emergent_proton lives one directory up (examples/cobordism); resolve relative to this
+# file so the canonical copy and a campaign-worktree copy both import their own tree's.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
 import emergent_proton as ep  # noqa: E402  (brings multicobordism_animation with it)
 
 

--- a/examples/cobordism/proton_campaign/worker.py
+++ b/examples/cobordism/proton_campaign/worker.py
@@ -1,9 +1,12 @@
-# Throwaway sweep worker (#555): one emergent-arm attempt per base seed, driven
-# stage-by-stage (mirroring ProtonIngredients.build with max_restarts=1) so the
-# unbounded stage-2 descent streams a progress line every chunk, and — for the
-# interesting attempts — records an animation in the style of the animation scripts
-# (renderer.py reuses emergent_proton's panels; frames land at the real pass/chunk
-# boundaries, so the GIF shows the exact recorded attempt).
+# Throwaway sweep worker (#555, #585): one emergent-arm attempt per base seed on the
+# JOINT three-pair node — inputs are the three Z3-symmetric neutral q-q̄ pairs (the
+# only prepared content, fixed for the whole build), output-target list empty, so the
+# proton must emerge from just the initial pairs. Driven stage-by-stage (init → evolve
+# → stage-2 to genuine stationarity → persistence) so the unbounded stage-2 descent
+# streams a progress line every chunk, and — for the interesting attempts — records an
+# animation in the style of the animation scripts (renderer.py reuses emergent_proton's
+# panels; frames land at the real pass/chunk boundaries, so the GIF shows the exact
+# recorded attempt).
 #
 # Machine-precision semantics: stage 2 is chunked, and a chunk that stops early on
 # runStage2's built-in relTol=1e-9 stationarity test IS the stationarity verdict.
@@ -47,8 +50,13 @@ PROGRESS_BYTE_CAP = 50 * 1024 * 1024        # per worker
 GIF_BYTE_CAP = 5 * 1024 * 1024 * 1024       # global, across all workers
 GEOMETRY_SCHEMA = 1                         # bump on any dump-format change
 
-STEP_A_LABEL = "Step A — recombination (→ diquark {1, ω})"
-STEP_B_LABEL = "Step B — formation (nothing pinned — final state emerges)"
+JOINT_LABEL = "Joint — 3 neutral q-q̄ pairs (nothing else prepared)"
+
+
+def conjugate_singlet():
+    """The antibaryon diagnostic target {1, ω̄, ω̄²} — read, never driven (the
+    pre-registered expectation is a baryon WITH a conjugate partner)."""
+    return [complex(z).conjugate() for z in cob.Proton.singlet()]
 
 
 def snapshot(node):
@@ -123,10 +131,11 @@ class AttemptState:
 
 
 def run_attempt_on_nodes(base, progress, recorder, state, nodes):
-    """The attempt physics on already-built nodes: init → evolve → stage-2 to genuine
-    stationarity per node, then the persistence loop on step B. Identical drive with
-    and without a recorder — frames are taken between engine calls, never instead."""
-    step_a, step_b = nodes[0][0], nodes[1][0]
+    """The attempt physics on the already-built joint node: init → evolve → stage-2 to
+    genuine stationarity, then the persistence loop — all on the ONE node whose fixed
+    three-pair inputs are the only prepared content. Identical drive with and without a
+    recorder — frames are taken between engine calls, never instead."""
+    joint = nodes[0][0]
 
     def frame(node_index, phase, subtitle=""):
         if recorder:
@@ -172,34 +181,31 @@ def run_attempt_on_nodes(base, progress, recorder, state, nodes):
 
     progress({"base_seed": base, "phase": "attempt_start"})
     frame(0, "seed")
-    frame(1, "seed")
-    run_node(step_a, 0, "A")
-    diquark_ru = float(step_a.r_u(step_a.st))
-    stage2_iters = run_node(step_b, 1, "B")
+    stage2_iters = run_node(joint, 0, "J")
 
     persistent = False
     for persist_pass in range(1, PERSIST_PASSES + 1):
-        before = snapshot(step_b)
-        step_b.run_stage1(max_steps=EVOLVE_STEPS, n_candidate_moves=CANDIDATES,
-                          patience=PATIENCE, grow_boundaries=False)
-        stage2_iters += stage2_to_stationarity(step_b, 1, "B")
-        after = snapshot(step_b)
+        before = snapshot(joint)
+        joint.run_stage1(max_steps=EVOLVE_STEPS, n_candidate_moves=CANDIDATES,
+                         patience=PATIENCE, grow_boundaries=False)
+        stage2_iters += stage2_to_stationarity(joint, 0, "J")
+        after = snapshot(joint)
         state.see(after)
         stable_f = abs(after["F"] - before["F"]) <= PERSIST_REL_TOL * max(
             abs(before["F"]), 1.0)
         persistent = (after["holes"] == before["holes"]
                       and after["b3"] == before["b3"] and stable_f)
-        progress(dict(base_seed=base, node="B", phase="persistence",
+        progress(dict(base_seed=base, node="J", phase="persistence",
                       persist_pass=persist_pass, persistent=persistent,
                       dF=before["F"] - after["F"], **after))
-        frame(1, "persistence", f" · pass {persist_pass}")
+        frame(0, "persistence", f" · pass {persist_pass}")
         if persistent:
             break
 
-    stationary = bool(step_b.last_stage2_stationary)
-    st = step_b.st
+    stationary = bool(joint.last_stage2_stationary)
+    st = joint.st
     squared = [e.getSquaredLength() for e in st.getEdgeList().toVector()]
-    final = snapshot(step_b)
+    final = snapshot(joint)
     return {
         "converged": stationary and persistent,
         "stationary": stationary,
@@ -211,6 +217,9 @@ def run_attempt_on_nodes(base, progress, recorder, state, nodes):
         "betti": list(cob.MultiCobordism.betti(st)),
         "singlet": float(cob.MultiCobordism.r_state(st, REGISTER_DEGREE,
                                                     cob.Proton.singlet())),
+        # the expected partner sector, read (never driven) beside the singlet
+        "singlet_conj": float(cob.MultiCobordism.r_state(st, REGISTER_DEGREE,
+                                                         conjugate_singlet())),
         "input_ru": final["rU"],
         "F": final["F"],
         "cells": final["cells"],
@@ -218,7 +227,6 @@ def run_attempt_on_nodes(base, progress, recorder, state, nodes):
         "re_min": min(l.real for l in squared),
         "re_max": max(l.real for l in squared),
         "im_max": max(abs(l.imag) for l in squared),
-        "diquark_ru": diquark_ru,
     }
 
 
@@ -226,8 +234,7 @@ def run_one(base, progress, args, frame_dir, gif_dir, geom_dir):
     """Build the attempt's nodes, run it (recorded when --animate), apply the
     keep-policy (GIF + geometry dump), return the result record fields."""
     ingredients = cob.ProtonIngredients(seed=base)
-    nodes = [(ingredients.recombination_node(base), STEP_A_LABEL),
-             (ingredients.formation_node(base + 1), STEP_B_LABEL)]
+    nodes = [(ingredients.joint_node(base), JOINT_LABEL)]
     state = AttemptState()
     recorder = None
     if args.animate:
@@ -254,12 +261,12 @@ def run_one(base, progress, args, frame_dir, gif_dir, geom_dir):
     # EVERY attempt gets a geometry dump — the only faithful record (the build is
     # not process-deterministic; the seed labels the attempt, it can't reproduce it).
     try:
-        st = nodes[1][0].st
+        st = nodes[-1][0].st
         meta = {"base_seed": base, "max_b3": state.max_b3,
                 "max_holes": state.max_holes}
         meta.update({k: result[k] for k in
                      ("converged", "stationary", "persistent", "holes",
-                      "betti", "singlet", "F")})
+                      "betti", "singlet", "singlet_conj", "F")})
         meta["hole_cells"] = [list(h) for h in
                               cob.MultiCobordism.emergent_holes(
                                   st, REGISTER_DEGREE)]

--- a/include/cobordism/ProtonIngredients.h
+++ b/include/cobordism/ProtonIngredients.h
@@ -82,6 +82,18 @@ class ProtonIngredients {
   /// third quark `{ω²}` inputs as `Proton::formationNode`, but `outputTargets = {}` —
   /// the final state emerges and is read off the whole afterwards.
   [[nodiscard]] std::shared_ptr<MultiCobordism> formationNode(std::uint64_t seed) const;
+  /// The joint inputs-only node (the design note's Rungs 1+2 collapsed to the
+  /// inputs-only shape): ONE MultiCobordism whose inputs are the three Z₃-symmetric
+  /// neutral q-q̄ pairs `{1,−1,0} ⊔ {0,1,−1} ⊔ {−1,0,1}` (each Σ = 0 — the only
+  /// prepared content, held representable through their `r_U` terms for the whole
+  /// build) and whose `outputTargets = {}`. No diquark, no bare quark, no
+  /// intermediate is ever imposed: the objective is `‖∇S‖² + Γ·Σᵢ w·r_U(inputᵢ)` and
+  /// whatever the whole cobordism comes to carry — the pre-registered expectation is
+  /// a baryon with a conjugate partner — is READ afterwards (singlet and
+  /// conjugate-singlet residuals as diagnostics, never drives). Inputs seeded at
+  /// v0/v1/v2 of the single Δ⁴ seed; the two-step nodes above remain the reference
+  /// oracle. NOT run (the caller drives it).
+  [[nodiscard]] std::shared_ptr<MultiCobordism> jointNode(std::uint64_t seed) const;
 
   /// True iff the kept attempt was stationary AND persistent (never a statement about
   /// the singlet or the hole count). Triggers `build()`.

--- a/src/cobordism/Bindings.cpp
+++ b/src/cobordism/Bindings.cpp
@@ -997,6 +997,15 @@ a diagnostic for comparing against the canonical build's carried level.)doc")
            "Step B with nothing pinned: the same ideal diquark {1,w} + third quark "
            "{w*w} inputs on the same single Delta^4 seed as Proton.formation_node, "
            "but with an EMPTY output-target list — the final state emerges.")
+      .def("joint_node", &ProtonIngredients::jointNode, py::arg("seed"),
+           "The joint inputs-only node: ONE MultiCobordism whose inputs are the three "
+           "Z3-symmetric neutral q-qbar pairs {1,-1,0} | {0,1,-1} | {-1,0,1} (each "
+           "Sigma = 0 — the only prepared content, fixed for the whole build) and "
+           "whose output-target list is EMPTY. No diquark, no bare quark, no "
+           "intermediate imposed; the pre-registered expectation (a baryon with a "
+           "conjugate partner) is READ off the relaxed whole afterwards — singlet and "
+           "conjugate-singlet residuals as diagnostics, never drives. The two-step "
+           "nodes remain the reference oracle. NOT run (the caller drives it).")
       .def("converged", &ProtonIngredients::converged,
            "True iff the kept attempt was stationary AND persistent — never a "
            "statement about the singlet or the hole count.")

--- a/src/cobordism/ProtonIngredients.cpp
+++ b/src/cobordism/ProtonIngredients.cpp
@@ -93,6 +93,33 @@ std::shared_ptr<MultiCobordism> ProtonIngredients::formationNode(
   return node;
 }
 
+std::shared_ptr<MultiCobordism> ProtonIngredients::jointNode(
+    std::uint64_t seed) const {
+  // The joint inputs-only node (semantics: jointNode in ProtonIngredients.h — the
+  // authoritative statement). Inputs are the three Z₃-symmetric neutral pairs, the
+  // ONLY prepared content; outputs = {}. No diquark, no bare quark, no intermediate
+  // imposed anywhere — the pre-registered expectation (a baryon with a conjugate
+  // partner) is read off the relaxed whole afterwards, never driven.
+  const std::vector<std::vector<complexd>> pairs = {
+      {complexd(1.0, 0.0), complexd(-1.0, 0.0), complexd(0.0, 0.0)},
+      {complexd(0.0, 0.0), complexd(1.0, 0.0), complexd(-1.0, 0.0)},
+      {complexd(-1.0, 0.0), complexd(0.0, 0.0), complexd(1.0, 0.0)}};
+  auto host = buildMinimalSeed();
+  // Capture the seed vertex IDS before constructing the node (see
+  // Proton::recombinationNode): precone_ > 0 regrows the complex in the ctor, but the
+  // seed ids persist.
+  std::vector<std::uint64_t> seedVertexIds;
+  for (const auto *vertex : host->getVertexList()->toVector())
+    seedVertexIds.push_back(vertex->getId());
+  auto node = std::make_shared<MultiCobordism>(
+      host, pairs,
+      std::vector<std::vector<complexd>>{},  // nothing pinned — the final state emerges
+      std::vector<int>{registerDegree_}, gamma_, seed, precone_);
+  node->setInputResidualWeight(inputResidualWeight_);
+  node->seedInputs({seedVertexIds[0], seedVertexIds[1], seedVertexIds[2]});
+  return node;
+}
+
 void ProtonIngredients::build(int maxRestarts, int initSteps, int evolveSteps,
                               int stage1CandidateMoves, int stage1Patience,
                               double stage2Beta, int stage2MaxIters,

--- a/tests/cobordism/test_proton_ingredients_python.py
+++ b/tests/cobordism/test_proton_ingredients_python.py
@@ -77,6 +77,25 @@ class ProtonIngredientsNodesTest(unittest.TestCase):
         r_at_weight_2 = ingredients_node.r_u(ingredients_node.st)
         self.assertAlmostEqual(r_at_weight_2, 2.0 * r_at_weight_1, places=9)
 
+    def test_joint_node_is_three_fixed_pairs_and_nothing_else(self):
+        # The joint inputs-only node (#585): THREE input blocks — the Z₃-symmetric
+        # neutral pairs, the only prepared content — and ZERO output blocks. Its r_u
+        # is purely the weighted input terms (linear in the input weight), and a short
+        # drive runs on it (the register degree, betti, and holes are readable).
+        node = cob.ProtonIngredients(seed=5).joint_node(5)
+        self.assertEqual(len(node.inputs), 3)
+        self.assertEqual(len(node.outputs), 0)
+        node.set_input_residual_weight(1.0)
+        r_at_weight_1 = node.r_u(node.st)
+        node.set_input_residual_weight(2.0)
+        r_at_weight_2 = node.r_u(node.st)
+        self.assertAlmostEqual(r_at_weight_2, 2.0 * r_at_weight_1, places=9)
+        node.run_stage1(max_steps=10, n_candidate_moves=4, patience=5,
+                        grow_boundaries=True)
+        betti = cob.MultiCobordism.betti(node.st)
+        self.assertTrue(len(betti) > 3)
+        self.assertTrue(math.isfinite(node.objective()))
+
     def test_canonical_formation_node_still_carries_the_singlet_term(self):
         # ...while the CANONICAL formation node has the weight-independent whole-read
         # singlet term on top, so its r_u is strictly sublinear in the input weight.


### PR DESCRIPTION
## Summary
Implements #585 (stacked on #579 — retarget lands automatically when that merges): the emergent arm now prepares **only the initial state**, per `fully_emergent_proton_design.tex` Rungs 1+2.

- **Engine**: `ProtonIngredients::jointNode(seed)` — one `MultiCobordism`, inputs = the Z₃-symmetric neutral pairs `{1,−1,0} ⊔ {0,1,−1} ⊔ {−1,0,1}` (each Σ=0, seeded at v0/v1/v2 of the single Δ⁴ seed, fixed for the whole build), `outputTargets = {}`. No diquark, no bare quark, no intermediate imposed. Two-step nodes kept as the reference oracle.
- **Worker**: single-node joint drive (init → evolve → stage-2 to stationarity → persistence); verdicts read the singlet **and** conjugate-singlet diagnostics (the pre-registered expectation is a baryon with a conjugate partner); `diquark_ru` retired; per-attempt geometry dumps inherited from #579.
- **Animation**: `emergent_proton.py` drives the joint node by default (`--two-step` = oracle), ported to the announce/paint hook API so `--live` uses the responsive driver (this file still had its own copy of the pre-#558 GUI-freeze bug); the chart grid is node-count-generic (one row per node — two-node layout pixel-identical); campaign renderer's hardcoded worktree path made relative.
- **Cutover**: `cutover_joint_arm.sh` stages the campaign switch (stop generation → archive data → detach worktree onto main → rebuild at the generation boundary → relaunch, same deadline). Deliberately manual — it kills in-flight attempts, so it runs only on an explicit go.

## Test plan
- [x] Rebuild; `test_proton_ingredients_python.py` fast lane: **6 passed** (incl. the new joint-node shape test: 3 input blocks, 0 outputs, r_U linear in input weight, short drive runs).
- [x] Joint smoke: init pass grows the complex across seeds (10–47 cells), all three pair inputs carried to r_U ~1e-30, singlet + conjugate diagnostics read.
- [x] Per-attempt dump on the joint state rebuilds via `fromCells` and verifies.
- [x] Single-node chart row renders through the campaign renderer; two-node oracle grid unchanged (2 panel rows).
- [ ] Campaign cutover (post-merge, on explicit go): run `cutover_joint_arm.sh` in the campaign worktree.

Closes #585.