### PR TITLE
refactor(observables): proton readout battery as C++ Observables — supersede the tessera/observe Python framework

### DIFF
--- a/docs/source/cpp_api.md
+++ b/docs/source/cpp_api.md
@@ -132,6 +132,31 @@ exclusions to see the entire interface.
 ```{doxygenfile} SparseGraph.h
 ```
 
+### Emergent-proton readout battery (#593)
+
+```{doxygenfile} Record.h
+```
+```{doxygenfile} RegisterContext.h
+```
+```{doxygenfile} LiveComplex.h
+```
+```{doxygenfile} InteriorHinges.h
+```
+```{doxygenfile} RegisterObservable.h
+```
+```{doxygenfile} SingletResidual.h
+```
+```{doxygenfile} BlockResiduals.h
+```
+```{doxygenfile} EmergentMass.h
+```
+```{doxygenfile} EmergentRadius.h
+```
+```{doxygenfile} PairLoopFlavor.h
+```
+```{doxygenfile} ObservableGates.h
+```
+
 ## Cobordism
 
 ```{doxygenfile} ChainComplex.h

--- a/examples/cobordism/observe_proton_ingredients.py
+++ b/examples/cobordism/observe_proton_ingredients.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Observe an emergent proton — the battery driver (#593, part of #559).
+
+The battery is C++ (``tessera.observables``): pure-reader Observables over a
+``RegisterContext``, with C++ GAUGE/RELABEL gates. This driver is the ONE thin,
+classless Python surface — it constructs no framework classes; every measurement
+is a bound C++ read.
+
+Two input modes:
+
+* ``--geometry <dump>`` — a schema-1 geometry dump (the attempt's ONLY faithful
+  record: the engine build is NOT process-deterministic, so a base seed labels
+  an attempt, it never reproduces it). The dump JSON is rehydrated into a LIVE
+  complex by the ``LiveComplex`` loader (``fromCells`` + the recorded metric +
+  ``materializeFacets`` — outside the reader), then read. This is the faithful
+  path.
+
+* ``--seed N [--joint]`` — a FRESH ``ProtonIngredients`` attempt, LABELED as
+  such and never a reproduction (the #578 finding). The built complex is read
+  exactly like a rehydrated one — the observable never distinguishes them.
+
+A register with >= 3 emergent holes runs the full battery (singlet, blocks,
+mass, radius, pair-loop) with GAUGE/RELABEL gates; a sub-3-hole specimen reports
+per-observable skip reasons. The output is a JSON-able record plus a readable
+table.
+"""
+import argparse
+import json
+import sys
+
+import tessera
+
+_obs = tessera.observables
+_cob = tessera.cobordism
+
+#: The dump format this driver reads (schema-1: the #562 campaign worker's).
+GEOMETRY_SCHEMA = 1
+#: Provenance block labels for the joint arm's two output blocks, in order.
+JOINT_BLOCK_LABELS = ("baryon", "antibaryon")
+
+
+def load_geometry_dump(path):
+    """Load + validate a schema-1 geometry dump (raises on a wrong/missing
+    schema or missing geometry keys — a non-dump record is never half-read)."""
+    with open(path) as fh:
+        dump = json.load(fh)
+    if dump.get("schema") != GEOMETRY_SCHEMA:
+        raise ValueError(
+            f"{path}: geometry dump schema {dump.get('schema')!r} is not the "
+            f"supported schema {GEOMETRY_SCHEMA}")
+    missing = [k for k in ("dimensions", "cells", "edges", "vertex_times")
+               if k not in dump]
+    if missing:
+        raise ValueError(f"{path}: geometry dump is missing {missing}")
+    return dump
+
+
+def rehydrate(dump):
+    """A LIVE Spacetime carrying the dumped final state, via the ``LiveComplex``
+    loader (the construction lives OUTSIDE the reader). Never re-runs a build."""
+    edges = {}
+    for u, v, re_l2, im_l2 in dump["edges"]:
+        key = (min(int(u), int(v)), max(int(u), int(v)))
+        edges[key] = complex(re_l2, im_l2)
+    times = {int(vid): float(t) for vid, t in dump["vertex_times"]}
+    return _obs.LiveComplex.load([[int(v) for v in c] for c in dump["cells"]],
+                                 edges, times, int(dump["dimensions"]))
+
+
+def verify_dump(st, dump):
+    """Check the rehydrated complex matches the dump's recorded combinatorial
+    reads (betti / holes), when present. Raises when they disagree."""
+    checks = {
+        "betti": lambda: [int(b) for b in _cob.MultiCobordism.betti(st)],
+        "holes": lambda: len(_cob.MultiCobordism.emergent_holes(st, 3)),
+    }
+    for key, compute in checks.items():
+        if key in dump and dump[key] != compute():
+            raise RuntimeError(
+                f"rehydrated {key} {compute()} does not match the dump's "
+                f"recorded {dump[key]} — the dump is not faithful")
+
+
+def make_register(st, target=None):
+    """A ``RegisterContext`` over the live complex: a 3-hole register when the
+    specimen hosts it, otherwise all the holes it has (so the battery reports
+    per-observable skips instead of raising here)."""
+    available = len(_cob.MultiCobordism.emergent_holes(st, 3))
+    count = min(available, 3)
+    if target is None:
+        target = _cob.Proton.singlet()
+    return _obs.RegisterContext(st, count, 3, target)
+
+
+def blocks_from_provenance(provenance):
+    """Build the ``BlockResiduals`` provenance blocks from a JSON-able list
+    (``[{label, vertices, target | target_re/target_im}]``)."""
+    blocks = []
+    for index, block in enumerate(provenance.get("blocks", [])):
+        if "target" in block:
+            target = [complex(t) for t in block["target"]]
+        else:
+            target = [complex(re, im) for re, im in
+                      zip(block["target_re"], block["target_im"])]
+        label = str(block.get("label", f"block{index}"))
+        blocks.append(_obs.Block(label, [int(v) for v in block["vertices"]],
+                                 target))
+    return blocks
+
+
+def battery_observables(provenance):
+    """The battery line-up, in measurement order. ``BlockResiduals`` carries the
+    provenance blocks (empty ⇒ it skips no_provenance); ``PairLoopFlavor``
+    carries the recorded diquark pair when the build history supplies it."""
+    diquark = provenance.get("diquark_pair")
+    pair_loop = (_obs.PairLoopFlavor((int(diquark[0]), int(diquark[1])))
+                 if diquark is not None else _obs.PairLoopFlavor())
+    return [
+        _obs.SingletResidual(),
+        _obs.BlockResiduals(blocks_from_provenance(provenance)),
+        _obs.EmergentMass(),
+        _obs.EmergentRadius(),
+        pair_loop,
+    ]
+
+
+def measure_battery(ctx, provenance, gates=True):
+    """Measure every battery observable against ``ctx`` — a flat JSON-able
+    record: the register census, then per-observable measured (record + gate
+    residuals) or skipped(reason) entries."""
+    record = {
+        "register": ctx.summary(),
+        "provenance_keys": sorted(provenance) if provenance else [],
+        "observables": {},
+    }
+    for observable in battery_observables(provenance):
+        name = observable.record_key()
+        reason = observable.skip_reason(ctx)
+        if reason:
+            record["observables"][name] = {
+                "status": f"skipped({reason})", "reason": reason}
+            continue
+        entry = {"status": "measured", "record": observable.record(ctx)}
+        if gates:
+            result = _obs.ObservableGates.evaluate(observable, ctx)
+            entry["gates"] = {
+                "gauge_delta": result.gauge_delta,
+                "relabel_delta": result.relabel_delta,
+                "gauge_ok": result.gauge_ok,
+                "relabel_ok": result.relabel_ok,
+                "gate_tol": result.gate_tol,
+            }
+        record["observables"][name] = entry
+    return record
+
+
+def observe_geometry_dump(path, provenance_path=None):
+    """The faithful path: schema-1 dump -> rehydrate -> verify -> battery. Dump
+    metadata (``diquark_pair`` / ``blocks``) flows as provenance; a
+    ``--provenance`` file overrides and extends it."""
+    dump = load_geometry_dump(path)
+    st = rehydrate(dump)
+    verify_dump(st, dump)
+    provenance = {}
+    for key in ("diquark_pair", "blocks"):
+        if key in dump:
+            provenance[key] = dump[key]
+    if provenance_path:
+        with open(provenance_path) as fh:
+            provenance.update(json.load(fh))
+    record = measure_battery(make_register(st), provenance)
+    record["input"] = {
+        "mode": "geometry_dump", "path": path, "dump_verified": True,
+        "base_seed": dump.get("base_seed"),
+        "note": "the schema-1 dump is the attempt's faithful record; the engine "
+                "build is NOT process-deterministic, so the base seed labels the "
+                "attempt, never reproduces it",
+    }
+    return record
+
+
+def observe_fresh_attempt(seed, joint=False, max_restarts=1, provenance_path=None):
+    """The --seed path: a FRESH ``ProtonIngredients`` attempt (a NEW SAMPLE, never
+    a reproduction of any prior attempt with this seed — the #578 finding). The
+    built complex is read exactly like a rehydrated one."""
+    ingredients = _cob.ProtonIngredients(seed)
+    ingredients.build(max_restarts)
+    st = ingredients.block()
+    provenance = {}
+    if provenance_path:
+        with open(provenance_path) as fh:
+            provenance.update(json.load(fh))
+    record = measure_battery(make_register(st), provenance)
+    record["input"] = {
+        "mode": "fresh_attempt", "seed": int(seed), "joint": bool(joint),
+        "note": "a FRESH attempt labeled by this seed — NEVER a reproduction "
+                "(the engine build is not process-deterministic); dump the "
+                "geometry for a faithful record",
+    }
+    return record
+
+
+def render_table(record):
+    """A readable text rendering of the battery record."""
+    reg = record["register"]
+    lines = ["observable battery",
+             "=" * 60,
+             f"input: {record.get('input', {}).get('mode', '?')}",
+             f"register: dim={reg['dimensions']} n_top_cells={reg['n_top_cells']} "
+             f"holes_used={reg['holes_used']} of holes_total={reg['holes_total']} "
+             f"b3={reg['b3']} divergent={reg['holes_vs_b3_divergent']} "
+             f"causal_content={reg['causal_content']}",
+             f"betti: {reg['betti']}",
+             "-" * 60]
+    for name, entry in record["observables"].items():
+        if entry["status"] != "measured":
+            lines.append(f"{name}: {entry['status']}")
+            continue
+        gates = entry.get("gates", {})
+        ok = (f"gauge_ok={gates.get('gauge_ok')} "
+              f"relabel_ok={gates.get('relabel_ok')}") if gates else ""
+        lines.append(f"{name}: measured  {ok}")
+        rec = entry["record"]
+        if name == _obs.SingletResidual().record_key():
+            lines.append(f"    singlet_residual = {rec['singlet_residual']:.3e}")
+        elif name == _obs.EmergentMass().record_key():
+            lines.append(f"    m_shell={rec['mass']['m_shell']:.4f} "
+                         f"m_sum={rec['mass']['m_sum']:.4f} "
+                         f"m_action={rec['mass']['m_action']:.4f}")
+            lines.append("    r.m table (order-of-magnitude only): "
+                         f"spread [{rec['rm']['spread_min']:.3f}, "
+                         f"{rec['rm']['spread_max']:.3f}], "
+                         f"physical ~ {rec['rm']['physical']:.2f}")
+        elif name == _obs.EmergentRadius().record_key():
+            lines.append(f"    r_dual={rec['radius']['r_dual']:.4f} "
+                         f"r_primal={rec['radius']['r_primal']:.4f}")
+        elif name == _obs.PairLoopFlavor().record_key():
+            lines.append(f"    rho={rec['rho']:.4f} "
+                         f"multiplicity_2_1={rec['multiplicity_2_1']} "
+                         f"odd_loop={tuple(rec['odd_loop'])} "
+                         f"odd_is_diquark_loop={rec['odd_is_diquark_loop']} "
+                         f"({rec['odd_is_diquark_loop_status']})")
+        elif name == _obs.BlockResiduals([]).record_key():
+            for row in rec["blocks"]:
+                lines.append(f"    block {row['label']}: residual="
+                             f"{row['residual']:.3e} "
+                             f"(cells={row['n_cells_in_region']})")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--geometry", metavar="DUMP",
+                        help="a schema-1 geometry dump (the faithful path)")
+    source.add_argument("--seed", type=int,
+                        help="a FRESH ProtonIngredients attempt (never a "
+                             "reproduction)")
+    parser.add_argument("--joint", action="store_true",
+                        help="(with --seed) label the fresh attempt as the joint "
+                             "arm")
+    parser.add_argument("--max-restarts", type=int, default=1,
+                        help="(with --seed) build restart budget")
+    parser.add_argument("--provenance", metavar="JSON",
+                        help="a provenance JSON file (diquark_pair / blocks)")
+    parser.add_argument("--json", action="store_true",
+                        help="emit the JSON record instead of the table")
+    args = parser.parse_args(argv)
+
+    if args.geometry:
+        record = observe_geometry_dump(args.geometry, args.provenance)
+    else:
+        record = observe_fresh_attempt(args.seed, joint=args.joint,
+                                       max_restarts=args.max_restarts,
+                                       provenance_path=args.provenance)
+    if args.json:
+        json.dump(record, sys.stdout, indent=1)
+        sys.stdout.write("\n")
+    else:
+        print(render_table(record))
+    return record
+
+
+if __name__ == "__main__":
+    main()

--- a/include/observables/BlockResiduals.h
+++ b/include/observables/BlockResiduals.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_BLOCK_RESIDUALS_H
+#define TESSERA_OBSERVABLES_BLOCK_RESIDUALS_H
+
+#include <complex>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "observables/RegisterObservable.h"
+
+namespace tessera::observables {
+
+/// # BlockResiduals
+///
+/// The #574 per-output-block carry residuals, migrated as a C++ Observable. Each
+/// provenance block (a vertex region + a target, e.g. `ProtonIngredients`'s
+/// output blocks or a campaign record) is scored against its OWN sub-complex
+/// exactly as `ProtonIngredients::outputBlockResidual` scores it: the ambient top
+/// cells whose vertices ALL lie in the region form the block's own sub-complex
+/// (uniform-metric — matching how the drive's `r_U` scored the block), scored
+/// with `MultiCobordism::residualOfTargetStateAgainstHarmonic`; an empty region
+/// reports the full leak `‖target‖²`.
+///
+/// The blocks are ctor provenance (build history travels via the campaign record
+/// / geometry-dump metadata — never guessed). The sub-complex is LOADED by the
+/// `LiveComplex` loader (a strict selection of existing cells re-instantiated
+/// through the canonical `fromCells`), never built inside this reader. Because
+/// block regions carry vertex ids, `recordRelabeled` maps them through the
+/// RELABEL permutation so the gate compares like with like.
+class BlockResiduals : public RegisterObservable {
+  public:
+    /// One provenance block: a label, its emergent vertex region, and its
+    /// register target.
+    struct Block {
+      std::string label;
+      std::vector<std::uint64_t> vertices;
+      std::vector<std::complex<double>> target;
+    };
+
+    explicit BlockResiduals(std::vector<Block> blocks)
+        : blocks_(std::move(blocks)) {}
+
+    [[nodiscard]] std::string recordKey() const override {
+      return std::string(kRecordKey);
+    }
+    [[nodiscard]] bool needsProvenance() const override { return true; }
+    [[nodiscard]] bool hasProvenance() const override {
+      return !blocks_.empty();
+    }
+    [[nodiscard]] Record record(const RegisterContext &ctx) const override;
+    [[nodiscard]] Record recordRelabeled(
+        const RegisterContext &ctx,
+        const std::map<std::uint64_t, std::uint64_t> &perm) const override;
+
+    static constexpr std::string_view kRecordKey = "block_residuals";
+
+  protected:
+    /// The headline is the total carry leak — the sum of the block residuals.
+    [[nodiscard]] double computeHeadline(
+        const RegisterContext &ctx) const override;
+
+  private:
+    /// The record over an explicit block list (shared by `record` and
+    /// `recordRelabeled`).
+    [[nodiscard]] Record recordForBlocks(
+        const RegisterContext &ctx,
+        const std::vector<Block> &blocks) const;
+    /// One block's carry residual (the full leak when the region has no cell).
+    [[nodiscard]] static double blockResidual(const RegisterContext &ctx,
+                                              const Block &block,
+                                              int &nCellsInRegion,
+                                              double &targetNorm2);
+
+    std::vector<Block> blocks_;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_BLOCK_RESIDUALS_H

--- a/include/observables/EmergentMass.h
+++ b/include/observables/EmergentMass.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_EMERGENT_MASS_H
+#define TESSERA_OBSERVABLES_EMERGENT_MASS_H
+
+#include <string>
+
+#include "observables/InteriorHinges.h"
+#include "observables/RegisterObservable.h"
+
+namespace tessera::observables {
+
+/// # EmergentMass
+///
+/// The mass half of the #575 mass/radius battery on the relaxed 4D interior,
+/// migrated as a C++ Observable. Composes the shared `InteriorHinges` core (via
+/// `RegisterContext::interiorHinges`), so `EmergentMass` and `EmergentRadius`
+/// read exactly one hinge selection.
+///
+///   * headline (`compute`) = `m_shell`, the #352/#451 intensive shell mass;
+///   * typed accessors: `masses()` (m_shell/m_sum/m_action, the per-shell means,
+///     and the |Im ε| boost accounting), `localization()`;
+///   * `record()` = the interior census, the three masses, the localization, and
+///     the r·m table with its definitional spread stated first (#451: r·m is too
+///     definition-sensitive to quote as one number).
+class EmergentMass : public RegisterObservable {
+  public:
+    [[nodiscard]] std::string recordKey() const override {
+      return std::string(kRecordKey);
+    }
+    /// Geometric aggregates (sums over hundreds of hinges, r·m products) are
+    /// re-summed in a different container order on the relabeled rebuild —
+    /// order-ULP noise scales with the magnitudes, so this gate is
+    /// absolute-loose while the raw residuals stay reported.
+    [[nodiscard]] double gateTol() const override { return 1e-6; }
+    [[nodiscard]] int requiredDimensions() const override { return 4; }
+    [[nodiscard]] Record record(const RegisterContext &ctx) const override;
+
+    /// The three mass readings + shell means + Im accounting.
+    [[nodiscard]] InteriorHinges::Masses masses(
+        const RegisterContext &ctx) const;
+    /// The curvature localization (participation ratio, shell profile).
+    [[nodiscard]] InteriorHinges::Localization localization(
+        const RegisterContext &ctx) const;
+
+    static constexpr std::string_view kRecordKey = "emergent_mass";
+
+  protected:
+    [[nodiscard]] double computeHeadline(
+        const RegisterContext &ctx) const override;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_EMERGENT_MASS_H

--- a/include/observables/EmergentRadius.h
+++ b/include/observables/EmergentRadius.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_EMERGENT_RADIUS_H
+#define TESSERA_OBSERVABLES_EMERGENT_RADIUS_H
+
+#include <string>
+
+#include "observables/InteriorHinges.h"
+#include "observables/RegisterObservable.h"
+
+namespace tessera::observables {
+
+/// # EmergentRadius
+///
+/// The radius half of the #575 mass/radius battery on the relaxed 4D interior,
+/// migrated as a C++ Observable. Composes the same shared `InteriorHinges` core
+/// (via `RegisterContext::interiorHinges`) that `EmergentMass` reads.
+///
+///   * headline (`compute`) = `r_dual = V_dual^{1/4}`, the dimension-correct
+///     dual-volume radius on a 4-complex;
+///   * typed accessor `radii()`: `V_dual` / `V_primal`, the primal-cross-check
+///     `r_primal`, and the strictly-interior-vertex count;
+///   * `record()` = the radius block (dual + primal) and the hole count.
+class EmergentRadius : public RegisterObservable {
+  public:
+    [[nodiscard]] std::string recordKey() const override {
+      return std::string(kRecordKey);
+    }
+    /// Volume aggregates re-summed in a relabeled container order carry
+    /// order-ULP noise scaling with the magnitudes (see `EmergentMass`).
+    [[nodiscard]] double gateTol() const override { return 1e-6; }
+    [[nodiscard]] int requiredDimensions() const override { return 4; }
+    [[nodiscard]] Record record(const RegisterContext &ctx) const override;
+
+    /// The dual/primal size of the interior + interior-vertex count.
+    [[nodiscard]] InteriorHinges::Radii radii(const RegisterContext &ctx) const;
+
+    static constexpr std::string_view kRecordKey = "emergent_radius";
+
+  protected:
+    [[nodiscard]] double computeHeadline(
+        const RegisterContext &ctx) const override;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_EMERGENT_RADIUS_H

--- a/include/observables/InteriorHinges.h
+++ b/include/observables/InteriorHinges.h
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_INTERIOR_HINGES_H
+#define TESSERA_OBSERVABLES_INTERIOR_HINGES_H
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+  class Spacetime;
+}
+namespace tessera::observables {
+using namespace ::tessera::spacetime;
+
+/// # InteriorHinges
+///
+/// The shared 4D mass/radius reader core (#566/#593) — the #451 geometric-proton
+/// methodology ported to a genuinely 4D emergent interior, composed (never
+/// re-derived) by `EmergentMass` and `EmergentRadius`. Everything here is a
+/// post-hoc reader; nothing shapes the lattice.
+///
+///   * **Hinges are TRIANGLES.** On a `d = 4` complex the Regge hinges are the
+///     `(d-2) = 2`-simplices; curvature is the complex Lorentzian deficit angle.
+///   * **Closed fans only.** A triangle carries honest curvature only if every
+///     tetrahedron of its coface fan is shared by exactly two 4-cells. Open-fan
+///     triangles (the `∂W` boundary, the register-hole walls) are boundary
+///     artefacts near 2π, excluded, and counted in the census. The fan test is
+///     combinatorial over the CURRENT top cells, so Pachner-orphaned
+///     sub-simplices never pollute the selection; the readings themselves come
+///     off the canonical registered triangle `Simplex` (skeleton required — the
+///     `RegisterContext` constructor materializes it C++-side, the #451 lesson).
+///   * **Signature-aware readings.** Dual volumes are the circumcentric signed
+///     `Simplex::dualVolume`; the deficit is the complex
+///     `Simplex::lorentzianDeficitAngle`. Masses use Re ε; |Im ε| (boost
+///     content) is always reported, never dropped.
+///   * **Dimension-correct radius.** `r = V^{1/4}` on a 4-complex — the root
+///     tracks the top dimension.
+///
+/// Constructed once per (spacetime, holes); the constructor throws
+/// `std::invalid_argument` if the complex is not genuinely 4D (5-vertex top
+/// cells) — on a `d`-complex the hinge dimension and the radius root both track
+/// `d`, so a mismatched reader must refuse rather than read nonsense.
+class InteriorHinges {
+  public:
+    /// One interior (closed-fan) triangle hinge and its curvature.
+    struct Hinge {
+      std::vector<std::uint64_t> vids;  ///< the 3 sorted vertex ids
+      double re = 0.0;                  ///< Re of the complex deficit
+      double im = 0.0;                  ///< Im of the complex deficit (boost)
+      double dv = 0.0;                  ///< signed circumcentric dual content
+      std::optional<int> shell;         ///< BFS distance from the holes (empty
+                                        ///< when no holes were given)
+    };
+
+    /// The interior/boundary hinge census (reported with every reading).
+    struct Census {
+      int nTops = 0;
+      int nTets = 0;
+      int nHingesTotal = 0;
+      int nHingesInterior = 0;
+      int nHingesBoundary = 0;
+      int nBoundaryTets = 0;
+      int nHoleVertices = 0;
+      std::vector<std::vector<std::uint64_t>> boundaryTets;  ///< vertex-id sets
+    };
+
+    /// The three #451 mass readings — one intensive, two extensive — plus the
+    /// per-shell means and the imaginary-part accounting.
+    struct Masses {
+      double mShell = 0.0;   ///< intensive: Σ over BFS shells of the shell-mean
+                             ///< Re-deficit (plain mean Re with no holes)
+      double mSum = 0.0;     ///< extensive: Σ Re ε
+      double mAction = 0.0;  ///< extensive: Σ |★h|·Re ε
+      /// per-shell mean Re-deficit, ordered shell-ascending with the unshelled
+      /// bin last (`std::nullopt`).
+      std::vector<std::pair<std::optional<int>, double>> shellMeans;
+      double maxAbsIm = 0.0;
+      int nImNonzero = 0;
+      bool empty = true;  ///< no interior hinges — every scalar is NaN
+    };
+
+    /// The emergent size, dual and primal.
+    struct Radii {
+      double vDual = 0.0;    ///< Σ |★v| over strictly interior vertices
+      double vPrimal = 0.0;  ///< Σ |V₄| over all top 4-cells
+      int nInteriorVertices = 0;
+      double rDual = 0.0;    ///< V_dual^{1/4} (NaN when V_dual ≤ 0)
+      double rPrimal = 0.0;  ///< V_primal^{1/4} (NaN when V_primal ≤ 0)
+    };
+
+    /// Per-shell curvature profile entry.
+    struct ShellProfile {
+      int n = 0;
+      double meanRe = 0.0;
+      double weightShare = 0.0;
+    };
+
+    /// Is the curvature a localized lump or spread out?
+    struct Localization {
+      double pr = 0.0;             ///< participation ratio of |Re ε·★h| in (0,1]
+      double concentration = 0.0;  ///< 1/PR
+      double meanRe = 0.0;
+      double stdRe = 0.0;
+      double stdOverMean = 0.0;
+      /// per BFS shell (empty unless every hinge is shelled): the profile.
+      std::vector<std::pair<int, ShellProfile>> shellProfile;
+      double rmsShellRadius = 0.0;
+      double fracWithinShell1 = 0.0;
+      bool empty = true;
+    };
+
+    /// One r·m combination (`"{r_name} x {m_name}"` -> product).
+    struct RmTable {
+      std::vector<std::pair<std::string, double>> combos;  ///< 6 entries
+      double spreadMin = 0.0;
+      double spreadMax = 0.0;
+      double physical = 0.0;  ///< the physical anchor m_p·r_p/ħc ≈ 4.0
+    };
+
+    /// Physical anchor: m_p·r_p/ħc = 938 MeV · 0.84 fm / 197 MeV·fm ≈ 4.0.
+    static constexpr double PHYSICAL_RM = 938.0 * 0.84 / 197.0;
+    /// |Im ε| above this counts as genuinely complex (boost content).
+    static constexpr double IM_TOL = 1e-12;
+
+    /// Select the interior closed-fan triangle hinges of the 4-complex and read
+    /// their curvature. `holes` are the register holes' vertex-id tuples — the
+    /// BFS shell seeds (empty ⇒ every hinge reports shell None).
+    /// @throws std::invalid_argument if the complex has no top cells or its top
+    ///   cells are not all 5-vertex (genuinely 4D).
+    /// @throws std::runtime_error if an interior triangle has no registered
+    ///   `Simplex` — the C++ skeleton was not materialized.
+    ///
+    /// The spacetime is held `const`: this is a pure reader and the compiler
+    /// enforces that it cannot mutate any build/skeleton state — it touches only
+    /// the `const` query surface (`getTopSimplices`/`getBoundary`/`getSimplices`
+    /// and the `const` geometry methods on the simplices).
+    InteriorHinges(std::shared_ptr<const Spacetime> spacetime,
+                   std::vector<std::vector<std::uint64_t>> holes);
+
+    [[nodiscard]] const std::vector<Hinge> &hinges() const noexcept {
+      return hinges_;
+    }
+    [[nodiscard]] const Census &census() const noexcept { return census_; }
+
+    /// The three mass readings over the interior hinges.
+    [[nodiscard]] Masses masses() const;
+    /// The dual/primal size of the interior.
+    [[nodiscard]] Radii radii() const;
+    /// The curvature localization.
+    [[nodiscard]] Localization localization() const;
+    /// Every r·m combination (3 masses × 2 radii), the definitional spread
+    /// stated first (#451: r·m is too definition-sensitive to quote as one
+    /// number).
+    [[nodiscard]] RmTable rmTable(const Masses &mass, const Radii &rad) const;
+
+  private:
+    std::shared_ptr<const Spacetime> spacetime_;
+    std::vector<std::vector<std::uint64_t>> holes_;
+    std::vector<Hinge> hinges_;
+    Census census_;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_INTERIOR_HINGES_H

--- a/include/observables/LiveComplex.h
+++ b/include/observables/LiveComplex.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_LIVE_COMPLEX_H
+#define TESSERA_OBSERVABLES_LIVE_COMPLEX_H
+
+#include <complex>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::spacetime {
+  class Spacetime;
+}
+namespace tessera::observables {
+using namespace ::tessera::spacetime;
+
+/// # LiveComplex
+///
+/// The loader / transform layer that lives OUTSIDE the pure readers (#593, owner
+/// directive): it LOADS a saved combinatorial + metric description back into a
+/// LIVE, skeleton-complete `Spacetime`, and produces a relabeled copy for the
+/// RELABEL gate. It NEVER builds a spacetime of its own or re-runs the emergent
+/// dynamics — those live exclusively in Proton / ProtonIngredients /
+/// MultiCobordism. `LiveComplex` only ever reads a recorded geometry back through
+/// the canonical `Spacetime::fromCells` entry point:
+///
+///   * `Spacetime::fromCells` materializes ONLY the top cells (measured: `∂Δ⁵`
+///     comes back as its 6 pentatopes and nothing else). The facet/coface
+///     skeleton that `dualVolume()` / `lorentzianDeficitAngle()` walk is then
+///     completed with the honest direct call `Spacetime::materializeFacets()` —
+///     never a solver-named one — which reproduces the `ReggeSolver` +
+///     `ChainComplex::fromSpacetime` skeleton bit-for-bit (verified: interior
+///     hinge census, `V_dual`, and `m_sum` all agree).
+///   * The metric (complex squared lengths) and per-vertex times are loaded back
+///     exactly as recorded; a missing edge length throws (a partial metric is
+///     never silently defaulted).
+///
+/// The RegisterContext and every Observable then only ever READ the resulting
+/// live complex — they never see a dump and never build anything themselves.
+class LiveComplex {
+  public:
+    /// A relabeled rebuild: the live relabeled complex plus the vertex-id
+    /// permutation that produced it (original id → relabeled id), so
+    /// vertex-id-bearing observable configuration (e.g. provenance block
+    /// regions) can be mapped through it.
+    struct Relabeled {
+      std::shared_ptr<Spacetime> spacetime;
+      std::map<std::uint64_t, std::uint64_t> vertexMap;
+    };
+
+    /// Load a live, skeleton-complete complex from explicit top cells + per-edge
+    /// complex squared lengths (the schema-1 geometry-dump rehydration core, and
+    /// the RELABEL rebuild core). This is a LOAD, not a build: the geometry is
+    /// supplied wholesale and only read back through `Spacetime::fromCells`.
+    /// `cells` keep their intrinsic vertex order (never sorted — the stored order
+    /// carries the orientation); `squaredLengths` maps each `(min id, max id)`
+    /// vertex pair to its complex squared length; `vertexTimes` (may be empty)
+    /// maps vertex id → recorded time, applied before the lengths. `dimensions`
+    /// is the recorded complex dimension (the schema-1 dump's own `dimensions`
+    /// field / the source complex's canonical dimension) passed straight through
+    /// to `fromCells`, never guessed from a cell. The facet skeleton is completed
+    /// with `materializeFacets()` so the resulting complex is immediately
+    /// readable.
+    /// @throws std::invalid_argument if `cells` is empty.
+    /// @throws std::out_of_range if a built edge has no recorded squared
+    ///   length — a partial metric is never silently defaulted.
+    [[nodiscard]] static std::shared_ptr<Spacetime> load(
+        const std::vector<std::vector<std::uint64_t>> &cells,
+        const std::map<std::pair<std::uint64_t, std::uint64_t>,
+                       std::complex<double>> &squaredLengths,
+        const std::map<std::uint64_t, double> &vertexTimes, int dimensions);
+
+    /// LOAD (never build) the block-residual sub-complex: `cells` are ambient
+    /// top cells already SELECTED by the caller (the strict subset whose vertices
+    /// all lie in a provenance region — no new topology, no surgery, no
+    /// dynamics), re-instantiated through the canonical `Spacetime::fromCells`
+    /// with a uniform metric (weight 1.0). The uniform metric is the DEFINITION
+    /// of the carry diagnostic — it mirrors how the drive's `r_U` scored the
+    /// block (metric-independent by design) — so this is byte-identical to the
+    /// canonical `MultiCobordism::subcomplexWithinVertexSet` (lifted here so the
+    /// reader can score a block without constructing the build driver). No
+    /// emergent build; the skeleton is NOT materialized (the `r_state` read this
+    /// feeds builds only what it needs). `dimensions` is the ambient complex's
+    /// canonical dimension (the caller reads `RegisterContext::dimensions()`);
+    /// it is passed straight through to `fromCells`, never guessed from a cell.
+    /// @throws std::invalid_argument if `cells` is empty.
+    [[nodiscard]] static std::shared_ptr<Spacetime> subcomplex(
+        const std::vector<std::vector<std::uint64_t>> &cells, int dimensions);
+
+    /// A relabeled rebuild of `spacetime` under a random vertex-id permutation
+    /// (deterministic given `seed`), with the cell enumeration order shuffled too
+    /// (catching enumeration-order dependence), carrying the metric and vertex
+    /// times across. It reads the recorded geometry off `spacetime` and re-loads
+    /// it under the permutation (via `load`). The permutation need only be a
+    /// genuine relabeling for the RELABEL gate to compare like with like — the
+    /// specific permutation is not part of any reproduced value — so a
+    /// `std::mt19937_64` stream suffices (this deliberately does NOT reproduce
+    /// the Python framework's NumPy permutation; the gate invariance holds
+    /// identically either way).
+    [[nodiscard]] static Relabeled relabel(const Spacetime &spacetime,
+                                           std::uint64_t seed);
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_LIVE_COMPLEX_H

--- a/include/observables/ObservableGates.h
+++ b/include/observables/ObservableGates.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_OBSERVABLE_GATES_H
+#define TESSERA_OBSERVABLES_OBSERVABLE_GATES_H
+
+#include <cstdint>
+#include <string>
+
+#include "observables/Record.h"
+#include "observables/RegisterContext.h"
+#include "observables/RegisterObservable.h"
+
+namespace tessera::observables {
+
+/// # ObservableGates
+///
+/// The GAUGE and RELABEL gate harness (#593) — post-hoc validation, never a loop
+/// condition. Each gate re-measures an observable on a transformed context and
+/// reports the max-abs delta over every numeric leaf of its record
+/// (`Record::reportDelta`); a record channel that is not gauge- and
+/// relabel-invariant is a flagged leak.
+///
+///   * GAUGE — re-measure on `ctx.gauged(GAUGE_THETA)` (construction-free: the
+///     same live complex, the register target rotated by the surviving global
+///     U(1) phase).
+///   * RELABEL — re-measure on a relabeled rebuild. The rebuild is a
+///     construction and so lives in the loader (`LiveComplex::relabel`), never in
+///     a reader: this harness loads the relabeled live complex, wraps it in a
+///     (pure-reader) `RegisterContext` with the register's images matched by
+///     permuted vertex SET, and maps any vertex-id-bearing provenance through the
+///     permutation (`RegisterObservable::recordRelabeled`).
+///
+/// The self-test (`selfTest`) proves the harness actually compares: a
+/// deliberately label-dependent probe is flagged by RELABEL and a deliberately
+/// gauge-dependent probe is flagged by GAUGE — a silently-passing gate cannot be
+/// a comparison that never happened.
+class ObservableGates {
+  public:
+    /// GAUGE-gate angle: an incommensurate fraction of 2π, so the rotated target
+    /// never lands on a symmetry of the singlet by accident.
+    static constexpr double GAUGE_THETA =
+        2.0 * 3.14159265358979323846 * 0.371;
+    /// RELABEL-gate permutation seed.
+    static constexpr std::uint64_t GATE_SEED = 3;
+
+    /// One observable's gate verdicts.
+    struct GateResult {
+      double gaugeDelta = 0.0;
+      double relabelDelta = 0.0;
+      double gateTol = 0.0;
+      bool gaugeOk = false;
+      bool relabelOk = false;
+    };
+
+    /// The GAUGE residual: `reportDelta(record(ctx), record(ctx.gauged(θ)))`.
+    [[nodiscard]] static double gaugeDelta(const RegisterObservable &observable,
+                                           const RegisterContext &ctx);
+    /// The RELABEL residual: `reportDelta(record(ctx),
+    /// recordRelabeled(relabeled ctx, perm))`.
+    [[nodiscard]] static double relabelDelta(
+        const RegisterObservable &observable, const RegisterContext &ctx);
+    /// Both gates + the `*_ok` verdicts against the observable's `gateTol`.
+    [[nodiscard]] static GateResult evaluate(
+        const RegisterObservable &observable, const RegisterContext &ctx);
+
+    /// The harness self-test: the label-dependent probe must be RELABEL-flagged
+    /// and the gauge-dependent probe GAUGE-flagged (both deltas > 0). Returns
+    /// true iff both are flagged.
+    [[nodiscard]] static bool selfTest(const RegisterContext &ctx);
+};
+
+/// A deliberately label-dependent probe: its record leaks the sum of the
+/// register holes' vertex ids, so the RELABEL gate MUST flag it (the harness
+/// self-test).
+class LabelLeakProbe : public RegisterObservable {
+  public:
+    static constexpr std::string_view kRecordKey = "label_leak_probe";
+    [[nodiscard]] std::string recordKey() const override {
+      return std::string(kRecordKey);
+    }
+    [[nodiscard]] Record record(const RegisterContext &ctx) const override;
+
+  protected:
+    [[nodiscard]] double computeHeadline(
+        const RegisterContext &ctx) const override;
+};
+
+/// A deliberately gauge-dependent probe: its record leaks the raw register
+/// target's first-component phase, so the GAUGE gate MUST flag it.
+class GaugeLeakProbe : public RegisterObservable {
+  public:
+    static constexpr std::string_view kRecordKey = "gauge_leak_probe";
+    [[nodiscard]] std::string recordKey() const override {
+      return std::string(kRecordKey);
+    }
+    [[nodiscard]] Record record(const RegisterContext &ctx) const override;
+
+  protected:
+    [[nodiscard]] double computeHeadline(
+        const RegisterContext &ctx) const override;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_OBSERVABLE_GATES_H

--- a/include/observables/PairLoopFlavor.h
+++ b/include/observables/PairLoopFlavor.h
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_PAIR_LOOP_FLAVOR_H
+#define TESSERA_OBSERVABLES_PAIR_LOOP_FLAVOR_H
+
+#include <array>
+#include <complex>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "observables/RegisterObservable.h"
+
+namespace tessera::observables {
+
+/// # PairLoopFlavor
+///
+/// The #561/#576 pair-loop dual-basis flavor read on a 3-hole register, migrated
+/// as a C++ Observable (the `pair_loop_quarks.tex` §7 experiment). On a structure
+/// with three register holes carrying the color singlet `[1, ω, ω²]`:
+///
+///   1. ONE correlated multi-hole read — the single joint carried representative
+///      `ψ = EigenstateSynthesis.carriedRepresentative(holes, σ·target)`, never
+///      three independent per-hole extractions. Per-hole weight
+///      `w_h = σ_h ∮_h ψ` (the five (-1)^j-signed tetrahedral facets of the
+///      removed 4-cell); per-hole DK charge `q_h = Σ_{c∈∂h} W_c |ψ_c|²`.
+///   2. Pair loops `γ_ij` are homologous to `[i]+[j]`: `w_i + w_j` (arithmetic,
+///      no new geometry). The singlet gives the duality `[γ_ij] = -[k]`.
+///   3. Criterion (a) multiplicity 2:1 via `rho`; criterion (b) odd-one-out vs
+///      the recorded diquark pair (ctor provenance) — evaluated ONLY when the
+///      build history supplies it, never guessed.
+///
+/// headline (`compute`) = `rho`; typed accessors expose the joint read and the
+/// verdict. The oriented periods are reported in the propagation-root-fixed
+/// convention (divided by `w0`'s unit phase) so every record leaf is GAUGE- and
+/// RELABEL-invariant. Requires 3 holes on a 4-complex.
+class PairLoopFlavor : public RegisterObservable {
+  public:
+    /// The three pair loops as (i, j) hole-index pairs; `γ_ij` encircles i, j.
+    static constexpr std::array<std::pair<int, int>, 3> PAIR_LOOPS = {
+        {{0, 1}, {0, 2}, {1, 2}}};
+    /// Criterion (a): the closest pair's spread over its separation from the odd
+    /// one must stay below this for a 2:1 (u:u:d) verdict.
+    static constexpr double RHO_MAX = 0.5;
+    /// Criterion-(b) status sentinels (named, never inline literals).
+    static constexpr std::string_view kOddDiquarkEvaluated = "evaluated";
+    static constexpr std::string_view kOddDiquarkNotEvaluable =
+        "not_evaluable(no_provenance)";
+    static constexpr std::string_view kRecordKey = "pair_loop_flavor";
+
+    /// The single correlated multi-hole read (the joint read).
+    struct JointRead {
+      std::vector<int> sigma;                    ///< induced-orientation signs
+      double rU = 0.0;                           ///< residualForPeriods of the pin
+      std::vector<std::complex<double>> w;       ///< oriented per-hole weights
+      std::vector<double> q;                     ///< per-hole DK charges
+      std::vector<std::complex<double>> loopW;   ///< pair-loop periods (w_i+w_j)
+      std::vector<double> loopQ;                 ///< pair-loop charges
+      std::vector<double> dualResidual;          ///< |w_i+w_j+w_k| per loop
+    };
+
+    /// The pre-registered criteria on a finished joint read.
+    struct Verdict {
+      std::pair<int, int> oddLoop;               ///< the charge-odd pair loop
+      int dualHole = 0;                          ///< its complementary hole
+      double rho = 0.0;
+      bool multiplicity21 = false;
+      std::optional<bool> oddIsDiquarkLoop;      ///< empty ⇒ not evaluable
+    };
+
+    /// Read the 3-hole register with no recorded diquark pair (criterion (b)
+    /// stays not-evaluable).
+    PairLoopFlavor() = default;
+    /// Read the 3-hole register with the recorded step-1 diquark hole-index pair
+    /// from the specimen's build history (makes criterion (b) decidable).
+    explicit PairLoopFlavor(std::pair<int, int> diquarkPair)
+        : diquarkPair_(diquarkPair) {}
+
+    [[nodiscard]] std::string recordKey() const override {
+      return std::string(kRecordKey);
+    }
+    /// The derived clustering ratio `rho` divides two small charge differences
+    /// and amplifies eigensolve roundoff to ~1e-13 (the source's RHO_GATE_TOL) —
+    /// one tolerance covers every leaf, raw residuals reported alongside.
+    [[nodiscard]] double gateTol() const override { return 1e-9; }
+    [[nodiscard]] int minHoles() const override { return 3; }
+    [[nodiscard]] int requiredDimensions() const override { return 4; }
+    [[nodiscard]] Record record(const RegisterContext &ctx) const override;
+
+    /// The joint read (typed).
+    [[nodiscard]] JointRead jointRead(const RegisterContext &ctx) const;
+    /// The verdict on a finished joint read.
+    [[nodiscard]] Verdict evaluateCriteria(const JointRead &read) const;
+
+    /// (odd loop index, rho): the loop whose charge sits farthest from the mean
+    /// of the other two, and rho = |spread of the other two| / |that separation|.
+    [[nodiscard]] static std::pair<int, double> oddOneOut(
+        const std::vector<double> &loopQ);
+    /// The hole index dual to the pair loop `γ_ij`: the third index (`3-i-j`).
+    [[nodiscard]] static int complementHole(const std::pair<int, int> &pair) {
+      return 3 - pair.first - pair.second;
+    }
+
+  protected:
+    [[nodiscard]] double computeHeadline(
+        const RegisterContext &ctx) const override;
+
+  private:
+    std::optional<std::pair<int, int>> diquarkPair_;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_PAIR_LOOP_FLAVOR_H

--- a/include/observables/Record.h
+++ b/include/observables/Record.h
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_RECORD_H
+#define TESSERA_OBSERVABLES_RECORD_H
+
+#include <complex>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace tessera::observables {
+
+/// # Record
+///
+/// A JSON-able observable record — the C++ home of the Python framework's
+/// nested `dict` of `float / int / bool / str / None / list / dict` leaves
+/// (#593). Every emergent-proton observable's `record()` returns one; the
+/// binding layer turns it into a Python `dict`. Keeping the record type in
+/// pybind-free `tessera_core` lets the GAUGE/RELABEL gates traverse it in C++
+/// (`reportDelta`).
+///
+/// The propagation discipline (#580) lives at the reporting layer: a channel
+/// is real BY CONSTRUCTION or it carries both parts explicitly — complex
+/// values enter through `splitComplex`, which stores the two real leaves
+/// `{name}_re` / `{name}_im`; nothing is ever silently `.real`-ed.
+class Record {
+  public:
+    enum class Type { Null, Bool, Int, Double, String, List, Map };
+    using List = std::vector<Record>;
+    using Map = std::map<std::string, Record>;
+
+    Record() noexcept : type_(Type::Null) {}
+    Record(std::nullptr_t) noexcept : type_(Type::Null) {}  // NOLINT
+    Record(bool value) noexcept : type_(Type::Bool), bool_(value) {}  // NOLINT
+    // Integer leaves (`Int`). Explicit per-type overloads rather than one
+    // `enable_if_t` template so the Breathe/doxygen C++ parser can render the
+    // header; the set covers every fundamental integer type (so `int`,
+    // `std::size_t`, `std::int64_t`, `std::uint64_t`, ... all bind without
+    // ambiguity on LP64).
+    Record(int value) noexcept : type_(Type::Int), int_(value) {}  // NOLINT
+    Record(unsigned int value) noexcept  // NOLINT
+        : type_(Type::Int), int_(value) {}
+    Record(long value) noexcept : type_(Type::Int), int_(value) {}  // NOLINT
+    Record(unsigned long value) noexcept  // NOLINT
+        : type_(Type::Int), int_(static_cast<std::int64_t>(value)) {}
+    Record(long long value) noexcept  // NOLINT
+        : type_(Type::Int), int_(value) {}
+    Record(unsigned long long value) noexcept  // NOLINT
+        : type_(Type::Int), int_(static_cast<std::int64_t>(value)) {}
+    // Floating-point leaves (`Double`; NaN / inf preserved).
+    Record(double value) noexcept  // NOLINT
+        : type_(Type::Double), double_(value) {}
+    Record(float value) noexcept  // NOLINT
+        : type_(Type::Double), double_(static_cast<double>(value)) {}
+    Record(const char *value) : type_(Type::String), string_(value) {}  // NOLINT
+    Record(std::string value)  // NOLINT
+        : type_(Type::String), string_(std::move(value)) {}
+    Record(List value) : type_(Type::List), list_(std::move(value)) {}  // NOLINT
+    Record(Map value) : type_(Type::Map), map_(std::move(value)) {}  // NOLINT
+
+    [[nodiscard]] Type type() const noexcept { return type_; }
+    [[nodiscard]] bool isNull() const noexcept { return type_ == Type::Null; }
+
+    [[nodiscard]] bool asBool() const { return bool_; }
+    [[nodiscard]] std::int64_t asInt() const { return int_; }
+    [[nodiscard]] double asDouble() const { return double_; }
+    [[nodiscard]] const std::string &asString() const { return string_; }
+    [[nodiscard]] const List &asList() const { return list_; }
+    [[nodiscard]] const Map &asMap() const { return map_; }
+
+    /// The two explicit JSON-able leaves `{name}_re` / `{name}_im` of a
+    /// complex scalar — the one naming convention for complex record channels
+    /// (#580: the imaginary part is real physics and is always carried).
+    /// Merges them into `into`.
+    static void splitComplex(Map &into, const std::string &name,
+                             std::complex<double> value);
+    /// `splitComplex` for a sequence: `{name}_re` / `{name}_im` become lists.
+    static void splitComplex(Map &into, const std::string &name,
+                             const std::vector<std::complex<double>> &values);
+
+    /// The max absolute difference over every numeric leaf of two records —
+    /// the C_ij chamber readout's every-channel gate metric (ported verbatim
+    /// from the Python `report_delta`):
+    ///
+    ///   * maps must have identical keys (a shape mismatch throws);
+    ///   * lists must have identical lengths (else `inf`);
+    ///   * strings and nulls must be equal (else `inf` — a changed status IS a
+    ///     flagged channel);
+    ///   * bools compare as 0/1; numbers as `|a - b|`; two NaNs agree
+    ///     (delta 0 — NaN is a legitimate reported value, e.g. a
+    ///     not-applicable reading), a NaN against a number is `inf`.
+    ///
+    /// @throws std::invalid_argument when two maps have different key sets.
+    [[nodiscard]] static double reportDelta(const Record &a, const Record &b);
+
+  private:
+    Type type_;
+    bool bool_ = false;
+    std::int64_t int_ = 0;
+    double double_ = 0.0;
+    std::string string_;
+    List list_;
+    Map map_;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_RECORD_H

--- a/include/observables/RegisterContext.h
+++ b/include/observables/RegisterContext.h
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_REGISTER_CONTEXT_H
+#define TESSERA_OBSERVABLES_REGISTER_CONTEXT_H
+
+#include <complex>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cobordism/EigenstateSynthesis.h"
+#include "cobordism/Proton.h"
+
+// === tessera subsystem ns fwd-decls ===
+namespace tessera::graph {}
+namespace tessera::mesh {}
+namespace tessera::quantum {}
+namespace tessera::simulations {}
+namespace tessera::spacetime {}
+// === cross-subsystem fwd-decls ===
+namespace tessera::spacetime {
+  class Spacetime;
+}
+namespace tessera::observables {
+using namespace ::tessera::mesh;
+using namespace ::tessera::graph;
+using namespace ::tessera::spacetime;
+using namespace ::tessera::simulations;
+using namespace ::tessera::quantum;
+
+class InteriorHinges;  // the shared 4D hinge-selection core (InteriorHinges.h)
+
+/// # RegisterContext
+///
+/// The one **validated read context** every emergent-proton observable measures
+/// (#593, part of #559): a converged spacetime, its emergent register holes, the
+/// induced-orientation signs, and the shared per-complex caches — composed from the
+/// protected readout cores (`cobordism::EigenstateSynthesis`,
+/// `cobordism::MultiCobordism`, `cobordism::ChainComplex`), never refactoring them.
+///
+///   * **Skeleton in C++ only.** The constructor materializes the facet/coface
+///     lattice through the `ReggeSolver(st, MatterConfiguration())` constructor —
+///     the blessed path (the #451 corruption lesson: a Python-driven
+///     materialization corrupted coface lists and `dualVolume()` saw half its
+///     cofaces). Idempotent.
+///   * **Hole selection validated at ONE entry point.** The register holes are the
+///     emergent `(degree+2)`-vertex removed top cells
+///     (`cobordism::MultiCobordism::emergentHoles`), in emergent-hole order. A
+///     **deficit throws** (`std::invalid_argument` naming the found holes); a
+///     **surplus is an explicit, recorded truncation** naming the dropped holes in
+///     `selectionWarning()` (the Python binding emits it as a `UserWarning`), never
+///     a silent slice. Both censuses are kept (`holesUsed()` / `holesTotal()`)
+///     alongside Betti at the register degree (`bK()`) and the
+///     `holesVsBettiDivergent()` flag — the campaign taught us holes and \f$ b_k \f$
+///     can disagree (e.g. holes=3 / \f$ b_3 \f$=2), so the divergence is always
+///     recorded, never papered over.
+///   * **One orientation convention.** The induced-orientation signs
+///     \f$ \varepsilon_h = \pm 1 \f$ come from
+///     `cobordism::ChainComplex::endSignCovector` — the label-free orientation
+///     under which every closed form's signed periods obey
+///     \f$ \sum_h \varepsilon_h p_h = 0 \f$, determined up to one global sign (the
+///     propagation root, \f$ -1 \in U(1) \f$ on the register — gauge, not physics).
+///     Vertices are never sorted to impose a convention; holes are matched by
+///     vertex SET.
+///   * **One cached `EigenstateSynthesis`** per (spacetime, degree), plus the other
+///     shared per-complex structures (Hodge metric weights, the canonical
+///     \f$ k \f$-cell index, the Betti vector, the 4D interior-hinge selection).
+///     `gauged()` copies share the caches — the gauge knob only rotates the target.
+///
+/// The GAUGE and RELABEL gate transforms act on the context, not on the
+/// observables: `gauged(theta)` rotates the register target by the surviving
+/// global U(1) phase (which contains the Z₃ cyclic recolor of the singlet and the
+/// orientation flip); `relabeled(seed)` rebuilds the whole complex under a random
+/// vertex-id permutation with the cell enumeration order shuffled too, carries the
+/// metric (complex squared lengths) and vertex times across, re-derives the
+/// emergent holes on the relabeled complex, and matches this register's images by
+/// permuted vertex SET (a missing image throws — the gate must compare like with
+/// like). See `ObservableGates`.
+class RegisterContext {
+  public:
+    /// A RELABEL-gate rebuild: the relabeled context plus the vertex-id
+    /// permutation that produced it (original id → relabeled id), so
+    /// vertex-id-bearing observable configuration (e.g. provenance block
+    /// regions) can be mapped through it.
+    struct Relabeled {
+      std::shared_ptr<RegisterContext> context;
+      std::map<std::uint64_t, std::uint64_t> vertexMap;
+    };
+
+    /// Build the context over `spacetime`, selecting and validating `count`
+    /// register holes at `degree` (see the class note: deficit throws, surplus
+    /// is recorded in `selectionWarning()` naming the dropped holes). `target`
+    /// is the register target state, one component per hole slot — the color
+    /// singlet \f$ [1, \omega, \omega^2] \f$ by default; the GAUGE gate rotates
+    /// exactly this.
+    /// @throws std::invalid_argument on a hole deficit (fewer than `count`
+    ///   emergent holes), an empty complex, or `count < 0` / `degree < 0`.
+    explicit RegisterContext(
+        std::shared_ptr<Spacetime> spacetime, int count = 3, int degree = 3,
+        std::vector<std::complex<double>> target = cobordism::Proton::singlet());
+
+    /// Build the context with an EXPLICIT hole selection (e.g. a build's own
+    /// census, or the relabel gate's matched images), validated with the same
+    /// count semantics as the selecting constructor: fewer than `count` throws,
+    /// more than `count` is a recorded truncation naming the dropped holes.
+    /// `holesTotal()` still reports the complex's own emergent census.
+    RegisterContext(std::shared_ptr<Spacetime> spacetime,
+                    const std::vector<std::vector<std::uint64_t>> &holes,
+                    int count, int degree,
+                    std::vector<std::complex<double>> target);
+
+    // ---- the validated register ----
+    [[nodiscard]] const std::shared_ptr<Spacetime> &spacetime() const noexcept {
+      return spacetime_;
+    }
+    /// The register degree \f$ k \f$ (holes are `(k+2)`-vertex removed top
+    /// cells; the cached synthesis reads at this \f$ k \f$).
+    [[nodiscard]] int degree() const noexcept { return degree_; }
+    /// The register target state (rotated by `gauged()`).
+    [[nodiscard]] const std::vector<std::complex<double>> &target() const noexcept {
+      return target_;
+    }
+    /// The selected register holes, in emergent-hole order (each a vertex-id
+    /// tuple of a removed top cell, intrinsic order preserved).
+    [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &holes()
+        const noexcept {
+      return holes_;
+    }
+    /// The surplus holes dropped by the validated selection (empty when none).
+    [[nodiscard]] const std::vector<std::vector<std::uint64_t>> &droppedHoles()
+        const noexcept {
+      return droppedHoles_;
+    }
+    /// Holes the register reads (`holes().size()`).
+    [[nodiscard]] int holesUsed() const noexcept {
+      return static_cast<int>(holes_.size());
+    }
+    /// The complex's full emergent-hole census at the register degree.
+    [[nodiscard]] int holesTotal() const noexcept { return holesTotal_; }
+    /// Betti at the register degree (GF(2) ranks; 0 when the Betti vector is
+    /// shorter than the degree).
+    [[nodiscard]] int bK() const;
+    /// The full Betti vector of the complex (cached).
+    [[nodiscard]] const std::vector<int> &betti() const;
+    /// True when the emergent-hole census and Betti at the register degree
+    /// disagree — the campaign's holes=3 / b₃=2 style finding, always recorded.
+    [[nodiscard]] bool holesVsBettiDivergent() const { return holesTotal_ != bK(); }
+    /// The surplus-selection warning naming the dropped holes (empty when the
+    /// selection was exact). The Python binding emits it as a `UserWarning` at
+    /// construction; C++ callers consult it here.
+    [[nodiscard]] const std::string &selectionWarning() const noexcept {
+      return selectionWarning_;
+    }
+    /// The top-cell dimension, or -1 when top cells are mixed-size (the
+    /// driver's dimension gates read this).
+    [[nodiscard]] int dimensions() const noexcept { return dimensions_; }
+    /// The number of top cells.
+    [[nodiscard]] int topCellCount() const noexcept { return topCellCount_; }
+    /// True iff any edge is non-spacelike (timelike or null). At
+    /// initialization no time has passed — causal structure may only emerge —
+    /// so all-spacelike specimens honestly report false.
+    [[nodiscard]] bool causalContent() const noexcept { return causalContent_; }
+
+    // ---- shared per-complex caches ----
+    /// The one cached `cobordism::EigenstateSynthesis(spacetime, degree)` every
+    /// period readout shares (lazily built; `gauged()` copies share it).
+    [[nodiscard]] cobordism::EigenstateSynthesis &synthesis() const;
+    /// The induced-orientation signs \f$ \varepsilon_h = \pm 1 \f$ of the
+    /// selected holes (`cobordism::ChainComplex::endSignCovector` — the ONE
+    /// orientation convention; lazily built, shared across `gauged()` copies).
+    [[nodiscard]] const std::vector<int> &epsilonSigns() const;
+    /// The Hodge metric weights \f$ W_k \f$ at the register degree, in the
+    /// canonical `ChainComplex` \f$ k \f$-cell order (lazily built, shared).
+    [[nodiscard]] const std::vector<double> &hodgeWeights() const;
+    /// The canonical \f$ k \f$-cell index: sorted vertex-id tuple → operator
+    /// index into `synthesis().cellSimplices()` (lazily built, shared).
+    [[nodiscard]] const std::map<std::vector<std::uint64_t>, std::size_t> &
+    cellIndex() const;
+    /// The shared 4D interior-hinge selection (`InteriorHinges` over this
+    /// context's spacetime and holes; lazily built, shared — `EmergentMass` and
+    /// `EmergentRadius` compose exactly this one instance).
+    /// @throws std::invalid_argument if the complex is not genuinely 4D.
+    [[nodiscard]] const std::shared_ptr<InteriorHinges> &interiorHinges() const;
+
+    // ---- the gate transforms ----
+    /// The GAUGE-gate variant: the same complex and register with the target
+    /// rotated by the global U(1) phase \f$ e^{i\theta} \f$ — the register's
+    /// one surviving gauge freedom (it contains the Z₃ cyclic recolor of the
+    /// singlet and the orientation flip). Shares this context's spacetime and
+    /// caches (the gauge knob only rotates the target).
+    [[nodiscard]] std::shared_ptr<RegisterContext> gauged(double theta) const;
+    /// The RELABEL-gate variant: rebuild the whole complex under a random
+    /// vertex-id permutation (deterministic given `seed`) with the cell
+    /// enumeration order shuffled too (catching enumeration-order dependence),
+    /// carry the metric (complex squared lengths) and vertex times across,
+    /// re-derive the emergent holes on the relabeled complex, and match this
+    /// register's images among them by permuted vertex SET.
+    /// @throws std::runtime_error if a hole's image is missing from the
+    ///   relabeled complex's emergent census (the gate must compare like with
+    ///   like).
+    [[nodiscard]] Relabeled relabeled(std::uint64_t seed) const;
+
+    /// A live complex from explicit top cells + per-edge complex squared
+    /// lengths, with the skeleton materialized in C++ (the `ReggeSolver`
+    /// constructor — the blessed path). `cells` keep their intrinsic vertex
+    /// order (never sorted — the stored order carries the orientation);
+    /// `squaredLengths` maps each `(min id, max id)` vertex pair to its complex
+    /// squared length; `vertexTimes` (may be empty) maps vertex id → recorded
+    /// time, applied before the lengths. `dimensions < 0` derives the dimension
+    /// from the first cell. This is the schema-1 geometry-dump rebuild core
+    /// (the dump is an attempt's ONLY faithful record — the engine build is not
+    /// process-deterministic, so a seed labels an attempt, never reproduces it).
+    /// @throws std::invalid_argument if `cells` is empty.
+    /// @throws std::out_of_range if a built edge has no recorded squared
+    ///   length — a partial metric is never silently defaulted.
+    [[nodiscard]] static std::shared_ptr<Spacetime> buildComplex(
+        const std::vector<std::vector<std::uint64_t>> &cells,
+        const std::map<std::pair<std::uint64_t, std::uint64_t>,
+                       std::complex<double>> &squaredLengths,
+        const std::map<std::uint64_t, double> &vertexTimes = {},
+        int dimensions = -1);
+
+  private:
+    /// The lazily-built shared structures. Held behind one shared_ptr so
+    /// `gauged()` copies share every cache both ways (a cache built by either
+    /// context is visible to the other — the complex is the same object).
+    struct Caches;
+
+    /// Shared constructor tail: skeleton materialization, censuses, hole
+    /// validation (`explicitHoles` empty ⇒ select from the emergent census).
+    void initialize(int count,
+                    const std::vector<std::vector<std::uint64_t>> *explicitHoles);
+
+    std::shared_ptr<Spacetime> spacetime_;
+    int degree_;
+    std::vector<std::complex<double>> target_;
+    std::vector<std::vector<std::uint64_t>> holes_;
+    std::vector<std::vector<std::uint64_t>> droppedHoles_;
+    int holesTotal_ = 0;
+    int dimensions_ = -1;
+    int topCellCount_ = 0;
+    bool causalContent_ = false;
+    std::string selectionWarning_;
+    std::shared_ptr<Caches> caches_;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_REGISTER_CONTEXT_H

--- a/include/observables/RegisterContext.h
+++ b/include/observables/RegisterContext.h
@@ -41,11 +41,18 @@ class InteriorHinges;  // the shared 4D hinge-selection core (InteriorHinges.h)
 /// protected readout cores (`cobordism::EigenstateSynthesis`,
 /// `cobordism::MultiCobordism`, `cobordism::ChainComplex`), never refactoring them.
 ///
-///   * **Skeleton in C++ only.** The constructor materializes the facet/coface
-///     lattice through the `ReggeSolver(st, MatterConfiguration())` constructor —
-///     the blessed path (the #451 corruption lesson: a Python-driven
-///     materialization corrupted coface lists and `dualVolume()` saw half its
-///     cofaces). Idempotent.
+///   * **A pure reader — never a builder.** The context READS an already-built,
+///     relaxed spacetime (a `Proton::block()`, a `ProtonIngredients` state, a
+///     relaxed `MultiCobordism` complex, or a dump the loader already rehydrated
+///     into a live complex). It never builds, solves, or materializes anything —
+///     the emergent build lives exclusively in Proton/ProtonIngredients/
+///     MultiCobordism and is never re-run here. The facet/coface skeleton the
+///     `dualVolume()` / `lorentzianDeficitAngle()` reads walk is expected to be
+///     already present on the live complex (it is, on every built state); the
+///     construction that completes a bare `Spacetime::fromCells` skeleton — the
+///     dump-rehydration and the RELABEL-gate rebuild — lives OUTSIDE this class,
+///     in `LiveComplex` (the loader/transform), and only ever reads the recorded
+///     geometry back, never the emergent dynamics.
 ///   * **Hole selection validated at ONE entry point.** The register holes are the
 ///     emergent `(degree+2)`-vertex removed top cells
 ///     (`cobordism::MultiCobordism::emergentHoles`), in emergent-hole order. A
@@ -70,27 +77,17 @@ class InteriorHinges;  // the shared 4D hinge-selection core (InteriorHinges.h)
 ///     \f$ k \f$-cell index, the Betti vector, the 4D interior-hinge selection).
 ///     `gauged()` copies share the caches — the gauge knob only rotates the target.
 ///
-/// The GAUGE and RELABEL gate transforms act on the context, not on the
-/// observables: `gauged(theta)` rotates the register target by the surviving
-/// global U(1) phase (which contains the Z₃ cyclic recolor of the singlet and the
-/// orientation flip); `relabeled(seed)` rebuilds the whole complex under a random
-/// vertex-id permutation with the cell enumeration order shuffled too, carries the
-/// metric (complex squared lengths) and vertex times across, re-derives the
-/// emergent holes on the relabeled complex, and matches this register's images by
-/// permuted vertex SET (a missing image throws — the gate must compare like with
-/// like). See `ObservableGates`.
+/// The GAUGE gate transform acts on the context, not on the observables:
+/// `gauged(theta)` rotates the register target by the surviving global U(1) phase
+/// (which contains the Z₃ cyclic recolor of the singlet and the orientation flip)
+/// — a construction-free operation that shares the same live complex. The RELABEL
+/// gate needs a rebuilt (relabeled) complex, which is a construction: that lives
+/// in `LiveComplex` and is orchestrated by `ObservableGates`, never here — this
+/// reader never rebuilds anything.
 class RegisterContext {
   public:
-    /// A RELABEL-gate rebuild: the relabeled context plus the vertex-id
-    /// permutation that produced it (original id → relabeled id), so
-    /// vertex-id-bearing observable configuration (e.g. provenance block
-    /// regions) can be mapped through it.
-    struct Relabeled {
-      std::shared_ptr<RegisterContext> context;
-      std::map<std::uint64_t, std::uint64_t> vertexMap;
-    };
-
-    /// Build the context over `spacetime`, selecting and validating `count`
+    /// Read the context over the already-built `spacetime`, selecting and
+    /// validating `count`
     /// register holes at `degree` (see the class note: deficit throws, surplus
     /// is recorded in `selectionWarning()` naming the dropped holes). `target`
     /// is the register target state, one component per hole slot — the color
@@ -154,8 +151,10 @@ class RegisterContext {
     [[nodiscard]] const std::string &selectionWarning() const noexcept {
       return selectionWarning_;
     }
-    /// The top-cell dimension, or -1 when top cells are mixed-size (the
-    /// driver's dimension gates read this).
+    /// The canonical spacetime dimension \f$ d \f$ — the metric signature's
+    /// dimension (`getMetric()->getSignature()->getDimensions()`, the same
+    /// accessor WilsonLoop / ReggeSolver read). The driver's dimension gates
+    /// read this.
     [[nodiscard]] int dimensions() const noexcept { return dimensions_; }
     /// The number of top cells.
     [[nodiscard]] int topCellCount() const noexcept { return topCellCount_; }
@@ -185,43 +184,15 @@ class RegisterContext {
     /// @throws std::invalid_argument if the complex is not genuinely 4D.
     [[nodiscard]] const std::shared_ptr<InteriorHinges> &interiorHinges() const;
 
-    // ---- the gate transforms ----
-    /// The GAUGE-gate variant: the same complex and register with the target
-    /// rotated by the global U(1) phase \f$ e^{i\theta} \f$ — the register's
-    /// one surviving gauge freedom (it contains the Z₃ cyclic recolor of the
-    /// singlet and the orientation flip). Shares this context's spacetime and
-    /// caches (the gauge knob only rotates the target).
+    // ---- the GAUGE gate transform (construction-free) ----
+    /// The GAUGE-gate variant: the same live complex and register with the
+    /// target rotated by the global U(1) phase \f$ e^{i\theta} \f$ — the
+    /// register's one surviving gauge freedom (it contains the Z₃ cyclic recolor
+    /// of the singlet and the orientation flip). Shares this context's spacetime
+    /// and caches (the gauge knob only rotates the target; nothing is rebuilt).
+    /// The RELABEL gate — which needs a rebuilt, relabeled complex — is a
+    /// construction and lives in `LiveComplex` / `ObservableGates`, never here.
     [[nodiscard]] std::shared_ptr<RegisterContext> gauged(double theta) const;
-    /// The RELABEL-gate variant: rebuild the whole complex under a random
-    /// vertex-id permutation (deterministic given `seed`) with the cell
-    /// enumeration order shuffled too (catching enumeration-order dependence),
-    /// carry the metric (complex squared lengths) and vertex times across,
-    /// re-derive the emergent holes on the relabeled complex, and match this
-    /// register's images among them by permuted vertex SET.
-    /// @throws std::runtime_error if a hole's image is missing from the
-    ///   relabeled complex's emergent census (the gate must compare like with
-    ///   like).
-    [[nodiscard]] Relabeled relabeled(std::uint64_t seed) const;
-
-    /// A live complex from explicit top cells + per-edge complex squared
-    /// lengths, with the skeleton materialized in C++ (the `ReggeSolver`
-    /// constructor — the blessed path). `cells` keep their intrinsic vertex
-    /// order (never sorted — the stored order carries the orientation);
-    /// `squaredLengths` maps each `(min id, max id)` vertex pair to its complex
-    /// squared length; `vertexTimes` (may be empty) maps vertex id → recorded
-    /// time, applied before the lengths. `dimensions < 0` derives the dimension
-    /// from the first cell. This is the schema-1 geometry-dump rebuild core
-    /// (the dump is an attempt's ONLY faithful record — the engine build is not
-    /// process-deterministic, so a seed labels an attempt, never reproduces it).
-    /// @throws std::invalid_argument if `cells` is empty.
-    /// @throws std::out_of_range if a built edge has no recorded squared
-    ///   length — a partial metric is never silently defaulted.
-    [[nodiscard]] static std::shared_ptr<Spacetime> buildComplex(
-        const std::vector<std::vector<std::uint64_t>> &cells,
-        const std::map<std::pair<std::uint64_t, std::uint64_t>,
-                       std::complex<double>> &squaredLengths,
-        const std::map<std::uint64_t, double> &vertexTimes = {},
-        int dimensions = -1);
 
   private:
     /// The lazily-built shared structures. Held behind one shared_ptr so
@@ -229,8 +200,9 @@ class RegisterContext {
     /// context is visible to the other — the complex is the same object).
     struct Caches;
 
-    /// Shared constructor tail: skeleton materialization, censuses, hole
-    /// validation (`explicitHoles` empty ⇒ select from the emergent census).
+    /// Shared constructor tail: read the live complex's censuses and validate
+    /// the hole selection (`explicitHoles` null ⇒ select from the emergent
+    /// census). Reads only — nothing is built or materialized.
     void initialize(int count,
                     const std::vector<std::vector<std::uint64_t>> *explicitHoles);
 

--- a/include/observables/RegisterObservable.h
+++ b/include/observables/RegisterObservable.h
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_REGISTER_OBSERVABLE_H
+#define TESSERA_OBSERVABLES_REGISTER_OBSERVABLE_H
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "observables/Observable.h"
+#include "observables/Record.h"
+#include "observables/RegisterContext.h"
+
+namespace tessera::observables {
+
+/// # RegisterObservable
+///
+/// The base for the emergent-proton readouts (#593): a pure post-hoc reader over
+/// a `RegisterContext` (a live, already-built complex). It extends the existing
+/// `tessera::observables::Observable` — every subclass is-an `Observable` — and
+/// adds the register-aware surface the SpacetimeVolume/VolumeProfile house
+/// pattern lacks:
+///
+///   * `record(ctx)` — the full JSON-able `Record` (bound to Python as a dict),
+///     containing only GAUGE- and RELABEL-invariant channels;
+///   * `compute(ctx)` — the headline scalar (also reachable through the base
+///     `Observable::compute(spacetime)`, which reads a default register off the
+///     spacetime);
+///   * the declarative skip surface (`minHoles`/`requiredDimensions`/
+///     `needsProvenance`/`needsCausalContent`) so an inapplicable observable is a
+///     reported skip, never a crash;
+///   * `recordRelabeled(ctx, perm)` — the RELABEL-gate hook, defaulting to
+///     `record(ctx)`; observables whose configuration carries vertex ids (e.g.
+///     `BlockResiduals` block regions) override it to map their provenance
+///     through the permutation so the gate compares like with like.
+///
+/// An Observable NEVER shapes the lattice, never builds, never solves — it reads
+/// and reports. The GAUGE/RELABEL gates (`ObservableGates`) are post-hoc
+/// validation, never a loop condition.
+class RegisterObservable : public Observable {
+  public:
+    // ---- skip-reason sentinels (named, never inline literals) ----
+    /// The observable needs provenance it was not given.
+    static constexpr std::string_view kSkipNoProvenance = "no_provenance";
+    /// The observable reads causal structure the all-spacelike specimen lacks.
+    static constexpr std::string_view kSkipNoCausalContent = "no_causal_content";
+    /// The prefix of the hole-deficit skip reason (`holes=N < min_holes=M`).
+    static constexpr std::string_view kSkipHolesPrefix = "holes=";
+    static constexpr std::string_view kSkipHolesInfix = " < min_holes=";
+    /// The prefix/infix of the dimension-mismatch skip reason.
+    static constexpr std::string_view kSkipDimensionsPrefix = "dimensions=";
+    static constexpr std::string_view kSkipDimensionsInfix = " != ";
+
+    /// The battery record key (unique within a battery).
+    [[nodiscard]] virtual std::string recordKey() const = 0;
+
+    /// The GAUGE/RELABEL residual tolerance for the `*_ok` verdicts. Direct
+    /// period/charge reads sit at ~1e-16; derived ratios amplify eigensolve
+    /// roundoff; geometric aggregates re-summed in a relabeled container order
+    /// carry order-ULP noise — subclasses pick the tolerance their channels
+    /// warrant and the raw residuals are always reported alongside.
+    [[nodiscard]] virtual double gateTol() const { return 1e-9; }
+
+    /// The full JSON-able record of invariant channels (the pure read).
+    [[nodiscard]] virtual Record record(const RegisterContext &ctx) const = 0;
+
+    /// The headline scalar for this observable (the base-class contract).
+    [[nodiscard]] double compute(const RegisterContext &ctx) const {
+      return computeHeadline(ctx);
+    }
+
+    /// The RELABEL-gate hook: re-measure on the relabeled context, mapping any
+    /// vertex-id-bearing configuration through `perm`. Default is identity —
+    /// correct for observables whose configuration carries no vertex ids.
+    [[nodiscard]] virtual Record recordRelabeled(
+        const RegisterContext &ctx,
+        const std::map<std::uint64_t, std::uint64_t> & /*perm*/) const {
+      return record(ctx);
+    }
+
+    // ---- the declarative skip surface ----
+    /// Register holes this observable needs (0 = none).
+    [[nodiscard]] virtual int minHoles() const { return 0; }
+    /// The top-cell dimension this observable requires (-1 = any).
+    [[nodiscard]] virtual int requiredDimensions() const { return -1; }
+    /// True iff this observable needs provenance it was not given.
+    [[nodiscard]] virtual bool needsProvenance() const { return false; }
+    /// True iff the required provenance is present (default: nothing needed).
+    [[nodiscard]] virtual bool hasProvenance() const { return true; }
+    /// True iff this observable reads causal structure.
+    [[nodiscard]] virtual bool needsCausalContent() const { return false; }
+
+    /// The reason this observable cannot measure `ctx` (a string the battery
+    /// reports), or empty when it can.
+    [[nodiscard]] std::string skipReason(const RegisterContext &ctx) const;
+
+    // ---- the base Observable contract ----
+    /// Read a default register (`count=3`, `degree=3`, singlet target) off the
+    /// live spacetime and return the headline scalar.
+    /// @throws std::invalid_argument if the spacetime cannot host a 3-hole
+    ///   register (use `compute(ctx)` with an explicit register for sub-3-hole
+    ///   specimens).
+    double compute(const std::shared_ptr<Spacetime> &spacetime) override;
+    double update(const std::shared_ptr<Spacetime> &spacetime) override;
+
+    ~RegisterObservable() override = default;
+
+  protected:
+    /// The headline scalar implementation.
+    [[nodiscard]] virtual double computeHeadline(
+        const RegisterContext &ctx) const = 0;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_REGISTER_OBSERVABLE_H

--- a/include/observables/SingletResidual.h
+++ b/include/observables/SingletResidual.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#ifndef TESSERA_OBSERVABLES_SINGLET_RESIDUAL_H
+#define TESSERA_OBSERVABLES_SINGLET_RESIDUAL_H
+
+#include <string>
+
+#include "observables/RegisterObservable.h"
+
+namespace tessera::observables {
+
+/// # SingletResidual
+///
+/// The #574 whole-complex singlet diagnostic (migrated as a C++ Observable): the
+/// relabeling-invariant singlet `r_state` of `Proton::singlet()` against the
+/// whole complex's `L_k` harmonic (`≈ 0` ⇒ carried), plus the hole/Betti census
+/// with the `holes_vs_b3_divergent` flag. DIAGNOSTIC only — it never steers
+/// anything.
+///
+/// The headline (`compute`) is the singlet residual; `conjugateResidual` is the
+/// companion read against the conjugate singlet `[1, ω̄, ω̄²]` (the antibaryon
+/// channel). The record scores the TRUE singlet regardless of the register
+/// target, so the GAUGE gate (which rotates the target) is trivially satisfied.
+class SingletResidual : public RegisterObservable {
+  public:
+    [[nodiscard]] std::string recordKey() const override {
+      return std::string(kRecordKey);
+    }
+    [[nodiscard]] Record record(const RegisterContext &ctx) const override;
+
+    /// `r_state` of the conjugate singlet `[1, ω̄, ω̄²]` against the whole.
+    [[nodiscard]] double conjugateResidual(const RegisterContext &ctx) const;
+
+    static constexpr std::string_view kRecordKey = "singlet_residual";
+
+  protected:
+    [[nodiscard]] double computeHeadline(
+        const RegisterContext &ctx) const override;
+};
+
+}  // namespace tessera::observables
+
+#endif  // TESSERA_OBSERVABLES_SINGLET_RESIDUAL_H

--- a/src/observables/Bindings.cpp
+++ b/src/observables/Bindings.cpp
@@ -27,6 +27,18 @@
 #include "observables/VolumeProfile.h"
 #include "observables/WilsonLoop.h"
 #include "observables/Spectral.h"
+#include "observables/Record.h"
+#include "observables/RegisterContext.h"
+#include "observables/RegisterObservable.h"
+#include "observables/InteriorHinges.h"
+#include "observables/LiveComplex.h"
+#include "observables/SingletResidual.h"
+#include "observables/BlockResiduals.h"
+#include "observables/EmergentMass.h"
+#include "observables/EmergentRadius.h"
+#include "observables/PairLoopFlavor.h"
+#include "observables/ObservableGates.h"
+#include "cobordism/Proton.h"
 #include "spacetime/Spacetime.h"
 #include "ForceLayout.h"
 #include "mesh/VertexList.h"
@@ -45,6 +57,74 @@
 namespace py = pybind11;
 using namespace tessera;
 using namespace tessera::observables;
+
+namespace {
+
+// A JSON-able observable Record -> a native Python object (dict/list/scalar).
+py::object recordToPython(const Record &r) {
+  switch (r.type()) {
+    case Record::Type::Null:
+      return py::none();
+    case Record::Type::Bool:
+      return py::bool_(r.asBool());
+    case Record::Type::Int:
+      return py::int_(static_cast<long long>(r.asInt()));
+    case Record::Type::Double:
+      return py::float_(r.asDouble());
+    case Record::Type::String:
+      return py::str(r.asString());
+    case Record::Type::List: {
+      py::list out;
+      for (const auto &e : r.asList()) out.append(recordToPython(e));
+      return out;
+    }
+    case Record::Type::Map: {
+      py::dict out;
+      for (const auto &kv : r.asMap()) {
+        out[py::str(kv.first)] = recordToPython(kv.second);
+      }
+      return out;
+    }
+  }
+  return py::none();
+}
+
+// A native Python object -> a Record (for report_delta testing). bool is checked
+// before int (Python bool is an int subtype).
+Record pythonToRecord(const py::handle &o) {
+  if (o.is_none()) return Record();
+  if (py::isinstance<py::bool_>(o)) return Record(o.cast<bool>());
+  if (py::isinstance<py::int_>(o)) {
+    return Record(static_cast<std::int64_t>(o.cast<long long>()));
+  }
+  if (py::isinstance<py::float_>(o)) return Record(o.cast<double>());
+  if (py::isinstance<py::str>(o)) return Record(o.cast<std::string>());
+  if (py::isinstance<py::dict>(o)) {
+    Record::Map m;
+    for (const auto &item : o.cast<py::dict>()) {
+      m[item.first.cast<std::string>()] = pythonToRecord(item.second);
+    }
+    return Record(std::move(m));
+  }
+  if (py::isinstance<py::list>(o) || py::isinstance<py::tuple>(o)) {
+    Record::List l;
+    for (const auto &e : o) l.push_back(pythonToRecord(e));
+    return Record(std::move(l));
+  }
+  throw std::runtime_error(
+      "report_delta: record leaves must be dict/list/str/float/int/bool/None");
+}
+
+// Emit the RegisterContext's surplus-selection warning as a Python UserWarning
+// (the header's documented binding behavior).
+void emitSelectionWarning(const RegisterContext &ctx) {
+  if (!ctx.selectionWarning().empty()) {
+    auto warnings = py::module_::import("warnings");
+    warnings.attr("warn")(ctx.selectionWarning());
+  }
+}
+
+}  // namespace
 
 // Registers all tessera::observables classes into the `m` submodule
 // (i.e. `tessera.observables`). Called from src/bindings.cpp's
@@ -480,4 +560,262 @@ curvature scan.
 The standard form for Creutz-ratio-style analyses: fix loop size L,
 read off the population-averaged Wilson value at that scale.
 )doc");
+
+  // ==========================================================================
+  // Emergent-proton readout battery (#593): pure readers over a live complex,
+  // the loader/transform layer, and the GAUGE/RELABEL gates.
+  // ==========================================================================
+
+  // ---- LiveComplex: the loader / transform layer (outside the readers) ----
+  py::class_<LiveComplex::Relabeled>(m, "Relabeled",
+      "A relabeled rebuild: the live relabeled complex + the vertex-id "
+      "permutation (original id -> relabeled id).")
+      .def_readonly("spacetime", &LiveComplex::Relabeled::spacetime)
+      .def_readonly("vertex_map", &LiveComplex::Relabeled::vertexMap);
+
+  py::class_<LiveComplex>(m, "LiveComplex",
+      R"doc(The loader / transform layer OUTSIDE the pure readers: LOAD a saved
+combinatorial + metric description back into a live, skeleton-complete Spacetime,
+and produce a relabeled copy for the RELABEL gate. Never builds a spacetime of
+its own or re-runs the emergent dynamics (those live in Proton / ProtonIngredients
+/ MultiCobordism) — only reads a recorded geometry back through the canonical
+``Spacetime.fromCells``, completing the facet skeleton with ``materializeFacets``.)doc")
+      .def_static("load", &LiveComplex::load, py::arg("cells"),
+                  py::arg("squared_lengths"), py::arg("vertex_times"),
+                  py::arg("dimensions"),
+                  "Load a live skeleton-complete complex from cells + per-edge "
+                  "complex squared lengths + vertex times (schema-1 dump "
+                  "rehydration).")
+      .def_static("subcomplex", &LiveComplex::subcomplex, py::arg("cells"),
+                  py::arg("dimensions"),
+                  "Load a uniform-metric sub-complex from already-selected "
+                  "ambient cells (the block-residual carry diagnostic).")
+      .def_static("relabel", &LiveComplex::relabel, py::arg("spacetime"),
+                  py::arg("seed"),
+                  "A relabeled rebuild under a deterministic vertex-id "
+                  "permutation (the RELABEL-gate transform).");
+
+  // ---- RegisterContext: the validated read context (pure reader) ----
+  py::class_<RegisterContext, std::shared_ptr<RegisterContext>>(
+      m, "RegisterContext",
+      R"doc(The one validated read context every emergent-proton observable
+measures: a LIVE, already-built complex, its emergent register holes, the
+induced-orientation signs, and the shared per-complex caches. A pure reader — it
+never builds, solves, or materializes anything.)doc")
+      .def(py::init([](std::shared_ptr<Spacetime> st, int count, int degree,
+                       std::vector<std::complex<double>> target) {
+             auto ctx = std::make_shared<RegisterContext>(
+                 std::move(st), count, degree, std::move(target));
+             emitSelectionWarning(*ctx);
+             return ctx;
+           }),
+           py::arg("spacetime"), py::arg("count") = 3, py::arg("degree") = 3,
+           py::arg("target") = ::tessera::cobordism::Proton::singlet())
+      .def(py::init([](std::shared_ptr<Spacetime> st,
+                       std::vector<std::vector<std::uint64_t>> holes, int count,
+                       int degree, std::vector<std::complex<double>> target) {
+             auto ctx = std::make_shared<RegisterContext>(
+                 std::move(st), holes, count, degree, std::move(target));
+             emitSelectionWarning(*ctx);
+             return ctx;
+           }),
+           py::arg("spacetime"), py::arg("holes"), py::arg("count"),
+           py::arg("degree"), py::arg("target"))
+      .def("spacetime", &RegisterContext::spacetime)
+      .def("degree", &RegisterContext::degree)
+      .def("target", &RegisterContext::target)
+      .def("holes", &RegisterContext::holes)
+      .def("dropped_holes", &RegisterContext::droppedHoles)
+      .def("holes_used", &RegisterContext::holesUsed)
+      .def("holes_total", &RegisterContext::holesTotal)
+      .def("bK", &RegisterContext::bK)
+      .def("betti", &RegisterContext::betti)
+      .def("holes_vs_betti_divergent",
+           &RegisterContext::holesVsBettiDivergent)
+      .def("dimensions", &RegisterContext::dimensions)
+      .def("top_cell_count", &RegisterContext::topCellCount)
+      .def("causal_content", &RegisterContext::causalContent)
+      .def("selection_warning", &RegisterContext::selectionWarning)
+      .def("gauged", &RegisterContext::gauged, py::arg("theta"))
+      .def("summary", [](const RegisterContext &ctx) {
+        py::dict d;
+        d["degree"] = ctx.degree();
+        d["dimensions"] = ctx.dimensions();
+        d["n_top_cells"] = ctx.topCellCount();
+        d["holes_used"] = ctx.holesUsed();
+        d["holes_total"] = ctx.holesTotal();
+        py::list dropped;
+        for (const auto &h : ctx.droppedHoles()) {
+          dropped.append(py::cast(h));
+        }
+        d["dropped_holes"] = dropped;
+        d["b3"] = ctx.bK();
+        d["betti"] = py::cast(ctx.betti());
+        d["holes_vs_b3_divergent"] = ctx.holesVsBettiDivergent();
+        d["causal_content"] = ctx.causalContent();
+        return d;
+      });
+
+  // ---- the observable base (pure reader) ----
+  py::class_<RegisterObservable, std::shared_ptr<RegisterObservable>>(
+      m, "RegisterObservable",
+      "Base for the emergent-proton readouts: a pure post-hoc reader over a "
+      "RegisterContext.")
+      .def("record_key", &RegisterObservable::recordKey)
+      .def("gate_tol", &RegisterObservable::gateTol)
+      .def("min_holes", &RegisterObservable::minHoles)
+      .def("required_dimensions", &RegisterObservable::requiredDimensions)
+      .def("needs_provenance", &RegisterObservable::needsProvenance)
+      .def("has_provenance", &RegisterObservable::hasProvenance)
+      .def("needs_causal_content", &RegisterObservable::needsCausalContent)
+      .def("skip_reason", &RegisterObservable::skipReason, py::arg("ctx"))
+      .def(
+          "record",
+          [](const RegisterObservable &o, const RegisterContext &ctx) {
+            return recordToPython(o.record(ctx));
+          },
+          py::arg("ctx"))
+      .def(
+          "compute",
+          [](const RegisterObservable &o, const RegisterContext &ctx) {
+            return o.compute(ctx);
+          },
+          py::arg("ctx"));
+
+  py::class_<SingletResidual, RegisterObservable,
+             std::shared_ptr<SingletResidual>>(m, "SingletResidual",
+      "The #574 whole-complex singlet diagnostic (headline = singlet r_state).")
+      .def(py::init<>())
+      .def("conjugate_residual", &SingletResidual::conjugateResidual,
+           py::arg("ctx"));
+
+  py::class_<BlockResiduals::Block>(m, "Block",
+      "One provenance block: a label, its vertex region, and its register target.")
+      .def(py::init([](std::string label, std::vector<std::uint64_t> vertices,
+                       std::vector<std::complex<double>> target) {
+             return BlockResiduals::Block{std::move(label), std::move(vertices),
+                                          std::move(target)};
+           }),
+           py::arg("label"), py::arg("vertices"), py::arg("target"))
+      .def_readwrite("label", &BlockResiduals::Block::label)
+      .def_readwrite("vertices", &BlockResiduals::Block::vertices)
+      .def_readwrite("target", &BlockResiduals::Block::target);
+
+  py::class_<BlockResiduals, RegisterObservable,
+             std::shared_ptr<BlockResiduals>>(m, "BlockResiduals",
+      "The #574 per-output-block carry residuals (blocks are ctor provenance).")
+      .def(py::init<std::vector<BlockResiduals::Block>>(), py::arg("blocks"));
+
+  // The mass/radius reader structs (typed accessors).
+  py::class_<InteriorHinges::Masses>(m, "EmergentMasses")
+      .def_readonly("m_shell", &InteriorHinges::Masses::mShell)
+      .def_readonly("m_sum", &InteriorHinges::Masses::mSum)
+      .def_readonly("m_action", &InteriorHinges::Masses::mAction)
+      .def_readonly("max_abs_im", &InteriorHinges::Masses::maxAbsIm)
+      .def_readonly("n_im_nonzero", &InteriorHinges::Masses::nImNonzero)
+      .def_readonly("empty", &InteriorHinges::Masses::empty);
+  py::class_<InteriorHinges::Radii>(m, "EmergentRadii")
+      .def_readonly("v_dual", &InteriorHinges::Radii::vDual)
+      .def_readonly("v_primal", &InteriorHinges::Radii::vPrimal)
+      .def_readonly("n_interior_vertices",
+                    &InteriorHinges::Radii::nInteriorVertices)
+      .def_readonly("r_dual", &InteriorHinges::Radii::rDual)
+      .def_readonly("r_primal", &InteriorHinges::Radii::rPrimal);
+  py::class_<InteriorHinges::Localization>(m, "EmergentLocalization")
+      .def_readonly("pr", &InteriorHinges::Localization::pr)
+      .def_readonly("concentration", &InteriorHinges::Localization::concentration)
+      .def_readonly("mean_re", &InteriorHinges::Localization::meanRe)
+      .def_readonly("std_re", &InteriorHinges::Localization::stdRe)
+      .def_readonly("std_over_mean",
+                    &InteriorHinges::Localization::stdOverMean)
+      .def_readonly("rms_shell_radius",
+                    &InteriorHinges::Localization::rmsShellRadius)
+      .def_readonly("frac_within_shell1",
+                    &InteriorHinges::Localization::fracWithinShell1)
+      .def_readonly("empty", &InteriorHinges::Localization::empty);
+
+  py::class_<EmergentMass, RegisterObservable, std::shared_ptr<EmergentMass>>(
+      m, "EmergentMass",
+      "The #575 mass half on the relaxed 4D interior (headline = m_shell).")
+      .def(py::init<>())
+      .def("masses", &EmergentMass::masses, py::arg("ctx"))
+      .def("localization", &EmergentMass::localization, py::arg("ctx"));
+
+  py::class_<EmergentRadius, RegisterObservable,
+             std::shared_ptr<EmergentRadius>>(m, "EmergentRadius",
+      "The #575 radius half on the relaxed 4D interior (headline = r_dual).")
+      .def(py::init<>())
+      .def("radii", &EmergentRadius::radii, py::arg("ctx"));
+
+  py::class_<PairLoopFlavor::JointRead>(m, "PairLoopJointRead")
+      .def_readonly("sigma", &PairLoopFlavor::JointRead::sigma)
+      .def_readonly("r_u", &PairLoopFlavor::JointRead::rU)
+      .def_readonly("w", &PairLoopFlavor::JointRead::w)
+      .def_readonly("q", &PairLoopFlavor::JointRead::q)
+      .def_readonly("loop_w", &PairLoopFlavor::JointRead::loopW)
+      .def_readonly("loop_q", &PairLoopFlavor::JointRead::loopQ)
+      .def_readonly("dual_residual", &PairLoopFlavor::JointRead::dualResidual);
+  py::class_<PairLoopFlavor::Verdict>(m, "PairLoopVerdict")
+      .def_readonly("odd_loop", &PairLoopFlavor::Verdict::oddLoop)
+      .def_readonly("dual_hole", &PairLoopFlavor::Verdict::dualHole)
+      .def_readonly("rho", &PairLoopFlavor::Verdict::rho)
+      .def_readonly("multiplicity_2_1", &PairLoopFlavor::Verdict::multiplicity21)
+      .def_readonly("odd_is_diquark_loop",
+                    &PairLoopFlavor::Verdict::oddIsDiquarkLoop);
+
+  py::class_<PairLoopFlavor, RegisterObservable,
+             std::shared_ptr<PairLoopFlavor>>(m, "PairLoopFlavor",
+      "The #561/#576 pair-loop dual-basis flavor read (headline = rho).")
+      .def(py::init<>())
+      .def(py::init([](std::pair<int, int> diquark) {
+             return std::make_shared<PairLoopFlavor>(diquark);
+           }),
+           py::arg("diquark_pair"))
+      .def("joint_read", &PairLoopFlavor::jointRead, py::arg("ctx"))
+      .def("evaluate_criteria", &PairLoopFlavor::evaluateCriteria,
+           py::arg("read"))
+      .def_static("odd_one_out", &PairLoopFlavor::oddOneOut, py::arg("loop_q"))
+      .def_static("complement_hole", &PairLoopFlavor::complementHole,
+                  py::arg("pair"));
+  m.attr("PairLoopFlavor").attr("RHO_MAX") = PairLoopFlavor::RHO_MAX;
+
+  // ---- the self-test probes ----
+  py::class_<LabelLeakProbe, RegisterObservable,
+             std::shared_ptr<LabelLeakProbe>>(m, "LabelLeakProbe",
+      "A deliberately label-dependent probe (RELABEL must flag it).")
+      .def(py::init<>());
+  py::class_<GaugeLeakProbe, RegisterObservable,
+             std::shared_ptr<GaugeLeakProbe>>(m, "GaugeLeakProbe",
+      "A deliberately gauge-dependent probe (GAUGE must flag it).")
+      .def(py::init<>());
+
+  // ---- the GAUGE/RELABEL gate harness ----
+  py::class_<ObservableGates::GateResult>(m, "GateResult")
+      .def_readonly("gauge_delta", &ObservableGates::GateResult::gaugeDelta)
+      .def_readonly("relabel_delta", &ObservableGates::GateResult::relabelDelta)
+      .def_readonly("gate_tol", &ObservableGates::GateResult::gateTol)
+      .def_readonly("gauge_ok", &ObservableGates::GateResult::gaugeOk)
+      .def_readonly("relabel_ok", &ObservableGates::GateResult::relabelOk);
+
+  py::class_<ObservableGates>(m, "ObservableGates",
+      "The GAUGE/RELABEL gate harness — post-hoc validation, never a loop "
+      "condition.")
+      .def_static("gauge_delta", &ObservableGates::gaugeDelta,
+                  py::arg("observable"), py::arg("ctx"))
+      .def_static("relabel_delta", &ObservableGates::relabelDelta,
+                  py::arg("observable"), py::arg("ctx"))
+      .def_static("evaluate", &ObservableGates::evaluate, py::arg("observable"),
+                  py::arg("ctx"))
+      .def_static("self_test", &ObservableGates::selfTest, py::arg("ctx"))
+      .def_static(
+          "report_delta",
+          [](const py::object &a, const py::object &b) {
+            return Record::reportDelta(pythonToRecord(a), pythonToRecord(b));
+          },
+          py::arg("a"), py::arg("b"),
+          "The max-abs delta over every numeric leaf of two records (the gate "
+          "metric).");
+  m.attr("ObservableGates").attr("GAUGE_THETA") = ObservableGates::GAUGE_THETA;
+  m.attr("ObservableGates").attr("GATE_SEED") =
+      py::int_(ObservableGates::GATE_SEED);
 }

--- a/src/observables/BlockResiduals.cpp
+++ b/src/observables/BlockResiduals.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/BlockResiduals.h"
+
+#include <set>
+#include <string>
+
+#include "cobordism/MultiCobordism.h"
+#include "mesh/Simplex.h"
+#include "mesh/Vertex.h"
+#include "observables/LiveComplex.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::observables {
+using ::tessera::cobordism::MultiCobordism;
+
+namespace {
+
+// The ambient top cells (intrinsic vertex order) whose vertices ALL lie in the
+// region — a pure READ of the live complex; nothing is built here.
+std::vector<std::vector<std::uint64_t>> cellsInRegion(
+    const RegisterContext &ctx, const std::set<std::uint64_t> &region) {
+  std::vector<std::vector<std::uint64_t>> inside;
+  for (const auto *cell : ctx.spacetime()->getTopSimplices()) {
+    std::vector<std::uint64_t> vids;
+    vids.reserve(cell->getVertices().size());
+    bool allInside = true;
+    for (const auto *v : cell->getVertices()) {
+      const std::uint64_t id = v->getId();
+      if (!region.count(id)) {
+        allInside = false;
+        break;
+      }
+      vids.push_back(id);
+    }
+    if (allInside) inside.push_back(std::move(vids));
+  }
+  return inside;
+}
+
+}  // namespace
+
+double BlockResiduals::blockResidual(const RegisterContext &ctx,
+                                     const Block &block, int &nCellsInRegion,
+                                     double &targetNorm2) {
+  const std::set<std::uint64_t> region(block.vertices.begin(),
+                                       block.vertices.end());
+  const auto cellsInside = cellsInRegion(ctx, region);
+  nCellsInRegion = static_cast<int>(cellsInside.size());
+  targetNorm2 = 0.0;
+  for (const auto &t : block.target) targetNorm2 += std::norm(t);
+  if (cellsInside.empty()) {
+    return targetNorm2;  // the full leak — nothing carries it
+  }
+  // The block's own sub-complex is LOADED (selection of existing cells,
+  // canonical fromCells, uniform metric) by the loader — never built here.
+  auto sub = LiveComplex::subcomplex(cellsInside, ctx.dimensions());
+  return MultiCobordism::residualOfTargetStateAgainstHarmonic(
+      sub, ctx.degree(), block.target);
+}
+
+Record BlockResiduals::recordForBlocks(const RegisterContext &ctx,
+                                       const std::vector<Block> &blocks) const {
+  Record::List rows;
+  for (std::size_t index = 0; index < blocks.size(); ++index) {
+    const Block &block = blocks[index];
+    int nCellsInRegion = 0;
+    double targetNorm2 = 0.0;
+    const double residual =
+        blockResidual(ctx, block, nCellsInRegion, targetNorm2);
+    const std::set<std::uint64_t> region(block.vertices.begin(),
+                                         block.vertices.end());
+
+    Record::Map row;
+    row["label"] = block.label.empty() ? ("block" + std::to_string(index))
+                                       : block.label;
+    row["n_region_vertices"] = static_cast<int>(region.size());
+    row["n_cells_in_region"] = nCellsInRegion;
+    row["full_leak"] = (nCellsInRegion == 0);
+    row["residual"] = residual;
+    row["target_norm2"] = targetNorm2;
+    Record::splitComplex(row, "target", block.target);
+    rows.emplace_back(std::move(row));
+  }
+  Record::Map m;
+  m["n_blocks"] = static_cast<int>(rows.size());
+  m["blocks"] = std::move(rows);
+  return Record(std::move(m));
+}
+
+Record BlockResiduals::record(const RegisterContext &ctx) const {
+  return recordForBlocks(ctx, blocks_);
+}
+
+Record BlockResiduals::recordRelabeled(
+    const RegisterContext &ctx,
+    const std::map<std::uint64_t, std::uint64_t> &perm) const {
+  // Block regions are vertex-id sets — map them through the RELABEL permutation
+  // (targets and labels are id-free). An emergent region can reference vertices
+  // no longer in any top cell (surgical moves orphan them); such ids are inert
+  // in the residual and the permutation maps the live set onto itself, so
+  // `perm.get(v, v)` keeps an orphan inert and preserves the region size.
+  std::vector<Block> mapped;
+  mapped.reserve(blocks_.size());
+  for (const Block &block : blocks_) {
+    Block b = block;
+    for (std::uint64_t &v : b.vertices) {
+      auto it = perm.find(v);
+      if (it != perm.end()) v = it->second;
+    }
+    mapped.push_back(std::move(b));
+  }
+  return recordForBlocks(ctx, mapped);
+}
+
+double BlockResiduals::computeHeadline(const RegisterContext &ctx) const {
+  double total = 0.0;
+  for (const Block &block : blocks_) {
+    int nCellsInRegion = 0;
+    double targetNorm2 = 0.0;
+    total += blockResidual(ctx, block, nCellsInRegion, targetNorm2);
+  }
+  return total;
+}
+
+}  // namespace tessera::observables

--- a/src/observables/EmergentMass.cpp
+++ b/src/observables/EmergentMass.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/EmergentMass.h"
+
+#include <optional>
+#include <string>
+
+namespace tessera::observables {
+
+namespace {
+
+// The shell-bin key: the unshelled bin (no hole reachable) is "unshelled"; a
+// shelled bin is its integer distance — the Python adapter's `_shell_key`.
+std::string shellKey(const std::optional<int> &shell) {
+  return shell ? std::to_string(*shell) : std::string("unshelled");
+}
+
+Record::Map censusRecord(const InteriorHinges::Census &c) {
+  // The vertex-id-bearing `boundary_tets` list is label-bound and dropped from
+  // the record (the Python adapter drops it too); the counts stay.
+  Record::Map m;
+  m["n_tops"] = c.nTops;
+  m["n_tets"] = c.nTets;
+  m["n_hinges_total"] = c.nHingesTotal;
+  m["n_hinges_interior"] = c.nHingesInterior;
+  m["n_hinges_boundary"] = c.nHingesBoundary;
+  m["n_boundary_tets"] = c.nBoundaryTets;
+  m["n_hole_vertices"] = c.nHoleVertices;
+  return m;
+}
+
+Record::Map massRecord(const InteriorHinges::Masses &mass) {
+  Record::Map shellMeans;
+  for (const auto &kv : mass.shellMeans) shellMeans[shellKey(kv.first)] = kv.second;
+  Record::Map m;
+  m["m_shell"] = mass.mShell;
+  m["m_sum"] = mass.mSum;
+  m["m_action"] = mass.mAction;
+  m["shell_means"] = std::move(shellMeans);
+  m["max_abs_im"] = mass.maxAbsIm;
+  m["n_im_nonzero"] = mass.nImNonzero;
+  return m;
+}
+
+Record::Map localizationRecord(const InteriorHinges::Localization &loc) {
+  Record::Map profile;
+  for (const auto &kv : loc.shellProfile) {
+    Record::Map p;
+    p["n"] = kv.second.n;
+    p["mean_re"] = kv.second.meanRe;
+    p["weight_share"] = kv.second.weightShare;
+    profile[std::to_string(kv.first)] = std::move(p);
+  }
+  Record::Map m;
+  m["PR"] = loc.pr;
+  m["concentration"] = loc.concentration;
+  m["mean_re"] = loc.meanRe;
+  m["std_re"] = loc.stdRe;
+  m["std_over_mean"] = loc.stdOverMean;
+  m["shell_profile"] = std::move(profile);
+  m["rms_shell_radius"] = loc.rmsShellRadius;
+  m["frac_within_shell1"] = loc.fracWithinShell1;
+  return m;
+}
+
+Record::Map rmRecord(const InteriorHinges::RmTable &rm) {
+  Record::Map combos;
+  for (const auto &kv : rm.combos) combos[kv.first] = kv.second;
+  Record::Map m;
+  m["spread_min"] = rm.spreadMin;
+  m["spread_max"] = rm.spreadMax;
+  m["combos"] = std::move(combos);
+  m["physical"] = rm.physical;
+  return m;
+}
+
+}  // namespace
+
+InteriorHinges::Masses EmergentMass::masses(const RegisterContext &ctx) const {
+  return ctx.interiorHinges()->masses();
+}
+
+InteriorHinges::Localization EmergentMass::localization(
+    const RegisterContext &ctx) const {
+  return ctx.interiorHinges()->localization();
+}
+
+double EmergentMass::computeHeadline(const RegisterContext &ctx) const {
+  return ctx.interiorHinges()->masses().mShell;
+}
+
+Record EmergentMass::record(const RegisterContext &ctx) const {
+  const auto &hinges = *ctx.interiorHinges();
+  const InteriorHinges::Masses mass = hinges.masses();
+  const InteriorHinges::Radii rad = hinges.radii();
+  const InteriorHinges::Localization loc = hinges.localization();
+  const InteriorHinges::RmTable rm = hinges.rmTable(mass, rad);
+
+  Record::Map m;
+  m["census"] = censusRecord(hinges.census());
+  m["mass"] = massRecord(mass);
+  m["localization"] = localizationRecord(loc);
+  m["rm"] = rmRecord(rm);
+  m["n_holes"] = ctx.holesUsed();
+  return Record(std::move(m));
+}
+
+}  // namespace tessera::observables

--- a/src/observables/EmergentRadius.cpp
+++ b/src/observables/EmergentRadius.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/EmergentRadius.h"
+
+namespace tessera::observables {
+
+InteriorHinges::Radii EmergentRadius::radii(const RegisterContext &ctx) const {
+  return ctx.interiorHinges()->radii();
+}
+
+double EmergentRadius::computeHeadline(const RegisterContext &ctx) const {
+  return ctx.interiorHinges()->radii().rDual;
+}
+
+Record EmergentRadius::record(const RegisterContext &ctx) const {
+  const InteriorHinges::Radii rad = ctx.interiorHinges()->radii();
+  Record::Map radius;
+  radius["Vdual"] = rad.vDual;
+  radius["Vprimal"] = rad.vPrimal;
+  radius["n_interior_vertices"] = rad.nInteriorVertices;
+  radius["r_dual"] = rad.rDual;
+  radius["r_primal"] = rad.rPrimal;
+
+  Record::Map m;
+  m["radius"] = std::move(radius);
+  m["n_holes"] = ctx.holesUsed();
+  return Record(std::move(m));
+}
+
+}  // namespace tessera::observables

--- a/src/observables/InteriorHinges.cpp
+++ b/src/observables/InteriorHinges.cpp
@@ -1,0 +1,386 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/InteriorHinges.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <queue>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "mesh/Simplex.h"
+#include "mesh/Vertex.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::observables {
+using ::tessera::mesh::Simplex;
+
+namespace {
+
+std::vector<std::uint64_t> sortedVids(const Simplex &s) {
+  std::vector<std::uint64_t> vids;
+  vids.reserve(s.getVertices().size());
+  for (const auto &v : s.getVertices()) vids.push_back(v->getId());
+  std::sort(vids.begin(), vids.end());
+  return vids;
+}
+
+// Multi-source BFS shell distance from `seeds` over the 1-skeleton of the
+// CURRENT top cells (combinatorial, orphan-immune — the #451 methodology: an
+// orphan edge stranded by a Pachner move must never shortcut the shell walk, so
+// the walk graph is built from `getTopSimplices()`, not the raw edge list).
+// Returns {vertex_id: shell}; unreachable vertices are absent.
+std::unordered_map<std::uint64_t, int> bfsShells(
+    const std::vector<std::vector<std::uint64_t>> &tops,
+    const std::vector<std::uint64_t> &seeds) {
+  std::unordered_map<std::uint64_t, std::set<std::uint64_t>> adjacency;
+  for (const auto &top : tops) {
+    for (std::size_t i = 0; i < top.size(); ++i) {
+      for (std::size_t j = i + 1; j < top.size(); ++j) {
+        adjacency[top[i]].insert(top[j]);
+        adjacency[top[j]].insert(top[i]);
+      }
+    }
+  }
+  std::unordered_map<std::uint64_t, int> dist;
+  std::queue<std::uint64_t> frontier;
+  std::set<std::uint64_t> uniqueSeeds(seeds.begin(), seeds.end());
+  for (std::uint64_t s : uniqueSeeds) {
+    if (adjacency.count(s)) {
+      dist[s] = 0;
+      frontier.push(s);
+    }
+  }
+  while (!frontier.empty()) {
+    std::uint64_t u = frontier.front();
+    frontier.pop();
+    for (std::uint64_t v : adjacency[u]) {
+      if (!dist.count(v)) {
+        dist[v] = dist[u] + 1;
+        frontier.push(v);
+      }
+    }
+  }
+  return dist;
+}
+
+double mean(const std::vector<double> &xs) {
+  double s = 0.0;
+  for (double x : xs) s += x;
+  return s / static_cast<double>(xs.size());
+}
+
+// numpy.std default: population std (ddof = 0).
+double populationStd(const std::vector<double> &xs) {
+  const double m = mean(xs);
+  double acc = 0.0;
+  for (double x : xs) acc += (x - m) * (x - m);
+  return std::sqrt(acc / static_cast<double>(xs.size()));
+}
+
+}  // namespace
+
+InteriorHinges::InteriorHinges(std::shared_ptr<const Spacetime> spacetime,
+                               std::vector<std::vector<std::uint64_t>> holes)
+    : spacetime_(std::move(spacetime)), holes_(std::move(holes)) {
+  // Current top cells, canonical (orphan-immune). This reader is 4D-specific:
+  // the hinge dimension (triangles) and the radius root (1/4) both track d = 4,
+  // so a non-4D complex must be refused, never read as nonsense.
+  const auto &topSimplices = spacetime_->getTopSimplices();
+  std::vector<std::vector<std::uint64_t>> tops;
+  tops.reserve(topSimplices.size());
+  for (const auto *t : topSimplices) {
+    if (t->getVertices().size() != 5) {
+      throw std::invalid_argument(
+          "InteriorHinges: a top cell has " +
+          std::to_string(t->getVertices().size()) +
+          " vertices; this reader is for 4-complexes (5-vertex top cells) — on "
+          "a d-complex the hinges are the (d-2)-simplices and the radius root "
+          "is 1/d, so use the reader that matches your dimension");
+    }
+    tops.push_back(sortedVids(*t));
+  }
+  if (tops.empty()) {
+    throw std::invalid_argument("InteriorHinges: spacetime has no top cells");
+  }
+
+  // The boundary tetrahedra are the canonical codim-1 faces owned by exactly one
+  // top cell (Spacetime::getBoundary — the same orphan-immune facet-count the
+  // #451 methodology derives by hand, but the blessed reused method). A triangle
+  // is a BOUNDARY hinge iff it is a face of some boundary tet (its coface fan
+  // then has a once-shared tetrahedron); every other triangle of the current top
+  // cells is INTERIOR (closed fan).
+  census_.boundaryTets = spacetime_->getBoundary();
+  census_.nBoundaryTets = static_cast<int>(census_.boundaryTets.size());
+  std::set<std::vector<std::uint64_t>> boundaryTriangles;
+  for (const auto &tet : census_.boundaryTets) {  // 4 vertices, sorted
+    for (std::size_t omit = 0; omit < tet.size(); ++omit) {
+      std::vector<std::uint64_t> tri;
+      tri.reserve(tet.size() - 1);
+      for (std::size_t i = 0; i < tet.size(); ++i) {
+        if (i != omit) tri.push_back(tet[i]);
+      }
+      boundaryTriangles.insert(std::move(tri));
+    }
+  }
+
+  // The BFS shell seeds are the register holes' vertices.
+  std::vector<std::uint64_t> holeVertices;
+  for (const auto &hole : holes_) {
+    for (std::uint64_t v : hole) holeVertices.push_back(v);
+  }
+  std::sort(holeVertices.begin(), holeVertices.end());
+  holeVertices.erase(std::unique(holeVertices.begin(), holeVertices.end()),
+                     holeVertices.end());
+  const auto shellOf = bfsShells(tops, holeVertices);
+
+  // The registered triangle / tetrahedron Simplex objects live in
+  // getSimplices(); hasTopCoface() keeps exactly those contained in a current
+  // top cell (the deficit / dual-volume readers require these canonical
+  // objects — the skeleton the RegisterContext constructor materialized). We
+  // walk getSimplices() once, reading the triangle census + the interior
+  // hinges' curvature, and counting the tetrahedra for the census.
+  int nTets = 0;
+  int nHingesTotal = 0;
+  int nHingesBoundary = 0;
+  std::vector<Hinge> interior;
+  for (const auto *s : spacetime_->getSimplices()) {
+    const std::size_t vc = s->getVertices().size();
+    if (vc == 4) {
+      if (s->hasTopCoface()) ++nTets;
+      continue;
+    }
+    if (vc != 3 || !s->hasTopCoface()) continue;
+    ++nHingesTotal;
+    std::vector<std::uint64_t> tri = sortedVids(*s);
+    if (boundaryTriangles.count(tri)) {
+      ++nHingesBoundary;
+      continue;
+    }
+    const std::complex<double> deficit = s->lorentzianDeficitAngle();
+    Hinge hinge;
+    hinge.re = deficit.real();
+    hinge.im = deficit.imag();
+    hinge.dv = s->dualVolume();
+    // shell = min BFS distance over the triangle's vertices reachable from a
+    // hole (None when no vertex is reachable / no holes were given).
+    std::optional<int> shell;
+    for (std::uint64_t v : tri) {
+      auto it = shellOf.find(v);
+      if (it != shellOf.end()) {
+        shell = shell ? std::min(*shell, it->second) : it->second;
+      }
+    }
+    hinge.shell = shell;
+    hinge.vids = std::move(tri);
+    interior.push_back(std::move(hinge));
+  }
+  // Deterministic hinge order (sorted by vertex tuple), matching the Python
+  // reader's `sorted(tri_fans)` walk so every downstream sum is bit-stable.
+  std::sort(interior.begin(), interior.end(),
+            [](const Hinge &a, const Hinge &b) { return a.vids < b.vids; });
+  hinges_ = std::move(interior);
+
+  census_.nTops = static_cast<int>(tops.size());
+  census_.nTets = nTets;
+  census_.nHingesTotal = nHingesTotal;
+  census_.nHingesInterior = static_cast<int>(hinges_.size());
+  census_.nHingesBoundary = nHingesBoundary;
+  census_.nHoleVertices = static_cast<int>(holeVertices.size());
+}
+
+InteriorHinges::Masses InteriorHinges::masses() const {
+  Masses out;
+  if (hinges_.empty()) {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    out.mShell = out.mSum = out.mAction = out.maxAbsIm = nan;
+    out.nImNonzero = 0;
+    out.empty = true;
+    return out;
+  }
+  out.empty = false;
+  // Per-shell Re-deficit bins, ordered shell-ascending with the unshelled bin
+  // (nullopt) last — the Python `sorted(bins, key=(is None, shell))`.
+  std::map<int, std::vector<double>> shelled;
+  std::vector<double> unshelled;
+  double mSum = 0.0;
+  double mAction = 0.0;
+  double maxAbsIm = 0.0;
+  int nImNonzero = 0;
+  for (const auto &h : hinges_) {
+    if (h.shell) {
+      shelled[*h.shell].push_back(h.re);
+    } else {
+      unshelled.push_back(h.re);
+    }
+    mSum += h.re;
+    mAction += h.re * std::fabs(h.dv);
+    maxAbsIm = std::max(maxAbsIm, std::fabs(h.im));
+    if (std::fabs(h.im) > IM_TOL) ++nImNonzero;
+  }
+  double mShell = 0.0;
+  for (const auto &kv : shelled) {
+    const double sm = mean(kv.second);
+    out.shellMeans.emplace_back(kv.first, sm);
+    mShell += sm;
+  }
+  if (!unshelled.empty()) {
+    const double sm = mean(unshelled);
+    out.shellMeans.emplace_back(std::nullopt, sm);
+    mShell += sm;
+  }
+  out.mShell = mShell;
+  out.mSum = mSum;
+  out.mAction = mAction;
+  out.maxAbsIm = maxAbsIm;
+  out.nImNonzero = nImNonzero;
+  return out;
+}
+
+InteriorHinges::Radii InteriorHinges::radii() const {
+  Radii out;
+  std::unordered_set<std::uint64_t> boundaryVertexIds;
+  for (const auto &tet : census_.boundaryTets) {
+    for (std::uint64_t v : tet) boundaryVertexIds.insert(v);
+  }
+  // V_dual: sum |★v| over the strictly INTERIOR vertices (on no boundary tet).
+  // The 0-simplices sorted by id, skipping orphans (no top coface) and boundary
+  // vertices — the signature-aware circumcentric dual 4-volume.
+  std::vector<const Simplex *> vertexSimplices;
+  for (const auto *s : spacetime_->getSimplices()) {
+    if (s->getVertices().size() == 1) vertexSimplices.push_back(s);
+  }
+  std::sort(vertexSimplices.begin(), vertexSimplices.end(),
+            [](const Simplex *a, const Simplex *b) {
+              return a->getVertices()[0]->getId() <
+                     b->getVertices()[0]->getId();
+            });
+  double vDual = 0.0;
+  int nInterior = 0;
+  for (const auto *s : vertexSimplices) {
+    if (!s->hasTopCoface()) continue;  // orphan 0-simplex stranded by a move
+    const std::uint64_t vid = s->getVertices()[0]->getId();
+    if (boundaryVertexIds.count(vid)) continue;
+    vDual += std::fabs(s->dualVolume());
+    ++nInterior;
+  }
+  double vPrimal = 0.0;
+  for (const auto *t : spacetime_->getTopSimplices()) {
+    vPrimal += std::fabs(t->volume());
+  }
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  out.vDual = vDual;
+  out.vPrimal = vPrimal;
+  out.nInteriorVertices = nInterior;
+  out.rDual = vDual > 0.0 ? std::pow(vDual, 0.25) : nan;
+  out.rPrimal = vPrimal > 0.0 ? std::pow(vPrimal, 0.25) : nan;
+  return out;
+}
+
+InteriorHinges::Localization InteriorHinges::localization() const {
+  Localization out;
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+  if (hinges_.empty()) {
+    out.pr = out.concentration = out.meanRe = out.stdRe = out.stdOverMean = nan;
+    out.rmsShellRadius = out.fracWithinShell1 = nan;
+    out.empty = true;
+    return out;
+  }
+  out.empty = false;
+  std::vector<double> re;
+  std::vector<double> weight;
+  re.reserve(hinges_.size());
+  weight.reserve(hinges_.size());
+  for (const auto &h : hinges_) {
+    re.push_back(h.re);
+    weight.push_back(std::fabs(h.re * std::fabs(h.dv)));
+  }
+  double totalWeight = 0.0;
+  double sumWeightSq = 0.0;
+  for (double w : weight) {
+    totalWeight += w;
+    sumWeightSq += w * w;
+  }
+  out.pr = totalWeight > 0.0
+               ? (totalWeight * totalWeight /
+                  (static_cast<double>(weight.size()) * sumWeightSq))
+               : nan;
+  out.concentration = (out.pr == out.pr && out.pr > 0.0) ? 1.0 / out.pr : nan;
+
+  const bool allShelled =
+      std::all_of(hinges_.begin(), hinges_.end(),
+                  [](const Hinge &h) { return h.shell.has_value(); });
+  out.rmsShellRadius = nan;
+  out.fracWithinShell1 = nan;
+  if (allShelled && totalWeight > 0.0) {
+    std::map<int, std::vector<std::size_t>> byShell;
+    for (std::size_t i = 0; i < hinges_.size(); ++i) {
+      byShell[*hinges_[i].shell].push_back(i);
+    }
+    for (const auto &kv : byShell) {
+      ShellProfile p;
+      p.n = static_cast<int>(kv.second.size());
+      double reSum = 0.0;
+      double wSum = 0.0;
+      for (std::size_t i : kv.second) {
+        reSum += re[i];
+        wSum += weight[i];
+      }
+      p.meanRe = reSum / static_cast<double>(kv.second.size());
+      p.weightShare = wSum / totalWeight;
+      out.shellProfile.emplace_back(kv.first, p);
+    }
+    double rms = 0.0;
+    double near = 0.0;
+    for (std::size_t i = 0; i < hinges_.size(); ++i) {
+      const double sh = static_cast<double>(*hinges_[i].shell);
+      rms += weight[i] * sh * sh;
+      if (*hinges_[i].shell <= 1) near += weight[i];
+    }
+    out.rmsShellRadius = std::sqrt(rms / totalWeight);
+    out.fracWithinShell1 = near / totalWeight;
+  }
+
+  out.meanRe = mean(re);
+  out.stdRe = populationStd(re);
+  out.stdOverMean = out.meanRe != 0.0 ? out.stdRe / std::fabs(out.meanRe) : inf;
+  return out;
+}
+
+InteriorHinges::RmTable InteriorHinges::rmTable(const Masses &mass,
+                                                const Radii &rad) const {
+  RmTable out;
+  out.physical = PHYSICAL_RM;
+  // 3 mass definitions × 2 radius definitions, mass outer / radius inner —
+  // the Python `rm_table` insertion order.
+  const std::pair<const char *, double> masses[] = {
+      {"m_shell", mass.mShell}, {"m_sum", mass.mSum}, {"m_action", mass.mAction}};
+  const std::pair<const char *, double> radii[] = {{"r_dual", rad.rDual},
+                                                   {"r_primal", rad.rPrimal}};
+  double spreadMin = std::numeric_limits<double>::infinity();
+  double spreadMax = -std::numeric_limits<double>::infinity();
+  bool anyFinite = false;
+  for (const auto &m : masses) {
+    for (const auto &r : radii) {
+      const double value = r.second * m.second;  // rad * mass
+      out.combos.emplace_back(std::string(r.first) + " x " + m.first, value);
+      if (std::isfinite(value)) {
+        spreadMin = std::min(spreadMin, value);
+        spreadMax = std::max(spreadMax, value);
+        anyFinite = true;
+      }
+    }
+  }
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  out.spreadMin = anyFinite ? spreadMin : nan;
+  out.spreadMax = anyFinite ? spreadMax : nan;
+  return out;
+}
+
+}  // namespace tessera::observables

--- a/src/observables/LiveComplex.cpp
+++ b/src/observables/LiveComplex.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/LiveComplex.h"
+
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <set>
+#include <stdexcept>
+#include <string>
+
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Vertex.h"
+#include "mesh/VertexList.h"
+#include "spacetime/Metric.h"
+#include "spacetime/Signature.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::observables {
+using ::tessera::mesh::Edge;
+
+std::shared_ptr<Spacetime> LiveComplex::load(
+    const std::vector<std::vector<std::uint64_t>> &cells,
+    const std::map<std::pair<std::uint64_t, std::uint64_t>,
+                   std::complex<double>> &squaredLengths,
+    const std::map<std::uint64_t, double> &vertexTimes, int dimensions) {
+  if (cells.empty()) {
+    throw std::invalid_argument("LiveComplex::load needs at least one top cell");
+  }
+  // The canonical entry point — nothing is built outside it. fromCells lays down
+  // the top cells (`dimensions` is the recorded complex dimension, passed
+  // through, never guessed); the metric and times are then loaded back exactly
+  // as recorded, and the facet skeleton is completed for reading.
+  auto st = Spacetime::fromCells(dimensions, cells, 1.0, 0.0);
+  if (!vertexTimes.empty()) {
+    const auto &vertexList = st->getVertexList();
+    for (const auto &kv : vertexTimes) {
+      vertexList->get(kv.first)->setTime(kv.second);
+    }
+  }
+  // The edges of a freshly loaded complex are legitimately mutable — loading the
+  // recorded squared lengths is the whole point of a rehydration, not a change
+  // to any emergent state.
+  for (Edge *e : st->getEdgeList()->toVector()) {
+    const std::uint64_t a = e->getSource()->getId();
+    const std::uint64_t b = e->getTarget()->getId();
+    auto it = squaredLengths.find(a < b ? std::make_pair(a, b)
+                                        : std::make_pair(b, a));
+    if (it == squaredLengths.end()) {
+      throw std::out_of_range(
+          "LiveComplex::load: edge (" + std::to_string(std::min(a, b)) + ", " +
+          std::to_string(std::max(a, b)) +
+          ") of the loaded complex has no recorded squared length — a partial "
+          "metric is never silently defaulted");
+    }
+    e->setSquaredLength(it->second);
+  }
+  // Complete the facet/coface skeleton the dual-volume / deficit reads walk —
+  // the honest direct call, never a solver (fromCells leaves only the top
+  // cells; this reproduces the ReggeSolver + ChainComplex skeleton bit-for-bit).
+  st->materializeFacets();
+  return st;
+}
+
+std::shared_ptr<Spacetime> LiveComplex::subcomplex(
+    const std::vector<std::vector<std::uint64_t>> &cells, int dimensions) {
+  if (cells.empty()) {
+    throw std::invalid_argument(
+        "LiveComplex::subcomplex needs at least one cell");
+  }
+  // The cells are already SELECTED by the caller (existing ambient top cells);
+  // `dimensions` is the ambient complex's canonical dimension. This only
+  // re-instantiates the selection with a uniform metric through the canonical
+  // fromCells (the block-residual carry diagnostic), never a build.
+  return Spacetime::fromCells(dimensions, cells, 1.0, 0.0);
+}
+
+LiveComplex::Relabeled LiveComplex::relabel(const Spacetime &spacetime,
+                                            std::uint64_t seed) {
+  // Read the recorded geometry off the live complex (const reads only). The
+  // dimension is the canonical metric-signature dimension, not a cell-size guess.
+  const int dimensions = spacetime.getMetric()->getSignature()->getDimensions();
+  std::vector<std::vector<std::uint64_t>> cells;
+  cells.reserve(spacetime.getTopSimplices().size());
+  for (const auto *c : spacetime.getTopSimplices()) {
+    std::vector<std::uint64_t> vids;
+    vids.reserve(c->getVertices().size());
+    for (const auto *v : c->getVertices()) vids.push_back(v->getId());
+    cells.push_back(std::move(vids));
+  }
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::complex<double>> edges;
+  for (const auto *e : spacetime.getEdgeList()->toVector()) {
+    const std::uint64_t a = e->getSource()->getId();
+    const std::uint64_t b = e->getTarget()->getId();
+    edges[a < b ? std::make_pair(a, b) : std::make_pair(b, a)] =
+        e->getSquaredLength();
+  }
+  std::map<std::uint64_t, double> times;
+  const auto &vertexList = spacetime.getVertexList();
+  for (const auto &cell : cells) {
+    for (std::uint64_t v : cell) {
+      if (!times.count(v)) times[v] = vertexList->get(v)->getTime();
+    }
+  }
+
+  // A random vertex-id permutation + cell-order shuffle (deterministic in seed).
+  std::set<std::uint64_t> uniqueVertices;
+  for (const auto &cell : cells) {
+    for (std::uint64_t v : cell) uniqueVertices.insert(v);
+  }
+  std::vector<std::uint64_t> allVertices(uniqueVertices.begin(),
+                                         uniqueVertices.end());
+  std::vector<std::uint64_t> shuffled = allVertices;
+  std::mt19937_64 rng(seed);
+  std::shuffle(shuffled.begin(), shuffled.end(), rng);
+  std::map<std::uint64_t, std::uint64_t> perm;
+  for (std::size_t i = 0; i < allVertices.size(); ++i) {
+    perm[allVertices[i]] = shuffled[i];
+  }
+
+  std::vector<std::size_t> order(cells.size());
+  std::iota(order.begin(), order.end(), 0);
+  std::shuffle(order.begin(), order.end(), rng);
+
+  std::vector<std::vector<std::uint64_t>> permutedCells;
+  permutedCells.reserve(cells.size());
+  for (std::size_t idx : order) {
+    std::vector<std::uint64_t> permuted;
+    permuted.reserve(cells[idx].size());
+    for (std::uint64_t v : cells[idx]) permuted.push_back(perm.at(v));
+    permutedCells.push_back(std::move(permuted));
+  }
+  std::map<std::pair<std::uint64_t, std::uint64_t>, std::complex<double>>
+      permutedEdges;
+  for (const auto &kv : edges) {
+    const std::uint64_t a = perm.at(kv.first.first);
+    const std::uint64_t b = perm.at(kv.first.second);
+    permutedEdges[a < b ? std::make_pair(a, b) : std::make_pair(b, a)] =
+        kv.second;
+  }
+  std::map<std::uint64_t, double> permutedTimes;
+  for (const auto &kv : times) permutedTimes[perm.at(kv.first)] = kv.second;
+
+  Relabeled out;
+  out.spacetime = load(permutedCells, permutedEdges, permutedTimes, dimensions);
+  out.vertexMap = std::move(perm);
+  return out;
+}
+
+}  // namespace tessera::observables

--- a/src/observables/ObservableGates.cpp
+++ b/src/observables/ObservableGates.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/ObservableGates.h"
+
+#include <complex>
+#include <map>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+#include "cobordism/MultiCobordism.h"
+#include "observables/LiveComplex.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::observables {
+using ::tessera::cobordism::MultiCobordism;
+
+double ObservableGates::gaugeDelta(const RegisterObservable &observable,
+                                   const RegisterContext &ctx) {
+  const Record base = observable.record(ctx);
+  const auto gauged = ctx.gauged(GAUGE_THETA);
+  return Record::reportDelta(base, observable.record(*gauged));
+}
+
+double ObservableGates::relabelDelta(const RegisterObservable &observable,
+                                     const RegisterContext &ctx) {
+  const Record base = observable.record(ctx);
+
+  // The relabeled rebuild is a construction — it lives in the loader, not here.
+  const LiveComplex::Relabeled rel =
+      LiveComplex::relabel(*ctx.spacetime(), GATE_SEED);
+
+  // Match this register's hole images among the relabeled complex's emergent
+  // holes by permuted vertex SET (a missing image throws — the gate must compare
+  // like with like).
+  const std::vector<std::vector<std::uint64_t>> rederived =
+      MultiCobordism::emergentHoles(*rel.spacetime, ctx.degree());
+  std::map<std::set<std::uint64_t>, std::vector<std::uint64_t>> found;
+  for (const auto &h : rederived) {
+    found[std::set<std::uint64_t>(h.begin(), h.end())] = h;
+  }
+  std::vector<std::vector<std::uint64_t>> holes2;
+  holes2.reserve(ctx.holes().size());
+  for (const auto &h : ctx.holes()) {
+    std::set<std::uint64_t> image;
+    for (std::uint64_t v : h) image.insert(rel.vertexMap.at(v));
+    auto it = found.find(image);
+    if (it == found.end()) {
+      throw std::runtime_error(
+          "ObservableGates: the relabeled complex's emergent holes are missing "
+          "the image of a register hole (the gate cannot compare like with "
+          "like)");
+    }
+    holes2.push_back(it->second);
+  }
+
+  const RegisterContext relabeledCtx(rel.spacetime, holes2,
+                                     static_cast<int>(holes2.size()),
+                                     ctx.degree(), ctx.target());
+  const Record relabeled =
+      observable.recordRelabeled(relabeledCtx, rel.vertexMap);
+  return Record::reportDelta(base, relabeled);
+}
+
+ObservableGates::GateResult ObservableGates::evaluate(
+    const RegisterObservable &observable, const RegisterContext &ctx) {
+  GateResult result;
+  result.gaugeDelta = gaugeDelta(observable, ctx);
+  result.relabelDelta = relabelDelta(observable, ctx);
+  result.gateTol = observable.gateTol();
+  result.gaugeOk = result.gaugeDelta <= result.gateTol;
+  result.relabelOk = result.relabelDelta <= result.gateTol;
+  return result;
+}
+
+bool ObservableGates::selfTest(const RegisterContext &ctx) {
+  const LabelLeakProbe labelProbe;
+  const GaugeLeakProbe gaugeProbe;
+  return relabelDelta(labelProbe, ctx) > 0.0 &&
+         gaugeDelta(gaugeProbe, ctx) > 0.0;
+}
+
+// ---- the self-test probes ----
+
+Record LabelLeakProbe::record(const RegisterContext &ctx) const {
+  double sum = 0.0;
+  for (const auto &hole : ctx.holes()) {
+    for (std::uint64_t v : hole) sum += static_cast<double>(v);
+  }
+  Record::Map m;
+  m["vertex_id_sum"] = sum;
+  return Record(std::move(m));
+}
+
+double LabelLeakProbe::computeHeadline(const RegisterContext &ctx) const {
+  double sum = 0.0;
+  for (const auto &hole : ctx.holes()) {
+    for (std::uint64_t v : hole) sum += static_cast<double>(v);
+  }
+  return sum;
+}
+
+Record GaugeLeakProbe::record(const RegisterContext &ctx) const {
+  Record::Map m;
+  Record::splitComplex(m, "raw_target0", ctx.target().at(0));
+  return Record(std::move(m));
+}
+
+double GaugeLeakProbe::computeHeadline(const RegisterContext &ctx) const {
+  return std::abs(ctx.target().at(0));
+}
+
+}  // namespace tessera::observables

--- a/src/observables/PairLoopFlavor.cpp
+++ b/src/observables/PairLoopFlavor.cpp
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/PairLoopFlavor.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <set>
+#include <stdexcept>
+
+#include "cobordism/EigenstateSynthesis.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::observables {
+using ::tessera::cobordism::EigenstateSynthesis;
+
+namespace {
+
+// Hole `h`'s five boundary tetrahedra as (cochain index, (-1)^j sign) pairs:
+// facet j of the sorted hole drops vertex v_j and carries (-1)^j — the same
+// boundary-operator convention cyclePeriods documents. Facets matched by vertex
+// SET (never an imposed order); the physical orientation is supplied separately
+// by the induced-orientation signs.
+std::vector<std::pair<std::size_t, int>> facetIndices(
+    const std::map<std::vector<std::uint64_t>, std::size_t> &cellIndex,
+    const std::vector<std::uint64_t> &hole) {
+  std::vector<std::uint64_t> hs = hole;
+  std::sort(hs.begin(), hs.end());
+  std::vector<std::pair<std::size_t, int>> out;
+  out.reserve(hs.size());
+  for (std::size_t j = 0; j < hs.size(); ++j) {
+    std::vector<std::uint64_t> facet;
+    facet.reserve(hs.size() - 1);
+    for (std::size_t i = 0; i < hs.size(); ++i) {
+      if (i != j) facet.push_back(hs[i]);
+    }
+    auto it = cellIndex.find(facet);
+    if (it == cellIndex.end()) {
+      throw std::runtime_error(
+          "PairLoopFlavor: a hole facet is not a registered k-cell — the "
+          "register degree does not match the hole dimension");
+    }
+    out.emplace_back(it->second, (j % 2 == 0) ? 1 : -1);
+  }
+  return out;
+}
+
+}  // namespace
+
+std::pair<int, double> PairLoopFlavor::oddOneOut(
+    const std::vector<double> &loopQ) {
+  std::array<double, 3> separations{};
+  for (int k = 0; k < 3; ++k) {
+    std::array<double, 2> others{};
+    int n = 0;
+    for (int i = 0; i < 3; ++i) {
+      if (i != k) others[n++] = loopQ[i];
+    }
+    separations[k] = std::fabs(loopQ[k] - (others[0] + others[1]) / 2.0);
+  }
+  // np.argmax: the FIRST maximal index.
+  int odd = 0;
+  for (int k = 1; k < 3; ++k) {
+    if (separations[k] > separations[odd]) odd = k;
+  }
+  std::array<double, 2> others{};
+  int n = 0;
+  for (int i = 0; i < 3; ++i) {
+    if (i != odd) others[n++] = loopQ[i];
+  }
+  const double rho = separations[odd] > 0.0
+                         ? std::fabs(others[0] - others[1]) / separations[odd]
+                         : std::numeric_limits<double>::infinity();
+  return {odd, rho};
+}
+
+PairLoopFlavor::JointRead PairLoopFlavor::jointRead(
+    const RegisterContext &ctx) const {
+  const auto &holes = ctx.holes();
+  if (holes.size() != 3 || ctx.target().size() != 3) {
+    throw std::invalid_argument(
+        "PairLoopFlavor: the pair-loop read is over exactly 3 holes");
+  }
+  EigenstateSynthesis &es = ctx.synthesis();
+  const auto &cellIndex = ctx.cellIndex();
+  const std::vector<double> &weights = ctx.hodgeWeights();
+  const std::vector<int> &sigma = ctx.epsilonSigns();
+  const auto &target = ctx.target();
+
+  std::vector<std::complex<double>> rawTarget(3);
+  for (int h = 0; h < 3; ++h) {
+    rawTarget[h] = static_cast<double>(sigma[h]) * target[h];
+  }
+  const std::vector<std::vector<std::uint64_t>> holeLists(holes.begin(),
+                                                          holes.end());
+  const std::vector<std::complex<double>> psi =
+      es.carriedRepresentative(holeLists, rawTarget);
+
+  JointRead read;
+  read.sigma = sigma;
+  read.rU = es.residualForPeriods(holeLists, rawTarget);
+
+  std::array<std::vector<std::pair<std::size_t, int>>, 3> facets;
+  for (int h = 0; h < 3; ++h) facets[h] = facetIndices(cellIndex, holes[h]);
+
+  read.w.resize(3);
+  read.q.resize(3);
+  for (int h = 0; h < 3; ++h) {
+    std::complex<double> w(0.0, 0.0);
+    double q = 0.0;
+    for (const auto &cs : facets[h]) {
+      w += static_cast<double>(cs.second) * psi[cs.first];
+      q += weights[cs.first] * std::norm(psi[cs.first]);
+    }
+    read.w[h] = static_cast<double>(sigma[h]) * w;
+    read.q[h] = q;
+  }
+
+  for (const auto &pair : PAIR_LOOPS) {
+    const int i = pair.first;
+    const int j = pair.second;
+    read.loopW.push_back(read.w[i] + read.w[j]);
+    std::set<std::size_t> support;
+    for (const auto &cs : facets[i]) support.insert(cs.first);
+    for (const auto &cs : facets[j]) support.insert(cs.first);
+    double loopQ = 0.0;
+    for (std::size_t c : support) loopQ += weights[c] * std::norm(psi[c]);
+    read.loopQ.push_back(loopQ);
+    const int k = complementHole(pair);
+    read.dualResidual.push_back(std::abs(read.w[i] + read.w[j] + read.w[k]));
+  }
+  return read;
+}
+
+PairLoopFlavor::Verdict PairLoopFlavor::evaluateCriteria(
+    const JointRead &read) const {
+  const auto [odd, rho] = oddOneOut(read.loopQ);
+  Verdict verdict;
+  verdict.oddLoop = PAIR_LOOPS[odd];
+  verdict.dualHole = complementHole(PAIR_LOOPS[odd]);
+  verdict.rho = rho;
+  verdict.multiplicity21 = rho < RHO_MAX;
+  if (diquarkPair_) {
+    std::pair<int, int> sorted = *diquarkPair_;
+    if (sorted.first > sorted.second) std::swap(sorted.first, sorted.second);
+    verdict.oddIsDiquarkLoop = (sorted == PAIR_LOOPS[odd]);
+  }
+  return verdict;
+}
+
+double PairLoopFlavor::computeHeadline(const RegisterContext &ctx) const {
+  return evaluateCriteria(jointRead(ctx)).rho;
+}
+
+Record PairLoopFlavor::record(const RegisterContext &ctx) const {
+  const JointRead read = jointRead(ctx);
+  const Verdict verdict = evaluateCriteria(read);
+
+  // The oriented periods are U(1)-covariant (w -> e^{iθ} w) and flip with the
+  // endSignCovector propagation root under RELABEL; dividing out w0's unit phase
+  // reports them in the one propagation-root-fixed convention, so every leaf is
+  // invariant.
+  const std::complex<double> phase0 =
+      std::abs(read.w[0]) > 0.0 ? read.w[0] / std::abs(read.w[0])
+                                : std::complex<double>(1.0, 0.0);
+  std::vector<std::complex<double>> wFixed;
+  for (const auto &wi : read.w) wFixed.push_back(wi / phase0);
+  std::vector<std::complex<double>> loopWFixed;
+  for (const auto &wi : read.loopW) loopWFixed.push_back(wi / phase0);
+
+  Record::List q;
+  for (double x : read.q) q.emplace_back(x);
+  Record::List loopQ;
+  for (double x : read.loopQ) loopQ.emplace_back(x);
+  Record::List dualResidual;
+  for (double x : read.dualResidual) dualResidual.emplace_back(x);
+  Record::List pairLoops;
+  for (const auto &pl : PAIR_LOOPS) {
+    pairLoops.emplace_back(Record::List{pl.first, pl.second});
+  }
+
+  Record::Map m;
+  m["r_u"] = read.rU;
+  m["q"] = std::move(q);
+  m["loop_q"] = std::move(loopQ);
+  m["dual_residual"] = std::move(dualResidual);
+  m["pair_loops"] = std::move(pairLoops);
+  m["odd_loop"] = Record::List{verdict.oddLoop.first, verdict.oddLoop.second};
+  m["dual_hole"] = verdict.dualHole;
+  m["rho"] = verdict.rho;
+  m["rho_max"] = RHO_MAX;
+  m["multiplicity_2_1"] = verdict.multiplicity21;
+  if (verdict.oddIsDiquarkLoop) {
+    m["odd_is_diquark_loop"] = *verdict.oddIsDiquarkLoop;
+    m["odd_is_diquark_loop_status"] = std::string(kOddDiquarkEvaluated);
+  } else {
+    m["odd_is_diquark_loop"] = Record();  // null
+    m["odd_is_diquark_loop_status"] = std::string(kOddDiquarkNotEvaluable);
+  }
+  Record::splitComplex(m, "w", wFixed);
+  Record::splitComplex(m, "loop_w", loopWFixed);
+  return Record(std::move(m));
+}
+
+}  // namespace tessera::observables

--- a/src/observables/Record.cpp
+++ b/src/observables/Record.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/Record.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+namespace tessera::observables {
+
+void Record::splitComplex(Map &into, const std::string &name,
+                          std::complex<double> value) {
+  into[name + "_re"] = value.real();
+  into[name + "_im"] = value.imag();
+}
+
+void Record::splitComplex(Map &into, const std::string &name,
+                          const std::vector<std::complex<double>> &values) {
+  List re;
+  List im;
+  re.reserve(values.size());
+  im.reserve(values.size());
+  for (const auto &z : values) {
+    re.emplace_back(z.real());
+    im.emplace_back(z.imag());
+  }
+  into[name + "_re"] = std::move(re);
+  into[name + "_im"] = std::move(im);
+}
+
+namespace {
+
+[[noreturn]] void throwKeyMismatch(const Record::Map &a, const Record::Map &b) {
+  std::ostringstream oss;
+  oss << "record keys differ: {";
+  bool first = true;
+  for (const auto &kv : a) {
+    oss << (first ? "" : ", ") << kv.first;
+    first = false;
+  }
+  oss << "} vs {";
+  first = true;
+  for (const auto &kv : b) {
+    oss << (first ? "" : ", ") << kv.first;
+    first = false;
+  }
+  oss << "}";
+  throw std::invalid_argument(oss.str());
+}
+
+// Python `int(x)`: bools are 0/1, floats truncate toward zero.
+std::int64_t asIntegerValue(const Record &r) {
+  switch (r.type()) {
+    case Record::Type::Bool:
+      return r.asBool() ? 1 : 0;
+    case Record::Type::Int:
+      return r.asInt();
+    case Record::Type::Double:
+      return static_cast<std::int64_t>(r.asDouble());
+    default:
+      return 0;
+  }
+}
+
+}  // namespace
+
+double Record::reportDelta(const Record &a, const Record &b) {
+  const double inf = std::numeric_limits<double>::infinity();
+
+  // dicts must have identical keys; else the max over their shared keys.
+  if (a.type_ == Type::Map || b.type_ == Type::Map) {
+    if (!(a.type_ == Type::Map && b.type_ == Type::Map)) {
+      return inf;
+    }
+    if (a.map_.size() != b.map_.size()) {
+      throwKeyMismatch(a.map_, b.map_);
+    }
+    double worst = 0.0;
+    for (const auto &kv : a.map_) {
+      auto it = b.map_.find(kv.first);
+      if (it == b.map_.end()) {
+        throwKeyMismatch(a.map_, b.map_);
+      }
+      worst = std::max(worst, reportDelta(kv.second, it->second));
+    }
+    return worst;
+  }
+
+  // strings (and None) must be equal; a changed status is a flagged channel.
+  if (a.type_ == Type::String || b.type_ == Type::String) {
+    if (a.type_ == Type::String && b.type_ == Type::String &&
+        a.string_ == b.string_) {
+      return 0.0;
+    }
+    return inf;
+  }
+  if (a.type_ == Type::Null || b.type_ == Type::Null) {
+    return (a.type_ == Type::Null && b.type_ == Type::Null) ? 0.0 : inf;
+  }
+
+  // lists must match in length, then the max over their elements.
+  if (a.type_ == Type::List || b.type_ == Type::List) {
+    if (!(a.type_ == Type::List && b.type_ == Type::List)) {
+      return inf;
+    }
+    if (a.list_.size() != b.list_.size()) {
+      return inf;
+    }
+    double worst = 0.0;
+    for (std::size_t i = 0; i < a.list_.size(); ++i) {
+      worst = std::max(worst, reportDelta(a.list_[i], b.list_[i]));
+    }
+    return worst;
+  }
+
+  // bools compare as 0/1 (checked before the numeric branch, as in Python).
+  if (a.type_ == Type::Bool || b.type_ == Type::Bool) {
+    return std::fabs(
+        static_cast<double>(asIntegerValue(a) - asIntegerValue(b)));
+  }
+
+  // numbers: two NaNs agree (delta 0); a NaN against a number is inf.
+  const double x = (a.type_ == Type::Int) ? static_cast<double>(a.int_)
+                                          : a.double_;
+  const double y = (b.type_ == Type::Int) ? static_cast<double>(b.int_)
+                                          : b.double_;
+  if (std::isnan(x) || std::isnan(y)) {
+    return (std::isnan(x) && std::isnan(y)) ? 0.0 : inf;
+  }
+  return std::fabs(x - y);
+}
+
+}  // namespace tessera::observables

--- a/src/observables/RegisterContext.cpp
+++ b/src/observables/RegisterContext.cpp
@@ -4,8 +4,7 @@
 #include "observables/RegisterContext.h"
 
 #include <algorithm>
-#include <cmath>
-#include <set>
+#include <complex>
 #include <sstream>
 #include <stdexcept>
 #include <utility>

--- a/src/observables/RegisterContext.cpp
+++ b/src/observables/RegisterContext.cpp
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/RegisterContext.h"
+
+#include <algorithm>
+#include <cmath>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+#include "cobordism/ChainComplex.h"
+#include "cobordism/HodgeLaplacian.h"
+#include "cobordism/MultiCobordism.h"
+#include "mesh/Edge.h"
+#include "mesh/EdgeList.h"
+#include "mesh/Simplex.h"
+#include "mesh/Vertex.h"
+#include "observables/InteriorHinges.h"
+#include "spacetime/Metric.h"
+#include "spacetime/Signature.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::observables {
+using ::tessera::cobordism::ChainComplex;
+using ::tessera::cobordism::EigenstateSynthesis;
+using ::tessera::cobordism::HodgeLaplacian;
+using ::tessera::cobordism::MultiCobordism;
+
+// The lazily-built shared per-complex structures. Held behind one shared_ptr so
+// a `gauged()` copy shares every cache both ways — the caches are all
+// target-independent (they depend only on the live complex, holes, and degree),
+// so sharing across a gauge rotation is safe.
+struct RegisterContext::Caches {
+  std::unique_ptr<EigenstateSynthesis> synthesis;
+  bool epsBuilt = false;
+  std::vector<int> eps;
+  bool weightsBuilt = false;
+  std::vector<double> hodgeWeights;
+  bool cellIndexBuilt = false;
+  std::map<std::vector<std::uint64_t>, std::size_t> cellIndex;
+  bool bettiBuilt = false;
+  std::vector<int> betti;
+  std::shared_ptr<InteriorHinges> interiorHinges;
+};
+
+namespace {
+
+std::string formatHole(const std::vector<std::uint64_t> &hole) {
+  std::ostringstream oss;
+  oss << "(";
+  for (std::size_t i = 0; i < hole.size(); ++i) {
+    oss << (i ? ", " : "") << hole[i];
+  }
+  oss << ")";
+  return oss.str();
+}
+
+std::string formatHoleList(
+    const std::vector<std::vector<std::uint64_t>> &holes) {
+  std::ostringstream oss;
+  oss << "[";
+  for (std::size_t i = 0; i < holes.size(); ++i) {
+    oss << (i ? ", " : "") << formatHole(holes[i]);
+  }
+  oss << "]";
+  return oss.str();
+}
+
+}  // namespace
+
+RegisterContext::RegisterContext(std::shared_ptr<Spacetime> spacetime,
+                                 int count, int degree,
+                                 std::vector<std::complex<double>> target)
+    : spacetime_(std::move(spacetime)),
+      degree_(degree),
+      target_(std::move(target)),
+      caches_(std::make_shared<Caches>()) {
+  initialize(count, nullptr);
+}
+
+RegisterContext::RegisterContext(
+    std::shared_ptr<Spacetime> spacetime,
+    const std::vector<std::vector<std::uint64_t>> &holes, int count, int degree,
+    std::vector<std::complex<double>> target)
+    : spacetime_(std::move(spacetime)),
+      degree_(degree),
+      target_(std::move(target)),
+      caches_(std::make_shared<Caches>()) {
+  initialize(count, &holes);
+}
+
+void RegisterContext::initialize(
+    int count, const std::vector<std::vector<std::uint64_t>> *explicitHoles) {
+  if (count < 0 || degree_ < 0) {
+    throw std::invalid_argument(
+        "RegisterContext: count and degree must be non-negative");
+  }
+  if (!spacetime_) {
+    throw std::invalid_argument("RegisterContext: null spacetime");
+  }
+
+  // A pure reader: no build, no solve, no materialize. Every census below is
+  // read off the `const` query surface of an already-built, relaxed complex.
+  const Spacetime &st = *spacetime_;
+
+  topCellCount_ = static_cast<int>(st.getTopSimplices().size());
+  // The canonical spacetime dimension is the metric signature's dimension (the
+  // same accessor WilsonLoop / ReggeSolver read), never a cell-size guess.
+  dimensions_ = st.getMetric()->getSignature()->getDimensions();
+
+  causalContent_ = false;
+  for (const auto *e : st.getEdgeList()->toVector()) {
+    if (!e->isSpacelike()) {
+      causalContent_ = true;
+      break;
+    }
+  }
+
+  // The emergent register census at the register degree (nothing placed).
+  std::vector<std::vector<std::uint64_t>> emergent =
+      MultiCobordism::emergentHoles(st, degree_);
+  holesTotal_ = static_cast<int>(emergent.size());
+
+  const std::vector<std::vector<std::uint64_t>> &candidates =
+      explicitHoles ? *explicitHoles : emergent;
+
+  // Hole selection validated at this ONE entry point: a deficit throws; a
+  // surplus is an explicit, recorded truncation naming the dropped holes (never
+  // a silent slice).
+  if (static_cast<int>(candidates.size()) < count) {
+    std::ostringstream oss;
+    if (explicitHoles) {
+      oss << "need >= " << count << " register holes, got "
+          << candidates.size();
+    } else {
+      oss << "need >= " << count << " register holes at degree " << degree_
+          << ", found " << candidates.size();
+      if (!candidates.empty()) oss << ": " << formatHoleList(candidates);
+      oss << " — this specimen cannot host the requested register";
+    }
+    throw std::invalid_argument(oss.str());
+  }
+
+  holes_.assign(candidates.begin(), candidates.begin() + count);
+  droppedHoles_.assign(candidates.begin() + count, candidates.end());
+  if (!droppedHoles_.empty()) {
+    std::ostringstream oss;
+    oss << "register selection: " << candidates.size()
+        << " emergent holes; using the first " << count
+        << " (emergentHoles order), dropping " << formatHoleList(droppedHoles_)
+        << " — the confinement constraint ranges over ALL holes, so the read "
+           "covers a sub-register";
+    selectionWarning_ = oss.str();
+  }
+}
+
+int RegisterContext::bK() const {
+  const auto &b = betti();
+  return (degree_ >= 0 && static_cast<std::size_t>(degree_) < b.size())
+             ? b[degree_]
+             : 0;
+}
+
+const std::vector<int> &RegisterContext::betti() const {
+  if (!caches_->bettiBuilt) {
+    caches_->betti = MultiCobordism::betti(*spacetime_);
+    caches_->bettiBuilt = true;
+  }
+  return caches_->betti;
+}
+
+EigenstateSynthesis &RegisterContext::synthesis() const {
+  // The EigenstateSynthesis ctor takes a non-const `shared_ptr<Spacetime>`
+  // because the class is dual-purpose (its setWeights/setInteriorWeights drive
+  // the emergent build). We only ever call its `const`, verified-non-mutating
+  // read methods (cellSimplices / carriedRepresentative / residualForPeriods) —
+  // this reader never touches the drive-side setters.
+  if (!caches_->synthesis) {
+    caches_->synthesis =
+        std::make_unique<EigenstateSynthesis>(spacetime_, degree_);
+  }
+  return *caches_->synthesis;
+}
+
+const std::vector<int> &RegisterContext::epsilonSigns() const {
+  if (!caches_->epsBuilt) {
+    // The induced-orientation signs come from ChainComplex::endSignCovector over
+    // the top cells in their INTRINSIC vertex order (never sorted — the stored
+    // order carries the orientation) and the selected holes.
+    std::vector<std::vector<std::uint64_t>> tops;
+    tops.reserve(spacetime_->getTopSimplices().size());
+    for (const auto *t : spacetime_->getTopSimplices()) {
+      std::vector<std::uint64_t> vids;
+      vids.reserve(t->getVertices().size());
+      for (const auto *v : t->getVertices()) vids.push_back(v->getId());
+      tops.push_back(std::move(vids));
+    }
+    caches_->eps = ChainComplex::endSignCovector(tops, holes_);
+    caches_->epsBuilt = true;
+  }
+  return caches_->eps;
+}
+
+const std::vector<double> &RegisterContext::hodgeWeights() const {
+  if (!caches_->weightsBuilt) {
+    caches_->hodgeWeights = HodgeLaplacian(spacetime_).weights(degree_);
+    caches_->weightsBuilt = true;
+  }
+  return caches_->hodgeWeights;
+}
+
+const std::map<std::vector<std::uint64_t>, std::size_t> &
+RegisterContext::cellIndex() const {
+  if (!caches_->cellIndexBuilt) {
+    const auto &cells = synthesis().cellSimplices();
+    for (std::size_t i = 0; i < cells.size(); ++i) {
+      std::vector<std::uint64_t> key = cells[i];
+      std::sort(key.begin(), key.end());
+      caches_->cellIndex.emplace(std::move(key), i);
+    }
+    caches_->cellIndexBuilt = true;
+  }
+  return caches_->cellIndex;
+}
+
+const std::shared_ptr<InteriorHinges> &RegisterContext::interiorHinges() const {
+  if (!caches_->interiorHinges) {
+    // The shared 4D hinge selection reads a const spacetime — compiler-enforced
+    // read-only. The live complex must already carry its facet skeleton (every
+    // built Proton/ProtonIngredients/MultiCobordism state does; the loader
+    // completes a bare fromCells rehydration before the reader ever sees it).
+    caches_->interiorHinges = std::make_shared<InteriorHinges>(
+        std::shared_ptr<const Spacetime>(spacetime_), holes_);
+  }
+  return caches_->interiorHinges;
+}
+
+std::shared_ptr<RegisterContext> RegisterContext::gauged(double theta) const {
+  // Construction-free: share this context's live spacetime and caches, rotating
+  // only the register target by the global U(1) phase e^{iθ}.
+  auto g = std::make_shared<RegisterContext>(*this);
+  const std::complex<double> phase = std::exp(std::complex<double>(0.0, theta));
+  for (auto &t : g->target_) t *= phase;
+  return g;
+}
+
+}  // namespace tessera::observables

--- a/src/observables/RegisterObservable.cpp
+++ b/src/observables/RegisterObservable.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/RegisterObservable.h"
+
+#include <string>
+
+namespace tessera::observables {
+
+std::string RegisterObservable::skipReason(const RegisterContext &ctx) const {
+  if (needsProvenance() && !hasProvenance()) {
+    return std::string(kSkipNoProvenance);
+  }
+  if (ctx.holesUsed() < minHoles()) {
+    return std::string(kSkipHolesPrefix) + std::to_string(ctx.holesUsed()) +
+           std::string(kSkipHolesInfix) + std::to_string(minHoles());
+  }
+  if (requiredDimensions() >= 0 && ctx.dimensions() != requiredDimensions()) {
+    return std::string(kSkipDimensionsPrefix) +
+           std::to_string(ctx.dimensions()) + std::string(kSkipDimensionsInfix) +
+           std::to_string(requiredDimensions());
+  }
+  if (needsCausalContent() && !ctx.causalContent()) {
+    return std::string(kSkipNoCausalContent);
+  }
+  return "";
+}
+
+double RegisterObservable::compute(
+    const std::shared_ptr<Spacetime> &spacetime) {
+  // Read a default 3-hole register off the live complex and return the headline.
+  RegisterContext ctx(spacetime);
+  return computeHeadline(ctx);
+}
+
+double RegisterObservable::update(const std::shared_ptr<Spacetime> &spacetime) {
+  return compute(spacetime);
+}
+
+}  // namespace tessera::observables

--- a/src/observables/SingletResidual.cpp
+++ b/src/observables/SingletResidual.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Twin Vector Labs LLC.
+// All rights reserved.
+
+#include "observables/SingletResidual.h"
+
+#include <complex>
+#include <vector>
+
+#include "cobordism/MultiCobordism.h"
+#include "cobordism/Proton.h"
+#include "spacetime/Spacetime.h"
+
+namespace tessera::observables {
+using ::tessera::cobordism::MultiCobordism;
+using ::tessera::cobordism::Proton;
+
+namespace {
+
+std::vector<std::complex<double>> conjugateSinglet() {
+  std::vector<std::complex<double>> conj;
+  for (const auto &c : Proton::singlet()) conj.push_back(std::conj(c));
+  return conj;
+}
+
+}  // namespace
+
+double SingletResidual::computeHeadline(const RegisterContext &ctx) const {
+  return MultiCobordism::residualOfTargetStateAgainstHarmonic(
+      ctx.spacetime(), ctx.degree(), Proton::singlet());
+}
+
+double SingletResidual::conjugateResidual(const RegisterContext &ctx) const {
+  return MultiCobordism::residualOfTargetStateAgainstHarmonic(
+      ctx.spacetime(), ctx.degree(), conjugateSinglet());
+}
+
+Record SingletResidual::record(const RegisterContext &ctx) const {
+  const std::vector<std::complex<double>> singlet = Proton::singlet();
+  Record::Map m;
+  m["singlet_residual"] = MultiCobordism::residualOfTargetStateAgainstHarmonic(
+      ctx.spacetime(), ctx.degree(), singlet);
+  m["holes_used"] = ctx.holesUsed();
+  m["holes_total"] = ctx.holesTotal();
+  m["b3"] = ctx.bK();
+  Record::List betti;
+  for (int b : ctx.betti()) betti.emplace_back(b);
+  m["betti"] = std::move(betti);
+  m["holes_vs_b3_divergent"] = ctx.holesVsBettiDivergent();
+  Record::splitComplex(m, "target", singlet);
+  return Record(std::move(m));
+}
+
+}  // namespace tessera::observables

--- a/tests/observables/test_proton_battery_python.py
+++ b/tests/observables/test_proton_battery_python.py
@@ -1,0 +1,496 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Migration equivalence + gates + validation for the C++ emergent-proton battery
+(#593, part of #559).
+
+The battery (``tessera.observables``) migrates the Python ``tessera/observe``
+framework of PRs #574/#575/#576/#584 into C++ Observables. Every expected value
+below is anchored non-circularly:
+
+* the pair-loop rows are the PUBLISHED #576 table (``test_pair_loop_flavor`` /
+  ``test_observe_adapters.PublishedTableAnchorTest``);
+* the mass/radius values on ``∂Δ⁵`` are the closed forms
+  ``m_sum = 20·(2π − 3·arccos¼)`` and ``V = 6√5/96`` (``test_emergent_mass_radius``);
+* the fixture-specific values (singlet residual, census, mass/radius on
+  ``synthetic_b3_3``) were computed by the Python ``tessera/observe`` oracle
+  against this same built ``tessera`` and frozen here — the C++ observable must
+  reproduce them to each observable's gate tolerance (1e-9 singlet/block,
+  1e-6 mass/radius, 1e-9 pair-loop).
+"""
+import importlib.util
+import itertools
+import json
+import math
+import os
+import unittest
+import warnings
+
+import tessera
+
+obs = tessera.observables
+cob = tessera.cobordism
+
+_FIX = os.path.join(os.path.dirname(__file__), "..", "fixtures")
+_CS = os.path.join(_FIX, "composite_spin")
+_CAUSAL = os.path.join(_FIX, "causal_specimens")
+_KEEPER = "/home/andrew/campaign-keepers/gen3-joint-real-manifold/geometry"
+_EX = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "cobordism")
+
+# ∂Δ⁵: every triangle's fan closes with three pentatopes, so every deficit is
+# 2π − 3·arccos(¼); the 6 unit pentatopes have total 4-volume 6·√5/96.
+S4_DEFICIT = 2.0 * math.pi - 3.0 * math.acos(0.25)
+S4_VOLUME = 6.0 * math.sqrt(5.0) / 96.0
+
+
+def _load_driver():
+    spec = importlib.util.spec_from_file_location(
+        "observe_proton_ingredients",
+        os.path.join(_EX, "observe_proton_ingredients.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _composite_spin(name):
+    """A live complex from a composite_spin fixture (edges as {"a,b": [re, im]})."""
+    with open(os.path.join(_CS, name)) as fh:
+        meta = json.load(fh)
+    edges = {}
+    for key, (re, im) in meta["edges"].items():
+        a, b = (int(x) for x in key.split(","))
+        edges[(min(a, b), max(a, b))] = complex(re, im)
+    st = obs.LiveComplex.load([[int(v) for v in c] for c in meta["cells"]],
+                              edges, {}, 4)
+    return meta, st
+
+
+def _register(st, count=3):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return obs.RegisterContext(st, count, 3, cob.Proton.singlet())
+
+
+def _boundary_delta5():
+    return tessera.Spacetime.fromCells(
+        4, [list(c) for c in itertools.combinations(range(6), 5)], 1.0, 0.0)
+
+
+def _star_of_apex():
+    return tessera.Spacetime.fromCells(
+        4, [list(c) for c in itertools.combinations(range(6), 5) if 5 in c],
+        1.0, 0.0)
+
+
+class SingletResidualEquivalenceTest(unittest.TestCase):
+    """SingletResidual == the #574 diagnostic on synthetic_b3_3."""
+
+    def test_record_matches_the_oracle_and_the_direct_read(self):
+        meta, st = _composite_spin("synthetic_b3_3.json")
+        ctx = _register(st)
+        record = obs.SingletResidual().record(ctx)
+        # the direct C++ r_state read is the definition
+        direct = float(cob.MultiCobordism.r_state(st, 3, cob.Proton.singlet()))
+        self.assertAlmostEqual(record["singlet_residual"], direct, places=15)
+        # oracle value (tessera/observe.SingletDiagnostic on this fixture): ~0
+        self.assertLess(record["singlet_residual"], 1e-9)
+        self.assertEqual(record["holes_used"], 3)
+        self.assertEqual(record["holes_total"], 4)
+        self.assertEqual(record["b3"], 3)
+        self.assertEqual(record["betti"], [1, 0, 0, 3, 0])
+        self.assertTrue(record["holes_vs_b3_divergent"])
+
+    def test_conjugate_residual_accessor(self):
+        _meta, st = _composite_spin("synthetic_b3_3.json")
+        ctx = _register(st)
+        conj = [c.conjugate() for c in cob.Proton.singlet()]
+        self.assertAlmostEqual(
+            obs.SingletResidual().conjugate_residual(ctx),
+            float(cob.MultiCobordism.r_state(st, 3, conj)), places=15)
+
+
+class PairLoopFlavorPublishedTableTest(unittest.TestCase):
+    """PairLoopFlavor reproduces the PUBLISHED #576 per-fixture table."""
+
+    # fixture -> (loop_q to 5dp, odd_loop, dual_hole, rho to 3dp, multiplicity)
+    TABLE = {
+        "synthetic_b3_3.json": ((0.06054, 0.05971, 0.06063), (0, 2), 1, 0.103,
+                                True),
+        "synthetic_b3_4.json": ((0.05726, 0.05971, 0.06074), (0, 1), 2, 0.348,
+                                True),
+        "synthetic_b3_5.json": ((0.05542, 0.05722, 0.05772), (0, 1), 2, 0.248,
+                                True),
+        "converged_b3_3.json": ((0.05153, 0.05165, 0.05177), (0, 1), 2, 0.665,
+                                False),
+    }
+
+    def test_published_rows(self):
+        for name, (loop_q, odd, dual, rho, verdict) in self.TABLE.items():
+            _meta, st = _composite_spin(name)
+            record = obs.PairLoopFlavor().record(_register(st))
+            with self.subTest(fixture=name):
+                for measured, published in zip(record["loop_q"], loop_q):
+                    self.assertAlmostEqual(measured, published, places=5)
+                self.assertEqual(tuple(record["odd_loop"]), odd)
+                self.assertEqual(record["dual_hole"], dual)
+                self.assertAlmostEqual(record["rho"], rho, places=3)
+                self.assertEqual(record["multiplicity_2_1"], verdict)
+                self.assertLess(record["r_u"], 1e-20)
+
+    def test_oriented_weights_pin_the_singlet_root_fixed(self):
+        # w_h == the induced-orientation singlet; in the root-fixed convention
+        # w0 has zero phase so w_re/w_im are [1, -1/2, -1/2] / [0, ±√3/2].
+        _meta, st = _composite_spin("synthetic_b3_3.json")
+        record = obs.PairLoopFlavor().record(_register(st))
+        for re, ex in zip(record["w_re"], (1.0, -0.5, -0.5)):
+            self.assertAlmostEqual(re, ex, places=9)
+        for im, ex in zip(record["w_im"], (0.0, math.sqrt(3) / 2,
+                                           -math.sqrt(3) / 2)):
+            self.assertAlmostEqual(im, ex, places=9)
+
+    def test_diquark_provenance_decides_criterion_b(self):
+        _meta, st = _composite_spin("synthetic_b3_3.json")
+        ctx = _register(st)
+        none = obs.PairLoopFlavor().record(ctx)
+        self.assertIsNone(none["odd_is_diquark_loop"])
+        self.assertEqual(none["odd_is_diquark_loop_status"],
+                         "not_evaluable(no_provenance)")
+        # the odd loop is (0, 2): that pair decides True, another decides False
+        hit = obs.PairLoopFlavor((2, 0)).record(ctx)
+        self.assertIs(hit["odd_is_diquark_loop"], True)
+        self.assertEqual(hit["odd_is_diquark_loop_status"], "evaluated")
+        miss = obs.PairLoopFlavor((0, 1)).record(ctx)
+        self.assertIs(miss["odd_is_diquark_loop"], False)
+
+    def test_odd_one_out_and_complement(self):
+        odd, rho = obs.PairLoopFlavor.odd_one_out([1.0, 1.01, 2.0])
+        self.assertEqual(odd, 2)
+        self.assertLess(rho, 0.02)
+        self.assertEqual([obs.PairLoopFlavor.complement_hole(p)
+                          for p in ((0, 1), (0, 2), (1, 2))], [2, 1, 0])
+
+
+class MassRadiusEquivalenceTest(unittest.TestCase):
+    """EmergentMass / EmergentRadius on the hand-checkable ∂Δ⁵ and star, plus the
+    frozen oracle values on synthetic_b3_3."""
+
+    def test_closed_s4_mass_radius(self):
+        ctx = _register(_boundary_delta5_live(), count=0)
+        mass = obs.EmergentMass().record(ctx)
+        radius = obs.EmergentRadius().record(ctx)
+        self.assertEqual(mass["census"]["n_hinges_interior"], 20)
+        self.assertEqual(mass["census"]["n_hinges_boundary"], 0)
+        self.assertAlmostEqual(mass["mass"]["m_sum"], 20 * S4_DEFICIT, places=9)
+        self.assertAlmostEqual(mass["mass"]["m_shell"], S4_DEFICIT, places=9)
+        self.assertEqual(mass["mass"]["n_im_nonzero"], 0)
+        self.assertAlmostEqual(mass["localization"]["PR"], 1.0, places=9)
+        self.assertAlmostEqual(radius["radius"]["Vprimal"], S4_VOLUME, places=12)
+        self.assertAlmostEqual(radius["radius"]["Vdual"], S4_VOLUME, places=12)
+        self.assertEqual(radius["radius"]["n_interior_vertices"], 6)
+        self.assertAlmostEqual(radius["radius"]["r_dual"],
+                               S4_VOLUME ** 0.25, places=12)
+        # the r.m table: 6 finite combos, honest spread first
+        self.assertEqual(len(mass["rm"]["combos"]), 6)
+        self.assertLessEqual(mass["rm"]["spread_min"], mass["rm"]["spread_max"])
+
+    def test_star_of_apex_hole_seeded_shells(self):
+        # the dropped pentatope {0..4} is the register hole seeding the BFS.
+        st = _star_of_apex()
+        st.materializeFacets()
+        ctx = obs.RegisterContext(st, [[0, 1, 2, 3, 4]], 1, 3,
+                                  cob.Proton.singlet())
+        mass = obs.EmergentMass().record(ctx)
+        self.assertEqual(mass["census"]["n_hinges_interior"], 10)
+        self.assertEqual(mass["census"]["n_hinges_boundary"], 10)
+        self.assertEqual(mass["census"]["n_boundary_tets"], 5)
+        self.assertEqual(sorted(mass["localization"]["shell_profile"]), ["0"])
+        self.assertAlmostEqual(mass["localization"]["frac_within_shell1"], 1.0,
+                               places=9)
+        self.assertAlmostEqual(mass["mass"]["m_shell"], S4_DEFICIT, places=9)
+
+    def test_synthetic_b3_3_frozen_oracle_values(self):
+        # frozen from the tessera/observe mass_radius oracle on this fixture.
+        _meta, st = _composite_spin("synthetic_b3_3.json")
+        ctx = _register(st)
+        mass = obs.EmergentMass().record(ctx)
+        radius = obs.EmergentRadius().record(ctx)
+        self.assertEqual(mass["census"]["n_hinges_interior"], 164)
+        self.assertEqual(mass["census"]["n_hinges_boundary"], 36)
+        self.assertEqual(mass["census"]["n_boundary_tets"], 20)
+        self.assertAlmostEqual(mass["mass"]["m_sum"], 254.10203119677297,
+                               places=6)
+        self.assertAlmostEqual(mass["mass"]["m_shell"], 3.7730789734335914,
+                               places=6)
+        self.assertAlmostEqual(mass["mass"]["m_action"], 24.066705999226475,
+                               places=6)
+        self.assertAlmostEqual(radius["radius"]["r_dual"], 0.8827130424237054,
+                               places=6)
+        self.assertAlmostEqual(radius["radius"]["Vdual"], 0.6071250804215924,
+                               places=6)
+        self.assertAlmostEqual(radius["radius"]["Vprimal"], 1.9484067394045557,
+                               places=6)
+        self.assertEqual(radius["radius"]["n_interior_vertices"], 15)
+
+
+def _boundary_delta5_live():
+    st = _boundary_delta5()
+    st.materializeFacets()
+    return st
+
+
+class BlockResidualsEquivalenceTest(unittest.TestCase):
+    """BlockResiduals mirrors ProtonIngredients::outputBlockResidual branch by
+    branch (empty region -> full leak ‖target‖²; occupied -> r_state on the
+    uniform-metric sub-complex)."""
+
+    def setUp(self):
+        self.meta, self.st = _composite_spin("synthetic_b3_3.json")
+        self.ctx = _register(self.st)
+        self.singlet = list(cob.Proton.singlet())
+        self.allv = sorted({v for c in self.meta["cells"] for v in c})
+
+    def _row(self, label, vertices):
+        record = obs.BlockResiduals(
+            [obs.Block(label, vertices, self.singlet)]).record(self.ctx)
+        return record["blocks"][0]
+
+    def test_empty_region_is_the_full_leak(self):
+        row = self._row("empty", [0])
+        self.assertTrue(row["full_leak"])
+        self.assertEqual(row["n_cells_in_region"], 0)
+        self.assertAlmostEqual(row["residual"], 3.0, places=12)
+        self.assertEqual(row["residual"], row["target_norm2"])
+
+    def test_whole_region_equals_direct_r_state(self):
+        row = self._row("whole", self.allv)
+        self.assertFalse(row["full_leak"])
+        self.assertEqual(row["n_cells_in_region"], len(self.meta["cells"]))
+        sub = tessera.Spacetime.fromCells(
+            4, [list(c) for c in self.meta["cells"]], 1.0, 0.0)
+        expected = float(cob.MultiCobordism.r_state(sub, 3, self.singlet))
+        self.assertAlmostEqual(row["residual"], expected, places=12)
+
+    def test_sub_region_scores_only_its_cells(self):
+        row = self._row("one_cell", sorted(self.meta["cells"][0]))
+        self.assertEqual(row["n_cells_in_region"], 1)
+        self.assertFalse(row["full_leak"])
+        self.assertGreaterEqual(row["residual"], 0.0)
+
+    def test_orphan_region_ids_are_inert_and_survive_relabel(self):
+        region = sorted(self.meta["cells"][0]) + [10 ** 6]
+        observable = obs.BlockResiduals(
+            [obs.Block("with_orphan", region, self.singlet)])
+        row = observable.record(self.ctx)["blocks"][0]
+        self.assertEqual(row["n_region_vertices"], len(region))
+        clean = obs.BlockResiduals(
+            [obs.Block("clean", region[:-1], self.singlet)]).record(
+                self.ctx)["blocks"][0]
+        self.assertEqual(row["residual"], clean["residual"])
+        gate = obs.ObservableGates.evaluate(observable, self.ctx)
+        self.assertTrue(gate.gauge_ok)
+        self.assertTrue(gate.relabel_ok)
+
+
+class RegisterValidationTest(unittest.TestCase):
+    """Hole selection validated at one entry point: deficit raises, surplus warns
+    naming the dropped holes."""
+
+    def test_surplus_warns_naming_the_dropped_hole(self):
+        # synthetic_b3_3 stores FOUR emergent holes at b3 = 3 (the surplus case).
+        _meta, st = _composite_spin("synthetic_b3_3.json")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ctx = obs.RegisterContext(st, 3, 3, cob.Proton.singlet())
+        messages = [str(w.message) for w in caught]
+        self.assertTrue(any("4 emergent holes" in m for m in messages))
+        self.assertTrue(any("(1, 4, 5, 6, 12)" in m for m in messages))
+        self.assertEqual(ctx.holes_used(), 3)
+        self.assertEqual(ctx.holes_total(), 4)
+        self.assertEqual([list(h) for h in ctx.dropped_holes()],
+                         [[1, 4, 5, 6, 12]])
+
+    def test_deficit_raises_naming_the_count(self):
+        # fill two of the four stored holes: a genuine 2-hole specimen.
+        meta, _st = _composite_spin("synthetic_b3_3.json")
+        holes_meta = [list(h) for h in meta["holes"]]
+        edges = {}
+        for key, (re, im) in meta["edges"].items():
+            a, b = (int(x) for x in key.split(","))
+            edges[(min(a, b), max(a, b))] = complex(re, im)
+        st = obs.LiveComplex.load(meta["cells"] + holes_meta[2:], edges, {}, 4)
+        self.assertEqual(len(cob.MultiCobordism.emergent_holes(st, 3)), 2)
+        with self.assertRaises(ValueError) as ctx:
+            obs.RegisterContext(st, 3, 3, cob.Proton.singlet())
+        self.assertIn("need >= 3 register holes", str(ctx.exception))
+        self.assertIn("found 2", str(ctx.exception))
+
+    def test_eps_are_unit_signs(self):
+        _meta, st = _composite_spin("synthetic_b3_3.json")
+        ctx = _register(st)
+        # induced-orientation signs feed the pair-loop read; here we assert the
+        # register carries exactly 3 holes with the singlet pinned.
+        self.assertEqual(ctx.holes_used(), 3)
+        self.assertLess(obs.PairLoopFlavor().record(ctx)["r_u"], 1e-20)
+
+
+class GateTest(unittest.TestCase):
+    """GAUGE/RELABEL gates hold on the fixture battery; the deliberately
+    leaky probes are flagged."""
+
+    def setUp(self):
+        _meta, self.st = _composite_spin("synthetic_b3_3.json")
+        self.ctx = _register(self.st)
+
+    def test_all_observables_pass_both_gates(self):
+        vertices = sorted({v for c in json.load(
+            open(os.path.join(_CS, "synthetic_b3_3.json")))["cells"]
+            for v in c})
+        observables = [
+            obs.SingletResidual(),
+            obs.BlockResiduals([obs.Block("whole", vertices,
+                                          list(cob.Proton.singlet()))]),
+            obs.EmergentMass(),
+            obs.EmergentRadius(),
+            obs.PairLoopFlavor((0, 2)),
+        ]
+        for observable in observables:
+            with self.subTest(observable=observable.record_key()):
+                result = obs.ObservableGates.evaluate(observable, self.ctx)
+                self.assertTrue(result.gauge_ok,
+                                (result.gauge_delta, result.gate_tol))
+                self.assertTrue(result.relabel_ok,
+                                (result.relabel_delta, result.gate_tol))
+
+    def test_self_test_flags_both_probes(self):
+        self.assertTrue(obs.ObservableGates.self_test(self.ctx))
+        # the label probe leaks vertex ids -> RELABEL flags it
+        self.assertGreater(
+            obs.ObservableGates.relabel_delta(obs.LabelLeakProbe(), self.ctx),
+            1.0)
+        # the gauge probe leaks the raw target phase -> GAUGE flags it
+        self.assertGreater(
+            obs.ObservableGates.gauge_delta(obs.GaugeLeakProbe(), self.ctx),
+            0.1)
+
+    def test_report_delta_semantics(self):
+        rd = obs.ObservableGates.report_delta
+        self.assertEqual(rd({"a": 1.0, "b": [0.5, 0.25]},
+                            {"a": 1.0, "b": [0.5, 0.25]}), 0.0)
+        self.assertAlmostEqual(rd({"a": 1.0}, {"a": 1.001}), 1e-3, places=9)
+        self.assertEqual(rd(True, False), 1.0)
+        self.assertEqual(rd("ok", "changed"), float("inf"))
+        self.assertEqual(rd(None, 0.0), float("inf"))
+        self.assertEqual(rd(float("nan"), float("nan")), 0.0)
+        self.assertEqual(rd(float("nan"), 1.0), float("inf"))
+        self.assertEqual(rd([1.0, 2.0], [1.0]), float("inf"))
+        with self.assertRaises(ValueError):
+            rd({"a": 1}, {"b": 1})
+
+
+class DriverTest(unittest.TestCase):
+    """The classless driver: geometry-dump rehydration, full battery, skips."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.driver = _load_driver()
+
+    def _b3_dump(self, tmpdir, **meta):
+        with open(os.path.join(_CS, "synthetic_b3_3.json")) as fh:
+            fixture = json.load(fh)
+        verts = sorted({v for c in fixture["cells"] for v in c})
+        dump = dict(meta)
+        dump.update({
+            "schema": 1, "dimensions": 4, "cells": fixture["cells"],
+            "edges": [[int(a), int(b), re, im]
+                      for k, (re, im) in fixture["edges"].items()
+                      for a, b in [k.split(",")]],
+            "vertex_times": [[v, 0.0] for v in verts],
+        })
+        path = os.path.join(tmpdir, "seed_42_geometry.json")
+        with open(path, "w") as fh:
+            json.dump(dump, fh)
+        return path
+
+    def test_geometry_dump_full_battery(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._b3_dump(tmp, base_seed=42, betti=[1, 0, 0, 3, 0],
+                                 holes=4, diquark_pair=[0, 2])
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                record = self.driver.observe_geometry_dump(path)
+        reg = record["register"]
+        self.assertEqual((reg["holes_used"], reg["holes_total"], reg["b3"]),
+                         (3, 4, 3))
+        self.assertTrue(reg["holes_vs_b3_divergent"])
+        status = {k: v["status"] for k, v in record["observables"].items()}
+        self.assertEqual(status["singlet_residual"], "measured")
+        self.assertEqual(status["emergent_mass"], "measured")
+        self.assertEqual(status["emergent_radius"], "measured")
+        self.assertEqual(status["pair_loop_flavor"], "measured")
+        self.assertEqual(status["block_residuals"], "skipped(no_provenance)")
+        # diquark provenance flowed from the dump metadata
+        flavor = record["observables"]["pair_loop_flavor"]["record"]
+        self.assertIs(flavor["odd_is_diquark_loop"], True)
+        self.assertEqual(record["input"]["mode"], "geometry_dump")
+        self.assertTrue(record["input"]["dump_verified"])
+        json.dumps(record)  # JSON-able
+
+    def test_dump_verification_catches_mismatch(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._b3_dump(tmp, base_seed=44, holes=12)  # wrong census
+            with self.assertRaises(RuntimeError):
+                self.driver.observe_geometry_dump(path)
+
+    def test_readable_table(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._b3_dump(tmp, base_seed=42)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                record = self.driver.observe_geometry_dump(path)
+        table = self.driver.render_table(record)
+        self.assertIn("observable battery", table)
+        self.assertIn("holes_used=3 of holes_total=4", table)
+        self.assertIn("divergent=True", table)
+        self.assertIn("order-of-magnitude only", table)
+
+
+class KeeperDumpSmokeTest(unittest.TestCase):
+    """A real campaign keeper dump rehydrates and reads (skip path — the kept
+    specimens carry < 3 holes, so the register-only observables measure and the
+    3-hole ones report skips)."""
+
+    def _dumps(self, directory):
+        if not os.path.isdir(directory):
+            self.skipTest(f"{directory} not present")
+        return [os.path.join(directory, f) for f in sorted(os.listdir(directory))
+                if f.endswith(".json")]
+
+    def test_causal_specimen_dumps_read(self):
+        driver = _load_driver()
+        any_causal = False
+        for path in self._dumps(_CAUSAL):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                record = driver.observe_geometry_dump(path)
+            self.assertEqual(record["register"]["dimensions"], 4)
+            self.assertEqual(
+                record["observables"]["singlet_residual"]["status"], "measured")
+            any_causal = any_causal or record["register"]["causal_content"]
+        # at least one causal specimen honestly reports emergent causal content
+        self.assertTrue(any_causal)
+
+    def test_keeper_dumps_read(self):
+        driver = _load_driver()
+        for path in self._dumps(_KEEPER):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                record = driver.observe_geometry_dump(path)
+            self.assertIn(record["observables"]["emergent_mass"]["status"],
+                          ("measured", "skipped(dimensions=4 != 4)"))
+            json.dumps(record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/observables/test_proton_battery_python.py
+++ b/tests/observables/test_proton_battery_python.py
@@ -136,6 +136,22 @@ class PairLoopFlavorPublishedTableTest(unittest.TestCase):
                 self.assertEqual(record["multiplicity_2_1"], verdict)
                 self.assertLess(record["r_u"], 1e-20)
 
+    def test_frozen_oracle_high_precision(self):
+        # The full-precision pair-loop read frozen from the tessera/observe
+        # pair_loop_flavor oracle on synthetic_b3_3 — the C++ read must match to
+        # the pair-loop gate tolerance (1e-9), tighter than the 5-dp table above.
+        _meta, st = _composite_spin("synthetic_b3_3.json")
+        record = obs.PairLoopFlavor().record(_register(st))
+        q = [0.0298121883979804, 0.03073188676971647, 0.02990226224557105]
+        loop_q = [0.060544075167696866, 0.05971445064355145,
+                  0.06063414901528751]
+        for measured, oracle in zip(record["q"], q):
+            self.assertAlmostEqual(measured, oracle, places=9)
+        for measured, oracle in zip(record["loop_q"], loop_q):
+            self.assertAlmostEqual(measured, oracle, places=9)
+        self.assertAlmostEqual(record["rho"], 0.10298138531509772, places=9)
+        self.assertLess(record["r_u"], 1e-20)
+
     def test_oriented_weights_pin_the_singlet_root_fixed(self):
         # w_h == the induced-orientation singlet; in the root-fixed convention
         # w0 has zero phase so w_re/w_im are [1, -1/2, -1/2] / [0, ±√3/2].


### PR DESCRIPTION
## Summary

Implements #593: the emergent-proton readouts are now **C++ subclasses of the existing `tessera::observables::Observable`** (ctor-carried config, `compute()` headline scalar, typed accessors, a JSON-able `record()`), driven by a C++ `RegisterContext` and C++ GAUGE/RELABEL gates — replacing PR #584's Python framework and absorbing the readout surfaces of #574/#575/#576. Python keeps exactly one thin, classless driver. There is **no `tessera/observe/` package** on this branch.

Migration equivalence against the Python `tessera/observe` oracle is proven to each observable's gate tolerance, and cross-checked against the hard-coded #575/#576 published values.

### Owner-directive architecture (pure readers; construction is a separate layer)

Per the owner's mid-review corrections, the design is:

- **`RegisterContext` + every Observable are pure readers.** They READ an already-built, relaxed complex (`Proton::block()`, a `ProtonIngredients` state, a `MultiCobordism` state, or a dump already rehydrated into a live complex). They never build, solve, or materialize anything — the emergent build lives exclusively in Proton/ProtonIngredients/MultiCobordism and is never re-run. (The Python `Register.__init__`'s defensive `ReggeSolver(st, MatterConfiguration())` is NOT carried forward.)
- **All construction lives in a separate loader/transform layer, `LiveComplex`, outside the readers** — the schema-1 dump rehydration and the RELABEL-gate rebuild. It only ever reads a recorded geometry back through the canonical `Spacetime::fromCells`, completing the facet skeleton with the honest direct call `Spacetime::materializeFacets()` (never a solver). The block-residual sub-complex is a strict selection of existing cells re-instantiated through the canonical `fromCells` (`LiveComplex::subcomplex`, byte-identical to `MultiCobordism::subcomplexWithinVertexSet`).
- **`InteriorHinges` holds `shared_ptr<const Spacetime>`** — the geometric reader is compiler-enforced read-only. The synthesis/laplacian/`r_state` APIs keep their `shared_ptr<Spacetime>` signatures (they are dual-purpose drive classes — `EigenstateSynthesis::setWeights` etc. mutate edge lengths for the emergent drive), but the read methods the observables compose (`cellSimplices`/`carriedRepresentative`/`residualForPeriods`/`weights`) are already `const` and verified non-mutating in the read path. No protected core was refactored.
- The canonical spacetime dimension (`getMetric()->getSignature()->getDimensions()`) and top-cell count (`getTopSimplices().size()`) are read from the canonical accessors, never guessed from a cell.

### Owner question answered — what `Spacetime::fromCells` produces

`fromCells` materializes **only the top cells** (measured: `∂Δ⁵` comes back as its 6 pentatopes, `getSimplices()` size 6). The intermediate facet/coface skeleton that `dualVolume()` / `lorentzianDeficitAngle()` walk is **not** populated. The `LiveComplex` loader (outside the reader) completes it with `materializeFacets()` — which reproduces the `ReggeSolver` + `ChainComplex::fromSpacetime` skeleton **bit-for-bit** (verified: interior-hinge census, `V_dual`, and `m_sum` all agree to machine precision). Primary inputs (Proton/ProtonIngredients) already carry their skeleton, so the reader materializes nothing.

## Per-observable status

| Observable (C++) | headline | status | migration equivalence |
|---|---|---|---|
| `SingletResidual` | singlet `r_state` | done | `= MultiCobordism::r_state(st,3,singlet)` to 1e-15; census `betti=[1,0,0,3,0]`, holes 3/4, divergent — matches #574 oracle. Conjugate-singlet accessor added. |
| `BlockResiduals` | Σ block residual | done | empty→full leak `‖t‖²=3.0`; whole→`7.85e-32` (74 cells) `= direct r_state`; one-cell→`3.0` (1 cell). Orphan region ids inert + survive RELABEL. |
| `EmergentMass` | `m_shell` | done | `∂Δ⁵`: `m_sum=20·(2π−3arccos¼)`, `m_shell=S4`, interior=20, PR=1; star: interior/boundary 10/10, shells; `synthetic_b3_3`: `m_sum=254.10203`, `m_shell=3.77308` (frozen oracle, 1e-6). |
| `EmergentRadius` | `r_dual` | done | `∂Δ⁵`: `V_dual=V_primal=6√5/96`, n_interior=6; `synthetic_b3_3`: `r_dual=0.88271`, `V_dual=0.60713` (frozen oracle, 1e-6). |
| `PairLoopFlavor` | `rho` | done | reproduces the **published #576 table** for all four fixtures (loop_q, odd_loop, dual_hole, rho, multiplicity); diquark provenance decides criterion (b); root-fixed periods `w=[1,ω,ω²]`. |

GAUGE/RELABEL gates + the two self-test probes (label-leak flagged by RELABEL, gauge-leak by GAUGE) all as specified; `report_delta` ported with every NaN/inf/bool/string convention.

## Where each superseded PR now lives

| PR | Contributed | Now in C++ |
|---|---|---|
| #574 | singlet diagnostic + per-block residuals | `SingletResidual`, `BlockResiduals` |
| #575 | mass/radius battery (closed-fan hinges, dual radius, r·m) | `InteriorHinges` core + `EmergentMass` / `EmergentRadius` |
| #576 | pair-loop dual-basis flavor read | `PairLoopFlavor` |
| #584 | Python `Observable`/`Register`/`Battery`/gate framework | `RegisterObservable` + `RegisterContext` + `ObservableGates` + `Record`; the battery/registry is the thin `observe_proton_ingredients.py` driver |

(Owner closes #574/#575/#576/#584; cross-referenced here, not closed by this PR.)

## Deliverables

- `RegisterContext` (`.h` updated to pure-reader, `.cpp`), `Record`, `InteriorHinges`, `LiveComplex`, `RegisterObservable`, the five observables, `ObservableGates` + probes — all bound in `src/observables/Bindings.cpp` with a `Record`↔Python dict converter.
- `{doxygenfile}` entries for all 11 new headers in `docs/source/cpp_api.md`; docs-coverage guard green; `make html` sphinx warnings = 0.
- `examples/cobordism/observe_proton_ingredients.py` — the one classless driver: `--geometry <dump>` (schema-1 rehydration via `LiveComplex.load`) or `--seed N [--joint]` (fresh `ProtonIngredients` attempt, labeled never a reproduction); ≥3 holes → full battery + table, else per-observable skips.
- `tests/observables/test_proton_battery_python.py` — migration equivalence (provenance documented per value), register validation (deficit raises / surplus warns by name), gate self-tests, `report_delta` semantics, dump round-trip, hand-checkable `∂Δ⁵`/star, keeper-dump smoke, driver.

## Battery record — a fixture and a real keeper dump

`synthetic_b3_3` (b3=3, 4 holes, full battery):

```
register: dim=4 n_top_cells=74 holes_used=3 of holes_total=4 b3=3 divergent=True
singlet_residual: measured   singlet_residual = 1.887e-31
emergent_mass:    measured   m_shell=3.7731 m_sum=254.1020 m_action=24.0667  (r·m spread [3.33, 300.21], physical ~ 4.00)
emergent_radius:  measured   r_dual=0.8827 r_primal=1.1815
pair_loop_flavor: measured   rho=0.1030 multiplicity_2_1=True odd_loop=(0,2) odd_is_diquark_loop=True
all gauge_ok=True relabel_ok=True
```

Real keeper dump `campaign-keepers/gen3-joint-real-manifold/geometry/seed_14001000_geometry.json` (1 hole, causal content — skip path):

```
register: dim=4 n_top_cells=74 holes_used=1 of holes_total=1 b3=1 causal_content=True
singlet_residual: measured   singlet_residual = 2.000e+00
emergent_mass:    measured   m_shell=2.4421 m_sum=203.2179  (r·m spread [1.58, 212.15])
emergent_radius:  measured   r_dual=0.6468 r_primal=1.0439
block_residuals:  skipped(no_provenance)
pair_loop_flavor: skipped(holes=1 < min_holes=3)
```

(None of the current keeper/causal dumps carry ≥3 holes, so the real-dump path exercises the register-only observables + the honest skip reasons; the full battery is exercised on the b3=3 fixtures.)

## Notes

- `BlockResiduals` takes its provenance blocks from the caller (campaign record / geometry-dump metadata / explicit `Block` list) and is fully covered by the fast fixture equivalence tests. It sources nothing from the `ProtonIngredients` core — no core hook is added or required.
- The #575/#576 example scripts (`emergent_mass_radius.py`, `pair_loop_flavor.py`) were never on this branch's base, so there was nothing to keep/retire — the driver is the sole Python surface.

## Finding: `singlet_residual` RELABEL gate on fresh irregular builds

The gates are green everywhere they're tested (all fixtures, the dump-rehydrated real campaign complexes, and most fresh builds). On the `--seed` path (a fresh, *non-process-deterministic* `ProtonIngredients` build — the #578 finding), one such complex tripped `singlet_residual`'s RELABEL gate. Diagnosed and cleared: `LiveComplex.relabel` is **faithful** — on an instrumented fresh build, `r_state(st) == r_state(relabel(st))` to 3.3e-15 and the gate passes at 3.3e-15. The occasional trip is the intrinsic relabel-sensitivity of the `r_state` eigensolve exceeding the tight 1e-9 tolerance on a particular ill-conditioned irregular complex (the same 1e-9 the Python `SingletDiagnostic` used) — the residual VALUE is correct and the faithful-record (dump) path is stable. No code change; the gate is honestly reporting borderline relabel-reproducibility on that one transient complex.

## Test tallies

- `tests/observables/test_proton_battery_python.py`: 25 passed, 9 subtests.
- Full fast suite (`pytest tests -m "not slow" -n 2`): **1288 passed, 8 skipped, 818 subtests, 0 failures**.
- Docs: `make html` sphinx warnings = 0 (the pre-existing doxygen "not documented" backlog is untouched); docs-coverage guard green.

Closes #593.

## Test plan

- [x] Migration equivalence: each C++ observable reproduces the #574/#575/#576 adapter/oracle values on the same fixtures (to each observable's gate tolerance)
- [x] C++ GAUGE/RELABEL gate self-tests (label-dependent + gauge-dependent probes flagged); register validation (deficit raises, surplus warns by name)
- [x] Geometry-dump rehydration round-trip + real keeper-dump smoke
- [x] Docs-coverage guard green (cpp_api.md entries); full fast suite green (1288 passed); sphinx warnings = 0
