### PR TITLE
fix(mesh,cobordism): eliminate silent Im-truncating .real() reads — enforce the real-ℓ² invariant loudly

### DIFF
--- a/examples/cobordism/proton_campaign/worker.py
+++ b/examples/cobordism/proton_campaign/worker.py
@@ -123,15 +123,37 @@ def dump_geometry(st, path, meta):
 
 
 class AttemptState:
-    """Running extremes the keep-policy and the final record read."""
+    """Running extremes the keep-policy and the final record read.
+
+    max_im / min_re_min are the trajectory-level metric channels: stage 2
+    constructs every trial exactly real (Im l^2 == 0 by construction, #589),
+    so a nonzero max_im flags an upstream Im producer that final-state reads
+    can never see — and min_re_min records how close the drive ever came to
+    the causal sector (Re l^2 < 0), the channel where causal content would
+    actually appear, at snapshot (pass/chunk) resolution."""
 
     def __init__(self):
         self.max_b3 = 0
         self.max_holes = 0
+        self.max_im = 0.0
+        self.min_re_min = float("inf")
 
     def see(self, snap):
         self.max_b3 = max(self.max_b3, snap["b3"])
         self.max_holes = max(self.max_holes, snap["holes"])
+        self.max_im = max(self.max_im, snap["im_max"])
+        self.min_re_min = min(self.min_re_min, snap["re_min"])
+
+    def verdict_fields(self):
+        """The extremes exactly as the verdict record carries them (min_re_min
+        is None when no snapshot was ever taken — never JSON Infinity)."""
+        return {
+            "max_holes": self.max_holes,
+            "max_b3": self.max_b3,
+            "max_im_seen": self.max_im,
+            "min_re_min": (None if self.min_re_min == float("inf")
+                           else self.min_re_min),
+        }
 
 
 def run_attempt_on_nodes(base, progress, recorder, state, nodes):
@@ -216,8 +238,7 @@ def run_attempt_on_nodes(base, progress, recorder, state, nodes):
         "persistent": persistent,
         "stage2_iters_total": stage2_iters,
         "holes": final["holes"],
-        "max_holes": state.max_holes,
-        "max_b3": state.max_b3,
+        **state.verdict_fields(),
         "betti": list(cob.MultiCobordism.betti(st)),
         "singlet": float(cob.MultiCobordism.r_state(st, REGISTER_DEGREE,
                                                     cob.Proton.singlet())),

--- a/include/mesh/Edge.h
+++ b/include/mesh/Edge.h
@@ -15,6 +15,8 @@
 #include <complex>
 #include <random>
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <vector>
 #include <cstdint>
 
