### PR TITLE
fix(cobordism,spacetime): exact dual-volume bookkeeping across SurgicalCone move and rollback

### DIFF
--- a/include/cobordism/SurgicalCone.h
+++ b/include/cobordism/SurgicalCone.h
@@ -52,9 +52,15 @@ using namespace ::tessera::spacetime;
 /// ## Lifecycle and exact reversibility
 /// Accepted moves are pushed on a stack; `rollback()` undoes the last one,
 /// restoring the complex — every edge length and phase — bit-for-bit, so a
-/// round trip leaves the dual Regge action (Re **and** Im) invariant. The moves
-/// are first-class and composable (cone-out two disjoint cells, then roll both
-/// back LIFO).
+/// round trip leaves the dual Regge action (Re **and** Im) invariant. The
+/// facet/coface bookkeeping is restored along with the values: a cone-out
+/// prunes the removed cell's orphaned faces before dropping their edges (a
+/// registered sub-simplex must never outlive its edges — one that does reads
+/// \f$ \ell^2 = 0 \f$ in every later Gram-matrix computation), and the
+/// rollback re-materializes the restored cell's face lattice, so the coface
+/// walk behind ``Simplex::dualVolume`` retraces the pre-move circumcentric
+/// dual volumes exactly (#587). The moves are first-class and composable
+/// (cone-out two disjoint cells, then roll both back LIFO).
 class SurgicalCone {
  public:
   /// Bind the cone to a spacetime. Does not mutate it.
@@ -65,8 +71,10 @@ class SurgicalCone {
   SurgicalCone &operator=(const SurgicalCone &) = delete;
 
   /// Gated surgical **cone-out**: remove the top cell whose sorted vertex ids
-  /// equal \p cell (plus its orphaned edges and any vertex thereby isolated),
-  /// then accept only if the result is a valid manifold-with-boundary. Returns
+  /// equal \p cell (plus its orphaned faces, its orphaned edges, and any
+  /// vertex thereby isolated — the registered simplex set stays exactly the
+  /// closure of the surviving top cells), then accept only if the result is a
+  /// valid manifold-with-boundary. Returns
   /// `(true, "ok")` on acceptance; otherwise the complex is restored and the
   /// reason returned. Rejects removing the last top cell (it would drop the
   /// complex dimension).
@@ -80,7 +88,9 @@ class SurgicalCone {
       const std::vector<std::uint64_t> &targetVerts);
 
   /// Undo the last accepted move (LIFO), restoring the complex bit-for-bit —
-  /// every edge length and phase. Returns `false` if nothing is applied.
+  /// every edge length and phase, and the restored cell's facet/coface
+  /// lattice (so circumcentric dual volumes retrace too). Returns `false` if
+  /// nothing is applied.
   bool rollback();
 
   /// Roll every accepted move back, restoring the original complex. Returns the
@@ -122,6 +132,13 @@ class SurgicalCone {
     /// the single fresh vertex (cone-in, to drop), each (id, coords). An empty
     /// coords vector marks a coordinate-free vertex.
     std::vector<std::pair<std::uint64_t, std::vector<double>>> verts;
+    /// Whether the removed top cell carried a materialized facet lattice at
+    /// move time (cone-out only). The undo then re-materializes the restored
+    /// cell's face lattice — the coface links ``Simplex::dualVolume`` walks —
+    /// instead of leaving the cell wired to vertices and edges alone. Left
+    /// `false` for cone-in and for hosts that never materialized facets, so
+    /// a rollback never creates bookkeeping the pre-move complex lacked.
+    bool hadFacets{false};
   };
 
   /// Top cells of the bound spacetime as sorted vertex-id tuples (canonical

--- a/include/spacetime/Spacetime.h
+++ b/include/spacetime/Spacetime.h
@@ -488,6 +488,23 @@ class Spacetime {
     /// number of simplices pruned.
     std::size_t pruneOrphanedSimplices();
 
+    /// Scoped variant: unregister the orphaned proper faces of **one** cell —
+    /// every registered sub-simplex spanned by a proper subset of
+    /// \p cellVertexIds that no current top cell covers. This is the same
+    /// operation as the full sweep restricted to a single (typically
+    /// just-removed) top cell's face lattice, so a move class can keep the
+    /// "registered simplices = closure of the top cells" invariant at
+    /// \f$ O(2^d) \f$ per move instead of an \f$ O(N) \f$ pass. Faces still
+    /// covered by a surviving top cell are kept. Pruning is essential before
+    /// :func:`removeEdge` on an orphaned edge: a registered face that outlives
+    /// its edge keeps an empty edge set and silently reads
+    /// \f$ \ell^2 = 0 \f$ in every Gram-matrix computation thereafter (#587).
+    /// Returns the number of simplices pruned.
+    /// @param cellVertexIds The vertex ids spanning the cell whose face
+    ///   lattice is checked (need not itself be registered).
+    std::size_t pruneOrphanedSimplices(
+        const std::vector<std::uint64_t> &cellVertexIds);
+
     /// Fully remove an edge from the complex: drop it from its endpoints'
     /// in/out edge lists and from the EdgeList. The caller is responsible
     /// for first removing any simplices that contain the edge.
@@ -562,6 +579,17 @@ class Spacetime {
     /// side-effect that :func:`getExternalSimplices` performs internally; call
     /// it directly when you want the materialization without the boundary scan.
     void materializeFacets() noexcept;
+
+    /// Scoped variant: materialize the face lattice of **one** simplex —
+    /// recursive ``Simplex::getFacets()`` from \p root down to its vertices,
+    /// wiring the facet/coface incidence of every face on the way. Faces that
+    /// already exist are reused (gaining only the missing coface link); the
+    /// rest are created and registered. ``Simplex::dualVolume`` walks a hinge
+    /// **up** through exactly these coface links, so a move class restoring a
+    /// removed cell must restore this lattice too (#587) — this does that at
+    /// \f$ O(2^d) \f$ instead of the full-complex fixpoint pass above.
+    /// @param root The simplex whose face lattice to materialize.
+    void materializeFacets(const SimplexPtr &root) noexcept;
 
     /// @return Simplices around the boundary of the simplicial complex. These simplices have at
     /// least one external face. They will tend to be in order of orientation (e.g. (4, 1) and (3, 2) for 4D CDT). Note

--- a/src/cobordism/SurgicalCone.cpp
+++ b/src/cobordism/SurgicalCone.cpp
@@ -146,6 +146,7 @@ std::pair<bool, std::string> SurgicalCone::coneOut(
   Move m;
   m.kind = Move::Kind::ConeOut;
   m.cell = want;
+  m.hadFacets = target->hasFacets();
   std::vector<::tessera::mesh::Edge *> toRemove;
   for (std::size_t i = 0; i + 1 < want.size(); ++i)
     for (std::size_t j = i + 1; j < want.size(); ++j) {
@@ -166,8 +167,13 @@ std::pair<bool, std::string> SurgicalCone::coneOut(
     if (it != vidx.end()) coordSnap[id] = coordsOf(it->second);
   }
 
-  // Mutate: drop the top cell, then its orphaned edges.
+  // Mutate: drop the top cell, then its orphaned faces, then its orphaned
+  // edges. The face prune must precede the edge removal (removeEdge's
+  // contract: no simplex may still contain the edge) — a registered face
+  // stripped of its edge would stay wired into the hinges' coface walk while
+  // reading l2 = 0 in every Gram-matrix computation, the #587 drift.
   st_->removeSimplex(target);
+  st_->pruneOrphanedSimplices(want);
   for (auto *e : toRemove)
     if (e != nullptr) st_->removeEdge(e);
 
@@ -259,7 +265,7 @@ void SurgicalCone::undoConeOut(const Move &m) {
     if (it == vidx.end()) return;  // a cell vertex vanished — cannot restore
     verts.push_back(it->second);
   }
-  st_->createSimplexTracked(verts);
+  const auto restored = st_->createSimplexTracked(verts);
 
   auto eidx = edgeIndex(st_);
   for (const auto &[u, v, w, theta] : m.edges) {
@@ -269,10 +275,24 @@ void SurgicalCone::undoConeOut(const Move &m) {
       it->second->setPhase(theta);
     }
   }
+
+  // Restore the cell's facet/coface lattice: createSimplexTracked wires the
+  // cell to vertices and edges only, so without this the restored cell is
+  // nobody's coface and every surrounding hinge's dualVolume misses its
+  // wedges until some global re-materialization — and the pruned faces
+  // (fresh objects bound to the fresh edges) would never come back at all.
+  // Skipped when the pre-move cell had no materialized facets, so the undo
+  // never creates bookkeeping the pre-move complex lacked.
+  if (m.hadFacets) st_->materializeFacets(restored.simplex);
 }
 
 void SurgicalCone::undoConeIn(const Move &m) {
-  // Drop the added top cell, its fresh edges, then the fresh apex vertex.
+  // Drop the added top cell, its orphaned faces, its fresh edges, then the
+  // fresh apex vertex. The face prune covers the case where the lattice was
+  // materialized between the accepted move and this rollback (e.g. a solver
+  // scoring the probe): the apex's faces would otherwise stay registered
+  // with their edges stripped — the same zombie class as the cone-out side.
+  // Faces shared with surviving top cells are kept.
   auto vidx = vertexIndex(st_);
   ::tessera::mesh::VertexPtrs verts;
   verts.reserve(m.cell.size());
@@ -283,6 +303,7 @@ void SurgicalCone::undoConeIn(const Move &m) {
   if (verts.size() == m.cell.size()) {
     if (auto s = st_->findSimplexByVerts(verts)) st_->removeSimplex(s);
   }
+  st_->pruneOrphanedSimplices(m.cell);
   auto eidx = edgeIndex(st_);
   for (const auto &[u, v, w, theta] : m.edges) {
     (void)w;

--- a/src/cobordism/SurgicalCone.cpp
+++ b/src/cobordism/SurgicalCone.cpp
@@ -173,7 +173,11 @@ std::pair<bool, std::string> SurgicalCone::coneOut(
   // stripped of its edge would stay wired into the hinges' coface walk while
   // reading l2 = 0 in every Gram-matrix computation, the #587 drift.
   st_->removeSimplex(target);
-  st_->pruneOrphanedSimplices(want);
+  // If anything was pruned, the undo must re-materialize even when the cell
+  // itself carried no facet cache (a partially materialized host can hold
+  // faces registered by a neighbor cell's getFacets) — registered faces are
+  // never lost across a round trip.
+  if (st_->pruneOrphanedSimplices(want) > 0) m.hadFacets = true;
   for (auto *e : toRemove)
     if (e != nullptr) st_->removeEdge(e);
 

--- a/src/spacetime/Bindings.cpp
+++ b/src/spacetime/Bindings.cpp
@@ -474,7 +474,9 @@ materialized facets. A closed manifold returns an empty list.
 Unlike getExternalSimplices (which returns whole boundary top cells and
 materializes facets as a side-effect), this returns the boundary faces
 themselves and leaves the complex untouched.)doc")
-      .def("materializeFacets", &Spacetime::materializeFacets,
+      .def("materializeFacets",
+           static_cast<void (Spacetime::*)() noexcept>(
+               &Spacetime::materializeFacets),
            R"doc(Force lazy facet materialization to a fixpoint.
 
 Creates and registers every face of every dimension (down to the
@@ -585,7 +587,9 @@ its top cells match.)doc")
            "Return a uniformly random vertex.")
       .def("removeSimplex", &Spacetime::removeSimplex, py::arg("simplex"),
            "Remove a top-dimensional simplex from the complex.")
-      .def("pruneOrphanedSimplices", &Spacetime::pruneOrphanedSimplices,
+      .def("pruneOrphanedSimplices",
+           static_cast<std::size_t (Spacetime::*)()>(
+               &Spacetime::pruneOrphanedSimplices),
            "Unregister sub-simplices (facets/hinges) orphaned by a move — "
            "registered but no longer a face of any current top cell. Returns "
            "the count pruned. Restores the simplex set to the exact closure of "

--- a/src/spacetime/Spacetime.cpp
+++ b/src/spacetime/Spacetime.cpp
@@ -8,6 +8,7 @@
 // (was: #include <pybind11/pybind11.h> — removed; unreferenced.)
 #include "Logger.h"
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <map>
 #include <memory>
@@ -714,6 +715,18 @@ void Spacetime::materializeFacets() noexcept {
   }
 }
 
+void Spacetime::materializeFacets(const SimplexPtr &root) noexcept {
+  // ``getFacets()`` hash-reuses a face that already exists (adding only the
+  // missing coface link back to its parent) and creates-and-registers the
+  // missing ones, so recursing from the root down to the vertices completes
+  // the root's whole face lattice and its coface wiring. Shared sub-faces are
+  // visited once per parent; every visit past the first is a cached no-op.
+  if (root == nullptr || root->size() <= 1) return;
+  for (const auto &facet : root->getFacets()) {
+    materializeFacets(facet);
+  }
+}
+
 SimplexSet Spacetime::getExternalSimplices() noexcept {
   // Boundary detection needs every facet's coface count to be complete: a facet
   // is on the boundary iff it has fewer than two cofaces. Force lazy facet
@@ -1348,6 +1361,39 @@ std::size_t Spacetime::pruneOrphanedSimplices() {
     if (s->hasTopCoface()) continue;                       // genuine face
     removeSimplex(s);
     ++pruned;
+  }
+  return pruned;
+}
+
+std::size_t Spacetime::pruneOrphanedSimplices(
+    const std::vector<std::uint64_t> &cellVertexIds) {
+  // Enumerate the proper faces of the cell (every non-empty strict subset of
+  // its vertex ids) and unregister each registered one that no current top
+  // cell covers. Largest faces first, so removeSimplex cleans a face's coface
+  // back-references while the face's own facets are still registered. The
+  // subset lookup uses the same commutative id-hash as createSimplex /
+  // findSimplexByVerts; the vertex-count check below keeps an (astronomically
+  // unlikely) hash collision from unregistering an unrelated simplex.
+  const std::size_t n = cellVertexIds.size();
+  if (n < 2 || n > 16) return 0;
+  std::size_t pruned = 0;
+  for (std::size_t faceSize = n - 1; faceSize >= 1; --faceSize) {
+    for (std::uint64_t mask = 1; mask < (std::uint64_t{1} << n); ++mask) {
+      if (static_cast<std::size_t>(std::popcount(mask)) != faceSize) continue;
+      std::uint64_t hash = 0;
+      for (std::size_t i = 0; i < n; ++i) {
+        if (mask & (std::uint64_t{1} << i)) {
+          hash ^= Fingerprint::mix64(cellVertexIds[i]);
+        }
+      }
+      auto *found = simplexIndex_.find(hash);
+      if (!found) continue;
+      SimplexPtr face = *found;
+      if (face->isStale() || face->size() != faceSize) continue;
+      if (face->hasTopCoface()) continue;  // covered by a surviving top cell
+      removeSimplex(face);
+      ++pruned;
+    }
   }
   return pruned;
 }

--- a/tests/cobordism/test_complex_rollback_records_python.py
+++ b/tests/cobordism/test_complex_rollback_records_python.py
@@ -97,6 +97,34 @@ def _tops(st):
                   for s in st.getTopSimplices())
 
 
+def _hinge_dual_volumes(st):
+    """{vertex id: dualVolume} over the registered 0-simplices — the
+    (d-2)-hinges of this 2D host. Reads the circumcentric coface walk, so it
+    is sensitive to the facet/coface bookkeeping, not just to edge values."""
+    out = {}
+    for s in st.getSimplices():
+        if len(s.getVertices()) == 1:
+            out[s.getVertices()[0].getId()] = s.dualVolume()
+    return out
+
+
+def _registered_faces(st, n_vertices):
+    """Sorted vertex-id tuples of the registered simplices carrying exactly
+    ``n_vertices`` vertices."""
+    return sorted(tuple(sorted(v.getId() for v in s.getVertices()))
+                  for s in st.getSimplices()
+                  if len(s.getVertices()) == n_vertices)
+
+
+def _assert_dual_volumes_equal(before, after, tol=1e-12):
+    assert set(after) == set(before), (
+        f"hinge set drifted: only-before={set(before) - set(after)} "
+        f"only-after={set(after) - set(before)}")
+    for vid, dv in before.items():
+        assert abs(after[vid] - dv) < tol, (
+            f"hinge v{vid}: dualVolume {dv!r} -> {after[vid]!r}")
+
+
 def _assert_state_equal(before, after, allow_missing=()):
     assert set(after) == set(before) - set(allow_missing), (
         f"edge set drifted: only-before={set(before) - set(after)} "
@@ -172,11 +200,10 @@ def test_cone_round_trip_preserves_complex_action_on_timelike_host():
     # may evaluate): the accepted cone-out round trip must retrace the full
     # COMPLEX dual Regge action, Re and Im — the hinge-exactness contract on
     # a mixed-causal-character host.  Closed host (the full icosahedron), the
-    # domain the existing hinge-exactness suites cover: on already-holed
-    # hosts an orphan-restoring rollback has a PRE-EXISTING circumcentric
-    # dual-volume bookkeeping drift (hinge deficits exact, dualVolume not)
-    # that is orthogonal to #581 — see the follow-up issue filed with this
-    # test.
+    # domain the existing hinge-exactness suites cover; the already-holed
+    # host, where the rollback must additionally restore an ORPHANED edge and
+    # the facet/coface bookkeeping around it (#587), is covered by
+    # test_cone_round_trip_retraces_dual_volumes_on_holed_host below.
     st = _full_icosa()
     _seed_signed_geometry(st, timelike_keys={(0, 1), (7, 10)})
     s0 = complex(T.ReggeSolver(st, T.MatterConfiguration()).dualReggeAction())
@@ -192,6 +219,83 @@ def test_cone_round_trip_preserves_complex_action_on_timelike_host():
     s1 = complex(T.ReggeSolver(st, T.MatterConfiguration()).dualReggeAction())
     assert abs(s1.real - s0.real) < 1e-9
     assert abs(s1.imag - s0.imag) < 1e-9
+
+
+def test_cone_round_trip_retraces_dual_volumes_on_holed_host():
+    # The #587 repro. Face [5,11,4] is the sole surviving coface of window
+    # rim edge (5,11), so coning it out orphans that edge. Removing the edge
+    # must also remove the registered (5,11) 1-simplex (a face that outlived
+    # its edge would read l^2 = 0 in every later Gram-matrix computation),
+    # and the rollback must restore the facet/coface lattice along with the
+    # edge values — every hinge's dualVolume and the complex dual action
+    # retrace IMMEDIATELY, not only after a global re-materialization.
+    st = _holed_icosa()
+    _seed_signed_geometry(st, timelike_keys={(0, 1), (7, 10)})
+    s0 = complex(T.ReggeSolver(st, T.MatterConfiguration()).dualReggeAction())
+    dv0 = _hinge_dual_volumes(st)
+    before = _edge_state(st)
+    faces0 = _registered_faces(st, 2)
+    tops_before = _tops(st)
+
+    sc = cob.SurgicalCone(st)
+    ok, reason = sc.coneOut([5, 11, 4])
+    assert ok, reason
+    # No zombie: the orphaned rim edge's 1-simplex is pruned with the edge.
+    assert (5, 11) not in _registered_faces(st, 2)
+
+    assert sc.rollback()
+    _assert_state_equal(before, _edge_state(st))
+    assert _tops(st) == tops_before
+    assert _registered_faces(st, 2) == faces0
+    _assert_dual_volumes_equal(dv0, _hinge_dual_volumes(st))
+    s1 = complex(T.ReggeSolver(st, T.MatterConfiguration()).dualReggeAction())
+    assert abs(s1.real - s0.real) < 1e-12
+    assert abs(s1.imag - s0.imag) < 1e-12
+    # A later global re-materialization must not shift anything either (the
+    # pre-fix failure mode: it wired a pruned-edge zombie back into the walk).
+    st.materializeFacets()
+    _assert_dual_volumes_equal(dv0, _hinge_dual_volumes(st))
+
+
+def test_rejected_cone_out_retraces_dual_volumes():
+    # The directedConeOut hot path scores dF across rejected probes on the
+    # SAME spacetime; the auto-rollback must leave every hinge's dualVolume
+    # unchanged or every later probe sees a phantom dual-volume delta (#587).
+    # Face [0,1,7] shares only vertex 0 with the window hole [0,11,5], so the
+    # gate rejects it (pinched link) after the cell was already removed.
+    st = _holed_icosa()
+    _seed_signed_geometry(st, timelike_keys={(0, 1), (7, 10)})
+    dv0 = _hinge_dual_volumes(st)
+
+    sc = cob.SurgicalCone(st)
+    ok, _ = sc.coneOut([0, 1, 7])
+    assert not ok, "removal pinching the hole rim must be rejected"
+    assert sc.depth == 0
+    _assert_dual_volumes_equal(dv0, _hinge_dual_volumes(st))
+
+
+def test_cone_in_rollback_after_materialization_leaves_no_orphan_faces():
+    # If the lattice is materialized between an accepted cone-in and its
+    # rollback (e.g. a solver scoring the probe), the fresh cell's faces
+    # exist by then; the rollback must drop them with the cell and its fresh
+    # edges — faces shared with surviving cells stay — so the registered
+    # simplex set returns exactly to the pre-move closure.
+    st = _holed_icosa()
+    _seed_complex_geometry(st)
+    before = _edge_state(st)
+    n_simplices_before = len(st.getSimplices())
+    faces0 = _registered_faces(st, 2)
+
+    sc = cob.SurgicalCone(st)
+    ok, reason = sc.coneIn([0, 5])  # cap part of the [0,11,5] window
+    if not ok:
+        pytest.skip(f"cone-in rejected on this host: {reason}")
+    st.materializeFacets()
+
+    assert sc.rollback()
+    _assert_state_equal(before, _edge_state(st))
+    assert _registered_faces(st, 2) == faces0
+    assert len(st.getSimplices()) == n_simplices_before
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

`SurgicalCone.coneOut` + `rollback()` on an already-holed host restores every edge value and hinge deficit exactly, but the circumcentric dual volumes at the re-created cell's vertices drift (issue #587's repro: v5 0.3164 → 0.2416, v11 0.5932 → 0.5183, `dualReggeAction` off by ~0.4 Re / ~0.09 Im). Any ΔF scored across an orphan-restoring probe on a holed host therefore sees a phantom dual-volume delta after rejection.

Diagnosis (confirmed by instrumented repro):

1. **The forward move creates a "zombie" sub-simplex.** Removing the orphaned rim edge (`Spacetime::removeEdge` → `Vertex::removeInEdge`/`removeOutEdge` → `Simplex::removeEdge`) strips that edge out of the *registered* 1-simplex that represents it in the facet/coface lattice. The 1-simplex stays registered — still a coface of its hinge 0-simplices — with an empty `edges` member, so every Gram-matrix read on it silently sees l² = 0.
2. **The rollback re-creates the cell but not its lattice wiring.** `undoConeOut` rebuilds the top cell via `createSimplexTracked`, which wires vertices and edges but no facet→coface links, so the restored cell contributes nothing to any hinge's dual volume until some later global re-materialization.
3. **Re-materialization then wires the zombie back in.** `getFacets()` on the restored cell hash-finds the still-registered zombie 1-simplex and re-links it — now reading l² = 0 — which is exactly the halfway-wrong dual volumes quoted in the issue.

Fix, by construction (no runtime guards in any read path):

- `SurgicalCone::coneOut` now prunes the removed cell's orphaned faces (registered proper faces left with no surviving top coface) immediately after the cell is removed, so no registered simplex ever outlives its edges.
- `undoConeOut` re-materializes the restored cell's face lattice (recursive `getFacets`) when the removed cell had materialized facets, so the facet/coface lattice — and hence every dual volume — retraces the pre-move state on both the rejected-probe path and the explicit rollback path.
- `undoConeIn` applies the same orphaned-face prune to the dropped cell, covering the symmetric case where the lattice was materialized between an accepted `coneIn` and its rollback.
- The scoped primitives live on `Spacetime` as overloads of the existing operations: `materializeFacets(root)` and `pruneOrphanedSimplices(cellVertexIds)`.

## Test plan
- [ ] New regression: holed-icosahedron `coneOut([5,11,4])` + `rollback()` retraces every hinge's `dualVolume` and the complex `dualReggeAction`, both immediately and after a fresh `ReggeSolver` re-materialization.
- [ ] New regression: a rejected `coneOut` probe leaves all dual volumes unchanged (the `directedConeOut` hot-path contract).
- [ ] Existing rollback/hinge-exactness suites pass (`tests/cobordism/test_complex_rollback_records_python.py`, surgical-cone topology suites).
- [ ] Full local `pytest tests/` in the worktree venv; CI `build.yml` green on the PR.

Closes #587.