@@ -172,14 +174,36 @@ class Edge {
     /// and the action never sees a round-trip.
     ///
     /// **Ordinary-Lorentzian convention (#580/#589):** \f$l^2\f$ is real and signed
-    /// (spacelike > 0, timelike < 0, null 0); the geometry stack reads
-    /// \f$\mathrm{Re}\,l^2\f$. The complexified (Picard–Lefschetz) theory is unbuilt,
-    /// and nothing is enforced at runtime — the dynamics keeps \f$l^2\f$ on the real
-    /// axis by construction (`MultiCobordism::runStage2`); storage round-trips a
-    /// general complex value exactly (rollback records, saddle bookkeeping).
+    /// (spacelike > 0, timelike < 0, null 0); the geometry stack reads it through
+    /// `getRealSquaredLength()`, which enforces the on-axis invariant loudly (#597)
+    /// instead of projecting. The complexified (Picard–Lefschetz) theory is unbuilt;
+    /// the dynamics keeps \f$l^2\f$ on the real axis by construction
+    /// (`MultiCobordism::runStage2`), and storage round-trips a general complex
+    /// value exactly (rollback records, saddle bookkeeping, historical dumps) —
+    /// only geometry consumption is on-axis.
     void setSquaredLength(std::complex<double> l2) noexcept {
       squaredLength_ = l2;
       length_ = std::sqrt(l2);
+    }
+
+    /// The geometry stack's read of \f$l^2\f$ (#589/#597): the real signed value,
+    /// with the ordinary-Lorentzian on-axis invariant enforced. A nonzero
+    /// \f$\mathrm{Im}\,l^2\f$ reaching the Gram/Cayley–Menger/action/register
+    /// pipeline is an upstream bug that a silent `.real()` projection would mask,
+    /// so it throws instead of truncating. Storage
+    /// (`getSquaredLength`/`setSquaredLength`) stays general-complex — use it, not
+    /// this, wherever a complex value is legitimate (Wick \f$|l^2|\f$ reads,
+    /// snapshots, rollback records, dump rehydration).
+    [[nodiscard]] double getRealSquaredLength() const {
+      if (squaredLength_.imag() != 0.0)
+        throw std::runtime_error(
+            "Edge(" + std::to_string(source->getId()) + "," +
+            std::to_string(target->getId()) + "): nonzero Im l^2 = " +
+            std::to_string(squaredLength_.imag()) +
+            " reached the geometry stack — the ordinary-Lorentzian convention "
+            "(#589) keeps l^2 real and signed, so this is an upstream bug, not "
+            "a value to project away");
+      return squaredLength_.real();
     }
 
     /// Set the (complex) edge length; the squared length is kept in sync as `l*l`. Use

--- a/src/cobordism/EigenstateSynthesis.cpp
+++ b/src/cobordism/EigenstateSynthesis.cpp
@@ -239,7 +239,7 @@ double EigenstateSynthesis::rayleigh(const std::vector<cd> &psi) const {
 std::vector<double> EigenstateSynthesis::weights() const {
   std::vector<double> w;
   w.reserve(edges_.size());
-  for (const auto e : edges_) w.push_back(e->getSquaredLength().real());
+  for (const auto e : edges_) w.push_back(e->getRealSquaredLength());
   return w;
 }
 
@@ -274,7 +274,7 @@ std::vector<double> EigenstateSynthesis::interiorWeights() const {
   std::vector<double> w;
   w.reserve(interiorEdgeIdx_.size());
   for (const auto i : interiorEdgeIdx_)
-    w.push_back(edges_[i]->getSquaredLength().real());
+    w.push_back(edges_[i]->getRealSquaredLength());
   return w;
 }
 
@@ -1443,7 +1443,7 @@ std::vector<double> EigenstateSynthesis::periodGradientOverLoops(
   std::map<std::pair<std::uint64_t, std::uint64_t>, double> l2map;
   for (auto *e : edges_)
     l2map[key(e->getSource()->getId(), e->getTarget()->getId())] =
-        e->getSquaredLength().real();
+        e->getRealSquaredLength();
   std::map<std::pair<std::uint64_t, std::uint64_t>, std::vector<std::size_t>> trisOf;
   for (std::size_t ti = 0; ti < n2; ++ti)
     for (int i = 0; i < 3; ++i)
@@ -2006,7 +2006,7 @@ std::vector<double> EigenstateSynthesis::periodGapForLoopsGradient(
   std::map<std::pair<std::uint64_t, std::uint64_t>, double> l2map;
   for (auto *e : edges_)
     l2map[key(e->getSource()->getId(), e->getTarget()->getId())] =
-        e->getSquaredLength().real();
+        e->getRealSquaredLength();
   std::map<std::pair<std::uint64_t, std::uint64_t>, std::vector<std::size_t>> trisOf;
   for (std::size_t ti = 0; ti < n2; ++ti)
     for (int i = 0; i < 3; ++i)
@@ -2219,7 +2219,7 @@ std::vector<double> EigenstateSynthesis::residualForPeriodsGradientGpu(
   std::map<std::pair<std::uint64_t, std::uint64_t>, double> l2map;
   for (auto *e : edges_)
     l2map[key(e->getSource()->getId(), e->getTarget()->getId())] =
-        e->getSquaredLength().real();
+        e->getRealSquaredLength();
   std::map<std::pair<std::uint64_t, std::uint64_t>, std::vector<std::size_t>> trisOf;
   for (std::size_t ti = 0; ti < n2; ++ti)
     for (int i = 0; i < 3; ++i)

--- a/src/cobordism/MultiCobordism.cpp
+++ b/src/cobordism/MultiCobordism.cpp
@@ -664,7 +664,7 @@ std::vector<double> MultiCobordism::runStage2(double beta, int maxIters,
     Eigen::VectorXd squaredLengths(edgeCount);
     for (std::size_t edgeIndex = 0; edgeIndex < edgeCount; ++edgeIndex)
       squaredLengths(edgeIndex) =
-          edges[edgeIndex]->getSquaredLength().real();
+          edges[edgeIndex]->getRealSquaredLength();
     const double currentObjective = objectiveTrace.back();
     // Relative stationarity: accept a step only when it lowers F by more than relTol
     // scaled by the current magnitude (an absolute floor of relTol when |F| < 1). The

--- a/src/mesh/Bindings.cpp
+++ b/src/mesh/Bindings.cpp
@@ -92,7 +92,13 @@ endpoint vertex IDs, so Edge(v1, v2) == Edge(v2, v1).)doc")
 
 Stored verbatim — NOT getLength()**2 — so the action never sees a sqrt/square
 round-trip. Real-signed for an ordinary Lorentzian edge, complex for a saddle
-geometry. This is what all geometry/action math reads.)doc")
+geometry. Storage-level read; the geometry stack reads getRealSquaredLength().)doc")
+      .def("getRealSquaredLength", &Edge::getRealSquaredLength,
+           R"doc(The geometry stack's read of l^2 (#589/#597): the real signed value
+with the ordinary-Lorentzian on-axis invariant enforced — raises RuntimeError on
+a nonzero Im l^2 instead of silently projecting it away. Use getSquaredLength()
+wherever a complex value is legitimate (Wick |l^2| reads, snapshots, rollback
+records, dump rehydration).)doc")
       .def("getLength", &Edge::getLength,
            R"doc(Return the (possibly complex) edge length — the causal DOF.
 

--- a/src/mesh/Simplex.cpp
+++ b/src/mesh/Simplex.cpp
@@ -671,7 +671,7 @@ std::vector<double> Simplex::gramMatrix(bool wickRotate) const {
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
         sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
-                               : e->getSquaredLength().real();
+                               : e->getRealSquaredLength();
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -700,7 +700,7 @@ std::vector<double> Simplex::cayleyMengerMatrix(bool wickRotate) const {
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
         sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
-                               : e->getSquaredLength().real();
+                               : e->getRealSquaredLength();
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -742,7 +742,7 @@ std::vector<double> Simplex::cayleyMengerCanonical(
         auto fp = Fingerprint::mix64(e->getSource()->getId()) ^
                   Fingerprint::mix64(e->getTarget()->getId());
         sqMap[fp] = wickRotate ? std::abs(e->getSquaredLength())
-                               : e->getSquaredLength().real();
+                               : e->getRealSquaredLength();
     }
     auto getSq = [&](int i, int j) -> double {
         if (i == j) return 0.0;
@@ -1151,7 +1151,7 @@ double Simplex::area(bool wickRotate) const {
     if (edges.size() < 3) return 0.0;
     auto sq = [&](std::size_t k) -> double {
         return wickRotate ? std::abs(edges[k]->getSquaredLength())
-                          : edges[k]->getSquaredLength().real();
+                          : edges[k]->getRealSquaredLength();
     };
     double a2 = sq(0);
     double b2 = sq(1);

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -132,13 +132,25 @@ Vertex::moveEdgesToImpl(
       targetVertex->removeInEdge(oldEdge);
     }
 
+    // Capture the exact state BEFORE the slot is freed: EdgeList::remove frees
+    // the pool slot and createEdge reuses freed slots, so oldEdge can alias the
+    // NEW edge afterwards — reading through it then returns the new edge's own
+    // fresh state, not the moved edge's (#597).
+    const std::complex<double> movedSquaredLength = oldEdge->getSquaredLength();
+    const double movedPhase = oldEdge->getPhase();
+
     spacetime->getEdgeList()->remove(oldEdge);
 
     // For inEdges: redirect edge to point TO the new vertex (new source = vertex)
     // For outEdges: redirect edge to point FROM the new vertex (new target = vertex)
     const auto &newEdge = (direction == EdgeDirection::In)
-                            ? spacetime->createEdge(sourceVertex, recipient, oldEdge->getSquaredLength().real())
-                            : spacetime->createEdge(recipient, targetVertex, oldEdge->getSquaredLength().real());
+                            ? spacetime->createEdge(sourceVertex, recipient, movedSquaredLength.real())
+                            : spacetime->createEdge(recipient, targetVertex, movedSquaredLength.real());
+    // The double-typed createEdge funnel launders the exact edge state; re-apply
+    // it in full (the RemoveMove/SurgicalCone restore idiom, #597): the complex
+    // l^2 verbatim and the U(1) connection phase, which the funnel drops to 0.
+    newEdge->setSquaredLength(movedSquaredLength);
+    newEdge->setPhase(movedPhase);
 
     newEdges.insert(newEdge);
   }

--- a/src/simulations/ReggeSolver.cpp
+++ b/src/simulations/ReggeSolver.cpp
@@ -348,7 +348,7 @@ double ReggeSolver::matterAction() const {
                 if (other->getId() == v2->getId()) {
                     if (e->isTimelike())
                         S -= wl.mass *
-                             std::sqrt(-e->getSquaredLength().real());
+                             std::sqrt(-e->getRealSquaredLength());
                     break;
                 }
             }

--- a/tests/cobordism/test_campaign_worker_verdict.py
+++ b/tests/cobordism/test_campaign_worker_verdict.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The campaign worker's verdict-record extremes (#597).
+
+Stage 2 constructs every trial exactly real (Im l^2 == 0 by construction,
+#589), so the worker's final-state reads can never surface a transient Im
+produced upstream — the verdict must carry the TRAJECTORY extremes instead:
+max_im_seen (a nonzero value flags an upstream Im producer) and min_re_min
+(how close the drive ever came to the causal sector Re l^2 < 0), accumulated
+over every pass/chunk snapshot.
+"""
+import importlib.util
+import os
+import unittest
+
+_CAMPAIGN = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         os.pardir, os.pardir, "examples", "cobordism",
+                         "proton_campaign")
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_CAMPAIGN, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class AttemptStateExtremes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.worker = _load("worker")
+
+    def test_no_snapshot_yields_null_min_re_min_not_json_infinity(self):
+        fields = self.worker.AttemptState().verdict_fields()
+        self.assertIsNone(fields["min_re_min"])
+        self.assertEqual(fields["max_im_seen"], 0.0)
+
+    def test_extremes_accumulate_over_snapshots(self):
+        state = self.worker.AttemptState()
+        state.see({"b3": 1, "holes": 2, "im_max": 0.0, "re_min": 0.9})
+        state.see({"b3": 3, "holes": 1, "im_max": 0.25, "re_min": -0.1})
+        state.see({"b3": 2, "holes": 4, "im_max": 0.0, "re_min": 0.5})
+        self.assertEqual(state.verdict_fields(), {
+            "max_holes": 4,
+            "max_b3": 3,
+            "max_im_seen": 0.25,
+            "min_re_min": -0.1,
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cobordism/test_real_l2_invariant_stage2.py
+++ b/tests/cobordism/test_real_l2_invariant_stage2.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""Stage 2 fails loudly on off-axis l^2 instead of projecting it (#597).
+
+runStage2's base point used to read getSquaredLength().real() — a silent
+projection that would mask any upstream Im producer forever (every trial is
+then constructed exactly real, #589, so the final state always reads
+Im == 0). With the checked read, a planted Im l^2 reaching the physics loop
+raises instead.
+"""
+import unittest
+
+import tessera
+
+cob = tessera.cobordism
+
+
+class Stage2OnAxisInvariant(unittest.TestCase):
+    def test_planted_im_l2_raises_in_stage2(self):
+        node = cob.ProtonIngredients(seed=0).joint_node(0)
+        node.st.getEdgeList().toVector()[0].setSquaredLength(complex(1.0, 0.25))
+        with self.assertRaisesRegex(RuntimeError, "Im l\\^2"):
+            node.run_stage2(beta=1.0, max_iters=1)
+
+    def test_real_geometry_relaxes_normally(self):
+        node = cob.ProtonIngredients(seed=0).joint_node(0)
+        node.run_stage2(beta=1.0, max_iters=1)   # must not raise
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mesh/test_real_l2_invariant.py
+++ b/tests/mesh/test_real_l2_invariant.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Twin Vector Labs LLC.
+# All rights reserved.
+"""The ordinary-Lorentzian on-axis invariant at the geometry read (#597).
+
+Storage (get/setSquaredLength) stays general-complex — rollback records and
+historical dump rehydration depend on exact round-trips — but the geometry
+stack reads l^2 through Edge.getRealSquaredLength(), which throws on a nonzero
+Im l^2 instead of silently projecting it away (#589 keeps l^2 real and signed
+by construction, so any resident Im is an upstream bug, not a value to drop).
+
+Also covers the one genuine truncation the #580-census residue audit found:
+Vertex.moveEdgesTo used to launder the exact edge state through the
+double-typed createEdge funnel — Re-only l^2 and a zeroed U(1) phase on every
+relocated edge. It must preserve both verbatim.
+"""
+import unittest
+
+import tessera
+
+
+def _spacetime():
+    sig = tessera.Signature(3, tessera.Lorentzian)
+    metric = tessera.Metric(True, sig)
+    st = tessera.Spacetime(metric, tessera.CDT, 1.0, 1.0,
+                           tessera.PREFERRED, tessera.SolidSimplex(3))
+    st.build()
+    return st
+
+
+class RealSquaredLengthInvariant(unittest.TestCase):
+    def test_on_axis_read_returns_the_signed_real_value(self):
+        st = _spacetime()
+        edge = st.getEdgeList().toVector()[0]
+        edge.setSquaredLength(complex(-2.25, 0.0))
+        self.assertEqual(edge.getRealSquaredLength(), -2.25)
+
+    def test_nonzero_im_l2_throws_instead_of_truncating(self):
+        st = _spacetime()
+        edge = st.getEdgeList().toVector()[0]
+        edge.setSquaredLength(complex(1.0, 0.5))
+        with self.assertRaisesRegex(RuntimeError, "Im l\\^2"):
+            edge.getRealSquaredLength()
+
+    def test_storage_still_round_trips_general_complex_exactly(self):
+        # The invariant lives at geometry consumption ONLY: rollback records
+        # and historical dumps must keep writing/reading complex l^2 verbatim.
+        st = _spacetime()
+        edge = st.getEdgeList().toVector()[0]
+        edge.setSquaredLength(complex(0.75, -0.3))
+        self.assertEqual(edge.getSquaredLength(), complex(0.75, -0.3))
+
+
+class MoveEdgesPreservesExactState(unittest.TestCase):
+    def test_moved_edge_keeps_complex_l2_and_phase(self):
+        # Two disjoint tetrahedra: the mover's and recipient's neighbourhoods
+        # are disjoint, so every relocated edge is a genuinely new edge. (On a
+        # complete graph the mover-recipient edge becomes a self-loop and the
+        # noexcept createEdge funnel terminates on it — pre-existing funnel
+        # behaviour, #599's territory, deliberately not exercised here.)
+        st = tessera.spacetime.Spacetime.fromCells(
+            3, [[0, 1, 2, 3], [4, 5, 6, 7]])
+        by_id = {v.getId(): v for v in st.getVertexList().toVector()}
+        mover, recipient = by_id[0], by_id[4]
+        planted_l2, planted_phase = complex(2.5, -0.75), 0.6
+        # Plant through the LIVE EdgeList handle: Vertex.getOutEdges/getInEdges
+        # return deep COPIES in Python (return_value_policy::copy propagates to
+        # the elements — the getFacets/getCofaces trap), so a plant through
+        # them never reaches the mesh.
+        moved = [e for e in st.getEdgeList().toVector()
+                 if mover.getId() in (e.getSource().getId(),
+                                      e.getTarget().getId())][0]
+        moved.setSquaredLength(planted_l2)
+        moved.setPhase(planted_phase)
+        _old, new_edges = mover.moveEdgesTo(recipient, st)
+        carriers = [e for e in new_edges
+                    if e.getSquaredLength() == planted_l2
+                    and e.getPhase() == planted_phase]
+        self.assertTrue(
+            carriers,
+            "no relocated edge carries the exact complex l^2 + U(1) phase — "
+            "the createEdge funnel laundered the state again")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mesh/test_real_signed_convention_python.py
+++ b/tests/mesh/test_real_signed_convention_python.py
@@ -1,18 +1,24 @@
-"""The ordinary-Lorentzian convention on the geometry stack (#580/#589).
+"""The ordinary-Lorentzian convention on the geometry stack (#580/#589/#597).
 
 Resident l^2 is REAL and SIGNED (spacelike > 0, timelike < 0, null 0); the
 non-Wick geometry entry points consume Re l^2 and the Wick-rotated paths |l^2|.
-There is NO runtime enforcement — the #582 interim `domain_error` guard is
-deleted (#589): the dynamics keeps l^2 on the real axis by construction
-(`MultiCobordism::runStage2` proposes exactly-real trials), and that invariant
-is proven where invariants live — in the suite
-(tests/cobordism/test_stage2_real_manifold_python.py) — never by a throw,
-veto, or backoff inside the physics loop.
+Storage stays unpoliced — set/getSquaredLength round-trip a general complex
+value exactly (rollback records, historical dumps). Geometry CONSUMPTION reads
+through the checked accessor `Edge::getRealSquaredLength` (#597): a resident
+Im l^2 reaching a non-Wick read raises instead of being silently projected.
+The dynamics still contains no gate, veto, or backoff — the invariant holds by
+construction (`MultiCobordism::runStage2` proposes exactly-real trials, proven
+where invariants live, in the suite:
+tests/cobordism/test_stage2_real_manifold_python.py); the throw never fires on
+a legal state and cannot alter the dynamics — it is the tripwire for what the
+suite cannot cover (a future move bug, a Python-side plant, a historical
+complex dump fed to live geometry), superseding #589's silent Re projection at
+the read layer (#597).
 
-These tests pin the convention itself: geometry never throws on a resident
-Im l^2 (nothing polices storage), the non-Wick read IS the Re projection
-(value-equal to the Im-zeroed twin), Wick paths stay Im-tolerant, and signed
-real (timelike) geometry — the supported Lorentzian case — keeps working.
+These tests pin the convention itself: geometry FAILS LOUDLY on a resident
+Im l^2 (#597; storage stays unpoliced), Wick paths stay Im-tolerant, and
+signed real (timelike) geometry — the supported Lorentzian case — keeps
+working.
 
 Also the plot-layout collapse: the layout rest length is the documented
 |Re l^2| with an epsilon floor, so a null edge cannot pin two vertices
@@ -76,23 +82,30 @@ class TestRealSignedConvention(unittest.TestCase):
         _edge_map(without_im)[(0, 1)].setSquaredLength(complex(1.0, 0.0))
         return with_im, without_im
 
-    def test_non_wick_reads_are_the_re_projection_no_throw(self):
-        # The convention, executable: geometry on an Im-carrying host neither
-        # throws (no runtime enforcement) nor differs from the Im-zeroed twin
-        # (the non-Wick read is exactly Re l^2).
+    def test_non_wick_reads_fail_loudly_on_resident_im(self):
+        # The convention, executable (#597 supersedes #589's silent projection
+        # at the read layer): geometry on an Im-carrying host THROWS at the
+        # checked read instead of projecting Re l^2 — a resident Im l^2 is an
+        # upstream bug (#589 keeps l^2 real by construction), never a value to
+        # drop. The Im-zeroed twin computes normally through the same paths.
         with_im, without_im = self._twin_hosts()
         tri_a = _by_verts(with_im, [0, 1, 2])
-        tri_b = _by_verts(without_im, [0, 1, 2])
-        self.assertEqual(tri_a.volume(), tri_b.volume())
-        v0_a, v0_b = _by_verts(with_im, [0]), _by_verts(without_im, [0])
-        self.assertEqual(complex(tri_a.lorentzianDihedralAngle(v0_a)),
-                         complex(tri_b.lorentzianDihedralAngle(v0_b)))
-        self.assertEqual(complex(v0_a.lorentzianDeficitAngle()),
-                         complex(v0_b.lorentzianDeficitAngle()))
+        v0_a = _by_verts(with_im, [0])
+        with self.assertRaisesRegex(RuntimeError, "Im l\\^2"):
+            tri_a.volume()
+        with self.assertRaisesRegex(RuntimeError, "Im l\\^2"):
+            complex(tri_a.lorentzianDihedralAngle(v0_a))
         solver_a = tessera.ReggeSolver(with_im, tessera.MatterConfiguration())
+        with self.assertRaisesRegex(RuntimeError, "Im l\\^2"):
+            complex(solver_a.dualReggeAction())
+        tri_b = _by_verts(without_im, [0, 1, 2])
+        v0_b = _by_verts(without_im, [0])
+        self.assertTrue(math.isfinite(float(tri_b.volume())))
+        self.assertTrue(math.isfinite(
+            abs(complex(tri_b.lorentzianDihedralAngle(v0_b)))))
         solver_b = tessera.ReggeSolver(without_im, tessera.MatterConfiguration())
-        self.assertEqual(complex(solver_a.dualReggeAction()),
-                         complex(solver_b.dualReggeAction()))
+        self.assertTrue(math.isfinite(
+            abs(complex(solver_b.dualReggeAction()))))
 
     def test_wick_paths_stay_im_tolerant(self):
         # |l^2| paths: the Euclidean/CDT pipeline reads the modulus and keeps


### PR DESCRIPTION
## Summary

The #580 census residue, implemented: no `.real()` anywhere silently drops a potentially nonzero imaginary part.

- **`Edge::getRealSquaredLength()`** — the geometry stack's checked read: the real signed ℓ², throwing on Im ℓ² ≠ 0 instead of projecting (the message names the edge, the value, and the #589 convention). All **14 convention-projection readers** convert to it: the Gram/Cayley–Menger/canonical/Heron non-Wick branches, the stage-2 base point, `ReggeSolver::matterAction`, and the `EigenstateSynthesis` weight reads + analytic-gradient `l2map` builds. **Storage stays general-complex** (`get/setSquaredLength` round-trip rollback records and historical dumps exactly); the ~33 mathematically-correct Re extractions (Wirtinger directions, Hermitian traces, Rayleigh quotients) are untouched. Full site-by-site classification: on #597.
- **`Vertex::moveEdgesToImpl`** — the one genuine truncation found: relocated edges were laundered through the double-typed `createEdge` funnel (Re-only ℓ², U(1) phase zeroed). Fixed with the RemoveMove/SurgicalCone restore idiom, with the state captured **before** `EdgeList::remove` frees the pool slot — `createEdge` reuses freed slots, so the old-edge pointer aliases the new edge after re-creation (reading through it post-create is a self-assignment; caught live by the new test).
- **Campaign worker verdict** — trajectory metric extremes `max_im_seen` / `min_re_min` over every pass/chunk snapshot (final-state reads can never surface a transient Im; the causal channel is min Re ℓ², not Im). Running #562 campaign untouched; frozen copies pick this up at a generation boundary.

**Design note for review — deliberate supersession**: #589 deleted the interim `domain_error` guard with the doctrine "invariants are proven in the suite, never by a throw in the physics loop". This PR supersedes that **at the read layer only**, per the #597 directive (stop truncating with `.real()` anywhere and everywhere): the dynamics still contains no gate/veto/backoff — the throw cannot fire on a legal state and cannot alter dynamics — it is the tripwire for what the suite cannot cover (a future move bug, a Python-side plant, a historical complex dump fed to live geometry). The convention test (`test_real_signed_convention_python.py`) is updated to pin the refined contract. If the assertion-gated variant is preferred instead, it is a two-line change to `Edge.h`.

## Test plan
- [x] Site classification (A/B/C) recorded on #597; census findings 1–4 verified fixed on main; stale census entry (`EdgeList::replace`) noted.
- [x] Planted-Im tests: the checked accessor throws (message names `Im l^2`); stage-2 raises on a planted Im through `run_stage2`; the Im-zeroed twin computes normally through the same paths; storage round-trips complex exactly.
- [x] `moveEdgesTo` preservation test (plants via the live `EdgeList` handle — `Vertex.getOut/InEdges` return deep copies in Python, noted in-test).
- [x] Worker verdict extremes unit tests (record fragment, no JSON Infinity).
- [x] Convention suite updated and green; mesh + cobordism fast lanes: **494 passed** (482+12), 7 skipped, 658 subtests, 0 failures locally.
- [ ] CI full suite on push.

Closes #597.
